### PR TITLE
Recognise more segfaults

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/TreeBest.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/TreeBest.pm
@@ -123,10 +123,10 @@ sub run_treebest_best {
         return $run_cmd->out unless ($run_cmd->exit_code);
 
         my $full_cmd = $run_cmd->cmd;
-        $self->throw("'$full_cmd' resulted in a segfault") if ($run_cmd->exit_code == 11);
 
         print STDERR "$full_cmd\n";
         my $logfile = $run_cmd->err;
+        $self->throw("'$full_cmd' resulted in a segfault") if ($run_cmd->exit_code == 11 or $logfile =~ /Segmentation fault/);
         $logfile =~ s/^Large distance.*$//mg;
         $logfile =~ s/\n\n*/\n/g;
         if (($logfile =~ /NNI/) || ($logfile =~ /Optimize_Br_Len_Serie/) || ($logfile =~ /Optimisation failed/) || ($logfile =~ /Brent failed/))  {


### PR DESCRIPTION
I had a job die on a segfault, except it had an error code 139 and not 11.

I'm not sure if exit code 11 is special for treebest. I don't know if there are cases where the exit code is 11, the log doesn't say segfault, and it is a segfault, but this change preserves the existing behaviour in that scenario.