### PR TITLE
Swap the two calls to storing parameters

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/CreateReuseSpeciesSets.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/CreateReuseSpeciesSets.pm
@@ -120,8 +120,8 @@ sub write_output {
 
     my $all_gdbs = $self->param('genome_dbs');
 
-    $self->_write_shared_ss('reuse', [grep {$_->{is_reused}} @$all_gdbs] );
     $self->_write_shared_ss('nonreuse', [grep {not $_->{is_reused}} @$all_gdbs] );
+    $self->_write_shared_ss('reuse', [grep {$_->{is_reused}} @$all_gdbs] );
 
     $self->db->hive_pipeline->add_new_or_update('PipelineWideParameters',
         'param_name' => 'species_count',


### PR DESCRIPTION
This change fixes an issue I have encountered when running the LoadMembers pipeline.

I am opting for "not reusing anything" in my run, and hence each of `@all_gdbs` is not reused. So the call to `$self->_write_shared_ss('nonreuse',...` proceeds by passing the empty SpeciesSet to `Bio::EnsEMBL::Compara::DBSQL::SpeciesSetAdaptor::store`, which mints a new dbID. The table in the Hive pipeline is empty at that point, so the next dbID for the `species-set` table is 1.

Then `$self->_write_shared_ss('reuse',...` happens, and a different execution path follows:
`$self->param('reference_dba')->get_SpeciesSetAdaptor->fetch_by_GenomeDBs($genome_dbs); in the [line 165 of this file](https://github.com/wbazant/ensembl-compara/blob/0bc014b76b777e4b0f0e88a47b3e031f6f57d88e/modules/Bio/EnsEMBL/Compara/RunnableDB/CreateReuseSpeciesSets.pm#L165) ` returns a $ss from my reference DB. Due to how my reference DB is structured (I wiped it before the pipeline run, and have a single SpeciesSet), this dbID also happens to be 1, I get a clash, and the pipeline fails.

Attaching: 
1. results of a successful run with this change in place
2. full stack trace manifesting the problem

1. 
```
Worker 74 [ UNSPECIALIZED ] Found 28 analyses matching '%' pattern
Worker 74 [ UNSPECIALIZED ] specializing to create_reuse_ss(8)
Created a new naked entry {"param_name" => "nonreuse_ss_id","param_value" => 1}
Created a new naked entry {"param_name" => "nonreuse_ss_csv","param_value" => "-1,127,32,90,118,71,102,18,125,16,44,55,84,27,95,57,20,109,151,89,148,31,35,11,78,93,106,65,29,138,114,58,153,15,137,81,60,101,73,86,76,62,67,139,129,2,17,110,82,147,135,14,112,69,145,49,24,140,124,104,131,121,79,154,23,96,126,47,8,98,37,117,43,5,33,21,63,7,26,80,119,99,72,74,61,108,115,92,103,10,113,152,142,91,48,107,87,77,133,149,123,50,39,64,97,12,41,52,56,45,66,19,54,70,68,1,136,88,116,144,141,30,100,25,128,28,120,156,134,40,75,83,59,150,155,130,53,122,143,42,22,46,13,105,6,85,36,3,94,146,51,9,111,38,4,34,132"}
Created a new naked entry {"param_name" => "reuse_ss_id","param_value" => 2}
Created a new naked entry {"param_name" => "reuse_ss_csv","param_value" => -1}
Created a new naked entry {"param_name" => "species_count","param_value" => 156}
Created a new naked entry {"param_name" => "are_all_species_reused","param_value" => 0}
Worker 74 [ Role 67 , create_reuse_ss(8) ] Job 6 : complete
Worker 74 [ Role 67 , create_reuse_ss(8) ] Having completed 1 jobs the Worker exits : NO_WORK
```

2. 
```
Worker 69 [ Role 63 , create_reuse_ss(8) ] Job 6 : died

Updating {"param_name" => "reuse_ss_id","param_value" => 1} with ({"param_value" => 1})

 at /nfs/production/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/modules/Bio/EnsEMBL/Hive/HivePipeline.pm line 180.
        Bio::EnsEMBL::Hive::HivePipeline::add_new_or_update(Bio::EnsEMBL::Hive::HivePipeline=HASH(0x2795138), "PipelineWideParameters", "param_name", "reuse_ss_id", "param_value", 1) called at /nfs/panda/ensemblgenomes/wormbase/software/packages/ensembl/branches/branch-92/ensembl-compara/modules/Bio/EnsEMBL/Compara/RunnableDB/CreateReuseSpeciesSets.pm line 146
        Bio::EnsEMBL::Compara::RunnableDB::CreateReuseSpeciesSets::_write_shared_ss(Bio::EnsEMBL::Compara::RunnableDB::CreateReuseSpeciesSets=HASH(0x2aebe10), "reuse", ARRAY(0x3a3ca80)) called at /nfs/panda/ensemblgenomes/wormbase/software/packages/ensembl/branches/branch-92/ensembl-compara/modules/Bio/EnsEMBL/Compara/RunnableDB/CreateReuseSpeciesSets.pm line 123
        Bio::EnsEMBL::Compara::RunnableDB::CreateReuseSpeciesSets::write_output(Bio::EnsEMBL::Compara::RunnableDB::CreateReuseSpeciesSets=HASH(0x2aebe10)) called at /nfs/production/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/modules/Bio/EnsEMBL/Hive/Process.pm line 146
        eval {...} called at /nfs/production/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/modules/Bio/EnsEMBL/Hive/Process.pm line 127
        Bio::EnsEMBL::Hive::Process::life_cycle(Bio::EnsEMBL::Compara::RunnableDB::CreateReuseSpeciesSets=HASH(0x2aebe10)) called at /nfs/production/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/modules/Bio/EnsEMBL/Hive/Worker.pm line 688
        eval {...} called at /nfs/production/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/modules/Bio/EnsEMBL/Hive/Worker.pm line 674
        Bio::EnsEMBL::Hive::Worker::run_one_batch(Bio::EnsEMBL::Hive::Worker=HASH(0x29438e8), ARRAY(0x3874940)) called at /nfs/production/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/modules/Bio/EnsEMBL/Hive/Worker.pm line 526
        Bio::EnsEMBL::Hive::Worker::run(Bio::EnsEMBL::Hive::Worker=HASH(0x29438e8), HASH(0x2a1a450)) called at /nfs/production/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/modules/Bio/EnsEMBL/Hive/Scripts/RunWorker.pm line 85
        eval {...} called at /nfs/production/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/modules/Bio/EnsEMBL/Hive/Scripts/RunWorker.pm line 94
        Bio::EnsEMBL::Hive::Scripts::RunWorker::runWorker(Bio::EnsEMBL::Hive::HivePipeline=HASH(0x2795138), HASH(0x1e81a30), HASH(0x1e81bc8), HASH(0x1e81cd0)) called at /nfs/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/scripts/runWorker.pl line 135
        main::main() called at /nfs/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/scripts/runWorker.pl line 23

Updating {"param_name" => "reuse_ss_csv","param_value" => -1} with ({"param_value" => -1})

 at /nfs/production/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/modules/Bio/EnsEMBL/Hive/HivePipeline.pm line 180.
        Bio::EnsEMBL::Hive::HivePipeline::add_new_or_update(Bio::EnsEMBL::Hive::HivePipeline=HASH(0x2795138), "PipelineWideParameters", "param_name", "reuse_ss_csv", "param_value", -1) called at /nfs/panda/ensemblgenomes/wormbase/software/packages/ensembl/branches/branch-92/ensembl-compara/modules/Bio/EnsEMBL/Compara/RunnableDB/CreateReuseSpeciesSets.pm line 152
        Bio::EnsEMBL::Compara::RunnableDB::CreateReuseSpeciesSets::_write_shared_ss(Bio::EnsEMBL::Compara::RunnableDB::CreateReuseSpeciesSets=HASH(0x2aebe10), "reuse", ARRAY(0x3a3ca80)) called at /nfs/panda/ensemblgenomes/wormbase/software/packages/ensembl/branches/branch-92/ensembl-compara/modules/Bio/EnsEMBL/Compara/RunnableDB/CreateReuseSpeciesSets.pm line 123
        Bio::EnsEMBL::Compara::RunnableDB::CreateReuseSpeciesSets::write_output(Bio::EnsEMBL::Compara::RunnableDB::CreateReuseSpeciesSets=HASH(0x2aebe10)) called at /nfs/production/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/modules/Bio/EnsEMBL/Hive/Process.pm line 146
        eval {...} called at /nfs/production/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/modules/Bio/EnsEMBL/Hive/Process.pm line 127
        Bio::EnsEMBL::Hive::Process::life_cycle(Bio::EnsEMBL::Compara::RunnableDB::CreateReuseSpeciesSets=HASH(0x2aebe10)) called at /nfs/production/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/modules/Bio/EnsEMBL/Hive/Worker.pm line 688
        eval {...} called at /nfs/production/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/modules/Bio/EnsEMBL/Hive/Worker.pm line 674
        Bio::EnsEMBL::Hive::Worker::run_one_batch(Bio::EnsEMBL::Hive::Worker=HASH(0x29438e8), ARRAY(0x3874940)) called at /nfs/production/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/modules/Bio/EnsEMBL/Hive/Worker.pm line 526
        Bio::EnsEMBL::Hive::Worker::run(Bio::EnsEMBL::Hive::Worker=HASH(0x29438e8), HASH(0x2a1a450)) called at /nfs/production/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/modules/Bio/EnsEMBL/Hive/Scripts/RunWorker.pm line 85
        eval {...} called at /nfs/production/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/modules/Bio/EnsEMBL/Hive/Scripts/RunWorker.pm line 94
        Bio::EnsEMBL::Hive::Scripts::RunWorker::runWorker(Bio::EnsEMBL::Hive::HivePipeline=HASH(0x2795138), HASH(0x1e81a30), HASH(0x1e81bc8), HASH(0x1e81cd0)) called at /nfs/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/scripts/runWorker.pl line 135
        main::main() called at /nfs/panda/ensemblgenomes/wormbase/software/packages/ehive/branches/2.4/ensembl-hive/scripts/runWorker.pl line 23
Worker 69 [ Role 63 , create_reuse_ss(8), Job 6 ] Fatal : Attempting to store an object with dbID=1 (ss=1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/17/18/19/20/21/22/23/24/25/26/27/28/29/30/31/32/33/34/35/36/37/38/39/40/41/42/43/44/45/46/47/48/49/50/51/52/53/54/55/56/57/58/59/60/61/62/63/64/65/66/67/68/69/70/71/72/73/74/75/76/77/78/79/80/81/82/83/84/85/86/87/88/89/90/91/92/93/94/95/96/97/98/99/100/101/102/103/104/105/106/107/108/109/110/111/112/113/114/115/116/117/118/119/120/121/122/123/124/125/126/127/128/129/130/131/132/133/134/135/136/137/138/139/140/141/142/143/144/145/146/147/148/149/150/151/152/153/154/155/156) experienced a collision with same dbID but different data
```
