### PR TITLE
Add prev_release to ENV.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/EpoLowCoverage_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/EpoLowCoverage_conf.pm
@@ -43,7 +43,6 @@ sub default_options {
 
         #'species_set_name'  => 'primates',
     'division' => 'vertebrates',
-	'prev_release'  => '#expr( #ensembl_release# - 1 )expr#',
 
     'work_dir' => '/hps/nobackup2/production/ensembl/' . join('/', $self->o('dbowner'), 'EPO_2X', $self->o('species_set_name') . '_' . $self->o('rel_with_suffix')),
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -67,6 +67,9 @@ sub shared_default_options {
         # Shared user used for shared files across all of Compara
         'shared_user'           => 'compara_ensembl',
 
+        # Previous EnsEMBL release number
+        'prev_release'          => Bio::EnsEMBL::ApiVersion::software_version()-1,
+
         # EG release number
         'eg_release'            => Bio::EnsEMBL::ApiVersion::software_version()-53,
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
@@ -63,8 +63,7 @@ sub pipeline_analyses_prep_master_db_for_release {
             -parameters => {
                 'schema_file'  => $self->o('schema_file'),
                 'patch_dir'    => $self->o('patch_dir'),
-                'prev_release' => '#expr( #release# - 1 )expr#',
-                'patch_names'  => '#patch_dir#/patch_#prev_release#_#release#_*.sql',
+                'patch_names'  => '#patch_dir#/patch_' . $self->o('prev_release') . '_#release#_*.sql',
             },
             -flow_into  => ['load_ncbi_node'],
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -356,7 +356,6 @@ sub default_options {
         # homology dumps options
         'homology_dumps_dir'       => $self->o('dump_dir'). '/homology_dumps/',
         'homology_dumps_shared_dir' => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('ensembl_release'),
-        'prev_release'  => '#expr( #ensembl_release# - 1 )expr#', # for homology_id_mapping
         'prev_homology_dumps_dir' => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('prev_release'),
     };
 }

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -118,7 +118,6 @@ sub default_options {
             # homology dumps options
             'homology_dumps_dir'       => $self->o('dump_dir'). '/homology_dumps/',
             'homology_dumps_shared_dir' => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('ensembl_release'),
-            'prev_release'  => '#expr( #ensembl_release# - 1 )expr#', # for homology_id_mapping
             'prev_homology_dumps_dir' => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('prev_release'),
             
            };


### PR DESCRIPTION
As we have done with our production environment, we seem to use this parameter often enough to move its declaration to `ENV.pm`. The pipelines that had it declared have been updated accordingly.

I have tracked all the dependencies of `EpoLowCoverage_conf.pm` and none of the analyses seem to use `prev_release` anymore, so I have removed it.