### PR TITLE
added composite index for seq_member_id and gene_member_id to seq_member

### DIFF
--- a/sql/table.sql
+++ b/sql/table.sql
@@ -882,7 +882,8 @@ CREATE TABLE seq_member (
   KEY (sequence_id),
   KEY (gene_member_id),
   KEY dnafrag_id_start (dnafrag_id,dnafrag_start),
-  KEY dnafrag_id_end (dnafrag_id,dnafrag_end)
+  KEY dnafrag_id_end (dnafrag_id,dnafrag_end),
+  KEY seq_member_gene_member_id_end (seq_member_id,gene_member_id)
 ) MAX_ROWS = 100000000 COLLATE=latin1_swedish_ci ENGINE=MyISAM;
 
 


### PR DESCRIPTION
We have some very large (>10000) bacterial gene families, and retrieving the members one by one is quite slow. If we use direct SQL to retrieve some details by joining family_member to seq_member to gene_member, the operation is made much faster (20s vs 0.3s) by adding a composite key of seq_member_id and gene_member_id to the seq_member table.
