### PR TITLE
Check that our gene-reuse detection matches the ensembl-metadata report

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/BuildNewMasterDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/BuildNewMasterDatabase_conf.pm
@@ -89,6 +89,7 @@ sub default_options {
         'create_all_mlss_exe'     => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/create_all_mlss.pl'),
         'xml_file'                => $self->o('config_dir') . '/mlss_conf.xml',
         'report_file'             => $self->o('work_dir') . '/mlss_ids_' . $self->o('division') . '.list',
+        'annotation_file'         => undef,
         'master_backup_file'      => $self->o('backups_dir') . '/new_master_' . $self->o('division') . '.sql',
         'patch_dir'               => $self->check_dir_in_ensembl('ensembl-compara/sql/'),
         'alias_file'              => $self->check_file_in_ensembl('ensembl-compara/scripts/taxonomy/ensembl_aliases.sql'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateHmmProfiles_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateHmmProfiles_conf.pm
@@ -135,7 +135,7 @@ sub default_options {
     # executable locations:
         # HMM specific parameters
         # The location of the HMM library:
-        'compara_hmm_library_basedir'               => '/hps/nobackup2/production/ensembl/' . $self->o('shared_user') . '/compara_hmm_'.$self->o('ensembl_release')."/",
+        'compara_hmm_library_basedir'               => $self->o('shared_hps_dir') . '/compara_hmm_'.$self->o('ensembl_release')."/",
         'target_compara_hmm_library_basedir'        => $self->o('warehouse_dir') . '/treefam_hmms/compara_hmm_'.$self->o('ensembl_release')."/",
         'treefam_hmm_library_basedir'               => $self->o('warehouse_dir') . '/treefam_hmms/2015-12-18/',
         'target_treefam_only_hmm_library_basedir'   => $self->o('warehouse_dir') . '/2015-12-18_only_TF_hmmer3/',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateSpeciesTree_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateSpeciesTree_conf.pm
@@ -63,7 +63,7 @@ sub default_options {
         'outgroup'        => 'saccharomyces_cerevisiae',
 
         'output_dir'        => $self->o('pipeline_dir'),
-        'sketch_dir'        => '/hps/nobackup2/production/ensembl/' . $self->o('shared_user') . '/species_tree/' . $self->o('division') . '_sketches',
+        'sketch_dir'        => $self->o('shared_hps_dir') . '/species_tree/' . $self->o('division') . '_sketches',
         'write_access_user' => $self->o('shared_user'),
 
         'mash_kmer_size'    => 24,

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/LoadMembers_conf.pm
@@ -60,6 +60,9 @@ sub default_options {
     # connection parameters to various databases:
         'master_db_is_missing_dnafrags' => 1,
 
+        # list of species that got an annotation update
+        'expected_updates_file' => undef,
+
     # Ensembl-specific databases
         #'staging_loc' => {
             #-host   => 'mysql-ens-sta-1',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -62,6 +62,7 @@ sub shared_default_options {
 
         # TODO: make a $self method that checks whether this already exists, to prevent clashes like in the LastZ pipeline
         'pipeline_dir'          => '/hps/nobackup2/production/ensembl/' . $ENV{'USER'} . '/' . $self->o('pipeline_name'),
+        'shared_hps_dir'        => '/hps/nobackup2/production/ensembl/' . $self->o('shared_user'),
         'warehouse_dir'         => '/nfs/production/panda/ensembl/warehouse/compara/',
 
         # Where to find the linuxbrew installation
@@ -73,15 +74,15 @@ sub shared_default_options {
         # NOTE: Can't use $self->check_file_in_ensembl as long as we don't produce a file for each division
         'reg_conf'              => $self->o('config_dir').'/production_reg_conf.pl',
         'binary_species_tree'   => $self->o('config_dir').'/species_tree.branch_len.nw',
-        'genome_dumps_dir'      => '/hps/nobackup2/production/ensembl/' . $self->o('shared_user') . '/genome_dumps/'.$self->o('division').'/',
+        'genome_dumps_dir'      => $self->o('shared_hps_dir') . '/genome_dumps/'.$self->o('division').'/',
 
         # HMM library
         'hmm_library_version'   => '2',
-        'hmm_library_basedir'   => '/hps/nobackup2/production/ensembl/' . $self->o('shared_user') . '/treefam_hmms/2019-01-02',
+        'hmm_library_basedir'   => $self->o('shared_hps_dir') . '/treefam_hmms/2019-01-02',
         #'hmm_library_version'   => '3',
-        #'hmm_library_basedir'   => '/hps/nobackup2/production/ensembl/' . $self->o('shared_user') . '/compara_hmm_91/',
+        #'hmm_library_basedir'   => $self->o('shared_hps_dir') . '/compara_hmm_91/',
         
-        'homology_dumps_shared_basedir' => '/hps/nobackup2/production/ensembl/' . $self->o('shared_user') . '/homology_dumps/'. $self->o('division'),
+        'homology_dumps_shared_basedir' => $self->o('shared_hps_dir') . '/homology_dumps/'. $self->o('division'),
     }
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Example/LoadMembersQfo_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Example/LoadMembersQfo_conf.pm
@@ -58,6 +58,8 @@ sub default_options {
     #load uniprot members for family pipeline
         'load_uniprot_members'      => 0,
 
+        # list of species that got an annotation update
+        'expected_updates_file' => undef,
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
@@ -110,7 +110,7 @@ sub default_options {
 
         # list of species that got an annotation update
         # ... assuming the same person has run both pipelines
-        'expected_updates_file' => '/hps/nobackup2/production/ensembl/' . $ENV{'USER'} . '/prep_' . $self->o('division') . '_master_for_rel_' . $self->o('rel_with_suffix') .  '/annotation_updates.list',
+        'expected_updates_file' => $self->o('shared_hps_dir') . '/ensembl-metadata/annotation_updates.' . $self->o('division') . '.' . $self->o('ensembl_release') . '.list',
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
@@ -111,7 +111,6 @@ sub default_options {
         # list of species that got an annotation update
         # ... assuming the same person has run both pipelines
         'expected_updates_file' => '/hps/nobackup2/production/ensembl/' . $ENV{'USER'} . '/prep_' . $self->o('division') . '_master_for_rel_' . $self->o('rel_with_suffix') .  '/annotation_updates.list',
-
     };
 }
 
@@ -613,4 +612,3 @@ sub pipeline_analyses {
 }
 
 1;
-

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
@@ -107,6 +107,11 @@ sub default_options {
         # members
         'include_nonreference' => 0,
         'include_patches'      => 0,
+
+        # list of species that got an annotation update
+        # ... assuming the same person has run both pipelines
+        'expected_updates_file' => '/hps/nobackup2/production/ensembl/' . $ENV{'USER'} . '/prep_' . $self->o('division') . '_master_for_rel_' . $self->o('rel_with_suffix') .  '/annotation_updates.list',
+
     };
 }
 
@@ -263,7 +268,16 @@ sub pipeline_analyses {
         {   -logic_name => 'create_reuse_ss',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::CreateReuseSpeciesSets',
             -rc_name => '2Gb_job',
-            -flow_into => [ 'nonpolyploid_genome_reuse_factory' ],
+            -flow_into  => [ 'compare_non_reused_genome_list' ],
+        },
+
+        {   -logic_name => 'compare_non_reused_genome_list',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::LoadMembers::CompareNonReusedGenomeList',
+            -parameters => {
+                'expected_updates_file' => $self->o('expected_updates_file'),
+                'current_release'       => $self->o('ensembl_release'),
+            },
+            -flow_into  => [ 'nonpolyploid_genome_reuse_factory' ],
         },
 
         {   -logic_name => 'check_reuse_db_is_patched',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
@@ -122,6 +122,7 @@ sub pipeline_analyses_prep_master_db_for_release {
                 'report_genomes_script' => $self->o('report_genomes_script'),
                 'additional_species'    => $self->o('additional_species'),
                 'work_dir'              => $self->o('work_dir'),
+                'annotation_file'       => $self->o('annotation_file'),
             },
             -flow_into  => {
                 '2->A' => [ 'add_species_into_master' ],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
@@ -70,6 +70,7 @@ sub default_options {
         'create_all_mlss_exe' => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/create_all_mlss.pl'),
         'xml_file'            => $self->check_file_in_ensembl('ensembl-compara/conf/' . $self->o('division') . '/mlss_conf.xml'),
         'report_file'         => $self->o( 'work_dir' ) . '/mlss_ids_' . $self->o('division') . '.list',
+        'annotation_file'     => $self->o( 'work_dir' ) . '/annotation_updates.list',
         'master_backup_file'  => $self->o('backups_dir') . '/compara_master_' . $self->o('division') . '.post' . $self->o('ensembl_release') . '.sql',
 
         'patch_dir'   => $self->check_dir_in_ensembl('ensembl-compara/sql/'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
@@ -70,7 +70,7 @@ sub default_options {
         'create_all_mlss_exe' => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/create_all_mlss.pl'),
         'xml_file'            => $self->check_file_in_ensembl('ensembl-compara/conf/' . $self->o('division') . '/mlss_conf.xml'),
         'report_file'         => $self->o( 'work_dir' ) . '/mlss_ids_' . $self->o('division') . '.list',
-        'annotation_file'     => $self->o( 'work_dir' ) . '/annotation_updates.list',
+        'annotation_file'     => $self->o('shared_hps_dir') . '/ensembl-metadata/annotation_updates.' . $self->o('division') . '.' . $self->o('ensembl_release') . '.list',
         'master_backup_file'  => $self->o('backups_dir') . '/compara_master_' . $self->o('division') . '.post' . $self->o('ensembl_release') . '.sql',
 
         'patch_dir'   => $self->check_dir_in_ensembl('ensembl-compara/sql/'),

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/BaseRunnable.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/BaseRunnable.pm
@@ -457,4 +457,22 @@ sub complete_early_if_branch_connected {
 }
 
 
+=head2 die_no_retry
+
+  Example     : $self->die_no_retry("GenomeDB dbID=45 is missing");
+  Description : Make the job "die" with the given error, but also tell eHive
+                that it is not worth retrying the job (the error is not
+                "transient").
+  Returntype  : none
+  Exceptions  : die
+
+=cut
+
+sub die_no_retry {
+    my $self = shift;
+    $self->input_job->transient_error(0);
+    die @_;
+}
+
+
 1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers/CompareNonReusedGenomeList.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers/CompareNonReusedGenomeList.pm
@@ -32,7 +32,7 @@ This RunnableDB compares the list of genomes that are expected to have an
 annotation update (provided in a file) to the actual list of genomes that
 cannot be reused.
 
-Both lists must match, and the job will fail if there are any references.
+Both lists must match, and the job will fail if there are any differences.
 If a difference happens to be fine, the species can be manually okay-ed
 by adding a parameter named "ok_${species_name}".
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers/CompareNonReusedGenomeList.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers/CompareNonReusedGenomeList.pm
@@ -1,0 +1,120 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::LoadMembers::CompareNonReusedGenomeList
+
+=head1 SYNOPSIS
+
+    standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::LoadMembers::CompareNonReusedGenomeList \
+        -compara_db $(mysql-ens-compara-prod-8 details url jalvarez_vertebrates_load_members_99) \
+        -expected_updates_file <(echo "homo_sapiens"; echo "mus_musculus"; echo "equus_caballus") \
+        -current_release 99 -nonreuse_ss_id 10000002
+
+=head1 DESCRIPTION
+
+This RunnableDB compares the list of genomes that are expected to have an
+annotation update (provided in a file) to the actual list of genomes that
+cannot be reused.
+
+Both lists must match, and the job fill fail if there are any references.
+If a difference happens to be fine, the species can be manually okay-ed
+by adding a parameter named "ok_${species_name}".
+Note: the Runnable respects the "do_not_reuse_list" parameter and won't
+complain that those species are not listed in the file.
+
+Finally, if the file path is not given (undefined), the analysis is
+skipped. This is useful for groups who don't use the ensembl-metadata
+service / the PrepareMasterDatabaseForRelease pipeline.
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::LoadMembers::CompareNonReusedGenomeList;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Utils::IO qw/slurp_to_array/;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub param_defaults {
+    my $self = shift @_;
+    return {
+        %{ $self->SUPER::param_defaults },
+        'expected_updates_file' => undef,
+        'do_not_reuse_list'     => [],
+    };
+}
+
+
+sub fetch_input {
+    my $self = shift @_;
+
+    my $expected_updates_file = $self->param('expected_updates_file');
+    unless ($expected_updates_file) {
+        $self->complete_early('No annotation file provided. Skipping this step');
+    }
+    unless (-e $expected_updates_file) {
+        $self->die_no_retry("'$expected_updates_file' doesn't exist");
+    }
+    my %expected_updated_gdbs   = map {$_ => 1} @{ slurp_to_array($expected_updates_file, 'chomp') };
+
+    my $current_release = $self->param_required('current_release');
+    my $nonreuse_ss_id  = $self->param_required('nonreuse_ss_id');
+    my $nonreuse_ss     = $self->compara_dba->get_SpeciesSetAdaptor->fetch_by_dbID($nonreuse_ss_id);
+    my %nonreuse_gdbs   = map {$_->name => 1} grep {$_->first_release < $current_release} @{$nonreuse_ss->genome_dbs};
+
+    my $do_not_reuse_list   = $self->param('do_not_reuse_list');
+    my %do_not_reuse_hash   = map {$_ => 1} @$do_not_reuse_list;
+
+    $self->param('nonreuse_gdbs', \%nonreuse_gdbs);
+    $self->param('expected_updated_gdbs', \%expected_updated_gdbs);
+    $self->param('do_not_reuse_hash', \%do_not_reuse_hash)
+}
+
+
+sub run {
+    my $self = shift @_;
+
+    my $nonreuse_gdbs           = $self->param('nonreuse_gdbs');
+    my $expected_updated_gdbs   = $self->param('expected_updated_gdbs');
+    my $do_not_reuse_hash       = $self->param('do_not_reuse_hash');
+
+    my $error_msg = '';
+
+    # In nonreuse_gdbs, but not in expected_updated_gdbs / do_not_reuse_hash
+    foreach my $name (keys %$nonreuse_gdbs) {
+        next if exists $do_not_reuse_hash->{$name};
+        next if exists $expected_updated_gdbs->{$name};
+        next if $self->param_exists("ok_$name") && $self->param("ok_$name");
+        $error_msg .= "$name can't be reused but is not listed as having an updated annotation.\n";
+    }
+
+    # In expected_updated_gdbs, but not in nonreuse_gdbs
+    foreach my $name (keys %$expected_updated_gdbs) {
+        next if exists $nonreuse_gdbs->{$name};
+        next if $self->param_exists("ok_$name") && $self->param("ok_$name");
+        $error_msg .= "$name is listed as having an updated annotation but we detected it can be reused.\n";
+    }
+
+    $self->die_no_retry($error_msg) if $error_msg;
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers/CompareNonReusedGenomeList.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers/CompareNonReusedGenomeList.pm
@@ -32,7 +32,7 @@ This RunnableDB compares the list of genomes that are expected to have an
 annotation update (provided in a file) to the actual list of genomes that
 cannot be reused.
 
-Both lists must match, and the job fill fail if there are any references.
+Both lists must match, and the job will fail if there are any references.
 If a difference happens to be fine, the species can be manually okay-ed
 by adding a parameter named "ok_${species_name}".
 Note: the Runnable respects the "do_not_reuse_list" parameter and won't

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers/CompareNonReusedGenomeList.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers/CompareNonReusedGenomeList.pm
@@ -58,6 +58,7 @@ sub param_defaults {
     my $self = shift @_;
     return {
         %{ $self->SUPER::param_defaults },
+
         'expected_updates_file' => undef,
         'do_not_reuse_list'     => [],
     };

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers/CompareNonReusedGenomeList.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers/CompareNonReusedGenomeList.pm
@@ -19,7 +19,7 @@ limitations under the License.
 
 Bio::EnsEMBL::Compara::RunnableDB::LoadMembers::CompareNonReusedGenomeList
 
-=head1 SYNOPSIS
+=head1 EXAMPLE
 
     standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::LoadMembers::CompareNonReusedGenomeList \
         -compara_db $(mysql-ens-compara-prod-8 details url jalvarez_vertebrates_load_members_99) \
@@ -35,12 +35,38 @@ cannot be reused.
 Both lists must match, and the job will fail if there are any references.
 If a difference happens to be fine, the species can be manually okay-ed
 by adding a parameter named "ok_${species_name}".
-Note: the Runnable respects the "do_not_reuse_list" parameter and won't
-complain that those species are not listed in the file.
 
-Finally, if the file path is not given (undefined), the analysis is
-skipped. This is useful for groups who don't use the ensembl-metadata
-service / the PrepareMasterDatabaseForRelease pipeline.
+The parameters are:
+
+=over
+
+=item expected_updates_file
+
+Optional. The path to the file that contains the names of all genome_dbs
+we expect an update for. If missing, the Runnable will immediately end
+(with a success status). This is useful for groups who don't use the
+ensembl-metadata service / the PrepareMasterDatabaseForRelease pipeline.
+If the parameter is set but the file doesn't exist, the Runnable will fail.
+
+=item current_release
+
+Mandatory. The current release number. Used to filter out the new genomes,
+since they are detected as non-reusable by the LoadMembers but are not
+listed under "updated_annotations" in the metadata report ("new_genomes"
+instead).
+
+=item nonreuse_ss_id
+
+Mandatory. The dbID if the species-set that holds the list of non-reusable
+species.
+
+=item do_not_reuse_list
+
+Optional. The list of species that we didn't want to reuse, regardless
+of their true reusability status. The RunnableDB will not complain about
+those.
+
+=back
 
 =cut
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromMetadataFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromMetadataFactory.pm
@@ -53,7 +53,7 @@ sub fetch_input {
 	my $genome_db_adaptor = $self->get_cached_compara_dba('master_db')->get_GenomeDBAdaptor;
 
 	# use metadata script to report genomes that need to be updated
-	my ($genomes_to_update, $renamed_genomes, $genomes_with_assembly_patches, $updated_annotations) = $self->fetch_genome_report($release, $division);
+    my ($genomes_to_update, $renamed_genomes, $genomes_with_assembly_patches, $updated_annotations) = $self->fetch_genome_report($release, $division);
 
     # prepare renaming SQL cmds
     my @rename_cmds;


### PR DESCRIPTION
With this change _PrepareMasterForRelease_ will write to a file the list of genomes that are reported to have a new annotation set. Then _LoadMembers_ will compare this list against the set of genomes that are not reused and complains about the differences.

I have introduced a mechanism to manually OK a difference as things like gene name / description updates are probably listed as "new annotation" but it's not something we care about in our reuse detection.
@JAlvarezJarreta made the comment this morning that _LoadMembers_ could read from the JSON reports directly. I decided to have a separate file because for Plants we need only certain species from the Vertebrates report, and I didn't want to list these species again in _LoadMembers_.

What I don't like in this implementation is that the file is created in the pipeline directory, so _LoadMembers_ is configured with a path that we hope is the path of the other pipeline, but if someone else is running it, or if the version suffix differs, this will break.

PS: I have also introduced a new method in _BaseRunnable_: `die_no_retry`, which sets "transient_error" to 0 since there is no point recomparing the lists.