### PR TITLE
Run podchecker on Travis

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/AlignSlice.pm
+++ b/modules/Bio/EnsEMBL/Compara/AlignSlice.pm
@@ -48,13 +48,13 @@ whilst the other Bio::EnsEMBL::Compara::AlignSlice::Slice objects might be made 
 genomic sequences, depending on the set of alignments. Here is a graphical representation:
 
   ref.Slice    **************************************************************
-  
+
   alignments    11111111111
                                2222222222222222
                                                      33333333333333333
 
   resulting Bio::EnsEMBL::Compara::AlignSlice:
-  
+
   AS::Slice 1  **************************************************************
   AS::Slice 2  .11111111111....2222222222222222......33333333333333333.......
 
@@ -79,7 +79,7 @@ Here is a graphical example showing this problem:
 
   ALN 1:   Human (ref) CTGTGAAAA----CCCCATTAGG
            Mouse (1)     CTGAAAATTTTCCCC
-  
+
   ALN 2:   Human (ref) CTGTGAAAA---CCCCATTAGG
            Mouse (1)         AAAGGGCCCCATTA
 
@@ -127,7 +127,7 @@ map features from one species onto the others.
 =head1 SYNOPSIS
 
   use Bio::EnsEMBL::Compara::AlignSlice;
-  
+
   ## You may create your own AlignSlice objects but if you are interested in
   ## getting AlignSlice built with data from an EnsEMBL Compara database you
   ## should consider using the Bio::EnsEMBL::Compara::DBSQL::AlignSliceAdaptor

--- a/modules/Bio/EnsEMBL/Compara/AlignSlice/Exon.pm
+++ b/modules/Bio/EnsEMBL/Compara/AlignSlice/Exon.pm
@@ -28,7 +28,7 @@ This module inherits attributes and methods from Bio::EnsEMBL::Exon module
 =head1 SYNOPSIS
 
   use Bio::EnsEMBL::Compara::AlignSlice::Exon;
-  
+
   my $exon = new Bio::EnsEMBL::Compara::AlignSlice::Exon(
       );
 

--- a/modules/Bio/EnsEMBL/Compara/AlignSlice/Slice.pm
+++ b/modules/Bio/EnsEMBL/Compara/AlignSlice/Slice.pm
@@ -1235,6 +1235,7 @@ sub _sort_Exons {
 #
 # WARNING - WARNING - WARNING - WARNING - WARNING - WARNING - WARNING
 #
+
 =head2 invert (not supported)
 
 Maybe at some point...

--- a/modules/Bio/EnsEMBL/Compara/ConservationScore.pm
+++ b/modules/Bio/EnsEMBL/Compara/ConservationScore.pm
@@ -369,6 +369,7 @@ sub end {
     my $self = shift;
    return $self->position; 
 }
+
 =head2 seq_region_pos
 
   Arg [1]    : (opt) integer

--- a/modules/Bio/EnsEMBL/Compara/ConstrainedElement.pm
+++ b/modules/Bio/EnsEMBL/Compara/ConstrainedElement.pm
@@ -33,7 +33,7 @@ Bio::EnsEMBL::Compara::ConstrainedElement - constrained element data produced by
 =head1 SYNOPSIS
 
   use Bio::EnsEMBL::Compara::ConstrainedElement;
-  
+
   my $constrained_element = new Bio::EnsEMBL::Compara::ConstrainedElement(
           -adaptor => $constrained_element_adaptor,
           -method_link_species_set_id => $method_link_species_set_id,

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/ConservationScoreAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/ConservationScoreAdaptor.pm
@@ -35,7 +35,7 @@ Bio::EnsEMBL::Compara::DBSQL::ConservationScoreAdaptor - Object adaptor to acces
   Connecting to the database using the Registry
 
      use Bio::EnsEMBL::Registry;
- 
+
      my $reg = "Bio::EnsEMBL::Registry";
 
       $reg->load_registry_from_db(-host=>"ensembldb.ensembl.org", -user=>"anonymous");

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/ConservationScoreArrayAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/ConservationScoreArrayAdaptor.pm
@@ -32,7 +32,7 @@ Bio::EnsEMBL::Compara::DBSQL::ConservationScoreArrayAdaptor
   Connecting to the database using the Registry
 
      use Bio::EnsEMBL::Registry;
- 
+
      my $reg = "Bio::EnsEMBL::Registry";
 
       $reg->load_registry_from_db(-host=>"ensembldb.ensembl.org", -user=>"anonymous");

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/DnaFragAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/DnaFragAdaptor.pm
@@ -41,7 +41,7 @@ Bio::EnsEMBL::Compara::DBSQL::DnaFragAdaptor
   my $dnafrag_adaptor = $reg->get_adaptor("Multi", "compara", "DnaFrag");
 
   $dnafrag_adaptor->store($dnafrag);
-  
+
   $dnafrag = $dnafrag_adaptor->fetch_by_dbID(905406);
   $dnafrag = $dnafrag_adaptor->fetch_by_GenomeDB_and_name($human_genome_db, 'X');
   $dnafrags = $dnafrag_adaptor->fetch_all_by_GenomeDB(

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/MethodLinkSpeciesSetAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/MethodLinkSpeciesSetAdaptor.pm
@@ -46,14 +46,14 @@ and method_link tables
 
   my $method_link_species_set = $mlssa->fetch_by_method_link_type_species_set_name(
         "EPO", "mammals")
-  
+
   my $method_link_species_sets = $mlssa->fetch_all_by_method_link_type("LASTZ_NET");
 
   my $method_link_species_sets = $mlssa->fetch_all_by_GenomeDB($genome_db);
 
   my $method_link_species_sets = $mlssa->fetch_all_by_method_link_type_GenomeDB(
         "PECAN", $gdb1);
-  
+
   my $method_link_species_set = $mlssa->fetch_by_method_link_type_GenomeDBs(
         "TRANSLATED_BLAT", [$gdb1, $gdb2]);
 

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/NCBITaxonAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/NCBITaxonAdaptor.pm
@@ -280,7 +280,9 @@ sub fetch_all {
 
 
 =head2 fetch_node_by_node_id
+
   Description: Alias for fetch_node_by_taxon_id. Please use the later instead
+
 =cut
 
 sub fetch_node_by_node_id {

--- a/modules/Bio/EnsEMBL/Compara/GenomicAlignBlock.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomicAlignBlock.pm
@@ -33,7 +33,7 @@ Bio::EnsEMBL::Compara::GenomicAlignBlock - Alignment of two or more pieces of ge
 =head1 SYNOPSIS
 
   use Bio::EnsEMBL::Compara::GenomicAlignBlock;
-  
+
   my $genomic_align_block = new Bio::EnsEMBL::Compara::GenomicAlignBlock(
           -adaptor => $genomic_align_block_adaptor,
           -method_link_species_set => $method_link_species_set,

--- a/modules/Bio/EnsEMBL/Compara/GenomicAlignGroup.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomicAlignGroup.pm
@@ -33,7 +33,7 @@ Bio::EnsEMBL::Compara::GenomicAlignGroup - Defines groups of genomic aligned seq
 =head1 SYNOPSIS
 
   use Bio::EnsEMBL::Compara::GenomicAlignGroup;
-  
+
   my $genomic_align_group = new Bio::EnsEMBL::Compara::GenomicAlignGroup (
           -adaptor => $genomic_align_group_adaptor,
           -genomic_align_array => [$genomic_align1, $genomic_align2...]

--- a/modules/Bio/EnsEMBL/Compara/Graph/GenomicAlignTreePhyloXMLWriter.pm
+++ b/modules/Bio/EnsEMBL/Compara/Graph/GenomicAlignTreePhyloXMLWriter.pm
@@ -19,12 +19,9 @@ limitations under the License.
 
 package Bio::EnsEMBL::Compara::Graph::GenomicAlignTreePhyloXMLWriter;
 
-=pod
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::Graph::GenomicAlignTreePhyloXMLWriter
-
 
 =head1 CONTACT
 
@@ -45,7 +42,6 @@ use Bio::EnsEMBL::Utils::Argument qw(rearrange);
 use Bio::EnsEMBL::Utils::Exception qw(throw warning);
 use Bio::EnsEMBL::Utils::Scalar qw(check_ref wrap_array);
 
-=pod
 
 =head2 new()
 
@@ -86,7 +82,6 @@ sub new {
   return $self;
 }
 
-=pod
 
 =head2 compact_alignments()
 
@@ -102,10 +97,6 @@ sub compact_alignments {
   return $self->{compact_alignments};
 }
 
-=pod
-
-
-=pod
 
 =head2 no_sequences()
 

--- a/modules/Bio/EnsEMBL/Compara/Graph/OrthoXMLWriter.pm
+++ b/modules/Bio/EnsEMBL/Compara/Graph/OrthoXMLWriter.pm
@@ -28,19 +28,19 @@ Bio::EnsEMBL::Compara::Graph::OrthoXMLWriter
 =head1 SYNOPSIS
 
   use Bio::EnsEMBL::Compara::Graph::OrthoXMLWriter;
-  
+
   my $string_handle = IO::String->new();
   my $w = Bio::EnsEMBL::Compara::Graph::OrthoXMLWriter->new(
     -SOURCE => 'Ensembl', -SOURCE_VERSION => 63, -HANDLE => $string_handle
   );
-  
+
   my $pt = $dba->get_GeneTreeAdaptor()->fetch_by_dbID(3);
-  
+
   $w->write_trees($pt);
   $w->finish(); #YOU MUST CALL THIS TO WRITE THE FINAL TAG
-  
+
   my $xml_scalar_ref = $string_handle->string_ref();
-  
+
   #Or to write to a file via IO::File
   my $file_handle = IO::File->new('output.xml', 'w');
   $w = Bio::EnsEMBL::Compara::Graph::OrthoXMLWriter->new(
@@ -49,7 +49,7 @@ Bio::EnsEMBL::Compara::Graph::OrthoXMLWriter
   $w->write_trees($pt);
   $w->finish(); #YOU MUST CALL THIS TO WRITE THE FINAL TAG
   $file_handle->close();
-  
+
   #Or letting this deal with it
   $w = Bio::EnsEMBL::Compara::Graph::OrthoXMLWriter->new(
     -SOURCE => 'Ensembl', -SOURCE_VERSION => 63, -FILE => 'loc.xml'

--- a/modules/Bio/EnsEMBL/Compara/HAL/HALXS/HALAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/HAL/HALXS/HALAdaptor.pm
@@ -25,7 +25,7 @@ limitations under the License.
 
 =head1 NAME
 
-    Bio::EnsEMBL::Compara::HAL::HALXS::HALAdaptor
+Bio::EnsEMBL::Compara::HAL::HALXS::HALAdaptor
 
 =cut
 

--- a/modules/Bio/EnsEMBL/Compara/NCBITaxon.pm
+++ b/modules/Bio/EnsEMBL/Compara/NCBITaxon.pm
@@ -131,23 +131,23 @@ sub genbank_hidden_flag {
                     split is compatible with BioPerl's Species classification
                     code and will return a data structure compatible with
                     that found in core species MetaContainers.
-                    
+
                     This code is a redevelopment of existing code which
                     descended down the taxonomy which had disadvanatages 
                     when a classification was requested on nodes causing
                     the taxonomy to bi/multi-furcate.
-                    
+
                     Note the String representation does have some disadvantages
                     when working with the poorer end of the taxonomy where
                     species nodes are not well defined. For these situations
                     you are better using the array representation and 
                     capturing the required information from the nodes.
-                    
+
                     Also to maintain the original functionality of the method
                     we filter any species, subspecies or subgenus nodes above
                     the current node. For the true classification always
                     call using the array structure.
-                    
+
                     Recalling this subroutine with the same parameters for
                     separators will return a cached representation. Calling
                     for AS_ARRAY will cause the classificaiton to be 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/WormProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/WormProteinTrees_conf.pm
@@ -28,7 +28,7 @@ limitations under the License.
 
 =head1 NAME
 
-  Bio::EnsEMBL::Compara::PipeConfig::EG::WormProteinTrees_conf
+Bio::EnsEMBL::Compara::PipeConfig::EG::WormProteinTrees_conf
 
 =head1 SYNOPSIS
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EpoLowCoverage_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EpoLowCoverage_conf.pm
@@ -46,7 +46,7 @@ developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
 
 Questions may also be sent to the Ensembl help desk at
 <http://www.ensembl.org/Help/Contact>.
-  
+
 =head1 AUTHORSHIP
 
 Ensembl Team. Individual contributions can be found in the GIT log.

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/GeneSetQC_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/GeneSetQC_conf.pm
@@ -1,4 +1,3 @@
-=pod
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Legacy/ImportUcscChainNet_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Legacy/ImportUcscChainNet_conf.pm
@@ -44,7 +44,7 @@ Bio::EnsEMBL::Compara::PipeConfig::Legacy::ImportUcscChainNet_conf
         pipeline_db (-host)
         resource_classes 
         ref_species (if not homo_sapiens)
-        
+
     #5. Run init_pipeline.pl script: eg for human self alignments
         init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Legacy::ImportUcscChainNet_conf --dbname hsap_hsap_ucsc_test --password <your_password) -mlss_id 1 --ref_species homo_sapiens --non_ref_species homo_sapiens --chain_file hg19.hg19.all.chain --net_file hg19.hg19.net --ref_chromInfo_file hsap/chromInfo.txt --ref_ucsc_map ctgPos.txt --ucsc_url http://hgdownload.cse.ucsc.edu/goldenPath/hg19/vsSelf/
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeHomologyIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeHomologyIntoRelease_conf.pm
@@ -55,7 +55,7 @@ use base ('Bio::EnsEMBL::Hive::PipeConfig::EnsemblGeneric_conf');
     Description : Implements default_options() interface method of Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf that is used to initialize default options.
                   In addition to the standard things it defines four options:
                     o('copying_capacity')   defines how many tables can be dumped and zipped in parallel
-                
+
                   There are rules dependent on two options that do not have defaults (this makes them mandatory):
                     o('password')       your read-write password for creation and maintenance of the hive database
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAlignerStats_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAlignerStats_conf.pm
@@ -56,6 +56,7 @@ The rest of the documentation details each of the object methods.
 Internal methods are usually preceded with an underscore (_)
 
 example : init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::PairAlignerStats_conf -compara_db <> -mlss_id <> -host <> -port <> --reg_conf
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::PairAlignerStats_conf;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/OrthologQM_Alignment_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/OrthologQM_Alignment_conf.pm
@@ -21,7 +21,7 @@ limitations under the License.
 
 
 =head1 NAME
-	
+
 Bio::EnsEMBL::Compara::PipeConfig::Plants::OrthologQM_Alignment_conf
 
 =head1 SYNOPSIS

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -25,7 +25,7 @@ Bio::EnsEMBL::Compara::PipeConfig::ProteinTrees_conf
 
     init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::ProteinTrees_conf -host mysql-ens-compara-prod-X -port XXXX \
         -division $COMPARA_DIV -mlss_id <curr_ptree_mlss_id>
-        
+
 =head1 DESCRIPTION
 
 The PipeConfig file for ProteinTrees pipeline that should automate most of the pre-execution tasks.

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MurinaeProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MurinaeProteinTrees_conf.pm
@@ -28,7 +28,7 @@ limitations under the License.
 
 =head1 NAME
 
-  Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::MurinaeProteinTrees_conf
+Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::MurinaeProteinTrees_conf
 
 =head1 SYNOPSIS
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/SusProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/SusProteinTrees_conf.pm
@@ -28,7 +28,7 @@ limitations under the License.
 
 =head1 NAME
 
-  Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::SusProteinTrees_conf
+Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::SusProteinTrees_conf
 
 =head1 SYNOPSIS
 

--- a/modules/Bio/EnsEMBL/Compara/Production/AlgorithmDiff.pm
+++ b/modules/Bio/EnsEMBL/Compara/Production/AlgorithmDiff.pm
@@ -39,7 +39,7 @@ Algorithm::Diff - Compute `intelligent' differences between two files / lists
   @diffs = diff( \@seq1, \@seq2 );
 
   @diffs = diff( \@seq1, \@seq2, $key_generation_function );
-  
+
   traverse_sequences( \@seq1, \@seq2,
                      { MATCH => $callback,
                        DISCARD_A => $callback,

--- a/modules/Bio/EnsEMBL/Compara/Production/Analysis/AlignmentNets.pm
+++ b/modules/Bio/EnsEMBL/Compara/Production/Analysis/AlignmentNets.pm
@@ -30,16 +30,6 @@
 
 Bio::EnsEMBL::Compara::Production::Analysis::AlignmentNets;
 
-=head1 SYNOPSIS
-
-
-=head1 DESCRIPTION
-
-
-=head1 METHODS
-
-=cut
-
 =head1 APPENDIX
 
 The rest of the documentation details each of the object methods. 

--- a/modules/Bio/EnsEMBL/Compara/Production/Analysis/Blastz.pm
+++ b/modules/Bio/EnsEMBL/Compara/Production/Analysis/Blastz.pm
@@ -377,7 +377,7 @@ sub eof {
 
  Arg [1]     : string $commandline (optional)
                command line used to obtain the blastz output which is parsed
-  
+
  Example     : $Blastz->commandline($commandline)
 
  Descritpion : get/set the commandline value and return it
@@ -402,7 +402,7 @@ sub command_line {
 
  Arg [1]     : string $matrix (optional)
                matrix used to obtain the blastz output which is parsed
-  
+
  Example     : $Blastz->matrix($matrix)
 
  Descritpion : get/set the matrix value and return it
@@ -427,7 +427,7 @@ sub matrix {
 
  Arg [1]     : string $options (optional)
                options used to obtain the blastz output which is parsed
-  
+
  Example     : $Blastz->options($options)
 
  Descritpion : get/set the options value and return it
@@ -461,7 +461,7 @@ sub _parsing_initialized {
 
  Arg [1]     : string $seqname (optional)
                name of the query sequence
-  
+
  Example     : $Blastz->seqname($seqname)
 
  Descritpion : get/set the seqname value and return it
@@ -486,7 +486,7 @@ sub seqname {
 
  Arg [1]     : string $hseqname (optional)
                name of the database sequence
-  
+
  Example     : $Blastz->hseqname($hseqname)
 
  Descritpion : get/set the hseqname value and return it
@@ -511,7 +511,7 @@ sub hseqname {
 
  Arg [1]     : int $length (optional)
                sequence length of the query sequence
-  
+
  Example     : $Blastz->length($length)
 
  Descritpion : get/set the length value and return it
@@ -536,7 +536,7 @@ sub length {
 
  Arg [1]     : int $length (optional)
                sequence length of the database sequence
-  
+
  Example     : $Blastz->hlength($length)
 
  Descritpion : get/set the hlength value and return it
@@ -561,7 +561,7 @@ sub hlength {
 
  Arg [1]     : int $strand (optional)
                strand of the query sequence
-  
+
  Example     : $Blastz->strand($strand)
 
  Descritpion : get/set the strand value and return it
@@ -586,7 +586,7 @@ sub strand {
 
  Arg [1]     : int $strand (optional)
                strand of the query sequence
-  
+
  Example     : $Blastz->hstrand($strand)
 
  Descritpion : get/set the hstrand value and return it

--- a/modules/Bio/EnsEMBL/Compara/Production/Projection/RunnableDB/ProjectOntologyXref.pm
+++ b/modules/Bio/EnsEMBL/Compara/Production/Projection/RunnableDB/ProjectOntologyXref.pm
@@ -77,6 +77,7 @@ use Bio::EnsEMBL::Compara::Production::Projection::Writer::MultipleWriter;
 
 
 #--- Non-hive methods
+
 =head2 new_without_hive()
 
   Arg [PROJECTION_ENGINE]       : (ProjectionEngine) The projection engine to use to transfer terms 

--- a/modules/Bio/EnsEMBL/Compara/Production/Projection/RunnableDB/ProjectOntologyXref.pm
+++ b/modules/Bio/EnsEMBL/Compara/Production/Projection/RunnableDB/ProjectOntologyXref.pm
@@ -84,7 +84,7 @@ use Bio::EnsEMBL::Compara::Production::Projection::Writer::MultipleWriter;
   Arg [TARGET_GENOME_DB]        : (GenomeDB)  GenomeDB to project terms to
   Arg [WRITE_DBA]               : (DBAdaptor) Required if not given -FILE; used to 
   Arg [FILE]                    : (String) Location of pipeline output; if given a directory it will generate a file name
-  
+
   Example    : See synopsis
   Description: Non-hive version of the object construction to be used with scripts
   Returntype : Bio::EnsEMBL::Compara::Production::Projection::RunnableDB::ProjectOntologyXref

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ComparaHMM/FactoryUnannotatedMembers.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ComparaHMM/FactoryUnannotatedMembers.pm
@@ -30,9 +30,6 @@ limitations under the License.
 
 Bio::EnsEMBL::Compara::RunnableDB::ComparaHMM::FactoryUnannotatedMembers
 
-=head1 SYNOPSIS
-
-
 =head1 DESCRIPTION
 
 Fetch sorted list of member_ids and create jobs for the next analysis

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ComparaHMM/HmmThresholdFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ComparaHMM/HmmThresholdFactory.pm
@@ -30,9 +30,6 @@ limitations under the License.
 
 Bio::EnsEMBL::Compara::RunnableDB::ComparaHMM::HmmThresholdFactory
 
-=head1 SYNOPSIS
-
-
 =head1 DESCRIPTION
 
 Fetch sorted list of member_ids and create jobs for the next analysis

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ComparaHMM/MultiHMMLoadModels.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ComparaHMM/MultiHMMLoadModels.pm
@@ -25,7 +25,6 @@ limitations under the License.
 
 Bio::EnsEMBL::Compara::RunnableDB::ComparaHMM::MultiHMMLoadModels
 
-
 =head1 SYNOPSIS
 
 To load RFAM models from the FTP, use these parameters:

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ComparaHMM/PantherLoadModels.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ComparaHMM/PantherLoadModels.pm
@@ -25,7 +25,6 @@ limitations under the License.
 
 Bio::EnsEMBL::Compara::RunnableDB::ComparaHMM::PantherLoadModels
 
-
 =head1 SYNOPSIS
 
 To load RFAM models from the FTP, use these parameters:

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/CopyTable.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/CopyTable.pm
@@ -23,10 +23,6 @@ limitations under the License.
 
 Bio::EnsEMBL::Compara::RunnableDB::CopyTable
 
-=head1 SYNOPSIS
-
-	
-
 =cut
 
 package Bio::EnsEMBL::Compara::RunnableDB::CopyTable;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/SymlinkPreviousDumps.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/SymlinkPreviousDumps.pm
@@ -23,10 +23,6 @@ limitations under the License.
 
 Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::SymlinkPreviousDumps
 
-=head1 SYNOPSIS
-
-	
-
 =cut
 
 package Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::SymlinkPreviousDumps;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/LoadTags.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/LoadTags.pm
@@ -41,7 +41,7 @@ use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
     Description : This runnable is used to inject the tags into the job parameters stack.
                   e.g. It can be used to load the tag aln_num_of_patterns to be used by the raxml_decision analysis. 
                   This runnable must be used upstream the target analysis, loading the tags and data-flowing them to the target analysis.
-    
+
                   #e.g. Tags and default values must be declared in the pipeline confuration file:
                   #
                   -parameters =>    {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/PairCollection.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/PairCollection.pm
@@ -36,7 +36,7 @@ Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::PairCollection
 		species1 & species2 : names of species of interest
 		species_set_name    : name of species_set
 		species_set_id      : dbID of species set of interest (usually used where species_set_name is ambiguous)
-	
+
 	Output:
 		pairs of genome_db_ids e.g. {species1_id => 150, species2_id => 125} 
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/AdjustBranchLengths.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/AdjustBranchLengths.pm
@@ -35,10 +35,6 @@ Bio::EnsEMBL::Compara::RunnableDB::SpeciesTree::AdjustBranchLengths
 Given a topology tree and a mash distance matrix, recompute branch lengths 
 using erable (https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4705742/)
 
-=head1 DESCRIPTION
-
-	
-
 =cut
 
 package Bio::EnsEMBL::Compara::RunnableDB::SpeciesTree::AdjustBranchLengths;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/GraftSubtrees.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/GraftSubtrees.pm
@@ -34,10 +34,6 @@ Bio::EnsEMBL::Compara::RunnableDB::SpeciesTree::GraftSubtrees
 
 Given a set of trees, graft subtrees together
 
-=head1 DESCRIPTION
-
-	
-
 =cut
 
 package Bio::EnsEMBL::Compara::RunnableDB::SpeciesTree::GraftSubtrees;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/GroupSpecies.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/GroupSpecies.pm
@@ -34,9 +34,6 @@ Bio::EnsEMBL::Compara::RunnableDB::SpeciesTree::GroupSpecies
 
 Splits species into groups, depending on the NCBI taxonomy
 
-=head1 DESCRIPTION
- 
-
 =cut
 
 package Bio::EnsEMBL::Compara::RunnableDB::SpeciesTree::GroupSpecies;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/PermuteMatrix.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/PermuteMatrix.pm
@@ -37,9 +37,6 @@ These submatrices are composed of:
 - taxonomic groups (eg. primates, rodents)
 - stepping up the taxonomy, create groups with more diverse species, but collapsing subclades which already have a tree
 
-=head1 DESCRIPTION
- 
-
 =cut
 
 package Bio::EnsEMBL::Compara::RunnableDB::SpeciesTree::PermuteMatrix;

--- a/modules/Bio/EnsEMBL/Compara/Utils/FamilyHash.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/FamilyHash.pm
@@ -45,16 +45,6 @@ sub convert {
   $self->member_src($member_source);
 
   $self->{_cached_seq_aligns} = {};
-=head
-  if ($aligned) {
-      my $aln = $fam->get_SimpleAlign(-SEQ_TYPE => ($self->cdna ? 'cds' : undef), -REMOVE_GAPS => 1);
-      foreach my $seq ($aln->each_seq) {
-          $self->{_cached_seq_aligns}->{$seq->display_id} = $seq->seq;
-      }
-  } else {
-      delete $self->{_cached_seq_aligns};
-  }
-=cut
   return $self->_family_object_to_hash($fam);
 }
 

--- a/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
@@ -50,6 +50,7 @@ our @EXPORT_OK;
     file
 
 =cut
+
 sub map_row_to_header {
     my ($line, $header) = @_;
     

--- a/modules/Bio/EnsEMBL/Compara/Utils/Projection.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Projection.pm
@@ -103,6 +103,7 @@ sub project_Slice_to_reference_toplevel {
     Exceptions  : none
     Caller      : general
     Status      : Stable
+
 =cut
 
 sub project_Slice_to_target_genome {

--- a/modules/Bio/EnsEMBL/Compara/Utils/Scalar.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Scalar.pm
@@ -80,7 +80,7 @@ our @EXPORT_OK;
                 a boolean indicating the situation.
 
                 Undefs cause exception circumstances.
-                
+
                 You can turn assertions off by using the global variable
                 $Bio::EnsEMBL::Utils::Scalar::ASSERTIONS = 0
   Returntype  : Boolean; true if we managed to get to the return

--- a/modules/t/alignSliceAdaptor.t
+++ b/modules/t/alignSliceAdaptor.t
@@ -377,12 +377,12 @@ do {
         1
     );
   ok($slice);
-  
+
   $align_slice = $align_slice_adaptor->fetch_by_Slice_MethodLinkSpeciesSet(
       $slice, $mlss, "expanded");
 
   ok($align_slice);
-  
+
   ok($align_slice->get_all_Slices('Homo sapiens')->[0]);
   ok($align_slice->get_all_Slices($species_name)->[0]);
   ok(length($align_slice->get_all_Slices('Homo sapiens')->[0]->seq),
@@ -390,7 +390,7 @@ do {
   my $seq = $align_slice->get_all_Slices('Homo sapiens')->[0]->seq;
   $seq =~ s/\-//g;
   ok($seq, $slice->seq);
-  
+
   debug("DEBUG slice " . @{$align_slice->get_all_Slices($species_name)}. "  $excess_start  $excess_end");
 
   my $other_gene = $align_slice->get_all_Slices($species_name)->[0]->get_all_Genes->[0];
@@ -419,7 +419,7 @@ do {
   }
   my $c_seq2 = substr($condensed_align_slice->get_all_Slices($species_name)->[0]->seq, $excess_start, -$excess_end);
   ok($c_seq1, $c_seq2);
-  
+
   $seq = $align_slice->get_all_Slices('Homo sapiens')->[0]->subseq($other_exon->start, $other_exon->end);
   $seq2 = "";
   foreach my $subseq ($seq =~ /([ACTG]+|\-+)/g) {
@@ -450,12 +450,12 @@ do {
         1
     );
   ok($slice);
-  
+
   $align_slice = $align_slice_adaptor->fetch_by_Slice_MethodLinkSpeciesSet(
       $slice, $mlss, "expanded");
 
   ok($align_slice);
-  
+
   ok($align_slice->get_all_Slices('Homo sapiens')->[0]);
   ok($align_slice->get_all_Slices($species_name)->[0]);
   ok(length($align_slice->get_all_Slices('Homo sapiens')->[0]->seq),
@@ -491,7 +491,7 @@ do {
   }
   my $c_seq2 = $condensed_align_slice->get_all_Slices($species_name)->[0]->seq;
   ok($c_seq1, $c_seq2);
-  
+
   $seq = $align_slice->get_all_Slices('Homo sapiens')->[0]->subseq($other_exon->start, $other_exon->end);
   $seq2 = "";
   foreach my $subseq ($seq =~ /([ACTG]+|\-+)/g) {
@@ -565,12 +565,12 @@ do {
         1
     );
   ok($slice);
-  
+
   $align_slice = $align_slice_adaptor->fetch_by_Slice_MethodLinkSpeciesSet(
       $slice, $mlss, "expanded");
 
   ok($align_slice);
-  
+
   ok($align_slice->get_all_Slices('Homo sapiens')->[0]);
   ok($align_slice->get_all_Slices($species_name)->[0]);
   ok(length($align_slice->get_all_Slices('Homo sapiens')->[0]->seq),
@@ -590,12 +590,12 @@ do {
         1
     );
   ok($slice);
-  
+
   $align_slice = $align_slice_adaptor->fetch_by_Slice_MethodLinkSpeciesSet(
       $slice, $mlss, "expanded");
 
   ok($align_slice);
-  
+
   ok($align_slice->get_all_Slices('Homo sapiens')->[0]);
   ok($align_slice->get_all_Slices($species_name)->[0]);
   ok(length($align_slice->get_all_Slices('Homo sapiens')->[0]->seq),
@@ -622,12 +622,12 @@ do {
         1
     );
   ok($slice);
-  
+
   $align_slice = $align_slice_adaptor->fetch_by_Slice_MethodLinkSpeciesSet(
       $slice, $mlss, "expanded");
 
   ok($align_slice);
-  
+
   ok($align_slice->get_all_Slices('Homo sapiens')->[0]);
   ok($align_slice->get_all_Slices($species_name)->[0]);
   ok(length($align_slice->get_all_Slices('Homo sapiens')->[0]->seq),
@@ -647,12 +647,12 @@ do {
         1
     );
   ok($slice);
-  
+
   $align_slice = $align_slice_adaptor->fetch_by_Slice_MethodLinkSpeciesSet(
       $slice, $mlss, "expanded");
 
   ok($align_slice);
-  
+
   ok($align_slice->get_all_Slices('Homo sapiens')->[0]);
   ok($align_slice->get_all_Slices($species_name)->[0]);
   ok(length($align_slice->get_all_Slices('Homo sapiens')->[0]->seq),
@@ -687,12 +687,12 @@ do {
         1
     );
   ok($slice);
-  
+
   $align_slice = $align_slice_adaptor->fetch_by_Slice_MethodLinkSpeciesSet(
       $slice, $human_rat_blastznet_mlss, "expanded");
 
   ok($align_slice);
-  
+
   ok($align_slice->get_all_Slices('Homo sapiens')->[0]);
   ok($align_slice->get_all_Slices('Rattus norvegicus')->[0]);
   ok(length($align_slice->get_all_Slices('Homo sapiens')->[0]->seq),
@@ -705,7 +705,7 @@ do {
   my $condensed_align_slice = $align_slice_adaptor->fetch_by_Slice_MethodLinkSpeciesSet(
       $slice, $human_rat_blastznet_mlss);
   ok($condensed_align_slice);
-  
+
   ok($condensed_align_slice->get_all_Slices('Homo sapiens')->[0]);
   ok($condensed_align_slice->get_all_Slices('Rattus norvegicus')->[0]);
   ok(length($condensed_align_slice->get_all_Slices('Homo sapiens')->[0]->seq),
@@ -778,7 +778,7 @@ do {
     }
     $last_end = $this_row->[1];
   }
-  
+
   $slice = $slice_adaptor->fetch_by_region(
         $slice_coord_system_name,
         $slice_seq_region_name,
@@ -787,12 +787,12 @@ do {
         1
     );
   ok($slice);
-  
+
   $align_slice = $align_slice_adaptor->fetch_by_Slice_MethodLinkSpeciesSet(
       $slice, $human_rat_blastznet_mlss, "expanded");
 
   ok($align_slice);
-  
+
   ok($align_slice->get_all_Slices('Homo sapiens')->[0]);
   ok($align_slice->get_all_Slices('Rattus norvegicus')->[0]);
   ok(length($align_slice->get_all_Slices('Homo sapiens')->[0]->seq),

--- a/modules/t/homologyAdaptor.t
+++ b/modules/t/homologyAdaptor.t
@@ -62,15 +62,15 @@ subtest "Test fetch methods", sub {
     my $member = $ma->fetch_by_stable_id($member_stable_id);
 
     ok($member);
-    
+
     my $homologies = $ha->fetch_all_by_Member($member);
-    
+
     ok($homologies);
-    
+
     $homologies = $ha->fetch_all_by_Member_method_link_type($member,"$method_link_type");
 
     #print STDERR "nb of homology: ", scalar @{$homology},"\n";
-    
+
     my ($homology_id, $stable_id, $method_link_species_set_id, $description,
         $subtype, $dn, $ds, $n, $s, $lnl, $threshold_on_ds) =
           $compara_dba->dbc->db_handle->selectrow_array("SELECT homology.*
@@ -82,7 +82,7 @@ subtest "Test fetch methods", sub {
         WHERE hm1.member_id = ".$member->dbID." and gdb.name = 'Rattus norvegicus'");
 
     my $homology = $ha->fetch_all_by_Member($member, -TARGET_SPECIES=>"Rattus norvegicus")->[0];
-    
+
     ok( $homology );
     ok( $homology->dbID, $homology_id );
     ok( $homology->stable_id, $stable_id );
@@ -91,36 +91,36 @@ subtest "Test fetch methods", sub {
     ok( $homology->method_link_species_set_id, $method_link_species_set_id );
     ok( $homology->method_link_type, "$method_link_type" );
     ok( $homology->adaptor->isa("Bio::EnsEMBL::Compara::DBSQL::HomologyAdaptor") );
-    
+
     $multi->hide('compara', 'homology');
     $multi->hide('compara', 'homology_member');
     $multi->hide('compara', 'method_link_species_set');
-    
+
     $homology->{'_dbID'} = undef;
     $homology->{'_adaptor'} = undef;
     $homology->{'_method_link_species_set_id'} = undef;
-    
+
     $ha->store($homology);
-    
+
     my $sth = $compara_dba->dbc->prepare('SELECT homology_id
                                 FROM homology
                                 WHERE homology_id = ?');
-    
+
     $sth->execute($homology->dbID);
-    
+
     ok($homology->dbID && ($homology->adaptor == $ha));
     debug("homology->dbID = " . $homology->dbID);
-    
+
     my ($id) = $sth->fetchrow_array;
     $sth->finish;
-    
+
     ok($id && $id == $homology->dbID);
     debug("[$id] == [" . $homology->dbID . "]?");
-    
+
     $multi->restore('compara', 'homology');
     $multi->restore('compara', 'homology_member');
     $multi->restore('compara', 'method_link_species_set');
-    
+
     $homologies = $ha->fetch_all_by_method_link_type("$method_link_type");
 
     ok($homologies);

--- a/modules/t/memberAdaptor.t
+++ b/modules/t/memberAdaptor.t
@@ -52,7 +52,7 @@ subtest "Test fetch methods", sub {
 
 
     my $member = $ma->fetch_by_stable_id($stable_id);
-    
+
     ok($member);
     ok( $member->dbID,  $member_id);
     ok( $member->stable_id, $stable_id );
@@ -71,10 +71,10 @@ subtest "Test fetch methods", sub {
     ($member_id, $stable_id, $version, $source_name, $taxon_id, $genome_db_id, $sequence_id,
      $gene_member_id, $description, $chr_name, $chr_start, $chr_end, $chr_strand) =
        $compara_dba->dbc->db_handle->selectrow_array("SELECT * FROM member WHERE source_name = 'ENSEMBLPEP' LIMIT 1");
-    
+
     # FIXME should be using SeqMemberAdaptor
     $member = $ma->fetch_by_stable_id($stable_id);
-    
+
     ok($member);
     ok( $member->dbID,  $member_id);
     ok( $member->stable_id, $stable_id );
@@ -89,29 +89,28 @@ subtest "Test fetch methods", sub {
     ok( $member->taxon_id, $taxon_id );
     ok( $member->genome_db_id, $genome_db_id );
     ok( $member->sequence_id );
-    
-    
+
     $multi->hide('compara', 'member');
     $member->{'_dbID'} = undef;
     $member->{'_adaptor'} = undef;
-    
+
     $ma->store($member);
-    
+
     my $sth = $compara_dba->dbc->prepare('SELECT member_id
                                 FROM member
                                 WHERE member_id = ?');
-    
+
     $sth->execute($member->dbID);
-    
+
     ok($member->dbID && ($member->adaptor == $ma));
     debug("member->dbID = " . $member->dbID);
-    
+
     my ($id) = $sth->fetchrow_array;
     $sth->finish;
-    
+
     ok($id && $id == $member->dbID);
     debug("[$id] == [" . $member->dbID . "]?");
-    
+
     $multi->restore('compara', 'member');
 
 

--- a/scripts/breakpoint_analysis/get_genomic_rearrangements.pl
+++ b/scripts/breakpoint_analysis/get_genomic_rearrangements.pl
@@ -18,7 +18,7 @@
 =pod
 
 =head1 DESCRIPTION
- 
+
  This script finds the number of collinear genomic blocks in an alignment. Information about the blocks are written to the given output file (this files tend to be 20mb and upwards in size).
  The threshold is used to determined 1: if a block is a non colinear block is big enough to be a valid breakpoint in the the genome and 2: if a block or colinear blocks should be printed to the output file.
  Also inversion bigger than the threshold are reported as breakpoints.
@@ -38,7 +38,6 @@
     -output     -> output file  format : -> ref_chr_id,ref_start,ref_end,nonref_chr_id,non_ref_start,nonref_end, genomic_block_ids
     -debug      -> if you want the debug statements printed to the screen
     example run : perl get_genomic_rearrangements.pl -species1 mus_caroli -species2 mus_pahari -threshold 10 -DB_species <mice_merged> -EPO <0/1> -output trial_b -reg_conf /nfs/users/nfs_w/wa2/Mouse_rearrangement_project/mouse_reg_livemirror_03_16.conf
-
 
 =cut
 

--- a/scripts/breakpoint_analysis/get_genomic_rearrangements.pl
+++ b/scripts/breakpoint_analysis/get_genomic_rearrangements.pl
@@ -33,7 +33,7 @@
     -EPO		-> set if yoiu want the breakpoints from the EPO alignments
 
     -threshold   -> the size of the threshold in kilobase
-	
+
 	-DB_species	-> the species name of the database (usually 'MULTI' for ensembl production dbs)
     -output     -> output file  format : -> ref_chr_id,ref_start,ref_end,nonref_chr_id,non_ref_start,nonref_end, genomic_block_ids
     -debug      -> if you want the debug statements printed to the screen

--- a/scripts/compare/flatten_mouse_files.pl
+++ b/scripts/compare/flatten_mouse_files.pl
@@ -15,10 +15,10 @@
 # limitations under the License.
 
 
-=pod
+=head1 DESCRIPTION
 
-    This script fetches data from MGI and maps its ids with Ensembl stable ids.
-    MGI annotations come dorectly from the web [http://www.genenames.org]
+This script fetches data from MGI and maps its ids with Ensembl stable ids.
+MGI annotations come dorectly from the web [http://www.genenames.org]
 
 =cut
 

--- a/scripts/compare/flatten_mouse_files.pl
+++ b/scripts/compare/flatten_mouse_files.pl
@@ -15,9 +15,11 @@
 # limitations under the License.
 
 
-=head1
+=pod
+
     This script fetches data from MGI and maps its ids with Ensembl stable ids.
     MGI annotations come dorectly from the web [http://www.genenames.org]
+
 =cut
 
 use strict;

--- a/scripts/compare/flatten_zebrafish_files.pl
+++ b/scripts/compare/flatten_zebrafish_files.pl
@@ -14,11 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-=head1
+=pod
+
     This script fetches data for zebrafish from [http://zfin.org]:
     homo_sapiens            = http://zfin.org/downloads/human_orthos.txt
     drosophila_melanogaster = http://zfin.org/downloads/fly_orthos.txt
     mus_musculus            = http://zfin.org/downloads/mouse_orthos.txt
+
 =cut
 
 use strict;

--- a/scripts/compare/flatten_zebrafish_files.pl
+++ b/scripts/compare/flatten_zebrafish_files.pl
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-=pod
+=head1 DESCRIPTION
 
-    This script fetches data for zebrafish from [http://zfin.org]:
+This script fetches data for zebrafish from [http://zfin.org]:
     homo_sapiens            = http://zfin.org/downloads/human_orthos.txt
     drosophila_melanogaster = http://zfin.org/downloads/fly_orthos.txt
     mus_musculus            = http://zfin.org/downloads/mouse_orthos.txt

--- a/scripts/production/verify_ancestral_dnafrags.pl
+++ b/scripts/production/verify_ancestral_dnafrags.pl
@@ -16,11 +16,11 @@
 
 =pod
 
-=head2 SYNOPSIS
+=head1 SYNOPSIS
 
     verify_ancestral_dnafrags.pl -compara $(mysql-ensembl details url ensembl_compara_89) -ancestral $(mysql-ensembl details url ensembl_ancestral_89)
 
-=head2 DESCRIPTION
+=head1 DESCRIPTION
 
 Check that the ancestral dnafrags of the compara database are in sync
 with the seq_regions of the ancestral (core) database

--- a/scripts/projection/map_coordinates.pl
+++ b/scripts/projection/map_coordinates.pl
@@ -14,14 +14,15 @@
 # limitations under the License.
 
 
+=pod
 
-=head
 desc: This script takes as input the desired coordinates on the genome of a given species and uses the genomic aligns block object and the mapper object to map those coordinates
 to their corresponding aligned coordinates on a target species genome.
 output: the output is an array of paired hash objects each pair respresenting a one to one mapping of the aligned coordinates on both source and target species
 
 ex: perl map_coordinates.pl --mlss_id 225 --source_sp Stickleback --target_sp (optional) --coord_system_name scaffold --seq_region_name scaffold_150 --start 167602 --end 167999
 	perl map_coordinates.pl --mlss_id 1134 --source_sp macaca_fascicularis --coord_system_name chromosome --seq_region_name 5 --start 890166 --end 890366 --target_sp nomascus_leucogenys
+
 =cut
 
 

--- a/scripts/projection/map_coordinates.pl
+++ b/scripts/projection/map_coordinates.pl
@@ -14,19 +14,18 @@
 # limitations under the License.
 
 
-=pod
+=head1 DESCRIPTION
 
-desc: This script takes as input the desired coordinates on the genome of a given species and uses the genomic aligns block object and the mapper object to map those coordinates
+This script takes as input the desired coordinates on the genome of a given species and uses the genomic aligns block object and the mapper object to map those coordinates
 to their corresponding aligned coordinates on a target species genome.
 output: the output is an array of paired hash objects each pair respresenting a one to one mapping of the aligned coordinates on both source and target species
 
-ex: perl map_coordinates.pl --mlss_id 225 --source_sp Stickleback --target_sp (optional) --coord_system_name scaffold --seq_region_name scaffold_150 --start 167602 --end 167999
+=head1 EXAMPLE
+
+        perl map_coordinates.pl --mlss_id 225 --source_sp Stickleback --target_sp (optional) --coord_system_name scaffold --seq_region_name scaffold_150 --start 167602 --end 167999
 	perl map_coordinates.pl --mlss_id 1134 --source_sp macaca_fascicularis --coord_system_name chromosome --seq_region_name 5 --start 890166 --end 890366 --target_sp nomascus_leucogenys
 
 =cut
-
-
-
 
 
 use strict;

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -38,22 +38,23 @@ export PERL5LIB=$PERL5LIB:$PWD/ensembl-io/modules
 
 ENSEMBL_PERL5OPT='-MDevel::Cover=+ignore,bioperl,+ignore,ensembl,+ignore,ensembl-test,+ignore,ensembl-variation,+ignore,ensembl-funcgen'
 ENSEMBL_TESTER="$PWD/ensembl-test/scripts/runtests.pl"
+ENSEMBL_TESTER_OPTIONS=()
 COMPARA_SCRIPTS=("$PWD/modules/t")
 CORE_SCRIPTS=("$PWD/ensembl/modules/t/compara.t")
 REST_SCRIPTS=("$PWD/ensembl-rest/t/genomic_alignment.t" "$PWD/ensembl-rest/t/info.t" "$PWD/ensembl-rest/t/taxonomy.t" "$PWD/ensembl-rest/t/homology.t" "$PWD/ensembl-rest/t/gene_tree.t" "$PWD/ensembl-rest/t/cafe_tree.t" "$PWD/ensembl-rest/t/family.t")
 
 if [ "$COVERALLS" = 'true' ]; then
   EFFECTIVE_PERL5OPT="$ENSEMBL_PERL5OPT"
-  ENSEMBL_TESTER="$ENSEMBL_TESTER -verbose"
+  ENSEMBL_TESTER_OPTIONS+=('-verbose')
 else
   EFFECTIVE_PERL5OPT=""
 fi
 
 echo "Running ensembl-compara test suite using $PERL5LIB"
-PERL5OPT="$EFFECTIVE_PERL5OPT" perl $ENSEMBL_TESTER "${COMPARA_SCRIPTS[@]}"
+PERL5OPT="$EFFECTIVE_PERL5OPT" perl "$ENSEMBL_TESTER" "${ENSEMBL_TESTER_OPTIONS[@]}" "${COMPARA_SCRIPTS[@]}"
 rt1=$?
 echo "Running ensembl test suite using $PERL5LIB"
-PERL5OPT="$EFFECTIVE_PERL5OPT" perl $ENSEMBL_TESTER "${CORE_SCRIPTS[@]}"
+PERL5OPT="$EFFECTIVE_PERL5OPT" perl "$ENSEMBL_TESTER" "${ENSEMBL_TESTER_OPTIONS[@]}" "${CORE_SCRIPTS[@]}"
 rt2=$?
 
 #if [[ "$TRAVIS_PERL_VERSION" != "5.14" ]]; then
@@ -61,7 +62,7 @@ rt2=$?
   #rt3=0
 #else
   echo "Running ensembl-rest test suite using $PERL5LIB"
-  PERL5OPT="$EFFECTIVE_PERL5OPT" perl $ENSEMBL_TESTER "${REST_SCRIPTS[@]}"
+  PERL5OPT="$EFFECTIVE_PERL5OPT" perl "$ENSEMBL_TESTER" "${ENSEMBL_TESTER_OPTIONS[@]}" "${REST_SCRIPTS[@]}"
   rt3=$?
 #fi
 

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -70,7 +70,12 @@ rt2=$?
 find docs modules scripts sql travisci -iname '*.t' -o -iname '*.pl' -o -iname '*.pm' \! -name 'LoadSynonyms.pm' \! -name 'HALAdaptor.pm' \! -name 'HALXS.pm' -print0 | xargs -0 -n 1 perl -c
 rt4=$?
 
-if [[ ($rt1 -eq 0) && ($rt2 -eq 0) && ($rt3 -eq 0) && ($rt4 -eq 0) ]]; then
+# Check that all the PODs are valid (we don't mind missing PODs at the moment)
+# Note the initial "!" to negate grep's return code
+! find docs modules scripts sql travisci -iname '*.t' -o -iname '*.pl' -o -iname '*.pm' -print0 | xargs -0 podchecker 2>&1 | grep -v ' pod syntax OK' | grep -v 'does not contain any pod commands'
+rt5=$?
+
+if [[ ($rt1 -eq 0) && ($rt2 -eq 0) && ($rt3 -eq 0) && ($rt4 -eq 0) && ($rt5 -eq 0)]]; then
   if [ "$COVERALLS" = 'true' ]; then
     echo "Running Devel::Cover coveralls report"
     cover --nosummary -report coveralls


### PR DESCRIPTION
This PR enables `podchecker`, a tool to check the syntax of Perl documentation blocks (PODs), on Travis. At the same time, I fixed the errors on existing files (there were not that many), and you can see the typical errors we had, e.g.:
 - it wants 1 blank line before and after each `=XXX` command, not more than 1 on the inside of the block
 - inside `=NAME` text should not be indented
 - sections cannot be empty
 - `=head2` must be preceded by `=head1`

I have also removed a few `=pod` that had no effect.