### PR TITLE
Script fails if preselection file is not supplied

### DIFF
--- a/scripts/pipeline/edit_collection.pl
+++ b/scripts/pipeline/edit_collection.pl
@@ -164,7 +164,9 @@ my $all_current_gdbs = [grep {($_->is_current or not $_->has_been_released) and 
 my @new_collection_gdbs = ();
 
 my %preselection = ();
-$preselection{$_} = 1 for @{ slurp_to_array($file, 1) };
+if ($file) {
+  $preselection{$_} = 1 for @{ slurp_to_array($file, 1) };
+}
 
 if ($collection_ss) {
     ## Here we are in "update mode"


### PR DESCRIPTION
My understanding is that it is optional to provide a file containing preselected species; the script currently fails if one is not provided, so I've just added a simple check.