### PR TITLE
Only compute Jaccard index if there are two databases to compare

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -3096,7 +3096,7 @@ sub core_pipeline_analyses {
             -parameters         => {
                 mode            => 'stable_id_mapping',
             },
-            -flow_into          => [ 'compute_jaccard_index' ],
+            -flow_into          => WHEN( '#reuse_db#' => 'compute_jaccard_index' ),
             %hc_analysis_params,
         },
 


### PR DESCRIPTION
I'm running a pipeline without reuse: `reuse_db` in `pipeline_wide_parameters` is set to `undef`. Also as far as I see, the output of the job just gets printed to stdout which is usually discarded. So I prefer if the job doesn't even get created in my pipeline.