### PR TITLE
Default for GOC: do not reuse db

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -326,6 +326,7 @@ sub default_options {
         'use_timetree_times'        => 0,
 
     # GOC parameters
+        'goc_reuse_db'                  => undef,
         'goc_taxlevels'                 => [],
         'goc_threshold'                 => undef,
         'calculate_goc_distribution'    => 1,


### PR DESCRIPTION
ProteinTrees don't run without specifying this. I've chosen undef. @muffato If it's a good default value, do merge!