### PR TITLE
feature_so_term implementation

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/ConstrainedElement.pm
+++ b/modules/Bio/EnsEMBL/Compara/ConstrainedElement.pm
@@ -721,6 +721,20 @@ sub feature_so_acc {
   return 'SO:0001009';
 }
 
+=head2 feature_so_term
+
+  Example     : $ce_so_acc = $ce->feature_so_term;
+  Description : This method returns a string containing the SO term of ConstrainedElement.
+  Returns     : string (Sequence Ontology term)
+
+=cut
+
+sub feature_so_term {
+  my $self = shift;
+
+  return 'DNA_constraint_sequence';
+}
+
 
 =head2 toString
 

--- a/modules/t/constrainedElement.t
+++ b/modules/t/constrainedElement.t
@@ -109,6 +109,7 @@ subtest "Test Bio::EnsEMBL::Compara::ConstrainedElement new(ALL) method", sub {
     is($ce->reference_dnafrag_id, $dnafrag_id, "dnafrag_id");
     is_deeply($ce->alignment_segments, $alignment_segments, "alignment_segments");
     is($ce->feature_so_acc, 'SO:0001009', 'ConstrainedElement feature SO acc is correct (DNA_constraint_sequence)');
+    is($ce->feature_so_term, 'DNA_constraint_sequence', 'ConstrainedElement feature SO term is correct (DNA_constraint_sequence)');
 
     done_testing();
 };


### PR DESCRIPTION
Bio::EnsEMBL::Feature in the core API is changing to implement a feature_so_term method, similar to the already existing feature_so_acc method.
These changes to the core API are included in https://github.com/Ensembl/ensembl/pull/364.

This updates the compara API to support that method where the feature_so_acc was already supported.
Tests have been updated.