### PR TITLE
Fix fetch_by_source_stable_id, fetch_by_SeqMember.

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/FamilyAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/FamilyAdaptor.pm
@@ -142,7 +142,7 @@ sub fetch_by_SeqMember {
   my $constraint = 'fm.seq_member_id = ?';
 
   $self->bind_param_generic_fetch($seq_member->dbID, SQL_INTEGER);
-  return $self->generic_fetch($constraint, $join);
+  return ($self->generic_fetch($constraint, $join)||[])->[0];
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/MemberAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/MemberAdaptor.pm
@@ -110,6 +110,7 @@ sub fetch_by_source_stable_id {  ## DEPRECATED
     my ($self, $source_name, $stable_id) = @_;
     deprecate('MemberAdaptor::fetch_by_source_stable_id() is deprecated and will be removed in e79. Use fetch_by_stable_id() instead');
     my $member = $self->fetch_by_stable_id($stable_id);
+    return undef unless $member;
     die "The member '$stable_id' has a different source_name than '$source_name': ".$member->source_name if $source_name and $source_name ne $member->source_name;
     return $member;
 }


### PR DESCRIPTION
Fix to get protein families view working. Fixes deprecated for e79 methods, but they're not supposed to stop working quite yet!
1. fetch_by_SeqMember should return only the unique SeqMember, not an arrayref, assuming its description is correct and based on how it is used.
2. fetch_by_Member_source_stable_id now prospectively tries calling >fetch_by_source_stable_id on GeneMemberAdaptor first, if that fails does the same on SeqMemberAdaptor. Sadly GeneMemberAdaptor failed too hard, so you could never retrieve SeqMembers with this method.
