### PR TITLE
Force fresh reload of non-coding genes

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/GeneMemberAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/GeneMemberAdaptor.pm
@@ -254,6 +254,16 @@ sub store {
 
 }
 
+sub delete {
+    my ($self, $gene_member) = @_;
+    foreach my $seq_member (@{$gene_member->get_all_SeqMembers}) {
+        $seq_member->adaptor->delete($seq_member);
+    }
+    $self->dbc->do('DELETE FROM gene_member_qc          WHERE gene_member_stable_id = ?', undef, $gene_member->stable_id);
+    $self->dbc->do('DELETE FROM member_xref             WHERE gene_member_id = ?', undef, $gene_member->dbID);
+    $self->dbc->do('DELETE FROM gene_member_hom_stats   WHERE gene_member_id = ?', undef, $gene_member->dbID);
+    $self->dbc->do('DELETE FROM gene_member             WHERE gene_member_id = ?', undef, $gene_member->dbID);
+}
 
 1;
 

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/SeqMemberAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/SeqMemberAdaptor.pm
@@ -452,6 +452,18 @@ sub _set_member_as_canonical {
 }
 
 
+sub delete {
+    my ($self, $seq_member) = @_;
+    $self->dbc->do('DELETE FROM seq_member_projection_stable_id WHERE target_seq_member_id = ?', undef, $seq_member->dbID);
+    $self->dbc->do('DELETE FROM seq_member_projection           WHERE source_seq_member_id = ?', undef, $seq_member->dbID);
+    $self->dbc->do('DELETE FROM seq_member_projection           WHERE target_seq_member_id = ?', undef, $seq_member->dbID);
+    $self->dbc->do('DELETE FROM gene_member_qc          WHERE seq_member_id = ?', undef, $seq_member->dbID);
+    $self->dbc->do('DELETE FROM hmm_annot               WHERE seq_member_id = ?', undef, $seq_member->dbID);
+    $self->dbc->do('DELETE FROM exon_boundaries         WHERE seq_member_id = ?', undef, $seq_member->dbID);
+    $self->dbc->do('DELETE FROM other_member_sequence   WHERE seq_member_id = ?', undef, $seq_member->dbID);
+    $self->dbc->do('DELETE FROM seq_member              WHERE seq_member_id = ?', undef, $seq_member->dbID);
+}
+
 
 1;
 

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/SeqMemberAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/SeqMemberAdaptor.pm
@@ -457,6 +457,8 @@ sub delete {
     $self->dbc->do('DELETE FROM seq_member_projection_stable_id WHERE target_seq_member_id = ?', undef, $seq_member->dbID);
     $self->dbc->do('DELETE FROM seq_member_projection           WHERE source_seq_member_id = ?', undef, $seq_member->dbID);
     $self->dbc->do('DELETE FROM seq_member_projection           WHERE target_seq_member_id = ?', undef, $seq_member->dbID);
+    $self->dbc->do('DELETE homology FROM homology JOIN homology_member USING (homology_id) WHERE seq_member_id = ?', undef, $seq_member->dbID);
+    $self->dbc->do('DELETE FROM homology_member         WHERE seq_member_id = ?', undef, $seq_member->dbID);
     $self->dbc->do('DELETE FROM gene_member_qc          WHERE seq_member_id = ?', undef, $seq_member->dbID);
     $self->dbc->do('DELETE FROM hmm_annot               WHERE seq_member_id = ?', undef, $seq_member->dbID);
     $self->dbc->do('DELETE FROM exon_boundaries         WHERE seq_member_id = ?', undef, $seq_member->dbID);

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/Vertebrates/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/Vertebrates/LoadMembers_conf.pm
@@ -87,6 +87,8 @@ sub default_options {
         'store_ncrna'               => 1,
         # Store other genes
         'store_others'              => 1,
+        # Only needed in e99
+        'fix_ncrna_members'         => 1,
 
     #load uniprot members for family pipeline
         'load_uniprot_members'      => 1,

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FixNonCodingMembers.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FixNonCodingMembers.pm
@@ -1,0 +1,113 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
+=pod
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::FixNonCodingMembers
+
+=head1 DESCRIPTION
+
+This RunnableDB is a variant of LoadMembers that will focus on non-coding genes and update
+the set of gene_members (adding new ones, and removing the ones that are not current any more).
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::FixNonCodingMembers;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::LoadMembers');
+
+
+### Let LoadMembers do the heavy-lifting, and then setup the structure to
+### track the genes scheduled for removal
+
+sub fetch_input {
+    my $self = shift @_;
+
+    $self->SUPER::fetch_input(@_);
+
+    # Make it clear we don't support coding genes
+    $self->param('store_coding', 0);
+
+    # Get the list of members that are currently in the database
+    my %members_to_match = map {$_->stable_id => $_}
+                           grep {$_->biotype_group ne 'coding'}
+                           @{$self->compara_dba->get_GeneMemberAdaptor->fetch_all_by_GenomeDB($self->param('genome_db'))};
+    $self->param('members_to_match', \%members_to_match);
+}
+
+
+sub run {
+    my $self = shift @_;
+
+    $self->SUPER::run(@_);
+
+    # Delete the members that were not found in the core database
+    foreach my $gene_member (values %{$self->param('members_to_match')}) {
+        $gene_member->adaptor->delete($gene_member);
+    }
+}
+
+
+### Override the store methods to also update the biotype and mark the
+### genes as seen
+
+sub store_ncrna_gene {
+    my $self = shift @_;
+
+    $self->SUPER::store_ncrna_gene(@_);
+
+    my $gene = $_[0];
+    $self->update_biotype_group($gene);
+    $self->mark_gene_as_seen($gene);
+}
+
+
+sub store_gene_generic {
+    my $self = shift @_;
+
+    $self->SUPER::store_gene_generic(@_);
+
+    my $gene = $_[0];
+    $self->update_biotype_group($gene);
+    $self->mark_gene_as_seen($gene);
+}
+
+
+### Helper methods
+
+sub mark_gene_as_seen {
+    my $self = shift;
+    my $gene = shift;
+    delete $self->param('members_to_match')->{$gene->stable_id};
+}
+
+sub update_biotype_group {
+    my $self = shift;
+    my $gene = shift;
+    # Some non-coding genes have a new biotype_group, e.g. mnoncoding -> lnoncoding
+    $self->compara_dba->dbc->do('UPDATE gene_member SET biotype_group = ? WHERE stable_id = ?', undef, lc $gene->get_Biotype->biotype_group, $gene->stable_id);
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers.pm
@@ -252,15 +252,23 @@ sub loadMembersFromCoreSlices {
 
           my $gene_member;
 
-          if ($self->param('store_coding') && (($biotype_group eq 'coding') or ($biotype_group eq 'lrg'))) {
+          if (($biotype_group eq 'coding') or ($biotype_group eq 'lrg')) {
+
+            if ($self->param('store_coding')) {
               $gene_member = $self->store_protein_coding_gene_and_all_transcripts($gene, $dnafrag);
+            }
 
-          } elsif ( $self->param('store_ncrna') && ($biotype_group =~ /noncoding$/) ) {
+          } elsif ( $biotype_group =~ /noncoding$/) {
+
+            if ($self->param('store_ncrna')) {
               $gene_member = $self->store_ncrna_gene($gene, $dnafrag);
+            }
 
-          } elsif ( $self->param('store_others') ) {
+          } else {
               # Catches pseudogenes, but also "undefined" and "no_group"
+            if ($self->param('store_others')) {
               $gene_member = $self->store_gene_generic($gene, $dnafrag);
+            }
           }
 
           unless ($gene_member) {


### PR DESCRIPTION
Follow-up of #125. Since the non-coding genes were ignored when assessing the reusability of genomes, we have reused gene-sets that have in reality changed and are out of sync with many core databases: 34 species have a different gene-set, 36 more species have the same gene-set but with different biotypes.

Note: this is only needed for Vertebrates because we don't run any pipelines on non-coding genes for Plants