### PR TITLE
Optimise dependencies in post-tree steps of protein tree pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/ProteinTrees_conf.pm
@@ -135,7 +135,7 @@ sub default_options {
 
     # CAFE parameters
         # Do we want to initialise the CAFE part now ?
-        'initialise_cafe_pipeline'  => 0,
+        'do_cafe'  => 0,
         #Use Timetree divergence times for the CAFETree internal nodes
         'use_timetree_times'        => 0,
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/ProteinTrees_conf.pm
@@ -135,7 +135,7 @@ sub default_options {
 
     # CAFE parameters
         # Do we want to initialise the CAFE part now ?
-        'do_cafe'  => 0,
+        'do_cafe'                   => 0,
         #Use Timetree divergence times for the CAFETree internal nodes
         'use_timetree_times'        => 0,
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Example/QfoProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Example/QfoProteinTrees_conf.pm
@@ -89,7 +89,7 @@ sub default_options {
         'prev_core_sources_locs'   => [ ],
 
         # Do we want to initialise the CAFE part now ?
-        'initialise_cafe_pipeline'  => 0,
+        'do_cafe'  => 0,
 
     };
 }
@@ -111,4 +111,3 @@ sub tweak_analyses {
 }
 
 1;
-

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -298,7 +298,7 @@ sub default_options {
 
     # CAFE parameters
         # Do we want to initialise the CAFE part now ?
-        'initialise_cafe_pipeline' => 1,
+        'do_cafe'                  => 1,
         'cafe_lambdas'             => '',  # For now, we don't supply lambdas
         'cafe_struct_tree_str'     => '',  # Not set by default
         'full_species_tree_label'  => 'default',
@@ -430,7 +430,7 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'use_notung'   => $self->o('use_notung'),
         'use_treerecs' => $self->o('use_treerecs'),
         'use_raxml'    => $self->o('use_raxml'),
-        'initialise_cafe_pipeline'   => $self->o('initialise_cafe_pipeline'),
+        'do_cafe'   => $self->o('do_cafe'),
         'do_stable_id_mapping'   => $self->o('do_stable_id_mapping'),
         'do_treefam_xref'   => $self->o('do_treefam_xref'),
         'do_homology_stats' => $self->o('do_homology_stats'),
@@ -601,7 +601,7 @@ sub core_pipeline_analyses {
         {   -logic_name => 'backbone_fire_posttree',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => {
-                '1->A'  => [ 'rib_fire_gene_qc' ],
+                '1->A'  => [ 'rib_group_1' ],
                 'A->1'  => [ 'backbone_pipeline_finished' ],
             },
         },
@@ -3260,6 +3260,47 @@ sub core_pipeline_analyses {
 
 # ---------------------------------------------[homology step]-----------------------------------------------------------------------
 
+        {   -logic_name => 'rib_group_1',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => {
+                '1->A' => [
+                    'rib_fire_gene_qc',
+                    'rib_fire_homology_id_mapping',
+                ],
+                'A->1' => 'rib_group_2'
+            },
+        },
+
+        {   -logic_name => 'rib_group_2',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => {
+                '1->A' => [
+                    'rib_fire_dnds',
+                    'rib_fire_cafe',
+                    'rib_fire_homology_stats',
+                    'rib_fire_hmm_build',
+                    'rib_fire_goc'
+                ],
+                'A->1' => 'rib_group_3',
+            },
+        },
+
+        {   -logic_name => 'rib_group_3',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => {
+                '1->A' => [
+                    'rib_fire_rename_labels',
+                    'rib_fire_move_polyploid',
+                ],
+                'A->1' => 'floating_rib',
+            },
+        },
+
+        {   -logic_name => 'rib_fire_move_polyploid',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => 'polyploid_move_back_factory',
+        },
+
         {   -logic_name => 'polyploid_move_back_factory',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
             -parameters => {
@@ -3267,9 +3308,7 @@ sub core_pipeline_analyses {
                 'normal_genomes'    => 0,
             },
             -flow_into => {
-                '2->A' => [ 'component_genome_dbs_move_back_factory' ],
-                'A->1' => [ 'floating_rib' ],
-                
+                2 => [ 'component_genome_dbs_move_back_factory' ],
             },
         },
 
@@ -3299,43 +3338,25 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'rib_fire_cafe',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-            -flow_into  => {
-                1 => [
-                    WHEN('#initialise_cafe_pipeline#' => 'CAFE_species_tree'),
-                    'rib_fire_homology_stats',
-                ],
-            },
+            -flow_into  => WHEN('#do_cafe#' => 'CAFE_species_tree'),
         },
 
         {   -logic_name => 'rib_fire_homology_stats',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-            -flow_into  => {
-                1 => [
-                    WHEN('#do_homology_stats#' => 'homology_stats_factory'),
-                    'set_default_values',
-                    'rib_fire_hmm_build',
-                ],
-            },
+            -flow_into  => [
+                WHEN('#do_homology_stats#' => 'homology_stats_factory'),
+                'set_default_values',
+            ],
         },
 
         {   -logic_name => 'rib_fire_hmm_build',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-            -flow_into  => {
-                1 => [
-                    WHEN('#do_hmm_export#' => 'build_HMM_factory'),
-                    'rib_fire_rename_labels',
-                ],
-            },
+            -flow_into  => WHEN('#do_hmm_export#' => 'build_HMM_factory'),
         },
-        
+
         {   -logic_name => 'rib_fire_gene_qc',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-            -flow_into  => {
-                1 => [
-                    WHEN('#do_gene_qc#' => 'get_species_set'),
-                    'rib_fire_homology_id_mapping',
-                ],
-            },
+            -flow_into  => WHEN('#do_gene_qc#' => 'get_species_set'),
         },
 
         {   -logic_name => 'rib_fire_homology_id_mapping',
@@ -3343,10 +3364,7 @@ sub core_pipeline_analyses {
             -parameters => {
                 'goc_taxlevels'         => $self->o('goc_taxlevels'),
             },
-            -flow_into  => {
-                '1->A' => WHEN('#do_homology_id_mapping#' => 'id_map_mlss_factory'),
-                'A->1' => 'group_genomes_under_taxa',
-            },
+            -flow_into  => WHEN('#do_homology_id_mapping#' => 'id_map_mlss_factory'),
         },
 
         {   -logic_name => 'rib_fire_rename_labels',
@@ -3354,13 +3372,7 @@ sub core_pipeline_analyses {
             -parameters => {
                 'label_prefix' => $self->o('label_prefix'),
             },
-            -flow_into  => {
-                # FIXME this assumes that label_prefix is set iff the collection is not "default"
-                1 => [
-                    WHEN('#label_prefix#' => 'rename_labels'),
-                    'rib_fire_goc',
-                ],
-            },
+            -flow_into  => WHEN('#label_prefix#' => 'rename_labels'), # FIXME this assumes that label_prefix is set if the collection is not "default"
         },
 
         {   -logic_name => 'floating_rib',
@@ -3373,8 +3385,7 @@ sub core_pipeline_analyses {
                 'taxlevels'             => $self->o('taxlevels'),
             },
             -flow_into => {
-                1 => [ 'rib_fire_cafe' ],
-                2 => [ 'rib_fire_dnds' ],
+                2 => [ 'mlss_factory' ],
             },
         },
 
@@ -3416,7 +3427,7 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'rib_fire_dnds',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-            -flow_into  => WHEN('#do_dnds#' => 'mlss_factory'),
+            -flow_into  => WHEN('#do_dnds#' => 'group_genomes_under_taxa'),
         },
 
         {   -logic_name => 'mlss_factory',
@@ -3540,10 +3551,7 @@ sub core_pipeline_analyses {
             -parameters => {
                 'taxlevels'             => $self->o('goc_taxlevels'),
             },
-            -flow_into  => {
-                '1->A' => WHEN( 'scalar(@{#taxlevels#})' => 'goc_entry_point' ),
-                'A->1' => ['polyploid_move_back_factory'],
-            },
+            -flow_into  => WHEN( 'scalar(@{#taxlevels#})' => 'goc_entry_point' ),
         },
 
         {   -logic_name => 'homology_stats_factory',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -430,7 +430,7 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'use_notung'   => $self->o('use_notung'),
         'use_treerecs' => $self->o('use_treerecs'),
         'use_raxml'    => $self->o('use_raxml'),
-        'do_cafe'   => $self->o('do_cafe'),
+        'do_cafe'      => $self->o('do_cafe'),
         'do_stable_id_mapping'   => $self->o('do_stable_id_mapping'),
         'do_treefam_xref'   => $self->o('do_treefam_xref'),
         'do_homology_stats' => $self->o('do_homology_stats'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -3551,7 +3551,7 @@ sub core_pipeline_analyses {
             -parameters => {
                 'taxlevels'             => $self->o('goc_taxlevels'),
             },
-            -flow_into  => WHEN( 'scalar(@{#taxlevels#})' => 'goc_entry_point' ),
+            -flow_into  => WHEN('scalar(@{#taxlevels#})' => 'goc_entry_point'),
         },
 
         {   -logic_name => 'homology_stats_factory',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsNcRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsNcRNAtrees_conf.pm
@@ -69,7 +69,7 @@ sub default_options {
             'ref_ortholog_db'   => 'compara_nctrees',
 
             # CAFE parameters
-            'initialise_cafe_pipeline'  => 0,
+            'do_cafe'  => 0,
     };
 }   
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
@@ -64,7 +64,7 @@ sub default_options {
 
     # CAFE parameters
         # Do we want to initialise the CAFE part now ?
-        'initialise_cafe_pipeline'  => 0,
+        'do_cafe'  => 0,
 
     # Extra analyses
         # Do we want the Gene QC part to run ?

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ncRNAtrees_conf.pm
@@ -66,7 +66,7 @@ sub default_options {
             'binary_species_tree_input_file' => $self->o('binary_species_tree'), # you can define your own species_tree for 'CAFE'. It *has* to be binary
 
             # CAFE parameters
-            'initialise_cafe_pipeline'  => 1,
+            'do_cafe'  => 1,
             # Use production names here
             'cafe_species'          => ['danio_rerio', 'taeniopygia_guttata', 'callithrix_jacchus', 'pan_troglodytes', 'homo_sapiens', 'mus_musculus'],
     };

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -130,7 +130,7 @@ sub default_options {
             'allow_ambiguity_codes'    => 1,
 
             # Do we want to initialise the CAFE part now ?
-            'initialise_cafe_pipeline'  => undef,
+            'do_cafe'  => undef,
             # Data needed for CAFE
             'cafe_lambdas'             => '',  # For now, we don't supply lambdas
             'cafe_struct_tree_str'     => '',  # Not set by default
@@ -180,7 +180,7 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
 
         'member_type'       => $self->o('member_type'),
         'create_ss_picts'   => $self->o('create_ss_picts'),
-        'initialise_cafe_pipeline'   => $self->o('initialise_cafe_pipeline'),
+        'do_cafe'   => $self->o('do_cafe'),
         'dbID_range_index'  => $self->o('dbID_range_index'),
         'clustering_mode'   => $self->o('clustering_mode'),
     }
@@ -543,8 +543,8 @@ sub core_pipeline_analyses {
                                      },
               -flow_into          => [ 'write_stn_tags',
                                        # 'backbone_fire_homology_dumps',
-                                        WHEN('#initialise_cafe_pipeline# and  #binary_species_tree_input_file#', 'CAFE_species_tree'),
-                                        WHEN('#initialise_cafe_pipeline# and !#binary_species_tree_input_file#', 'make_full_species_tree'),
+                                        WHEN('#do_cafe# and  #binary_species_tree_input_file#', 'CAFE_species_tree'),
+                                        WHEN('#do_cafe# and !#binary_species_tree_input_file#', 'make_full_species_tree'),
                                     ],
               %hc_params,
             },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -130,7 +130,7 @@ sub default_options {
             'allow_ambiguity_codes'    => 1,
 
             # Do we want to initialise the CAFE part now ?
-            'do_cafe'  => undef,
+            'do_cafe'                  => undef,
             # Data needed for CAFE
             'cafe_lambdas'             => '',  # For now, we don't supply lambdas
             'cafe_struct_tree_str'     => '',  # Not set by default
@@ -180,7 +180,7 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
 
         'member_type'       => $self->o('member_type'),
         'create_ss_picts'   => $self->o('create_ss_picts'),
-        'do_cafe'   => $self->o('do_cafe'),
+        'do_cafe'           => $self->o('do_cafe'),
         'dbID_range_index'  => $self->o('dbID_range_index'),
         'clustering_mode'   => $self->o('clustering_mode'),
     }


### PR DESCRIPTION
Note: some optimisations had already been made during introduction of homology dumps.

Since moving to flatfiles, the dependencies are as follows:
-  homology dumps required by `gene_member_qc`, `homology_id_mapping`, `homology_dnds`, `homology_stats`, `goc` ( & `wga`, but this is a separate pipeline)
- `gene_member_qc` required by `homology_dnds`
- `homology_id_mapping` required by `homology_dnds`, maybe `goc` if we reintroduce reuse ( & `wga`)

This results in the following running order:
1. `homology_dumps`
2. `gene_member_qc` & `homology_id_mapping`
3. everything else

Note: I have also added a flag to turn dNdS off by default (as discussed with @dthybert)

New structure can be seen here: http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-10&port=4648&dbname=carlac_ptrees_test (it's much messier without the semaphores! 😅)