### PR TITLE
Populate the Category field of the Jira tickets

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
@@ -32,6 +32,10 @@ use Bio::EnsEMBL::Utils::Argument qw(rearrange);
 use Bio::EnsEMBL::Utils::IO qw (slurp);
 use Bio::EnsEMBL::Utils::Logger;
 
+# JIRA identifiers of the custom field used in Compara (ENSCOMPARASW)
+use constant DIVISION_CUSTOM_FIELD_ID => 'customfield_11130';
+use constant CATEGORY_CUSTOM_FIELD_ID => 'customfield_11333';
+
 # Used to automatically populate the category when none is given
 my %component_to_category = (
     'Relco tasks'       => 'Production::Relco',
@@ -374,20 +378,20 @@ sub _json_to_jira {
         push @{$jira_hash{'components'}}, { 'name' => $_ } for @{$extra_components};
     }
     # $jira_hash{'categories'}
-    $jira_hash{'customfield_11333'} = [];
+    $jira_hash{CATEGORY_CUSTOM_FIELD_ID} = [];
     if ($json_hash->{'category'}) {
-        push @{$jira_hash{'customfield_11333'}}, { 'value' => $json_hash->{'category'} };
+        push @{$jira_hash{CATEGORY_CUSTOM_FIELD_ID}}, { 'value' => $json_hash->{'category'} };
     } elsif ($json_hash->{'categories'}) {
-        push @{$jira_hash{'customfield_11333'}}, { 'value' => $_ } for @{$json_hash->{'categories'}};
+        push @{$jira_hash{CATEGORY_CUSTOM_FIELD_ID}}, { 'value' => $_ } for @{$json_hash->{'categories'}};
     }
     if ($extra_categories) {
-        push @{$jira_hash{'customfield_11333'}}, { 'value' => $_ } for @{$extra_categories};
+        push @{$jira_hash{CATEGORY_CUSTOM_FIELD_ID}}, { 'value' => $_ } for @{$extra_categories};
     }
-    unless (scalar(@{$jira_hash{'customfield_11333'}})) {
+    unless (scalar(@{$jira_hash{CATEGORY_CUSTOM_FIELD_ID}})) {
         # Fallback to automatically setting the categories from the component names
         foreach my $component (map {$_->{'name'}} @{$jira_hash{'components'}}) {
             if (exists $component_to_category{$component}) {
-                push @{$jira_hash{'customfield_11333'}}, { 'value' => $component_to_category{$component} };
+                push @{$jira_hash{CATEGORY_CUSTOM_FIELD_ID}}, { 'value' => $component_to_category{$component} };
             }
         }
     }
@@ -410,7 +414,7 @@ sub _json_to_jira {
     }
     # $jira_hash{'division'}
     if ($self->{_division} ne '') {
-        $jira_hash{'customfield_11130'} = { 'value' => $self->{_division} };
+        $jira_hash{DIVISION_CUSTOM_FIELD_ID} = { 'value' => $self->{_division} };
     }
     # $jira_hash{'assignee'}
     if ($json_hash->{'assignee'}) {

--- a/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
@@ -388,7 +388,7 @@ sub _json_to_jira {
         push @{$jira_hash{CATEGORY_CUSTOM_FIELD_ID}}, { 'value' => $_ } for @{$extra_categories};
     }
     unless (scalar(@{$jira_hash{CATEGORY_CUSTOM_FIELD_ID}})) {
-        # Fallback to automatically setting the categories from the component names
+        # Fallback to automatically set the categories from the component names
         foreach my $component (map {$_->{'name'}} @{$jira_hash{'components'}}) {
             if (exists $component_to_category{$component}) {
                 push @{$jira_hash{CATEGORY_CUSTOM_FIELD_ID}}, { 'value' => $component_to_category{$component} };

--- a/scripts/jira_tickets/create_datacheck_tickets.pl
+++ b/scripts/jira_tickets/create_datacheck_tickets.pl
@@ -107,11 +107,13 @@ foreach my $testcase ( keys %$testcase_failures ) {
 # Add subtasks to the initial ticket
 $dc_task_json_ticket->[0]->{subtasks} = \@json_subtasks;
 my $components = ['Java Healthchecks', 'Production tasks'];
+my $categories = ['Bug::Internal', 'Production::Tasks'];
 # Create all JIRA tickets
 my $dc_task_keys = $jira_adaptor->create_tickets(
     -JSON_OBJ         => $dc_task_json_ticket,
     -DEFAULT_PRIORITY => 'Blocker',
     -EXTRA_COMPONENTS => $components,
+    -EXTRA_CATEGORIES => $categories,
     -DRY_RUN          => $dry_run
 );
 # Create a blocker issue link between the newly created datacheck ticket and the

--- a/scripts/jira_tickets/create_datacheck_tickets.pl
+++ b/scripts/jira_tickets/create_datacheck_tickets.pl
@@ -15,6 +15,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 =cut
 
 =head2 DESCRIPTION

--- a/scripts/jira_tickets/create_healthcheck_tickets.pl
+++ b/scripts/jira_tickets/create_healthcheck_tickets.pl
@@ -86,11 +86,13 @@ foreach my $testcase ( keys %$testcase_failures ) {
 # Add subtasks to the initial ticket
 $hc_task_json_ticket->[0]->{subtasks} = \@json_subtasks;
 my $components = ['Java Healthchecks', 'Production tasks'];
+my $categories = ['Bug::Internal', 'Production::Tasks'];
 # Create all JIRA tickets
 my $hc_task_keys = $jira_adaptor->create_tickets(
     -JSON_OBJ         => $hc_task_json_ticket,
     -DEFAULT_PRIORITY => 'Blocker',
     -EXTRA_COMPONENTS => $components,
+    -EXTRA_CATEGORIES => $categories,
     -DRY_RUN          => $dry_run
 );
 # Create a blocker issue link between the newly created HC ticket and the

--- a/scripts/jira_tickets/create_healthcheck_tickets.pl
+++ b/scripts/jira_tickets/create_healthcheck_tickets.pl
@@ -15,6 +15,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 =cut
 
 =head2 SUMMARY


### PR DESCRIPTION
Categories are mostly handled the same way as Components (multi-value fields, but using the `value` key in JSON rather than `name`).

HC and DC tickets are under _Bug::Internal_ and _Production::Tasks_.

Instead of defining the Category in every entry of our JSON config files (for the relco / production tickets), I've made `Utils::JIRA` automatically populate it from the Component, since in this case there is a a 1-to-1 mapping. Categories are automatically set _only_ if none is given, and it will only work for the components that can be mapped (relco and production).