### PR TITLE
Fix typo: ->para() -> ->param()

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CAFESpeciesTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CAFESpeciesTree.pm
@@ -154,7 +154,7 @@ sub run {
             Bio::EnsEMBL::Compara::Utils::SpeciesTree::ultrametrize_from_timetree($species_tree_root);
             print "AFTER ultrametrize_from_timetree:\n";
         } else {
-            $self->para('use_timetree', 0);
+            $self->param('use_timetree', 0);
         }
     }
     unless ($self->param('use_timetree')) {


### PR DESCRIPTION
Pipeline fails at CAFE_species_tree because of a simple typo. Not found in 93.