### PR TITLE
fixed incorrect number of placeholders

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/GeneMemberAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/GeneMemberAdaptor.pm
@@ -222,7 +222,7 @@ sub store {
                               canonical_member_id,
                               taxon_id, genome_db_id, biotype_group, description,
                               dnafrag_id, dnafrag_start, dnafrag_end, dnafrag_strand, display_label)
-                            VALUES (?,?,?,?,?,?,?,?,?,?,?,?)");
+                            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)");
 
   my $insertCount = $sth->execute($member->stable_id,
                   $member->version,


### PR DESCRIPTION
I noticed failures when calling store on gene members in the EG family pipeline. Appears to be a result of an extra column being added without the requisite number of placeholders. The following seems to fix it.