### PR TITLE
Zero is a valid value in conditional, so conditional should check for defined-ness not truth

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/StoreGocStatsAsMlssTags.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/StoreGocStatsAsMlssTags.pm
@@ -77,7 +77,7 @@ sub write_output {
   	my $mlss = $self->param('mlss');
   	foreach my $dist (@{$self->param('goc_distribution')}) {
 
-  		if (!$dist->[0]) {
+  		if (! defined $dist->[0]) {
   			$mlss->store_tag("n_goc_null",               $dist->[1]);
   		}
   		else {


### PR DESCRIPTION
The consequence of this bug is that the value for "n_goc_0" is inserted into the "n_goc_null" field, and the "n_goc_0" field never gets a value (i.e. is always NULL).