### PR TITLE
SequenceOntologyMapper deprecation update

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/ConstrainedElement.pm
+++ b/modules/Bio/EnsEMBL/Compara/ConstrainedElement.pm
@@ -718,6 +718,21 @@ sub get_all_overlapping_regulatory_motifs {
 } 
 
 
+=head2 feature_so_acc
+
+  Example     : $ce_so_acc = $ce->feature_so_acc;
+  Description : This method returns a string containing the SO accession number of ConstrainedElement.
+  Returns     : string (Sequence Ontology accession number)
+
+=cut
+
+sub feature_so_acc {
+  my $self = shift;
+
+  return 'SO:0001009';
+}
+
+
 =head2 toString
 
   Example    : print $member->toString();

--- a/modules/t/constrainedElement.t
+++ b/modules/t/constrainedElement.t
@@ -108,6 +108,7 @@ subtest "Test Bio::EnsEMBL::Compara::ConstrainedElement new(ALL) method", sub {
     is($ce->slice, $slice, "slice");
     is($ce->reference_dnafrag_id, $dnafrag_id, "dnafrag_id");
     is_deeply($ce->alignment_segments, $alignment_segments, "alignment_segments");
+    is($ce->feature_so_acc, 'SO:0001009', 'ConstrainedElement feature SO acc is correct (DNA_constraint_sequence)');
 
     done_testing();
 };


### PR DESCRIPTION
`Bio::EnsEMBL::Utils::SequenceOntologyMapper` is being deprecated with https://github.com/Ensembl/ensembl/pull/246
That functionality is being replaced with Bio::EnsEMBL::Feature::feature_so_acc, and all features will be able to use that method provided they declare a constant SO_ACC.
I'm making sure all the 'features' that were supported on SequenceOntologyMapper are compliant so that pipelines that use it can be updated seamlessly.
One of those 'features' is ConstrainedElement, which is technically not a feature and thus needs it's own feature_so_acc method. 