### PR TITLE
Updated pipeline flags and included option to add genomes from registry conf file

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/Ensembl/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/Ensembl/PrepareMasterDatabaseForRelease_conf.pm
@@ -32,7 +32,7 @@ Bio::EnsEMBL::Compara::PipeConfig::EBI::Ensembl::PrepareMasterDatabaseForRelease
 
 =head1 DESCRIPTION
 
-    Add/update all species to master database
+    Prepare master database for next release
 
 
 =head1 SYNOPSIS
@@ -65,6 +65,7 @@ sub default_options {
 
         'division'               => 'vertebrates',
         'assembly_patch_species' => [ 'homo_sapiens', 'mus_musculus', 'danio_rerio' ],
+        'do_load_timetree'       => 1,
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/Plants/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/Plants/PrepareMasterDatabaseForRelease_conf.pm
@@ -32,7 +32,7 @@ Bio::EnsEMBL::Compara::PipeConfig::EBI::Plants::PrepareMasterDatabaseForRelease_
 
 =head1 DESCRIPTION
 
-    Add/update all species to master database
+    Prepare master database for next release
 
 
 =head1 SYNOPSIS

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromMetadataFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromMetadataFactory.pm
@@ -21,15 +21,16 @@ limitations under the License.
 
 =head1 NAME
 
-Bio::EnsEMBL::Compara::RunnableDB::PrepareMaster::UpdateGenomesFactory
+Bio::EnsEMBL::Compara::RunnableDB::PrepareMaster::UpdateGenomesFromMetadataFactory
 
 =head1 SYNOPSIS
 
-
+Returns the list of species/genomes to update, rename and retire in the master
+database, obtained from ensembl-metadata
 
 =cut
 
-package Bio::EnsEMBL::Compara::RunnableDB::PrepareMaster::UpdateGenomesFactory;
+package Bio::EnsEMBL::Compara::RunnableDB::PrepareMaster::UpdateGenomesFromMetadataFactory;
 
 use warnings;
 use strict;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromRegFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromRegFactory.pm
@@ -1,0 +1,53 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=pod
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::PrepareMaster::UpdateGenomesFromRegFactory
+
+=head1 SYNOPSIS
+
+Returns the list of species/genomes to add to the master database from the core
+databases in the registry file
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::PrepareMaster::UpdateGenomesFromRegFactory;
+
+use warnings;
+use strict;
+use Bio::EnsEMBL::Registry;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+sub fetch_input {
+    my $self = shift;
+    my $species_list = Bio::EnsEMBL::Registry->get_all_species();
+    $self->param('species_to_update', $species_list);
+}
+
+sub write_output {
+    my $self = shift;
+    my @new_genomes_dataflow = map { {species_name => $_, force => 0} } @{ $self->param('species_to_update') };
+    $self->dataflow_output_id(\@new_genomes_dataflow, 2);
+}
+
+1;


### PR DESCRIPTION
@muffato mentioned in our last meeting that aliases can be applied safely to all divisions (condition removed in the pipeline), and that `load_timetree` should be handled with a flag as the new `test` division might need it too. Furthermore, to create a master database from scratch we need to be able to add genomes directly from the registry conf file, ignoring the default option (through `ensembl-metadata`). This has been added to the pipeline.

I have also taken the opportunity to update the documentation as certain bits seemed outdated.