### PR TITLE
By default don't load_uniprot_members (will fail without mlssid)

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
@@ -96,7 +96,7 @@ sub default_options {
         'store_others'              => 1,
 
     #load uniprot members for family pipeline
-        'load_uniprot_members'      => 1,
+        'load_uniprot_members'      => 0,
         'family_mlss_id'            => undef, 
         'work_dir'        => '/hps/nobackup2/production/ensembl/' . $self->o( 'ENV', 'USER' ) . '/LoadMembers_pipeline/' . $self->o('pipeline_name'),
         'uniprot_dir'     => $self->o('work_dir').'/uniprot',


### PR DESCRIPTION
The pipeline will fail if load_uniprot_members = 1 and family_mlss_id = undef. (It's not dire because there are no other work to do after this).
The Ensembl version sets both parameters.