### PR TITLE
Correct typo in key

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/Utils/GeneTreeHash.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/GeneTreeHash.pm
@@ -161,7 +161,7 @@ sub _convert_node {
   }
   $hash->{confidence} = {};
   if ($boot) {
-    $hash->{confidence}{boostrap} = $boot + 0;
+    $hash->{confidence}{bootstrap} = $boot + 0;
   }
   if ($dcs) {
     $hash->{confidence}{duplication_confidence_score} = $dcs + 0;


### PR DESCRIPTION
'bootstrap' has been mistyped as 'boostrap', which ends up propagating into the REST API.