### PR TITLE
Update SqlHealthChecks.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/SqlHealthChecks.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/SqlHealthChecks.pm
@@ -218,17 +218,16 @@ our $config = {
                 query => 'SELECT root_id FROM gene_tree_root WHERE stable_id LIKE "Node%"',
             },
             {
-                description => 'The version must be filled for the trees that have an Ensembl stable_id and empty for the other rows',
-                query => 'SELECT root_id FROM gene_tree_root WHERE stable_id LIKE "E%" XOR version IS NOT NULL',
+                description => 'The version must be filled for the trees that have a stable_id and empty for the other rows',
+                query => 'SELECT root_id FROM gene_tree_root WHERE stable_id LIKE "%GT%" XOR version IS NOT NULL',
             },
             {
                 description => 'There are stable IDs coming from at least 2 releases (Have you configured "mapping_db" correctly ?)',
-                query => 'SELECT DISTINCT LEFT(stable_id, 9) AS prefix FROM gene_tree_root WHERE stable_id LIKE "E%"',
+                query => 'SELECT DISTINCT LEFT(stable_id, 9) AS prefix FROM gene_tree_root WHERE stable_id LIKE "%GT%"',
                 expected_size => '>= 2',
             },
         ],
     },
-
 
     ### EPO Removed members
     #########################


### PR DESCRIPTION
WormBase ParaSite gene tree IDs look like `WBGT00800000173205`. I'm actually not sure where I've configured that, but it corresponds to a WB "prefix" in the mapping session:
```
mysql-pan-prod ensembl_compara_master_parasite -e 'select * from mapping_session'
mapping_session_id      type    when_mapped     rel_from        rel_to  prefix
1       tree    2019-07-01 12:25:32     95      97      WB
```
Changing the SQL to the more general form would make the healthchecks work for these IDs.