### PR TITLE
Add metazoan taxonomic levels

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HighConfidenceOrthologs_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HighConfidenceOrthologs_conf.pm
@@ -75,6 +75,18 @@ sub default_options {
                 'thresholds'    => [ 50, 50, 25 ],
             },
             {
+                'taxa'          => [ 'Aculeata', 'Anophelinae', 'Caenorhabditis', 'Drosophila', 'Glossinidae', 'Onchocercidae' ],
+                'thresholds'    => [ 50, 50, 25 ],
+            },
+            {
+                'taxa'          => [ 'Brachycera', 'Culicinae', 'Hemiptera', 'Phlebotominae' ],
+                'thresholds'    => [ 25, 25, 25 ],
+            },
+            {
+                'taxa'          => [ 'Chelicerata', 'Diptera', 'Hymenoptera', 'Nematoda' ],
+                'thresholds'    => [ undef, undef, 25 ],
+            },
+            {
                 'taxa'          => [ 'all' ],
                 'thresholds'    => [ undef, undef, 25 ],
             },


### PR DESCRIPTION
I realise that I could have merged the first new set of tax with the previous option, and that the last one is redundant given the 'all' category; but I thought it best to keep the non-vertebrate taxa separate, in case we want to tweak the thresholds in the future.