### PR TITLE
clusterset_id for stats jobs is not set everywhere

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/GeneMemberHomologyStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/GeneMemberHomologyStats.pm
@@ -102,7 +102,7 @@ sub pipeline_analyses_hom_stats {
         {   -logic_name => 'set_default_values',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
             -parameters => {
-                'clusterset_id' => $self->o('collection'),
+                'clusterset_id' => $self->o('collection') // "default",
                 'sql'   => [
                     'DELETE FROM gene_member_hom_stats',
                     'INSERT INTO gene_member_hom_stats (gene_member_id, collection)


### PR DESCRIPTION
The job `set_default_values` came out like that in my run of the ProteinTrees pipeline:

```
Bio::EnsEMBL::Hive::RunnableDB::SqlCmd     | {"clusterset_id" => undef,"sql" => ["DELETE FROM gene_member_hom_stats","INSERT INTO gene_member_hom_stats (gene_member_id, collection)\n                     SELECT gene_member_id, \"#clusterset_id#\"\n                     FROM gene_member"]}
```

This failed, because SqlCmd didn't like inserting with the undefined value.

This is probably not a robust fix, it tries to replicate the previous behaviour but I don't really have the big picture for making this right.

@mateuspatricio do have a look! think after 1ee5d93ecc74 not every pipeline will have a set `collection` which should go there - the commit removes it from INPUT_PLUS and a few more places, and sets it in PostHomologyMerge_conf.pm, but not everywhere else.


