### PR TITLE
bugfix: don't reload species that only have a patch assembly update

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/BuildNewMasterDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/BuildNewMasterDatabase_conf.pm
@@ -109,7 +109,6 @@ sub default_options {
         'list_genomes_script'     => undef, # required but not used: do_update_from_metadata = 0
         'report_genomes_script'   => undef, # required but not used: do_update_from_metadata = 0
         'update_metadata_script'  => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/update_master_db.pl'),
-        'assembly_patch_species'  => [], # by default, skip this step
         'additional_species'      => {}, # by default, skip this step
         'do_update_from_metadata' => 0,
         'do_load_lrg_dnafrags'    => 0,

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/Plants/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/Plants/PrepareMasterDatabaseForRelease_conf.pm
@@ -66,7 +66,6 @@ sub default_options {
         %{$self->SUPER::default_options},   # inherit the generic ones
 
         'division'               => 'plants',
-        'assembly_patch_species' => [ 'homo_sapiens' ],
         'additional_species'     => {
             'vertebrates' => ['homo_sapiens', 'caenorhabditis_elegans', 'ciona_savignyi', 'drosophila_melanogaster', 'saccharomyces_cerevisiae'],
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/Vertebrates/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EBI/Vertebrates/PrepareMasterDatabaseForRelease_conf.pm
@@ -66,7 +66,6 @@ sub default_options {
         %{$self->SUPER::default_options},   # inherit the generic ones
 
         'division'               => 'vertebrates',
-        'assembly_patch_species' => [ 'homo_sapiens', 'mus_musculus', 'danio_rerio' ],
         'do_load_lrg_dnafrags'   => 1,
         'do_load_timetree'       => 1,
     };

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
@@ -127,6 +127,7 @@ sub pipeline_analyses_prep_master_db_for_release {
                 '2->A' => [ 'add_species_into_master' ],
                 '3->A' => [ 'retire_species_from_master' ],
                 '4->A' => [ 'rename_genome' ],
+                '5->A' => [ 'load_assembly_patches' ],
                 'A->1' => [ 'sync_metadata' ],
             },
             -rc_name    => '16Gb_job',
@@ -170,7 +171,7 @@ sub pipeline_analyses_prep_master_db_for_release {
             },
             -flow_into  => WHEN(
                 '#do_load_lrg_dnafrags#' => 'load_lrg_dnafrags',
-                ELSE 'assembly_patch_factory',
+                ELSE 'update_collection',
             ),
         },
 
@@ -179,19 +180,7 @@ sub pipeline_analyses_prep_master_db_for_release {
             -parameters => {
                 'compara_db' => $self->o('master_db'),
             },
-            -flow_into  => [ 'assembly_patch_factory' ],
-        },
-
-         {  -logic_name => 'assembly_patch_factory',
-            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
-            -parameters => {
-                'inputlist'    => $self->o('assembly_patch_species'),
-                'column_names' => ['species_name'],
-            },
-            -flow_into  => {
-                '2->A' => [ 'load_assembly_patches' ],
-                'A->1' => [ 'update_collection' ],
-            },
+            -flow_into  => [ 'update_collection' ],
         },
 
         {   -logic_name => 'load_assembly_patches',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
@@ -94,7 +94,6 @@ sub default_options {
         'list_genomes_script'    => $self->check_exe_in_ensembl('ensembl-metadata/misc_scripts/get_list_genomes_for_division.pl'),
         'report_genomes_script'  => $self->check_exe_in_ensembl('ensembl-metadata/misc_scripts/report_genomes.pl'),
         'update_metadata_script' => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/update_master_db.pl'),
-        'assembly_patch_species' => [],
         'additional_species'     => {},
         # Example:
         #'additional_species'     => {'vertebrates' => ['homo_sapiens', 'drosophila_melanogaster'],},


### PR DESCRIPTION
We can rely on the metadata service to report an assembly change for patch updates (they've made the change in e98). So instead of hardcoding a list of species we expect patches for, the pipeline will check whether the assembly updates reported by the metadata service correspond to patch updates, e.g. `GRCh38.p12` → `GRCh38.p13` and call `load_assembly_patches` instead of `add_species_into_master`.
