### PR TITLE
Break supertrees consistently with quick_tree_break

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/QuickTreeBreak.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/QuickTreeBreak.pm
@@ -258,7 +258,7 @@ sub do_quicktree_loop {
     my $stn_map = $supertree_root->species_tree->get_genome_db_id_2_node_hash;
     
     # generate alignment file
-    my $input_aln_species = $self->dumpTreeMultipleAlignmentToWorkdir($supertree_root->children->[0]->get_AlignedMemberSet(), 'stockholm', {-APPEND_SPECIES_TREE_NODE_ID => \%stn_map});
+    my $input_aln_species = $self->dumpTreeMultipleAlignmentToWorkdir($supertree_root->children->[0]->get_AlignedMemberSet(), 'stockholm', {-APPEND_SPECIES_TREE_NODE_ID => $stn_map});
     my $quicktree_newick_string = $self->run_quicktreebreak($input_aln_species);
     my $treebest_rooted_string = $self->run_treebest_sdi($quicktree_newick_string, 1);
     my $newtree = Bio::EnsEMBL::Compara::Graph::NewickParser::parse_newick_into_tree($treebest_rooted_string);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/QuickTreeBreak.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/QuickTreeBreak.pm
@@ -362,7 +362,7 @@ sub generate_subtrees {
     my $max_subtree = $newtree;
     my $half_count = int(scalar(@{$members})/2);
     while ($keep_breaking) {
-        @children = sort { $a->node_id <=> $b->node_id } @{$max_subtree->children};        
+        @children = sort { $a->node_id <=> $b->node_id } @{$max_subtree->children};
         my $max_num_leaves = 0;
         foreach my $child (@children) {
             my $num_leaves = scalar(@{$child->get_all_leaves});

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/QuickTreeBreak.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/QuickTreeBreak.pm
@@ -255,11 +255,7 @@ sub do_quicktree_loop {
     my $supertree_root = shift;
     
     # create map for genome_db_id => species_tree_nodes
-    # {genome_db_id => SpeciesTreeNode}
-    my %stn_map;
-    foreach my $leaf ( @{$supertree_root->children->[0]->get_all_leaves} ) {
-        $stn_map{$leaf->genome_db_id} = $leaf->species_tree_node;
-    }
+    my $stn_map = $supertree_root->species_tree->get_genome_db_id_2_node_hash;
     
     # generate alignment file
     my $input_aln_species = $self->dumpTreeMultipleAlignmentToWorkdir($supertree_root->children->[0]->get_AlignedMemberSet(), 'stockholm', {-APPEND_SPECIES_TREE_NODE_ID => \%stn_map});


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-2450

Solution involves:
- ensuring child nodes are always traversed in the same order
- resolving the gene tree with the species tree using `treebest sdi`