### PR TITLE
This fix an issue that we encounter in the Gene Tree Highlighting pip…

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/XrefAssociationAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/XrefAssociationAdaptor.pm
@@ -62,7 +62,7 @@ use Data::Dumper;
 
 use base ('Bio::EnsEMBL::Compara::DBSQL::BaseAdaptor');
 
-my $insert_member_base_sql = q/insert into member_xref(gene_member_id,dbprimary_acc,external_db_id)/;
+my $insert_member_base_sql = q/insert ignore into member_xref(gene_member_id,dbprimary_acc,external_db_id)/;
 
 my $insert_member_sql = $insert_member_base_sql. q/ select gene_member_id,?,? from gene_member where stable_id=? and source_name='ENSEMBLGENE'/;
  


### PR DESCRIPTION
…eline when running on collections. The failure is because there are two versions of the same gene annotation (i.e. same stable IDs), one single species and one in a collection db, so the pipeline tries to run the same SQL for both species. The latter is not included in gene trees anyway. Insert ignore resolve the issue for us