### PR TITLE
Support both version nomenclatures

### DIFF
--- a/scripts/jira_tickets/merged_release_graph.js
+++ b/scripts/jira_tickets/merged_release_graph.js
@@ -95,7 +95,7 @@ function process_tickets(json) {
 
 
 // fetch ticket status from REST API
-var endpoint_ticket_list = 'https://www.ebi.ac.uk/panda/jira/rest/api/2/search/?jql=project=ENSCOMPARASW+AND+fixVersion="Ensembl+__RELEASE__"+AND+component+IN+("Relco+tasks","Production+tasks")+AND+labels+IS+NOT+EMPTY+ORDER+BY+created+ASC,id+ASC&maxResults=100';
+var endpoint_ticket_list = 'https://www.ebi.ac.uk/panda/jira/rest/api/2/search/?jql=project=ENSCOMPARASW+AND+(+fixVersion="Ensembl+__RELEASE__"+OR+fixVersion="Release+__RELEASE__"+)+AND+component+IN+("Relco+tasks","Production+tasks")+AND+labels+IS+NOT+EMPTY+ORDER+BY+created+ASC,id+ASC&maxResults=100';
 var release = $.urlParam("release");
 var pipelines = {};
 $('#progress').text("Loading e" + release + " graph");
@@ -116,7 +116,7 @@ $.ajax({
         $('#progress').text("Loading all e" + release + " tickets");
         $.ajax({
             type: "GET",
-            url: endpoint_ticket_list.replace('__RELEASE__', release),
+            url: endpoint_ticket_list.replace(/__RELEASE__/g, release),
             success: process_tickets,
             error: function(jqXHR, status, error) {
                 $('#progress').text("Error fetching the e" + release + " tickets: " + error);

--- a/scripts/jira_tickets/merged_release_graph.js
+++ b/scripts/jira_tickets/merged_release_graph.js
@@ -95,7 +95,7 @@ function process_tickets(json) {
 
 
 // fetch ticket status from REST API
-var endpoint_ticket_list = 'https://www.ebi.ac.uk/panda/jira/rest/api/2/search/?jql=project=ENSCOMPARASW+AND+(+fixVersion="Ensembl+__RELEASE__"+OR+fixVersion="Release+__RELEASE__"+)+AND+component+IN+("Relco+tasks","Production+tasks")+AND+labels+IS+NOT+EMPTY+ORDER+BY+created+ASC,id+ASC&maxResults=100';
+var endpoint_ticket_list = 'https://www.ebi.ac.uk/panda/jira/rest/api/2/search/?jql=project=ENSCOMPARASW+AND+fixVersion+IN+("Ensembl+__RELEASE__",+"Release+__RELEASE__")+AND+component+IN+("Relco+tasks","Production+tasks")+AND+labels+IS+NOT+EMPTY+ORDER+BY+created+ASC,id+ASC&maxResults=100';
 var release = $.urlParam("release");
 var pipelines = {};
 $('#progress').text("Loading e" + release + " graph");

--- a/scripts/jira_tickets/release_dashboard.js
+++ b/scripts/jira_tickets/release_dashboard.js
@@ -13,7 +13,7 @@ String.prototype.capitalize = function() {
 }
 
 // fetch ticket status from REST API
-var endpoint_ticket_list = 'https://www.ebi.ac.uk/panda/jira/rest/api/2/search/?jql=project=ENSCOMPARASW+AND+issuetype=Task+AND+fixVersion="Ensembl+__RELEASE__"+AND+component="Relco+tasks"+AND+cf[11130]=__DIVISION__+ORDER+BY+created+ASC,id+ASC&maxResults=500';
+var endpoint_ticket_list = 'https://www.ebi.ac.uk/panda/jira/rest/api/2/search/?jql=project=ENSCOMPARASW+AND+issuetype=Task+AND+(+fixVersion="Ensembl+__RELEASE__"+OR+fixVersion="Release+__RELEASE__"+)+AND+component="Relco+tasks"+AND+cf[11130]=__DIVISION__+ORDER+BY+created+ASC,id+ASC&maxResults=500';
 var endpoint_ticket_subtasks = 'https://www.ebi.ac.uk/panda/jira/rest/api/2/search/?jql=project=ENSCOMPARASW+AND+parent="__PARENT__"+ORDER+BY+created+ASC,id+ASC&maxResults=500';
 
 var endpoint_ticket_query = 'https://www.ebi.ac.uk/panda/jira/rest/api/2/issue';
@@ -88,7 +88,7 @@ function process_task(task) { return function(json) {
 
 for(var j = 0; j < all_divisions.length; j++){
     var division = all_divisions[j];
-    var endpoint = endpoint_ticket_list.replace('__RELEASE__', release).replace('__DIVISION__', division);
+    var endpoint = endpoint_ticket_list.replace(/__RELEASE__/g, release).replace('__DIVISION__', division);
     console.log(endpoint);
     $('body').append('<div id="' + division + '"></div>');
     $.ajax(endpoint, {

--- a/scripts/jira_tickets/release_dashboard.js
+++ b/scripts/jira_tickets/release_dashboard.js
@@ -13,7 +13,7 @@ String.prototype.capitalize = function() {
 }
 
 // fetch ticket status from REST API
-var endpoint_ticket_list = 'https://www.ebi.ac.uk/panda/jira/rest/api/2/search/?jql=project=ENSCOMPARASW+AND+issuetype=Task+AND+(+fixVersion="Ensembl+__RELEASE__"+OR+fixVersion="Release+__RELEASE__"+)+AND+component="Relco+tasks"+AND+cf[11130]=__DIVISION__+ORDER+BY+created+ASC,id+ASC&maxResults=500';
+var endpoint_ticket_list = 'https://www.ebi.ac.uk/panda/jira/rest/api/2/search/?jql=project=ENSCOMPARASW+AND+issuetype=Task+AND+fixVersion+IN+("Ensembl+__RELEASE__",+"Release+__RELEASE__")+AND+component="Relco+tasks"+AND+cf[11130]=__DIVISION__+ORDER+BY+created+ASC,id+ASC&maxResults=500';
 var endpoint_ticket_subtasks = 'https://www.ebi.ac.uk/panda/jira/rest/api/2/search/?jql=project=ENSCOMPARASW+AND+parent="__PARENT__"+ORDER+BY+created+ASC,id+ASC&maxResults=500';
 
 var endpoint_ticket_query = 'https://www.ebi.ac.uk/panda/jira/rest/api/2/issue';


### PR DESCRIPTION
I've realised that with #120 deployed, the dashboard and graphs were not displaying anything for e98 (and previous releases), simply because there are indeed no tickets for a version "Ensembl 98".

Since JIRA only filters the version names as text, without checking that they really exist etc, I would propose to filter across both nomenclatures, so that the e98 pages still work.

PS: the new versions are already under ~compara_ensembl/public_html. If you want I can restore the release/99 version to demonstrate they can't fetch anything ?