### PR TITLE
Switch to using opt for hdf5

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/HAL/HALXS/Makefile-Linuxbrew.PL
+++ b/modules/Bio/EnsEMBL/Compara/HAL/HALXS/Makefile-Linuxbrew.PL
@@ -22,8 +22,8 @@ my $linuxbrew_home = $ARGV[0] || $ENV{LINUXBREW_HOME};
 die "The path to the linuxbrew installation must be provided, either on the command-line or via the environment LINUXBREW_HOME" unless $linuxbrew_home;
 
 my $lib_location = $linuxbrew_home.'/lib';
-# We need a specific version of hdf5 that is not the default one
-my $hdf5_location = $linuxbrew_home.'/Cellar/hdf5@1.8/1.8.19';
+# We need hdf5 1.8. That is not the default one. Use opt to path to the latest version
+my $hdf5_location = $linuxbrew_home.'/opt/hdf5@1.8';
 
 print "! Using linuxbrew installation at $ENV{LINUXBREW_HOME}\n";
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence


### PR DESCRIPTION
Rather than hard-coding the path for hdf5 1.8 keg we can use Linuxbrew's 
opt directory to always use the latest build. Since this will always be the 1.8 release
there should be little to no reason why sub-release bumps will affect the HAL bindings. 
If they did we would have to rebuild the hal bindings in XS and in Linuxbrew.