### PR TITLE
Updated LastZ_NET and LastZ_PATCH node names and latter's descriptions

### DIFF
--- a/scripts/jira_tickets/compara_merged.dot
+++ b/scripts/jira_tickets/compara_merged.dot
@@ -1,4 +1,7 @@
 digraph {
+    "Patches against their primary assembly";
+    "Patches against other species";
+
     "Genome dumps" -> "Species-tree";
     "Species-tree" -> { "EPO", "Mercator Pecan", "Protein-trees" };
     {"EPO", "All LastZ"} -> "EPO-2X";
@@ -7,7 +10,6 @@ digraph {
     "ncRNA-trees" -> "ncRNA-trees WGA Orthology QC" [fontsize="8", label="Orthologues and\nhomology_id mapping\nonly"];
     {"All LastZ", "EPO"} -> "All alignments for WGA Orthology QC" -> {"Protein-trees WGA Orthology QC", "ncRNA-trees WGA Orthology QC"};
     "LastZ" -> "All LastZ" -> "Synteny";
-    "LastZ_PATCH" -> "LastZ_NET" -> "All LastZ";
 
     "Gene-tree reindexing" -> "ncRNA-trees" [style="dashed", dir=none, fontsize="8", label="XOR", headport="murinae:w", tailport="murinae:s"];
     "Gene-tree reindexing" -> "Protein-trees" [style="dashed", dir=none, fontsize="8", label="XOR", headport="murinae:e", tailport="murinae:s"];

--- a/scripts/jira_tickets/jira_recurrent_tickets.vertebrates.json
+++ b/scripts/jira_tickets/jira_recurrent_tickets.vertebrates.json
@@ -223,39 +223,39 @@
          },
          {
              "component": "Production tasks",
-             "description": "https://github.com/Ensembl/ensembl-compara/blob/release/97/docs/production/READMEs/pair_aligner_patches.rst",
+             "description": "https://github.com/Ensembl/ensembl-compara/blob/release/<version>/docs/production/READMEs/pair_aligner_patches.rst",
              "summary": "Run LastZ_PATCH alignments for human",
-             "name_on_graph": "LastZ_PATCH:Human"
+             "name_on_graph": "Patches against their primary assembly:Human"
          },
          {
              "component": "Production tasks",
-             "description": "https://github.com/Ensembl/ensembl-compara/blob/release/97/docs/production/READMEs/pair_aligner_patches.rst",
+             "description": "https://github.com/Ensembl/ensembl-compara/blob/release/<version>/docs/production/READMEs/pair_aligner_patches.rst",
              "summary": "Run LastZ_PATCH alignments for mouse",
-             "name_on_graph": "LastZ_PATCH:Mouse"
+             "name_on_graph": "Patches against their primary assembly:Mouse"
          },
          {
              "component": "Production tasks",
-             "description": "https://github.com/Ensembl/ensembl-compara/blob/release/97/docs/production/READMEs/pair_aligner_patches.rst",
+             "description": "https://github.com/Ensembl/ensembl-compara/blob/release/<version>/docs/production/READMEs/pair_aligner_patches.rst",
              "summary": "Run LastZ_PATCH alignments for zebrafish",
-             "name_on_graph": "LastZ_PATCH:Zebrafish"
+             "name_on_graph": "Patches against their primary assembly:Zebrafish"
          },
          {
              "component": "Production tasks",
              "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+DNA+data#MergetheDNAdata-Patchalignments",
              "summary": "Top-up LastZ_NET human alignments",
-             "name_on_graph": "LastZ_NET:Human"
+             "name_on_graph": "Patches against other species:Human"
          },
          {
              "component": "Production tasks",
              "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+DNA+data#MergetheDNAdata-Patchalignments",
              "summary": "Top-up LastZ_NET mouse alignments",
-             "name_on_graph": "LastZ_NET:Mouse"
+             "name_on_graph": "Patches against other species:Mouse"
          },
          {
              "component": "Production tasks",
              "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+DNA+data#MergetheDNAdata-Patchalignments",
              "summary": "Top-up LastZ_NET zebrafish alignments",
-             "name_on_graph": "LastZ_NET:Zebrafish"
+             "name_on_graph": "Patches against other species:Zebrafish"
          },
          {
             "component": "Production tasks",


### PR DESCRIPTION
To avoid name collisions for LastZ_NET, it has been renamed. LastZ_PATCH has also been renamed accordingly and its descriptions in the JIRA ticket generator updated to remove the hard-coded release version.