### PR TITLE
Remove trailing whitespace in newick trees

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/Graph/NewickParser.pm
+++ b/modules/Bio/EnsEMBL/Compara/Graph/NewickParser.pm
@@ -146,7 +146,6 @@ sub parse_newick_into_tree
       elsif ($state == 3) { # optional : and distance
         if($token eq ':') {
           $token = next_token(\@char_array, "[,);");
-          chomp $token;
           $node->distance_to_parent($token);
           if($debug) { print("set distance: $token"); $node->print_node; }
           $token = next_token(\@char_array, ",);"); #move to , or )
@@ -251,6 +250,11 @@ sub next_token {
   }
   unless(scalar(@$char_array)) {
     throw("couldn't find delimiter $delim\n");
+  }
+
+  # Remove the trailing whitespace
+  while (scalar(@token_array) and $whitespace->{$token_array[-1]}) {
+      pop @token_array;
   }
 
   # We want to consume at least 1 character

--- a/modules/Bio/EnsEMBL/Compara/Utils/SpeciesTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/SpeciesTree.pm
@@ -281,7 +281,8 @@ sub new_from_newick {
 
     # First, we remove the extra species that the tree may contain
     foreach my $node (@{$species_tree_root->get_all_leaves}) {
-        my $name = $node->name;
+      my $name = $node->name;
+      if ($name) {
         my $gdb = $all_genome_dbs{lc $name};
         if ((not $gdb) and ($name =~ m/^(.*)_([^_]*)$/)) {
             # Perhaps the node represents the component of a polyploid genome
@@ -297,6 +298,12 @@ sub new_from_newick {
             $node->{_tmp_gdb} = $gdb;
         } else {
             warn "'" . $name, "' not found in the genome_db table.\n";
+        }
+      } else {
+        warn "Node number " . $node->node_id . " has no name. Discarding it.\n";
+      }
+
+        unless ($node->{_tmp_gdb}) {
             unless ($node->has_parent) {
                 # Not a single leaf is found in the genome_db table
                 return undef;

--- a/modules/Bio/EnsEMBL/Compara/Utils/SpeciesTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/SpeciesTree.pm
@@ -313,7 +313,9 @@ sub new_from_newick {
             my ($node, $leaves) = @_;
             my $int_taxon = $ncbi_taxa_a->fetch_first_shared_ancestor_indexed(map {$_->{_tmp_gdb}->taxon} @$leaves);
             $node->taxon_id($int_taxon->taxon_id);
-            $node->node_name($int_taxon->name) unless $node->name =~ /[A-Za-z]+/;
+            unless ($node->name && $node->name =~ /[A-Za-z]+/) {
+                $node->node_name($int_taxon->name);
+            }
         } );
 
     return $species_tree_root;

--- a/modules/Bio/EnsEMBL/Compara/Utils/SpeciesTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/SpeciesTree.pm
@@ -281,8 +281,9 @@ sub new_from_newick {
 
     # First, we remove the extra species that the tree may contain
     foreach my $node (@{$species_tree_root->get_all_leaves}) {
-        my $gdb = $all_genome_dbs{lc $node->name};
-        if ((not $gdb) and ($node->name =~ m/^(.*)_([^_]*)$/)) {
+        my $name = $node->name;
+        my $gdb = $all_genome_dbs{lc $name};
+        if ((not $gdb) and ($name =~ m/^(.*)_([^_]*)$/)) {
             # Perhaps the node represents the component of a polyploid genome
             my $pgdb = $all_genome_dbs{lc $1};
             if ($pgdb and $pgdb->is_polyploid) {
@@ -295,7 +296,7 @@ sub new_from_newick {
             $node->node_name($gdb->get_scientific_name('unique'));
             $node->{_tmp_gdb} = $gdb;
         } else {
-            warn $node->name, " not found in the genome_db table";
+            warn $name, " not found in the genome_db table";
             unless ($node->has_parent) {
                 # Not a single leaf is found in the genome_db table
                 return undef;

--- a/modules/Bio/EnsEMBL/Compara/Utils/SpeciesTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/SpeciesTree.pm
@@ -296,7 +296,7 @@ sub new_from_newick {
             $node->node_name($gdb->get_scientific_name('unique'));
             $node->{_tmp_gdb} = $gdb;
         } else {
-            warn $name, " not found in the genome_db table";
+            warn "'" . $name, "' not found in the genome_db table.\n";
             unless ($node->has_parent) {
                 # Not a single leaf is found in the genome_db table
                 return undef;

--- a/modules/t/Utils/SpeciesTree.t
+++ b/modules/t/Utils/SpeciesTree.t
@@ -95,7 +95,7 @@ subtest 'new_from_newick' => sub {
 
     warning_like {
         Bio::EnsEMBL::Compara::Utils::SpeciesTree->new_from_newick( '(aegilops_tauschii_A)', $dba );
-    } qr/aegilops_tauschii_A not found in the genome_db table/;
+    } qr/'aegilops_tauschii_A' not found in the genome_db table/;
 
     throws_ok {Bio::EnsEMBL::Compara::Utils::SpeciesTree->new_from_newick( '(triticum_aestivum_X)', $dba )}
                 qr/No component named 'X' in 'triticum_aestivum'/, 'Non-existing component';

--- a/modules/t/Utils/SpeciesTree.t
+++ b/modules/t/Utils/SpeciesTree.t
@@ -73,7 +73,7 @@ subtest 'new_from_newick' => sub {
     #ok(1); return;
 
     test_new_from_newick(
-        '((homo_sapiens,(genus_species,mus_musculus))my_name,danio_rerio)',
+        "((homo_sapiens\n  ,(genus_species,\n\n   mus_musculus))\n     my_name,danio_rerio\n)",
         '((134,150),154)',
         '((10090,9606)314146,7955)117571',
         '((Homo sapiens,Mus musculus GRCm38)my_name,Danio rerio)Euteleostomi',


### PR DESCRIPTION
This would make the convention used in the Plants species-tree to add trailing commas everywhere redundant.
The code now handles graciously unnamed nodes (instead of warning about undefined values in several places).