### PR TITLE
Don't die in warn if there are no translations.

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers.pm
@@ -348,7 +348,7 @@ sub store_gene_and_all_transcripts {
     }
 
     # Some of the "polymorphic_pseudogene" have a non-translatable canonical peptide. This is a hack to get the longest translation
-    if (not defined $canonicalPeptideMember and $self->param('find_canonical_translations_for_polymorphic_pseudogene') and $gene->biotype eq 'polymorphic_pseudogene') {
+    if ($longestTranslation and not defined $canonicalPeptideMember and $self->param('find_canonical_translations_for_polymorphic_pseudogene') and $gene->biotype eq 'polymorphic_pseudogene') {
         $self->warning($gene->stable_id."'s canonical transcript does not have a translation. Will use the longest peptide instead: ".$longestTranslation->stable_id);
         $canonicalPeptideMember = $longestTranslation;
     }


### PR DESCRIPTION
In Vega we sometimes have funny members with no translations at all. LoadMembers (and everything else) copes with this fine, except for a warn.
