### PR TITLE
Fix/speciestree

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateSpeciesTree_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateSpeciesTree_conf.pm
@@ -55,7 +55,6 @@ sub default_options {
 
         # 'division'        => 'vertebrates',
         'outgroup'        => 'saccharomyces_cerevisiae',
-        'outgroup_id'     => 127,
 
         'output_dir'        => $self->o('pipeline_dir'),
         'sketch_dir'        => '/hps/nobackup2/production/ensembl/' . $self->o('shared_user') . '/species_tree/' . $self->o('division') . '_sketches',
@@ -67,7 +66,7 @@ sub default_options {
         'master_db'          => 'compara_master',
 
         'representative_species' => undef,
-        'taxonomic_ranks' => ['order', 'class', 'phylum', 'kingdom'],
+        'taxonomic_ranks' => ['genus', 'family', 'order', 'class', 'phylum', 'kingdom'],
         'custom_groups'   => ['Vertebrata', 'Sauropsida', 'Amniota', 'Tetrapoda'],
 
 
@@ -110,12 +109,14 @@ sub pipeline_analyses {
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::SpeciesTree::GroupSpecies',
             -flow_into  => {
                 1 => [ 'check_sketches' ],
+                2 => [ '?table_name=pipeline_wide_parameters' ],
             },
             -input_ids => [{
               'sketch_dir'        => $self->o('sketch_dir'),
               'collection'        => $self->o('collection'),
               'species_set_id'    => $self->o('species_set_id'),
               'compara_db'        => $self->o('master_db'),
+              'outgroup'          => $self->o('outgroup'),
             }],
         },
 
@@ -229,7 +230,6 @@ sub pipeline_analyses {
           -parameters => {
               'taxonomic_ranks' => $self->o('taxonomic_ranks'),
               'custom_groups'   => $self->o('custom_groups'  ),
-              'outgroup_id'     => $self->o('outgroup_id'),
           },
           -flow_into => {
               '2->A' => [ 'neighbour_joining_tree' ],
@@ -266,7 +266,6 @@ sub pipeline_analyses {
               'erable_exe'    => $self->o('erable_exe'),
               'unroot_script' => $self->o('unroot_script'),
               'reroot_script' => $self->o('reroot_script'),
-              'outgroup_id'   => $self->o('outgroup_id'),
           },
           -flow_into => {
               1 => ['copy_files_to_sketch_dir'],

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/AdjustBranchLengths.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/AdjustBranchLengths.pm
@@ -135,7 +135,7 @@ sub _write_unrooted_tree {
 	$self->_spurt($rooted_tree_file, $rooted_tree);
 
 	my $unroot_script = $self->param_required('unroot_script');
-	my $unroot_run = $self->run_command("$unroot_script $rooted_tree_file > $outfile");
+	my $unroot_run = $self->run_command("$unroot_script -t $rooted_tree_file > $outfile");
 	die $unroot_run->err if $unroot_run->err;
 }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/CheckSketches.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/CheckSketches.pm
@@ -79,18 +79,6 @@ sub fetch_input {
 		}
 		@genome_dbs = @{ $species_set->genome_dbs };
 	}
-	
-	# # add any optional outgroups
-	# if ( $self->param('outgroup_gdbs') ) {
-	# 	foreach my $gdb_id ( @{ $self->param('outgroup_gdbs') } ) {
-	# 		my $this_gdb = $gdb_adaptor->fetch_by_dbID( $gdb_id );
-	# 		die "Outgroup species genome_db $gdb_id could not be found in the database" unless $this_gdb;
-	# 		push( @genome_dbs, $this_gdb );
-	# 	}
-	# }
-
-	# print "\n\nGENOME_DBS:\n";
-	# print Dumper \@genome_dbs;
 
 	$self->param( 'genome_dbs', \@genome_dbs );
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/GraftSubtrees.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/GraftSubtrees.pm
@@ -59,8 +59,8 @@ sub run {
 
 	my %trees = %{ $self->param('trees')}; # assuming { group_id => { tree => newick_string, outgroup => outgroup_id } }
 
-	# my $root_tree = $trees{root}->{tree};
-	my $root_tree = $trees{1}->{tree};
+	my $root_tree = $trees{$self->param_required('root_id')}->{tree};
+	# my $root_tree = $trees{1}->{tree};
 	my $final_tree = $root_tree;
 
 	print "original tree: $final_tree\n" if $self->debug;
@@ -90,9 +90,11 @@ sub run {
 	}
 
 	# do final reroot on overall outgroup
-	my $overall_outgroup = $self->param('outgroup_genome_db_id');
+	my $overall_outgroup = $self->param('outgroup_id');
 	$final_tree = $self->_root_newick_on_outgroup( $final_tree, "gdb$overall_outgroup" ) if defined $overall_outgroup;
-
+  
+	die "Final tree is empty" if $final_tree eq "";
+	
 	print "ultimate tree (?) : $final_tree\n\n";
 
 	$self->param('final_tree', $final_tree);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/PermuteMatrix.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/PermuteMatrix.pm
@@ -60,8 +60,8 @@ sub param_defaults {
     return {
         %{$self->SUPER::param_defaults},
         'min_group_size'  => 4,
-        #'taxonomic_ranks' => ['order', 'class', 'phylum', 'kingdom'],
-        'taxonomic_ranks' => ['genus'],
+        'taxonomic_ranks' => ['genus', 'family', 'order', 'class', 'phylum', 'kingdom'],
+        #'taxonomic_ranks' => ['genus', 'family'],
         # 'custom_groups'   => ['Vertebrata', 'Sauropsida', 'Amniota', 'Tetrapoda'],
         # 'outgroup_id' => '127', # outgroup for everything
 
@@ -97,7 +97,7 @@ sub fetch_input {
 
 	my (@prev_group_ids, %all_groups, @matrices_dataflow, $this_outgroup);
 	foreach my $group_taxon_id ( @tax_groups_ids ) {
-    $group_taxon_id=4527;
+    # $group_taxon_id=4527;
 		my $current_group_taxon = $ncbi_adaptor->fetch_node_by_taxon_id($group_taxon_id);
 		print " -- Grouping " . $current_group_taxon->name . "...\n" if $self->debug;
 
@@ -107,8 +107,14 @@ sub fetch_input {
 		print "\t -- fetching submatrix for " . scalar @group_gdbs . " genomes\n" if $self->debug;
 		my $submatrix = $distance_matrix->prune_gdbs_from_matrix( \@group_gdbs );
 
+    # # if all species are in the submatrix, we should stop traversing up the taxonomy
+    # my $orig_size = scalar $distance_matrix->members;
+    # my $sub_size  = scalar $submatrix->members;
+    # print "orig_size: $orig_size\tsub_size: $sub_size\n";
+    # last if $orig_size == $sub_size;
+
 		# add an outgroup
-		if ( $group_taxon_id == $ncbi_adaptor->fetch_node_by_name('root')->dbID ) {
+		if ( $group_taxon_id == $self->param('root_id') ) {
 			$this_outgroup = $self->param_required('outgroup_id');
 		} else {
 			($submatrix, $this_outgroup) = $self->_add_outgroup( $submatrix, $distance_matrix );
@@ -124,13 +130,13 @@ sub fetch_input {
 			$submatrix = $submatrix->collapse_group_in_matrix( $prev_group_gdbs, "mrg_$prev_group" );
 		}
 
-    next if $self->_empty_submatrix($submatrix);
+    next if Bio::EnsEMBL::Compara::Utils::DistanceMatrix->empty_submatrix($submatrix);
 
 		# add to dataflow
 		my $mdf = { 
 			group_key => $group_taxon_id, 
 			distance_matrix => $submatrix, 
-			outgroup => $this_outgroup 
+			outgroup => $this_outgroup
 		};
 		push( @matrices_dataflow, $mdf );
 		unshift( @prev_group_ids, $group_taxon_id );
@@ -149,6 +155,7 @@ sub write_output {
 	#     { group_key => $key2, distance_matrix => $matrix2 }, # no outgroup
 	# ]
 	$self->dataflow_output_id( $self->param('matrices_dataflow'), 2 );
+  $self->dataflow_output_id( { root_id => $self->param('root_id') }, 1 );
 }
 
 sub _add_outgroup {
@@ -159,6 +166,7 @@ sub _add_outgroup {
 
 	my ( $closest_gdb_id, $min_distance) = (undef, 100);
 	foreach my $full_key ( $full_matrix->members ) {
+    print "FULL_KEY: $full_key\n";
 		next if ( defined $self->param('blacklisted_genome_db_ids') && grep { $full_key eq $_ } @{$self->param('blacklisted_genome_db_ids')} ); # skip any that are on the naughty list
 		next if (grep { $_ eq $full_key } @sub_gdb_ids); # skip any that exist in the submatrix
     next unless defined $full_matrix->distance($rep_gdb_id, $full_key);
@@ -219,9 +227,18 @@ sub _taxonomic_groups {
 		my $this_gdb_taxon = $ncbi_adaptor->fetch_node_by_taxon_id($gdb->taxon_id);
 		foreach my $rank ( @ranks ) {
 			my $this_rank_taxon = $self->_taxonomic_rank($this_gdb_taxon, $rank);
-			$group_taxon_ids{$this_rank_taxon} = 1 if $this_rank_taxon;
+			$group_taxon_ids{$this_rank_taxon} += 1 if $this_rank_taxon;
 		}
 	}
+
+  # filter ranks shared across all species
+  # only ranks describing subsets of the species set should be included
+  foreach my $key ( keys %group_taxon_ids ) {
+      delete $group_taxon_ids{$key} if $group_taxon_ids{$key} == (scalar(@$gdbs));
+      unless ((scalar keys %group_taxon_ids) < 20) {
+        delete $group_taxon_ids{$key} if $group_taxon_ids{$key} < (scalar(@$gdbs)/10);
+      }
+  }
 
 	# now, add in the additional groupings, if any
 	if ( $self->param('custom_groups') ) {
@@ -240,20 +257,14 @@ sub _taxonomic_groups {
 	my @sorted_taxon_ids = map {$_->dbID} @sorted_taxa;
 
 	# finally, add the root
-	my $root_taxon = $ncbi_adaptor->fetch_node_by_name('root');
+  my $largest_group = $sorted_taxa[-1];
+  my $root_taxon = $ncbi_adaptor->fetch_parent_for_node($largest_group);
+  
+	# my $root_taxon = $ncbi_adaptor->fetch_node_by_name('root');
 	push(@sorted_taxon_ids, $root_taxon->dbID); # usually 1, but fetch from db just incase
+  $self->param('root_id', $root_taxon->dbID);
 
 	return @sorted_taxon_ids;
-}
-
-sub _empty_submatrix {
-  my ($self, $submatrix) = @_;
-
-  my @members = $submatrix->members;
-  foreach my $member ( @members ) {
-    return 0 unless $member =~ m/^mrg_/;
-  }
-  return 1;
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
@@ -95,7 +95,7 @@ sub members {
 
 sub distance {
 	my ($matrix, $s1, $s2, $new_distance) = @_;
-
+  
 	return $matrix->{$s1}->{$s2} unless defined $new_distance;
 	$matrix->{$s1}->{$s2} = $new_distance;
 	$matrix->{$s2}->{$s1} = $new_distance;
@@ -223,11 +223,15 @@ sub add_taxonomic_distance {
 
 sub prune_gdbs_from_matrix {
 	my ( $matrix, $gdb_list ) = @_;
-	
 	my @gdb_id_list = map {$_->dbID} @$gdb_list;
+	@gdb_id_list = grep { defined && m/[^\s]/ } @gdb_id_list;
 	my $submatrix = Bio::EnsEMBL::Compara::Utils::DistanceMatrix->new();
 	foreach my $gdb1 ( @gdb_id_list ) {
 		foreach my $gdb2 ( @gdb_id_list ) {
+			#print Dumper $submatrix;
+			#print "$gdb1 $gdb2 ".$matrix->distance($gdb1, $gdb2)."\n";
+			
+			next unless defined $matrix->distance($gdb1, $gdb2);
 			$submatrix = $submatrix->distance( $gdb1, $gdb2, $matrix->distance($gdb1, $gdb2) );
 		}
 	}
@@ -362,6 +366,16 @@ sub phylip_from_matrix {
 		$reformatted_matrix = "    $species_count\n" . $reformatted_matrix;
 	}
 	spurt($phylip_file, $reformatted_matrix);
+}
+
+sub _empty_submatrix {
+  my ($self, $submatrix) = @_;
+
+  my @members = $submatrix->members;
+  foreach my $member ( @members ) {
+    return 0 unless $member =~ m/^mrg_/;
+  }
+  return 1;
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
@@ -368,7 +368,7 @@ sub phylip_from_matrix {
 	spurt($phylip_file, $reformatted_matrix);
 }
 
-sub _empty_submatrix {
+sub empty_submatrix {
   my ($self, $submatrix) = @_;
 
   my @members = $submatrix->members;

--- a/scripts/species_tree/unroot_newick.py
+++ b/scripts/species_tree/unroot_newick.py
@@ -15,15 +15,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, os
+import sys, os, argparse
 from ete3 import Tree
 
-infile = sys.argv[1]
-if not os.path.isfile(infile):
-	sys.stderr.write("File %s not found", infile)
-	sys.exit(1)
+parser = argparse.ArgumentParser()
+parser.add_argument('-t', '--tree')
+parser.add_argument('-bl', '--branch_lengths', action='store_true')
+parser.add_argument('-v', '--verbose', action='store_true')
+opts = parser.parse_args(sys.argv[1:])
 
-t = Tree(infile)
-root = t.get_tree_root()
-root.unroot()
-print(root.write(format=5))
+if not os.path.isfile(opts.tree):
+	sys.stderr.write("File %s not found", opts.tree)
+	sys.exit(1)
+	 
+t = Tree(opts.tree)
+if opts.verbose == True:
+	orig_root = t.get_tree_root()
+	sys.stderr.write("ORIGINAL TREE:\n" + orig_root.write(format=9) + "\n\n\n")
+
+# intial unroot
+t.unroot()	
+# reroot by midpoint to force unrooting later
+midpoint = t.get_midpoint_outgroup()
+t.set_outgroup(midpoint)
+
+if opts.verbose == True:
+	sys.stderr.write("MIDPOINT ROOTING:\n" + t.write(format=9) + "\n\n\n")
+
+# final forced unrooting of tree to be absolutely sure	
+t.unroot()
+
+if opts.verbose == True:
+	sys.stderr.write("UNROOTED:\n" + t.write(format=9) + "\n\n\n")
+	
+if opts.branch_lengths == True:
+	print(t.write(format=5))
+else:
+	print(t.write(format=9))


### PR DESCRIPTION
The species tree worked perfectly for the large default species_sets such as vertebrates but was not set up to work for smaller species_sets such as 10 rice species. There were complications with the outgroup and species_set parameters conflicting with the collection parameters, now only the outgroup species name is needed, the genome_db_id will be collected through the genome_db adaptor. The root is also now decided based on species_set rather than forced to be the tree of life ancestral root. The un-rooting step worked well for the large trees, but was unable to unroot the smaller trees without a forced midpoint rooting first.