### PR TITLE
Do not assume a division is an Ensembl division

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -74,8 +74,8 @@ sub shared_default_options {
         'linuxbrew_home'        => $ENV{'LINUXBREW_HOME'},
 
         # All the fixed parameters that depend on a "division" parameter
-        'reg_conf'              => $self->check_file_in_ensembl('ensembl-compara/scripts/pipeline/production_reg_'.$self->o('division').'_conf.pl'),
         # NOTE: Can't use $self->check_file_in_ensembl as long as we don't produce a file for each division
+        'reg_conf'              => $self->o('ensembl_cvs_root_dir').'/ensembl-compara/scripts/pipeline/production_reg_'.$self->o('division').'_conf.pl',
         'binary_species_tree'   => $self->o('ensembl_cvs_root_dir').'/ensembl-compara/scripts/pipeline/species_tree.' . $self->o('division') . '.branch_len.nw',
         'genome_dumps_dir'      => '/hps/nobackup2/production/ensembl/compara_ensembl/genome_dumps/'.$self->o('division').'/',
 


### PR DESCRIPTION
I came across this while running the Load Members pipeline. It wouldn't start, because there isn't a `parasite` conf in the source code, and calling `check_file_in_ensembl` doesn't let me overwrite it., I think someone already had this problem because there's something similar in the `#NOTE:` comment above `binary_species_tree`.