### PR TITLE
small bugfix

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAligner_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAligner_conf.pm
@@ -516,6 +516,7 @@ sub pipeline_analyses {
  	       -module     => 'Bio::EnsEMBL::Compara::RunnableDB::PairAligner::DumpDnaCollection',
  	       -parameters => {
 			       'faToNib_exe' => $self->o('faToNib_exe'),
+			       'dump_min_nib_size' => $self->o('dump_min_nib_size'),
                                'overwrite'=>1,
 			      },
 	       -hive_capacity => 10,


### PR DESCRIPTION
My pipeline fell through to this highmem analysis and promptly died with the error:
`ParamError: value for param_required('dump_min_nib_size') is required and has to be defined`

Simply adding dump_min_nib_size with the same value as for dump_large_nib_for_chains fixed the issue.