### PR TITLE
Fixed bug at line 44 of RetireSpeciesFromMaster.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/RetireSpeciesFromMaster.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/RetireSpeciesFromMaster.pm
@@ -41,7 +41,7 @@ use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 sub fetch_input {
   my $self = shift;
   my $master_dba = $self->get_cached_compara_dba('master_db');
-  my $genome_db_adaptor = master_dba->get_GenomeDBAdaptor;
+  my $genome_db_adaptor = $master_dba->get_GenomeDBAdaptor;
   my $genome_db  = $genome_db_adaptor->fetch_by_name_assembly($self->param_required('species_name'));
   $genome_db_adaptor->retire_object($genome_db);
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/RetireSpeciesFromMaster.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/RetireSpeciesFromMaster.pm
@@ -39,11 +39,11 @@ use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
 sub fetch_input {
-  my $self = shift;
-  my $master_dba = $self->get_cached_compara_dba('master_db');
-  my $genome_db_adaptor = $master_dba->get_GenomeDBAdaptor;
-  my $genome_db  = $genome_db_adaptor->fetch_by_name_assembly($self->param_required('species_name'));
-  $genome_db_adaptor->retire_object($genome_db);
+    my $self = shift;
+    my $master_dba = $self->get_cached_compara_dba('master_db');
+    my $genome_db_adaptor = $master_dba->get_GenomeDBAdaptor;
+    my $genome_db  = $genome_db_adaptor->fetch_by_name_assembly($self->param_required('species_name'));
+    $genome_db_adaptor->retire_object($genome_db);
 }
 
 1;


### PR DESCRIPTION
Missing `$` before `master_dba`.
I have taken the opportunity to reformat the tab to Compara's standard (4 white spaces instead of 2).