### PR TITLE
Set the flag 'filter_duplicates_net' to 1 for filter_duplicates analysis at the netting step.

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAligner_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAligner_conf.pm
@@ -701,7 +701,8 @@ sub pipeline_analyses {
            {  -logic_name   => 'filter_duplicates_net',
               -module        => 'Bio::EnsEMBL::Compara::RunnableDB::PairAligner::FilterDuplicates',
               -parameters    => { 
-                                 'window_size' => $self->o('window_size') 
+                                 'window_size' => $self->o('window_size'),
+                                 'filter_duplicates_net' => 1,
                                 },
               -hive_capacity => 50,
               -batch_size    => 3,
@@ -714,7 +715,8 @@ sub pipeline_analyses {
            {  -logic_name   => 'filter_duplicates_net_himem',
               -module        => 'Bio::EnsEMBL::Compara::RunnableDB::PairAligner::FilterDuplicates',
               -parameters    => { 
-                                 'window_size' => $self->o('window_size') 
+                                 'window_size' => $self->o('window_size'),
+                                 'filter_duplicates_net' => 1,
                                 },
               -hive_capacity => 50,
               -batch_size    => 3,


### PR DESCRIPTION
Set the flag 'filter_duplicates_net' to 1 for analysis, 'filter_duplicates_net' and 'filter_duplicates_net_himem', as done in EGPairAligner.pm, to make sure the filtering duplicates logic, at the net step, is consistent.
