### PR TITLE
Add extra support for pig breeds MSAs

### DIFF
--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -173,13 +173,13 @@
             "component": "Production tasks",
             "description": "relco_doc#Releasecoordinationdocumentation-Mainsite",
             "summary": "Run Pig breeds EPO",
-            "name_on_graph": "EPO:Pig breeds"
+            "name_on_graph": "EPO:PigBreeds"
          },
          {
             "component": "Production tasks",
             "description": "relco_doc#Releasecoordinationdocumentation-Mainsite",
             "summary": "Run Pig breeds EPO_low",
-            "name_on_graph": "EPO-2X:Pig breeds"
+            "name_on_graph": "EPO-2X:PigBreeds"
          },
          {
             "component": "Production tasks",

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -173,13 +173,13 @@
             "component": "Production tasks",
             "description": "relco_doc#Releasecoordinationdocumentation-Mainsite",
             "summary": "Run Pig breeds EPO",
-            "name_on_graph": "EPO:PigBreeds"
+            "name_on_graph": "EPO:Pig_breeds"
          },
          {
             "component": "Production tasks",
             "description": "relco_doc#Releasecoordinationdocumentation-Mainsite",
             "summary": "Run Pig breeds EPO_low",
-            "name_on_graph": "EPO-2X:PigBreeds"
+            "name_on_graph": "EPO-2X:Pig_breeds"
          },
          {
             "component": "Production tasks",

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -172,6 +172,18 @@
          {
             "component": "Production tasks",
             "description": "relco_doc#Releasecoordinationdocumentation-Mainsite",
+            "summary": "Run Pig breeds EPO",
+            "name_on_graph": "EPO:Pig breeds"
+         },
+         {
+            "component": "Production tasks",
+            "description": "relco_doc#Releasecoordinationdocumentation-Mainsite",
+            "summary": "Run Pig breeds EPO_low",
+            "name_on_graph": "EPO-2X:Pig breeds"
+         },
+         {
+            "component": "Production tasks",
+            "description": "relco_doc#Releasecoordinationdocumentation-Mainsite",
             "summary": "Run Amniotes pecan",
             "name_on_graph": "Mercator Pecan:Amniotes"
          },

--- a/conf/vertebrates/mlss_conf.xml
+++ b/conf/vertebrates/mlss_conf.xml
@@ -128,7 +128,7 @@
     <!-- Pigs -->
     <!-- Special case: base EPO should remain internal/unreleased, but should still be updated -->
     <multiple_alignment method="EPO" no_release="1">
-      <species_set name="livestock" display_name="livestock">
+      <species_set name="livestock">
         <genome name="sus_scrofa"/>
         <genome name="sus_scrofa_usmarc"/>
         <genome name="bos_taurus"/>

--- a/conf/vertebrates/mlss_conf.xml
+++ b/conf/vertebrates/mlss_conf.xml
@@ -23,7 +23,7 @@
     </collection>
 
     <!-- Pig-breeds analyses, incl. closely related -->
-    <collection name="sus">
+    <collection name="livestock">
       <taxonomic_group taxon_name="Sus"/>
       <genome name="ovis_aries"/>
       <genome name="bos_taurus"/>
@@ -128,7 +128,7 @@
     <!-- Pigs -->
     <!-- Special case: base EPO should remain internal/unreleased, but should still be updated -->
     <multiple_alignment method="EPO" no_release="1">
-      <species_set name="pig_breeds">
+      <species_set name="livestock" display_name="livestock">
         <genome name="sus_scrofa"/>
         <genome name="sus_scrofa_usmarc"/>
         <genome name="bos_taurus"/>
@@ -137,7 +137,7 @@
       </species_set>
     </multiple_alignment>
     <multiple_alignment method="EPO_LOW_COVERAGE" gerp="1">
-      <species_set name="sus" display_name="pig_breeds" in_collection="sus">
+      <species_set name="pig_breeds" display_name="pig breeds" in_collection="livestock">
         <taxonomic_group taxon_name="Eutheria"/> <!-- everything in the collection -->
       </species_set>
     </multiple_alignment>
@@ -194,10 +194,10 @@
   <gene_trees>
     <protein_trees collection="default"/>
     <protein_trees collection="murinae"/>
-    <protein_trees collection="sus"/>
+    <protein_trees collection="livestock"/>
     <nc_trees collection="default"/>
     <nc_trees collection="murinae"/>
-    <nc_trees collection="sus"/>
+    <nc_trees collection="livestock"/>
   </gene_trees>
 
   <species_trees>

--- a/conf/vertebrates/mlss_conf.xml
+++ b/conf/vertebrates/mlss_conf.xml
@@ -22,6 +22,7 @@
       <taxonomic_group taxon_name="Murinae"/>
     </collection>
 
+    <!-- Pig-breeds analyses, incl. closely related -->
     <collection name="sus">
       <taxonomic_group taxon_name="Sus"/>
       <genome name="ovis_aries"/>
@@ -125,11 +126,22 @@
     </multiple_alignment>
 
     <!-- Pigs -->
-    <multiple_alignment method="EPO+EPO_LOW_COVERAGE" gerp="1">
-      <species_set name="sus">
-        <taxonomic_group taxon_name="Sus"/>
+    <!-- Special case: base EPO should remain internal/unreleased, but should still be updated -->
+    <multiple_alignment method="EPO" no_release="1">
+      <species_set name="pig_breeds">
+        <genome name="sus_scrofa"/>
+        <genome name="sus_scrofa_usmarc"/>
+        <genome name="bos_taurus"/>
+        <genome name="ovis_aries"/>
+        <genome name="equus_caballus"/>
       </species_set>
     </multiple_alignment>
+    <multiple_alignment method="EPO_LOW_COVERAGE" gerp="1">
+      <species_set name="sus" display_name="pig_breeds" in_collection="sus">
+        <taxonomic_group taxon_name="Eutheria"/> <!-- everything in the collection -->
+      </species_set>
+    </multiple_alignment>
+    
 
     <!-- Amniotes, excl. mouse strains -->
     <multiple_alignment method="PECAN" gerp="1">

--- a/conf/vertebrates/mlss_conf.xml
+++ b/conf/vertebrates/mlss_conf.xml
@@ -22,8 +22,8 @@
       <taxonomic_group taxon_name="Murinae"/>
     </collection>
 
-    <!-- Pig-breeds analyses, incl. closely related -->
-    <collection name="livestock">
+    <!-- Pig-breeds analyses, incl. closely related outgroups -->
+    <collection name="pig_breeds">
       <taxonomic_group taxon_name="Sus"/>
       <genome name="ovis_aries"/>
       <genome name="bos_taurus"/>
@@ -128,7 +128,7 @@
     <!-- Pigs -->
     <!-- Special case: base EPO should remain internal/unreleased, but should still be updated -->
     <multiple_alignment method="EPO" no_release="1">
-      <species_set name="livestock">
+      <species_set name="pig_breeds" display_name="pig breeds">
         <genome name="sus_scrofa"/>
         <genome name="sus_scrofa_usmarc"/>
         <genome name="bos_taurus"/>
@@ -137,7 +137,7 @@
       </species_set>
     </multiple_alignment>
     <multiple_alignment method="EPO_LOW_COVERAGE" gerp="1">
-      <species_set name="pig_breeds" display_name="pig breeds" in_collection="livestock">
+      <species_set name="pig_breeds" display_name="pig breeds" in_collection="pig_breeds">
         <taxonomic_group taxon_name="Eutheria"/> <!-- everything in the collection -->
       </species_set>
     </multiple_alignment>
@@ -194,10 +194,10 @@
   <gene_trees>
     <protein_trees collection="default"/>
     <protein_trees collection="murinae"/>
-    <protein_trees collection="livestock"/>
+    <protein_trees collection="pig_breeds"/>
     <nc_trees collection="default"/>
     <nc_trees collection="murinae"/>
-    <nc_trees collection="livestock"/>
+    <nc_trees collection="pig_breeds"/>
   </gene_trees>
 
   <species_trees>

--- a/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
@@ -815,20 +815,26 @@ sub create_multiple_wga_mlsss {
 
     my @mlsss;
     push @mlsss, create_mlss($method, $species_set, $source, $url);
-    $mlsss[-1]->{_no_release} = ($no_release || 0);
     if ($with_gerp) {
         my $ce_method = $compara_dba->get_MethodAdaptor->fetch_by_type('GERP_CONSTRAINED_ELEMENT');
         push @mlsss, create_mlss($ce_method, $species_set, $source, $url);
-        $mlsss[-1]->{_no_release} = ($no_release || 0);
         my $cs_method = $compara_dba->get_MethodAdaptor->fetch_by_type('GERP_CONSERVATION_SCORE');
         push @mlsss, create_mlss($cs_method, $species_set, $source, $url);
-        $mlsss[-1]->{_no_release} = ($no_release || 0);
     }
     if ($method->type eq 'CACTUS_HAL') {
         my $pw_method = $compara_dba->get_MethodAdaptor->fetch_by_type('CACTUS_HAL_PW');
         push @mlsss, @{ create_mlsss_on_pairs($pw_method, $species_set->genome_dbs, $source, $url) };
-        $mlsss[-1]->{_no_release} = ($no_release || 0);
-    }    
+    } 
+    
+    if ( $no_release ) {
+        my @nr_mlsss;
+        foreach my $mlss ( @mlsss ) {
+            $mlss->{_no_release} = $no_release;
+            push @nr_mlsss, $mlss;
+        }
+        @mlsss = @nr_mlsss;
+    }
+       
     return \@mlsss;
 }
 

--- a/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
@@ -827,12 +827,9 @@ sub create_multiple_wga_mlsss {
     } 
     
     if ( $no_release ) {
-        my @nr_mlsss;
         foreach my $mlss ( @mlsss ) {
             $mlss->{_no_release} = $no_release;
-            push @nr_mlsss, $mlss;
         }
-        @mlsss = @nr_mlsss;
     }
        
     return \@mlsss;

--- a/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
@@ -811,20 +811,24 @@ sub create_pairwise_wga_mlsss {
 }
 
 sub create_multiple_wga_mlsss {
-    my ($compara_dba, $method, $species_set, $with_gerp, $source, $url) = @_;
+    my ($compara_dba, $method, $species_set, $with_gerp, $no_release, $source, $url) = @_;
 
     my @mlsss;
     push @mlsss, create_mlss($method, $species_set, $source, $url);
+    $mlsss[-1]->{_no_release} = ($no_release || 0);
     if ($with_gerp) {
         my $ce_method = $compara_dba->get_MethodAdaptor->fetch_by_type('GERP_CONSTRAINED_ELEMENT');
         push @mlsss, create_mlss($ce_method, $species_set, $source, $url);
+        $mlsss[-1]->{_no_release} = ($no_release || 0);
         my $cs_method = $compara_dba->get_MethodAdaptor->fetch_by_type('GERP_CONSERVATION_SCORE');
         push @mlsss, create_mlss($cs_method, $species_set, $source, $url);
+        $mlsss[-1]->{_no_release} = ($no_release || 0);
     }
     if ($method->type eq 'CACTUS_HAL') {
         my $pw_method = $compara_dba->get_MethodAdaptor->fetch_by_type('CACTUS_HAL_PW');
         push @mlsss, @{ create_mlsss_on_pairs($pw_method, $species_set->genome_dbs, $source, $url) };
-    }
+        $mlsss[-1]->{_no_release} = ($no_release || 0);
+    }    
     return \@mlsss;
 }
 

--- a/scripts/jira_tickets/compara_merged.dot
+++ b/scripts/jira_tickets/compara_merged.dot
@@ -16,6 +16,7 @@ digraph {
     "Gene-tree reindexing" -> "ncRNA-trees" [style="dashed", dir=none, fontsize="8", label="XOR"];
     "Gene-tree reindexing" -> "Protein-trees" [style="dashed", dir=none, fontsize="8", label="XOR"];
     "EPO" -> "EPO" [style="dashed", fontsize="8", label="Anchor\nmapping\nonly", headport="Primates:e", tailport="Mammals:e"];
+    "EPO" -> "EPO" [style="dashed", fontsize="8", label="Anchor\nmapping\nonly", headport="Pig breeds:e", tailport="Mammals:e"];
     "EPO" -> "Age of Base" [style="dashed", headport="Human:e", tailport="Mammals:w"];
     "EPO" -> "Ancestral Alleles" [style="dashed", headport="Vertebrates:w", tailport="Primates:w"];
     "Protein-trees" -> "Protein-trees" [style="dashed", fontsize="8", xlabel="Orthologues\nonly", headport="Murinae:w", tailport="Default vertebrates:w"];

--- a/scripts/pipeline/compara_db_config.rng
+++ b/scripts/pipeline/compara_db_config.rng
@@ -196,6 +196,14 @@
                   </choice>
                 </attribute>
               </optional>
+              <optional>
+                <attribute name="no_release" blockly:blockName="No release">
+                  <choice>
+                    <value blockly:blockName="Yes">1</value>
+                    <value blockly:blockName="No">0</value>
+                  </choice>
+                </attribute>
+              </optional>
             </element>
           </oneOrMore>
         </element>

--- a/scripts/pipeline/create_all_mlss.pl
+++ b/scripts/pipeline/create_all_mlss.pl
@@ -370,6 +370,7 @@ while (my $aref1 = shift @refs) {
 }
 
 foreach my $xml_msa (@{$division_node->findnodes('multiple_alignments/multiple_alignment')}) {
+    my $no_release = $xml_msa->getAttribute('no_release') || 0;
     if ($xml_msa->getAttribute('method') =~ /(.*)\+(.*)/) {
         # Assume we combine two pipelines (presumably EPO and EPO_LOW_COVERAGE)
         my $method1 = $compara_dba->get_MethodAdaptor->fetch_by_type($1);
@@ -382,13 +383,13 @@ foreach my $xml_msa (@{$division_node->findnodes('multiple_alignments/multiple_a
             throw(sprintf('All the genomes of the "%s" set are "good for alignment". No need to require %s', $species_set2->name, $method2->type));
         }
         my $species_set1 = Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_species_set(\@good_gdbs, $species_set2->name);
-        push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_multiple_wga_mlsss($compara_dba, $method1, $species_set1) };
-        push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_multiple_wga_mlsss($compara_dba, $method2, $species_set2, ($xml_msa->getAttribute('gerp') // 0)) };
+        push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_multiple_wga_mlsss($compara_dba, $method1, $species_set1, undef, $no_release) };
+        push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_multiple_wga_mlsss($compara_dba, $method2, $species_set2, ($xml_msa->getAttribute('gerp') // 0), $no_release) };
         next;
     }
     my $method = $compara_dba->get_MethodAdaptor->fetch_by_type($xml_msa->getAttribute('method'));
     my $species_set = make_named_species_set_from_XML_node($xml_msa, $method, $division_genome_dbs);
-    push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_multiple_wga_mlsss($compara_dba, $method, $species_set, ($xml_msa->getAttribute('gerp') // 0)) };
+    push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_multiple_wga_mlsss($compara_dba, $method, $species_set, ($xml_msa->getAttribute('gerp') // 0), $no_release) };    
 }
 
 foreach my $xml_self_aln (@{$division_node->findnodes('self_alignments/genome')}) {

--- a/scripts/pipeline/create_all_mlss.pl
+++ b/scripts/pipeline/create_all_mlss.pl
@@ -389,7 +389,7 @@ foreach my $xml_msa (@{$division_node->findnodes('multiple_alignments/multiple_a
     }
     my $method = $compara_dba->get_MethodAdaptor->fetch_by_type($xml_msa->getAttribute('method'));
     my $species_set = make_named_species_set_from_XML_node($xml_msa, $method, $division_genome_dbs);
-    push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_multiple_wga_mlsss($compara_dba, $method, $species_set, ($xml_msa->getAttribute('gerp') // 0), $no_release) };    
+    push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_multiple_wga_mlsss($compara_dba, $method, $species_set, ($xml_msa->getAttribute('gerp') // 0), $no_release) };
 }
 
 foreach my $xml_self_aln (@{$division_node->findnodes('self_alignments/genome')}) {


### PR DESCRIPTION
The pig breeds are a special case with regards to their EPO & EPO2x - only the EPO2x is 'released'. The base EPO is kept internal. This needs to be captured by the MLSS XML definition: allow a `no_release` tag in MSA definitions. this allows us to keep the mlss up-to-date, but never tag it to be released. This includes:

- updating the XML schema definition to allow `no_release` attribute
- inserting a mechanism into `create_all_mlss.pl` to correctly handle the attribute
- updating the `mlss_conf.xml` to capture our requirements for the pig breeds

Additionally, the EPO and EPO2x for pigs have been added to the JIRA ticket JSON and dependency graph `.dot` file.