### PR TITLE
Add custom mapped_gene_ratio_per_taxon for the WBPS config stored in this repo

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/EG/WBParaSiteProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/EG/WBParaSiteProteinTrees_conf.pm
@@ -119,6 +119,14 @@ sub default_options {
       'master_db' => '',
 
       exclude_gene_analysis => {  'macrostomum_lignano_prjna284736' =>  ['mlignano_schatz_gene_bad']  },
+      
+      'mapped_gene_ratio_per_taxon' => {
+          '2759'   => 0.25, #eukaryotes, 
+          '119089' => 0.5, # Chromadorea, i.e. nematodes that are not clade I
+          '6243'   => 0.65, # Clade V nematodes
+          '6199'   => 0.65, # Tapeworms
+          '6179'   => 0.65, # Flukes
+      },
 
       ######## THESE ARE PASSED INTO LOAD_REGISTRY_FROM_DB SO PASS IN DB_VERSION
       ######## ALSO RAISE THE POINT ABOUT LOAD_FROM_MULTIPLE_DBs


### PR DESCRIPTION
The default of 0.5 unique genes is not good enough as we have some really weird animals - also, their genomes are not very good. 

Proportions from WBPS14 run are in: https://gist.github.com/wbazant/7b8f398ff43f764b6acfae6051285102