### PR TITLE
Fix/speciestree

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateSpeciesTree_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateSpeciesTree_conf.pm
@@ -30,6 +30,12 @@ limitations under the License.
 
 =cut
 
+=head1 DESCRIPTION
+
+Pipeline to create species trees. If '--species_set_id' is provided, then '--collection' is ignored.
+
+=cut
+
 package Bio::EnsEMBL::Compara::PipeConfig::CreateSpeciesTree_conf;
 
 use strict;
@@ -55,7 +61,6 @@ sub default_options {
 
         # 'division'        => 'vertebrates',
         'outgroup'        => 'saccharomyces_cerevisiae',
-        'outgroup_id'     => 127,
 
         'output_dir'        => $self->o('pipeline_dir'),
         'sketch_dir'        => '/hps/nobackup2/production/ensembl/' . $self->o('shared_user') . '/species_tree/' . $self->o('division') . '_sketches',
@@ -67,7 +72,7 @@ sub default_options {
         'master_db'          => 'compara_master',
 
         'representative_species' => undef,
-        'taxonomic_ranks' => ['order', 'class', 'phylum', 'kingdom'],
+        'taxonomic_ranks' => ['genus', 'family', 'order', 'class', 'phylum', 'kingdom'],
         'custom_groups'   => ['Vertebrata', 'Sauropsida', 'Amniota', 'Tetrapoda'],
 
 
@@ -110,12 +115,14 @@ sub pipeline_analyses {
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::SpeciesTree::GroupSpecies',
             -flow_into  => {
                 1 => [ 'check_sketches' ],
+                2 => [ '?table_name=pipeline_wide_parameters' ],
             },
             -input_ids => [{
               'sketch_dir'        => $self->o('sketch_dir'),
               'collection'        => $self->o('collection'),
               'species_set_id'    => $self->o('species_set_id'),
               'compara_db'        => $self->o('master_db'),
+              'outgroup'          => $self->o('outgroup'),
             }],
         },
 
@@ -229,7 +236,6 @@ sub pipeline_analyses {
           -parameters => {
               'taxonomic_ranks' => $self->o('taxonomic_ranks'),
               'custom_groups'   => $self->o('custom_groups'  ),
-              'outgroup_id'     => $self->o('outgroup_id'),
           },
           -flow_into => {
               '2->A' => [ 'neighbour_joining_tree' ],
@@ -266,7 +272,6 @@ sub pipeline_analyses {
               'erable_exe'    => $self->o('erable_exe'),
               'unroot_script' => $self->o('unroot_script'),
               'reroot_script' => $self->o('reroot_script'),
-              'outgroup_id'   => $self->o('outgroup_id'),
           },
           -flow_into => {
               1 => ['copy_files_to_sketch_dir'],

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/AdjustBranchLengths.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/AdjustBranchLengths.pm
@@ -135,7 +135,7 @@ sub _write_unrooted_tree {
 	$self->_spurt($rooted_tree_file, $rooted_tree);
 
 	my $unroot_script = $self->param_required('unroot_script');
-	my $unroot_run = $self->run_command("$unroot_script $rooted_tree_file > $outfile");
+	my $unroot_run = $self->run_command("$unroot_script -t $rooted_tree_file > $outfile");
 	die $unroot_run->err if $unroot_run->err;
 }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/CheckSketches.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/CheckSketches.pm
@@ -79,18 +79,6 @@ sub fetch_input {
 		}
 		@genome_dbs = @{ $species_set->genome_dbs };
 	}
-	
-	# # add any optional outgroups
-	# if ( $self->param('outgroup_gdbs') ) {
-	# 	foreach my $gdb_id ( @{ $self->param('outgroup_gdbs') } ) {
-	# 		my $this_gdb = $gdb_adaptor->fetch_by_dbID( $gdb_id );
-	# 		die "Outgroup species genome_db $gdb_id could not be found in the database" unless $this_gdb;
-	# 		push( @genome_dbs, $this_gdb );
-	# 	}
-	# }
-
-	# print "\n\nGENOME_DBS:\n";
-	# print Dumper \@genome_dbs;
 
 	$self->param( 'genome_dbs', \@genome_dbs );
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/GraftSubtrees.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/GraftSubtrees.pm
@@ -59,8 +59,7 @@ sub run {
 
 	my %trees = %{ $self->param('trees')}; # assuming { group_id => { tree => newick_string, outgroup => outgroup_id } }
 
-	# my $root_tree = $trees{root}->{tree};
-	my $root_tree = $trees{1}->{tree};
+	my $root_tree = $trees{$self->param_required('root_id')}->{tree};
 	my $final_tree = $root_tree;
 
 	print "original tree: $final_tree\n" if $self->debug;
@@ -90,9 +89,11 @@ sub run {
 	}
 
 	# do final reroot on overall outgroup
-	my $overall_outgroup = $self->param('outgroup_genome_db_id');
+	my $overall_outgroup = $self->param('outgroup_id');
 	$final_tree = $self->_root_newick_on_outgroup( $final_tree, "gdb$overall_outgroup" ) if defined $overall_outgroup;
-
+  
+	die "Final tree is empty" if $final_tree eq "";
+	
 	print "ultimate tree (?) : $final_tree\n\n";
 
 	$self->param('final_tree', $final_tree);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/GroupSpecies.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/GroupSpecies.pm
@@ -73,18 +73,23 @@ sub fetch_input {
 	my $ss_adaptor = $dba->get_SpeciesSetAdaptor;
 	
 	my $species_set;
-	if ( $collection ) {
-		$species_set = $ss_adaptor->fetch_collection_by_name($collection);
-	} elsif ( $species_set_id ) {
-		$species_set = $ss_adaptor->fetch_by_dbID($species_set_id);
-		$self->param('collection', $species_set->name); # set this for file naming later
-	}
+    
+    if ( $species_set_id ) {
+        $species_set = $ss_adaptor->fetch_by_dbID($species_set_id);
+        $self->param('collection', $species_set->name); # set this for file naming later
+    } elsif ( $collection ) {
+        $species_set = $ss_adaptor->fetch_collection_by_name($collection);
+    }
 	my @genome_dbs = grep {$_->name ne 'ancestral_sequences'} @{ $species_set->genome_dbs };
 
 	my @gdb_id_list = map { $_->dbID } @genome_dbs;
-	push( @gdb_id_list, @{ $self->param('outgroup_gdbs') } ) if $self->param('outgroup_gdbs');
 	@gdb_id_list = sort {$a <=> $b} @gdb_id_list; 
 	$self->param( 'dataflow_groups', [{ genome_db_ids => \@gdb_id_list, collection => $self->param('collection')}] );
+    
+    #Find outgroup_id
+    my $outgroup_name = $self->param('outgroup');
+    my $outgroup_genome_db = $gdb_adaptor->fetch_by_name_assembly($outgroup_name);
+    $self->param('outgroup_genome_db_id', $outgroup_genome_db->dbID);
 }
 
 sub _print_gdb_list {
@@ -122,6 +127,11 @@ sub write_output {
 		$self->dataflow_output_id( $group_set, 1 );
 		$c++;
 	}
+    
+    $self->dataflow_output_id( {
+        'param_name' =>'outgroup_id',
+        'param_value' => $self->param('outgroup_genome_db_id')
+    }, 2 );
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
@@ -95,7 +95,7 @@ sub members {
 
 sub distance {
 	my ($matrix, $s1, $s2, $new_distance) = @_;
-
+  
 	return $matrix->{$s1}->{$s2} unless defined $new_distance;
 	$matrix->{$s1}->{$s2} = $new_distance;
 	$matrix->{$s2}->{$s1} = $new_distance;
@@ -223,11 +223,15 @@ sub add_taxonomic_distance {
 
 sub prune_gdbs_from_matrix {
 	my ( $matrix, $gdb_list ) = @_;
-	
 	my @gdb_id_list = map {$_->dbID} @$gdb_list;
+	@gdb_id_list = grep { defined && m/[^\s]/ } @gdb_id_list;
 	my $submatrix = Bio::EnsEMBL::Compara::Utils::DistanceMatrix->new();
 	foreach my $gdb1 ( @gdb_id_list ) {
 		foreach my $gdb2 ( @gdb_id_list ) {
+			#print Dumper $submatrix;
+			#print "$gdb1 $gdb2 ".$matrix->distance($gdb1, $gdb2)."\n";
+			
+			next unless defined $matrix->distance($gdb1, $gdb2);
 			$submatrix = $submatrix->distance( $gdb1, $gdb2, $matrix->distance($gdb1, $gdb2) );
 		}
 	}
@@ -362,6 +366,16 @@ sub phylip_from_matrix {
 		$reformatted_matrix = "    $species_count\n" . $reformatted_matrix;
 	}
 	spurt($phylip_file, $reformatted_matrix);
+}
+
+sub _empty_submatrix {
+  my ($self, $submatrix) = @_;
+
+  my @members = $submatrix->members;
+  foreach my $member ( @members ) {
+    return 0 unless $member =~ m/^mrg_/;
+  }
+  return 1;
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
@@ -95,7 +95,7 @@ sub members {
 
 sub distance {
 	my ($matrix, $s1, $s2, $new_distance) = @_;
-  
+
 	return $matrix->{$s1}->{$s2} unless defined $new_distance;
 	$matrix->{$s1}->{$s2} = $new_distance;
 	$matrix->{$s2}->{$s1} = $new_distance;
@@ -228,8 +228,6 @@ sub prune_gdbs_from_matrix {
 	my $submatrix = Bio::EnsEMBL::Compara::Utils::DistanceMatrix->new();
 	foreach my $gdb1 ( @gdb_id_list ) {
 		foreach my $gdb2 ( @gdb_id_list ) {
-			#print Dumper $submatrix;
-			#print "$gdb1 $gdb2 ".$matrix->distance($gdb1, $gdb2)."\n";
 			
 			next unless defined $matrix->distance($gdb1, $gdb2);
 			$submatrix = $submatrix->distance( $gdb1, $gdb2, $matrix->distance($gdb1, $gdb2) );
@@ -368,14 +366,14 @@ sub phylip_from_matrix {
 	spurt($phylip_file, $reformatted_matrix);
 }
 
-sub _empty_submatrix {
-  my ($self, $submatrix) = @_;
+sub empty_submatrix {
+    my ($self, $submatrix) = @_;
 
-  my @members = $submatrix->members;
-  foreach my $member ( @members ) {
-    return 0 unless $member =~ m/^mrg_/;
-  }
-  return 1;
+    my @members = $submatrix->members;
+    foreach my $member ( @members ) {
+        return 0 unless $member =~ m/^mrg_/;
+    }
+    return 1;
 }
 
 1;

--- a/scripts/species_tree/unroot_newick.py
+++ b/scripts/species_tree/unroot_newick.py
@@ -15,15 +15,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, os
+import sys, os, argparse
 from ete3 import Tree
 
-infile = sys.argv[1]
-if not os.path.isfile(infile):
-	sys.stderr.write("File %s not found", infile)
-	sys.exit(1)
+parser = argparse.ArgumentParser()
+parser.add_argument('-t', '--tree')
+parser.add_argument('-bl', '--branch_lengths', action='store_true')
+parser.add_argument('-v', '--verbose', action='store_true')
+opts = parser.parse_args(sys.argv[1:])
 
-t = Tree(infile)
-root = t.get_tree_root()
-root.unroot()
-print(root.write(format=5))
+if not os.path.isfile(opts.tree):
+	sys.stderr.write("File %s not found", opts.tree)
+	sys.exit(1)
+	 
+t = Tree(opts.tree)
+if opts.verbose == True:
+	orig_root = t.get_tree_root()
+	sys.stderr.write("ORIGINAL TREE:\n" + orig_root.write(format=9) + "\n\n\n")
+
+# intial unroot
+t.unroot()	
+# reroot by midpoint to force unrooting later
+midpoint = t.get_midpoint_outgroup()
+t.set_outgroup(midpoint)
+
+if opts.verbose == True:
+	sys.stderr.write("MIDPOINT ROOTING:\n" + t.write(format=9) + "\n\n\n")
+
+# final forced unrooting of tree to be absolutely sure	
+t.unroot()
+
+if opts.verbose == True:
+	sys.stderr.write("UNROOTED:\n" + t.write(format=9) + "\n\n\n")
+	
+if opts.branch_lengths == True:
+	print(t.write(format=5))
+else:
+	print(t.write(format=9))


### PR DESCRIPTION
The species tree worked perfectly for the large default species_sets such as vertebrates but was not set up to work for smaller species_sets such as 10 rice species. There were complications with the outgroup and species_set parameters conflicting with the collection parameters, now only the outgroup species name is needed, the genome_db_id will be collected through the genome_db adaptor. The root is also now decided based on species_set rather than forced to be the tree of life ancestral root. The un-rooting step worked well for the large trees, but was unable to unroot the smaller trees without a forced midpoint rooting first.