### PR TITLE
Add mlss_id to the params that are exported to store_goc_dist_as_Tags

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/Calculate_goc_perc_above_threshold.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/Calculate_goc_perc_above_threshold.pm
@@ -87,7 +87,12 @@ sub write_output {
   	my $self = shift @_;
     print $self->param('thresh') , "  :  goc_threshold \n" , $self->param('perc_above_thresh') , "  :  perc_above_thresh \n " if ( $self->debug >3 );
     #goc threshold need to be dataflow'd  beacuse if it is given a default value by the user this would not have been dataflow'd atleast once, hence the next runnable after this will not be able to access it, causing failure.
-    $self->dataflow_output_id( {'perc_above_thresh' => $self->param('perc_above_thresh'), 'goc_dist' => $self->param('goc_dist'), 'goc_threshold' => $self->param('thresh')} , 1);
+    $self->dataflow_output_id( {
+        'perc_above_thresh' => $self->param('perc_above_thresh'),
+        'goc_dist' => $self->param('goc_dist'),
+        'goc_threshold' => $self->param('thresh'),
+        'goc_mlss_id' => $self->param('goc_mlss_id'),
+      } , 1);
 }
 
 


### PR DESCRIPTION
Calculate_goc_perc_above_threshold.pm did not return the mlss_id that
was needed by store_goc_dist_as_Tags.