### PR TITLE
Remove an unused parameter from ProteinTrees_conf.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -212,12 +212,9 @@ sub default_options {
         'tf_release'                => undef,
 
     # plots
-        #compute Jaccard Index
+        #compute Jaccard Index and Gini coefficient (Lorenz curve)
         'do_jaccard_index'          => 1,
         'jaccard_index_script'      => $self->check_exe_in_ensembl('ensembl-compara/scripts/homology/plotJaccardIndex.r'),
-
-        #Compute Gini coefficient (Lorenz curve)
-        'do_gini_coefficient'       => 1,
         'lorentz_curve_script'      => $self->check_exe_in_ensembl('ensembl-compara/scripts/homology/plotLorentzCurve.r'),
 
     # HMM specific parameters (mostly set in the ENV file)


### PR DESCRIPTION
Remove a parameter that doesn't do anything: the jaccard index and gini coefficient are calculated in one script.

Came to look at this because we don't have a reuse_db set and the job didn't run - but you've fixed this already.