### PR TITLE
Set empty array for Dump pipeline mlss_ids parameter

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
@@ -95,7 +95,8 @@ sub default_options {
         'dump_dir'        => '#dump_root#/release-#curr_release#',
 		'lastz_dump_path' => 'maf/ensembl-compara/pairwise_alignments', # where, from the FTP root, is the LASTZ dumps?
         'reuse_prev_rel'  => 1, # copy symlinks from previous release dumps
-        'updated_mlss_ids' => [], #the list of mlss_ids that we have re_ran/updated and cannot be detected through first_release
+        #'updated_mlss_ids' => [1142,1143,1134,1141], #the list of mlss_ids that we have re_ran/updated and cannot be detected through first_release
+        'updated_mlss_ids' => [],
 		# define input options for DumpMultiAlign for each method_link_type
         'alignment_dump_options' => {
         	EPO              => {format => 'emf+maf'},

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
@@ -95,7 +95,7 @@ sub default_options {
         'dump_dir'        => '#dump_root#/release-#curr_release#',
 		'lastz_dump_path' => 'maf/ensembl-compara/pairwise_alignments', # where, from the FTP root, is the LASTZ dumps?
         'reuse_prev_rel'  => 1, # copy symlinks from previous release dumps
-        #'updated_mlss_ids' => [1142,1143,1134,1141], #the list of mlss_ids that we have re_ran/updated and cannot be detected through first_release
+        'updated_mlss_ids' => [], #the list of mlss_ids that we have re_ran/updated and cannot be detected through first_release
 		# define input options for DumpMultiAlign for each method_link_type
         'alignment_dump_options' => {
         	EPO              => {format => 'emf+maf'},


### PR DESCRIPTION
For non-vert dumps we don't always have a parameter to supply to 'update_mlss_ids', so it's easier if it defaults to an empty array.