### PR TITLE
bumping lastz version to match the cellar

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/BaseAge_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/BaseAge_conf.pm
@@ -98,7 +98,7 @@ sub default_options {
 #            'curr_core_sources_locs'    => [ $self->o('livemirror_loc') ],
 
             # executable locations:
-            'big_bed_exe' => $self->o('ensembl_cellar').'/kent/v335/bin/bedToBigBed',
+            'big_bed_exe' => $self->o('ensembl_cellar').'/kent/v335_1/bin/bedToBigBed',
 
             #Locations to write output files
             'bed_dir'        => sprintf('/hps/nobackup/production/ensembl/%s/%s', $ENV{USER}, $self->o('pipeline_name')),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/EG/TBlat_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/EG/TBlat_conf.pm
@@ -131,10 +131,10 @@ sub default_options {
 
 	    #Location of executables
 	    'pair_aligner_exe' => '/nfs/panda/ensemblgenomes/production/compara/binaries/blat',
-            'faToNib_exe'       => $self->o('ensembl_cellar').'/kent/v335/bin/faToNib',
-            'lavToAxt_exe'      => $self->o('ensembl_cellar').'/kent/v335/bin/lavToAxt',
-            'axtChain_exe'      => $self->o('ensembl_cellar').'/kent/v335/bin/axtChain',
-            'chainNet_exe'      => $self->o('ensembl_cellar').'/kent/v335/bin/chainNet',
+            'faToNib_exe'       => $self->o('ensembl_cellar').'/kent/v335_1/bin/faToNib',
+            'lavToAxt_exe'      => $self->o('ensembl_cellar').'/kent/v335_1/bin/lavToAxt',
+            'axtChain_exe'      => $self->o('ensembl_cellar').'/kent/v335_1/bin/axtChain',
+            'chainNet_exe'      => $self->o('ensembl_cellar').'/kent/v335_1/bin/chainNet',
 
             # healthcheck
             'do_compare_to_previous_db' => 0,

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/Lastz_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/Lastz_conf.pm
@@ -32,10 +32,10 @@ sub default_options {
 
         #Location of executables
         'pair_aligner_exe'  => $self->o('ensembl_cellar').'/lastz/1.04.00/bin/lastz',
-        'faToNib_exe'       => $self->o('ensembl_cellar').'/kent/v335/bin/faToNib',
-        'lavToAxt_exe'      => $self->o('ensembl_cellar').'/kent/v335/bin/lavToAxt',
-        'axtChain_exe'      => $self->o('ensembl_cellar').'/kent/v335/bin/axtChain',
-        'chainNet_exe'      => $self->o('ensembl_cellar').'/kent/v335/bin/chainNet',
+        'faToNib_exe'       => $self->o('ensembl_cellar').'/kent/v335_1/bin/faToNib',
+        'lavToAxt_exe'      => $self->o('ensembl_cellar').'/kent/v335_1/bin/lavToAxt',
+        'axtChain_exe'      => $self->o('ensembl_cellar').'/kent/v335_1/bin/axtChain',
+        'chainNet_exe'      => $self->o('ensembl_cellar').'/kent/v335_1/bin/chainNet',
 
     };
 }

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/Lastz_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/Lastz_conf.pm
@@ -31,7 +31,7 @@ sub default_options {
         %{$self->SUPER::default_options},   # inherit the generic ones
 
         #Location of executables
-        'pair_aligner_exe'  => $self->o('ensembl_cellar').'/lastz/1.02.00/bin/lastz',
+        'pair_aligner_exe'  => $self->o('ensembl_cellar').'/lastz/1.04.00/bin/lastz',
         'faToNib_exe'       => $self->o('ensembl_cellar').'/kent/v335/bin/faToNib',
         'lavToAxt_exe'      => $self->o('ensembl_cellar').'/kent/v335/bin/lavToAxt',
         'axtChain_exe'      => $self->o('ensembl_cellar').'/kent/v335/bin/axtChain',


### PR DESCRIPTION
The new cellar, under /nfs/software/ensembl/RHEL7-JUL2017-core2, has LASTZ version 1.04.00 rather than 1.02.00.