### PR TITLE
Allow using a more fitting term than strain, e.g. breed

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
@@ -669,7 +669,7 @@ sub get_scientific_name {
 
     my $n = $self->taxon_id ? (($self->{'_taxon'} || $self->adaptor) ? $self->taxon->scientific_name : 'Taxon ' . $self->taxon_id) : $self->name;
     if (my $strain_name = $self->strain_name) {
-        my ($foo, $unqualified_strain_name) = split(/  */, $strain_name, 2);
+        my ($foo, $unqualified_strain_name) = split(/ +/, $strain_name, 2);
         $n .= " $strain_name" if $n !~ /\b$unqualified_strain_name$/;
     }
     $n .= sprintf(' (component %s)', $self->genome_component) if $self->genome_component;

--- a/modules/t/test-genome-DBs/homology/compara/genome_db.txt
+++ b/modules/t/test-genome-DBs/homology/compara/genome_db.txt
@@ -71,16 +71,16 @@
 159	30608	microcebus_murinus	Mmur_2.0	2016-06-Ensembl	0	1	\N	\N	Mouse Lemur	\N	86	\N
 158	9544	macaca_mulatta	Mmul_8.0.1	2016-06-Ensembl	1	1	\N	\N	Macaque	\N	86	\N
 157	9031	gallus_gallus	Gallus_gallus-5.0	2016-06-Ensembl	1	1	\N	\N	Chicken	\N	86	\N
-160	10090	mus_musculus_129s1svimj	129S1_SvImJ_v1	2016-07-External	1	1	\N	129S1SvImJ	Mouse 129S1/SvImJ	\N	86	\N
-162	10090	mus_musculus_balbcj	BALB_cJ_v1	2016-07-External	1	1	\N	BALBcJ	Mouse BALB/cJ	\N	86	\N
-165	10091	mus_musculus_casteij	CAST_EiJ_v1	2016-07-External	1	1	\N	CASTEiJ	Mouse CAST/EiJ	\N	86	\N
-172	39442	mus_musculus_pwkphj	PWK_PhJ_v1	2016-07-External	1	1	\N	PWKPhJ	Mouse PWK/PhJ	\N	86	\N
-174	10096	mus_spretus_spreteij	SPRET_EiJ_v1	2016-07	1	1	\N	SPRETEiJ	Mouse SPRET/EiJ	\N	86	\N
-2080	4565	triticum_aestivum	TGACv1	2015-12-TGACv1	1	1	\N	Chinese Spring	Triticum aestivum	\N	85	\N
-2081	4565	triticum_aestivum	TGACv1	2015-12-TGACv1	1	1	A	Chinese Spring	Triticum aestivum	\N	85	\N
-2082	4565	triticum_aestivum	TGACv1	2015-12-TGACv1	1	1	B	Chinese Spring	Triticum aestivum	\N	85	\N
-2083	4565	triticum_aestivum	TGACv1	2015-12-TGACv1	1	1	D	Chinese Spring	Triticum aestivum	\N	85	\N
-2084	4565	triticum_aestivum	TGACv1	2015-12-TGACv1	1	1	U	Chinese Spring	Triticum aestivum	\N	85	\N
+160	10090	mus_musculus_129s1svimj	129S1_SvImJ_v1	2016-07-External	1	1	\N	strain 129S1SvImJ	Mouse 129S1/SvImJ	\N	86	\N
+162	10090	mus_musculus_balbcj	BALB_cJ_v1	2016-07-External	1	1	\N	strain BALBcJ	Mouse BALB/cJ	\N	86	\N
+165	10091	mus_musculus_casteij	CAST_EiJ_v1	2016-07-External	1	1	\N	strain CASTEiJ	Mouse CAST/EiJ	\N	86	\N
+172	39442	mus_musculus_pwkphj	PWK_PhJ_v1	2016-07-External	1	1	\N	strain PWKPhJ	Mouse PWK/PhJ	\N	86	\N
+174	10096	mus_spretus_spreteij	SPRET_EiJ_v1	2016-07	1	1	\N	strain SPRETEiJ	Mouse SPRET/EiJ	\N	86	\N
+2080	4565	triticum_aestivum	TGACv1	2015-12-TGACv1	1	1	\N	strain Chinese Spring	Triticum aestivum	\N	85	\N
+2081	4565	triticum_aestivum	TGACv1	2015-12-TGACv1	1	1	A	strain Chinese Spring	Triticum aestivum	\N	85	\N
+2082	4565	triticum_aestivum	TGACv1	2015-12-TGACv1	1	1	B	strain Chinese Spring	Triticum aestivum	\N	85	\N
+2083	4565	triticum_aestivum	TGACv1	2015-12-TGACv1	1	1	D	strain Chinese Spring	Triticum aestivum	\N	85	\N
+2084	4565	triticum_aestivum	TGACv1	2015-12-TGACv1	1	1	U	strain Chinese Spring	Triticum aestivum	\N	85	\N
 1983	4572	triticum_urartu	ASM34745v1	2014-05-BGI	0	0	\N	\N	Triticum urartu	\N	73	\N
 1984	37682	aegilops_tauschii	ASM34733v1	2014-05-BGI	0	0	\N	\N	Aegilops tauschii	\N	73	\N
 2088	112509	hordeum_vulgare	Hv_IBSC_PGSB_v2	2016-05-IBSC_1.0	1	0	\N	\N	Hordeum vulgare	\N	89	\N

--- a/modules/t/test-genome-DBs/mus_musculus/core/meta.txt
+++ b/modules/t/test-genome-DBs/mus_musculus/core/meta.txt
@@ -185,3 +185,4 @@
 642	\N	patch	patch_96_97_e.sql|add_stable_id_event_type_rnaproduct
 643	\N	patch	patch_97_98_a.sql|schema_version
 644	\N	patch	patch_98_99_a.sql|schema_version
+645	1	strain.type	strain


### PR DESCRIPTION
See https://www.ebi.ac.uk/panda/jira/browse/ENSINT-317 for more information.

Here I change the content of `genome_db.strain_name` to explicitly include "strain", "breed", etc.
There will be some SQL to apply to the vertebrates and plants databases (e99 and master), see https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-2532, following the staging-patch https://github.com/Ensembl/staging-patches/pull/325/files

Note that `strain.type` is currently optional but will at some point be made mandatory via a DataCheck. Then we should be able to remove default value `|| 'strain'`