### PR TITLE
Pre release 94 deprecation

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -10,6 +10,11 @@
 
 # Deprecated methods scheduled for deletion
 
+## get VariationFeatures for AlignSlice, to be removed in Ensembl 95 
+
+* `AlignSlice::Slice::get_all_VariationFeatures_by_VariationSet`
+* `AlignSlice::Slice::get_all_genotyped_VariationFeatures`
+
 ## Taggable AUTOLOAD-ed methods, to be removed in Ensembl 94
 
 * `Taggable::get_value_for_XXX()`

--- a/modules/Bio/EnsEMBL/Compara/AlignSlice/Slice.pm
+++ b/modules/Bio/EnsEMBL/Compara/AlignSlice/Slice.pm
@@ -67,7 +67,7 @@ use Bio::EnsEMBL::Slice;
 use Bio::EnsEMBL::CoordSystem;
 use Bio::EnsEMBL::Compara::AlignSlice::Translation;
 use Bio::EnsEMBL::Utils::Argument qw(rearrange);
-use Bio::EnsEMBL::Utils::Exception qw(throw warning info verbose);
+use Bio::EnsEMBL::Utils::Exception qw(deprecate throw warning info verbose);
 use Scalar::Util qw(weaken);
 
 
@@ -1995,7 +1995,7 @@ sub get_all_VariationFeatures {
 
 sub get_all_VariationFeatures_by_VariationSet {
   my $self = shift;
-
+  deprecate('get_all_VariationFeatures_by_VariationSet is deprecated and will be removed in e95.');
   return $self->_method_returning_simple_features("get_all_VariationFeatures_by_VariationSet", @_)
 }
 
@@ -2018,7 +2018,7 @@ sub get_all_VariationFeatures_by_VariationSet {
 
 sub get_all_genotyped_VariationFeatures {
   my $self = shift;
-
+  deprecate('get_all_genotyped_VariationFeatures is deprecated and will be removed in e95.');
   return $self->_method_returning_simple_features("get_all_genotyped_VariationFeatures", @_)
 }
 


### PR DESCRIPTION
I have an ongoing effort with core to remove variation dependencies from the core API. It turns out there is some code called on AlignSlice objects. I cannot remove the ones that are used in the webcode: AlignSlice::Slice::get_all_VariationFeatures. But get_all_VariationFeatures_by_VariationSet and get_all_genotyped_VariationFeatures are not used in the webcode and therefor can be removed. Let me know if you have any concerns. Also let me know if remove for e95 is fine or if you prefer a later release. Thanks.