### PR TITLE
Pairwise alignment and self-alignment of polyploid genomes

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
+++ b/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
@@ -452,7 +452,7 @@ sub find_pairwise_reference {
         if ($genome_dbs->[0]->genome_component eq $ref_component) {
             return @$genome_dbs;
         } elsif ($genome_dbs->[1]->genome_component eq $ref_component) {
-            return ()$genome_dbs->[1], $genome_dbs->[0]);
+            return ($genome_dbs->[1], $genome_dbs->[0]);
         } else {
             @$genome_dbs = sort { $a->genome_component cmp $b->genome_component } @$genome_dbs;
             return @$genome_dbs;

--- a/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
+++ b/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
@@ -17,19 +17,13 @@ limitations under the License.
 
 =cut
 
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
-Bio::EnsEMBL::Compara::MethodLinkSpeciesSet -
-Relates every method_link with the species_set for which it has been used
+Bio::EnsEMBL::Compara::MethodLinkSpeciesSet
+
+=head1 DESCRIPTION
+
+Relates every method_link with the species_set for which it has been used.
 
 =head1 SYNOPSIS
 
@@ -61,11 +55,10 @@ GET VALUES
 
 =head1 APPENDIX
 
-The rest of the documentation details each of the object methods. Internal methods are usually preceded with a _
+The rest of the documentation details each of the object methods.
+Internal methods are usually preceded with an underscore (_).
 
 =cut
-
-
 
 package Bio::EnsEMBL::Compara::MethodLinkSpeciesSet;
 
@@ -75,6 +68,7 @@ use warnings;
 use Bio::EnsEMBL::Utils::Exception qw(throw warning);
 use Bio::EnsEMBL::Utils::Argument qw(rearrange);
 use Bio::EnsEMBL::Utils::Scalar qw(:assert);
+
 use Bio::EnsEMBL::Compara::Method;
 use Bio::EnsEMBL::Compara::SpeciesSet;
 
@@ -415,7 +409,7 @@ sub filename {
                 declared, the reference genome will be in first position. If
                 not, the usual reference species will be first. If none of the
                 previous conditions apply, the list is sorted alphabetically.
-                For self-alignments, the single genome is returned twice.
+                Note that for self-alignments only one genome is returned.
   Return type : array of Bio::EnsEMBL::Compara::GenomeDB objects
   Exceptions  : none
 
@@ -428,33 +422,39 @@ sub find_pairwise_reference {
     die "Cactus alignments are reference-free\n" if $self->method->type eq 'CACTUS_HAL_PW';
     my $genome_dbs = $self->species_set->genome_dbs;
 
-    # For self-alignments, return the single genome twice
-    return ($genome_dbs->[0], $genome_dbs->[0]) if (scalar(@{$genome_dbs}) == 1);
+    # For self-alignments, return the single genome
+    return $genome_dbs if (scalar(@$genome_dbs) == 1);
 
-    # First, check for reference MLSS tags
-    my $ref_name = $self->get_value_for_tag('reference_species', '');
-    my $ref_component = $self->get_value_for_tag('reference_component', '');
-    if (($genome_dbs->[0]->name eq $ref_name) || ($genome_dbs->[0]->genome_component eq $ref_component)) {
-        # List already in correct order
-        return @$genome_dbs;
-    } elsif (($genome_dbs->[1]->name eq $ref_name) || ($genome_dbs->[1]->genome_component eq $ref_component)) {
-        return ($genome_dbs->[1], $genome_dbs->[0]);
-    } elsif ($genome_dbs->[0]->name eq $genome_dbs->[1]->name) {
-        # For polyploid self-alignments, both genomes have the same name, so
-        # sort them alphabetically by component
-        @$genome_dbs = sort { $a->genome_component cmp $b->genome_component } @$genome_dbs;
-        return @$genome_dbs;
-    } else {
-        # In any other case, always place usual references first
-        my @ref_list = qw(homo_sapiens mus_musculus gallus_gallus oryzias_latipes arabidopsis_thaliana vitis_vinifera oryza_sativa);
-        if ( grep { $genome_dbs->[0]->name eq $_ } @ref_list ) {
-            # List already in correct order
+    if ($genome_dbs->[0]->name ne $genome_dbs->[1]->name) {
+        # Genome vs genome PWA
+        my $ref_name = $self->get_value_for_tag('reference_species', '');
+        if ($genome_dbs->[0]->name eq $ref_name) {
             return @$genome_dbs;
-        } elsif ( grep { $genome_dbs->[1]->name eq $_ } @ref_list ) {
+        } elsif ($genome_dbs->[1]->name eq $ref_name) {
             return ($genome_dbs->[1], $genome_dbs->[0]);
         } else {
-            # Return alphabetical order
-            @$genome_dbs = sort { $a->name cmp $b->name } @$genome_dbs;
+            # In any other case, always place usual references first
+            my @ref_list = qw(homo_sapiens mus_musculus gallus_gallus oryzias_latipes arabidopsis_thaliana vitis_vinifera oryza_sativa);
+            if ( grep { $genome_dbs->[0]->name eq $_ } @ref_list ) {
+                # List already in correct order
+                return @$genome_dbs;
+            } elsif ( grep { $genome_dbs->[1]->name eq $_ } @ref_list ) {
+                return ($genome_dbs->[1], $genome_dbs->[0]);
+            } else {
+                # Return alphabetical order on name
+                @$genome_dbs = sort { $a->name cmp $b->name } @$genome_dbs;
+                return @$genome_dbs;
+            }
+        }
+    } else {
+        # Same genome: component vs component PWA
+        my $ref_component = $self->get_value_for_tag('reference_component', '');
+        if ($genome_dbs->[0]->genome_component eq $ref_component) {
+            return @$genome_dbs;
+        } elsif ($genome_dbs->[1]->genome_component eq $ref_component) {
+            return ()$genome_dbs->[1], $genome_dbs->[0]);
+        } else {
+            @$genome_dbs = sort { $a->genome_component cmp $b->genome_component } @$genome_dbs;
             return @$genome_dbs;
         }
     }

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/Lastz_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/Lastz_conf.pm
@@ -39,15 +39,8 @@ Bio::EnsEMBL::Compara::PipeConfig::EG::Lastz_conf
 
 =head1 DESCRIPTION  
 
-This is a Ensembl Genomes configuration file for LastZ pipeline.
-
-=head1 CONTACT
-
-Please email comments or questions to the public Ensembl
-developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-Questions may also be sent to the Ensembl help desk at
-<http://www.ensembl.org/Help/Contact>.
+This is a Ensembl Genomes configuration file for LastZ pipeline. Please, refer
+to the parent class for further information.
 
 =cut
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Lastz_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Lastz_conf.pm
@@ -40,14 +40,6 @@ Bio::EnsEMBL::Compara::PipeConfig::Lastz_conf
 This is a base configuration file for LastZ pipeline, based on the generic
 PairAligner pipeline.
 
-=head1 CONTACT
-
-Please email comments or questions to the public Ensembl
-developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-Questions may also be sent to the Ensembl help desk at
-<http://www.ensembl.org/Help/Contact>.
-
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Lastz_conf;
@@ -110,5 +102,6 @@ sub default_options {
 	    'net_output_method_link' => [16, 'LASTZ_NET'],
 	};
 }
+
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/Lastz_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/Lastz_conf.pm
@@ -58,6 +58,7 @@ use warnings;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::Lastz_conf');
 
+
 sub default_options {
 my ($self) = @_;
     return {
@@ -69,6 +70,7 @@ my ($self) = @_;
         'bidirectional' => 1,
     };
 }
+
 
 sub tweak_analyses {
     my $self = shift;
@@ -92,5 +94,6 @@ sub tweak_analyses {
         $analyses_by_name->{$logic_name}->{'-rc_name'} = $overriden_rc_names{$logic_name};
     }
 }
+
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/Lastz_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/Lastz_conf.pm
@@ -29,15 +29,8 @@ Bio::EnsEMBL::Compara::PipeConfig::Plants::Lastz_conf
 
 =head1 DESCRIPTION  
 
-This is a Plants configuration file for LastZ pipeline.
-
-=head1 CONTACT
-
-Please email comments or questions to the public Ensembl
-developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-Questions may also be sent to the Ensembl help desk at
-<http://www.ensembl.org/Help/Contact>.
+This is a Plants configuration file for LastZ pipeline. Please, refer to the
+parent class for further information.
 
 =cut
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/Lastz_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/Lastz_conf.pm
@@ -15,6 +15,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
+=cut
+
 =head1 NAME
 
 Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::Lastz_conf
@@ -26,15 +28,8 @@ Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::Lastz_conf
 
 =head1 DESCRIPTION
 
-This is a Vertebrates configuration file for LastZ pipeline.
-
-=head1 CONTACT
-
-Please email comments or questions to the public Ensembl
-developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-Questions may also be sent to the Ensembl help desk at
-<http://www.ensembl.org/Help/Contact>.
+This is a Vertebrates configuration file for LastZ pipeline. Please, refer
+to the parent class for further information.
 
 =cut
 
@@ -54,5 +49,6 @@ sub default_options {
         'division'  => 'vertebrates',
 	};
 }
+
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomicAlignBlock/PopulateNewDatabase.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomicAlignBlock/PopulateNewDatabase.pm
@@ -17,31 +17,19 @@ limitations under the License.
 
 =cut
 
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::GenomicAlignBlock::PopulateNewDatabase
 
-=cut
-
 =head1 DESCRIPTION
 
-Runs the $ENSEMBL_CVS_ROOT_DIR/ensembl-compara/scripts/pipeline/populate_new_database.pl script, dealing with missing parameters
-
-=cut
+Runs the $ENSEMBL_CVS_ROOT_DIR/ensembl-compara/scripts/pipeline/populate_new_database.pl
+script, dealing with missing parameters.
 
 =head1 APPENDIX
 
 The rest of the documentation details each of the object methods.
-Internal methods are usually preceded with a _
+Internal methods are usually preceded with an underscore (_).
 
 =cut
 
@@ -49,6 +37,7 @@ package Bio::EnsEMBL::Compara::RunnableDB::GenomicAlignBlock::PopulateNewDatabas
 
 use strict;
 use warnings;
+
 use Time::HiRes qw(time gettimeofday tv_interval);
 
 use Bio::EnsEMBL::Hive::Utils ('destringify');

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/DetectComponentMLSSs.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/DetectComponentMLSSs.pm
@@ -102,9 +102,10 @@ sub write_output {
 
     foreach my $main_mlss_id ( keys %{$component_mlss_ids} ) {
         if (@{$component_mlss_ids->{$main_mlss_id}}) {
-            $self->dataflow_output_id({'principal_mlss_id'  => $main_mlss_id,
-                                       'component_mlss_ids' => $component_mlss_ids->{$main_mlss_id}},
-                                      3);
+            $self->dataflow_output_id({
+                'principal_mlss_id'  => $main_mlss_id,
+                'component_mlss_ids' => $component_mlss_ids->{$main_mlss_id}
+            }, 3);
         }
         $self->dataflow_output_id(
             {'mlss_id' => $main_mlss_id, 'inputlist' => \@input_list, 'column_names' => $column_names},

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/DetectComponentMLSSs.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/DetectComponentMLSSs.pm
@@ -1,0 +1,118 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::PairAligner::DetectComponentMLSSs
+
+=head1 DESCRIPTION
+
+Detect component MLSSs (those with mlss_tag "principal_mlss_id") and group them
+to lift their genomic_aligns and genomic_align_blocks to the corresponding
+principal MLSS.
+
+=over
+
+=item net_mlss_ids
+
+Mandatory. List of LASTZ_NET MLSS ids.
+
+=item do_pairwise_gabs
+
+Optional. Perform "pairwise genomic_align_blocks" healthcheck on the principal
+MLSS after the data has been lifted?
+
+=item do_compare_to_previous_db
+
+Optional. Perform "compare to previous DB" healthcheck on the principal MLSS
+after the data has been lifted?
+
+=back
+
+=head1 EXAMPLES
+
+    standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::PairAligner::DetectComponentMLSSs \
+        -compara_db $(mysql-ens-compara-prod-8-ensadmin details url jalvarez_shoots_lastz) \
+        -net_mlss_ids [5,6] -do_pairwise_gabs 1
+
+=head1 APPENDIX
+
+The rest of the documentation details each of the object methods.
+Internal methods are usually preceded with an underscore (_).
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::PairAligner::DetectComponentMLSSs;
+
+use warnings;
+use strict;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub fetch_input {
+    my $self = shift;
+
+    my $net_mlss_ids = $self->param_required('net_mlss_ids');
+    my $mlss_adaptor = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor();
+
+    my %mlsss;
+    foreach my $mlss_id ( @{$net_mlss_ids} ) {
+        my $this_mlss = $mlss_adaptor->fetch_by_dbID($mlss_id);
+        my $principal_mlss_id = $this_mlss->get_tagvalue('principal_mlss_id');
+        if (defined $principal_mlss_id) {
+            push @{$mlsss{$principal_mlss_id}}, $mlss_id;
+        } else {
+            push @{$mlsss{$mlss_id}}, $mlss_id;
+        }
+    }
+    $self->param('mlsss', \%mlsss);
+
+    my @hc_tests;
+    push @hc_tests, 'pairwise_gabs' if $self->param('do_pairwise_gabs');
+    push @hc_tests, 'compare_to_previous_db' if $self->param('do_compare_to_previous_db');
+    $self->param('hc_tests', \@hc_tests);
+}
+
+
+sub write_output {
+    my $self = shift;
+    
+    my $mlsss    = $self->param('mlsss');
+    my $hc_tests = $self->param('hc_tests');
+
+    my $column_names = ['mlss_id', 'test'];
+    my @input_list;
+    push @input_list, ['#mlss_id#', $_] for @{$hc_tests};
+
+    foreach my $mlss_id ( keys %{$mlsss} ) {
+        # The principal MLSS id will not be part of the MLSS ids array
+        $self->dataflow_output_id(
+            {'principal_mlss_id' => $mlss_id, 'component_mlss_ids' => $mlsss->{$mlss_id}},
+            3
+        ) if ($mlsss->{$mlss_id}->[0] != $mlss_id);
+        $self->dataflow_output_id(
+            {'mlss_id' => $mlss_id, 'inputlist' => \@input_list, 'column_names' => $column_names},
+            2
+        );
+    }
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/LiftComponentAlignments.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/LiftComponentAlignments.pm
@@ -1,0 +1,139 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::PairAligner::LiftComponentAlignments
+
+=head1 DESCRIPTION
+
+Lift the component genomic_aligns and genomic_align_blocks to their
+corresponding principal and update the dnafrag_id in the genomic_align table.
+
+=over
+
+=item principal_mlss_id
+
+Mandatory. The MLSS id of the principal PWA.
+
+=item component_mlss_ids
+
+Mandatory. List of component MLSS ids linked to the principal_mlss_id.
+
+=back
+
+=head1 EXAMPLES
+
+    standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::PairAligner::LiftComponentAlignments \
+        -compara_db $(mysql-ens-compara-prod-8-ensadmin details url jalvarez_shoots_lastz) \
+        -principal_mlss_id 2 -component_mlss_ids [5,6]
+
+=head1 APPENDIX
+
+The rest of the documentation details each of the object methods.
+Internal methods are usually preceded with an underscore (_).
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::PairAligner::LiftComponentAlignments;
+
+use warnings;
+use strict;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub param_defaults {
+    my $self = shift;
+
+    return {
+        %{$self->SUPER::param_defaults},
+
+        'mlss_padding_n_zeros' => 10.,
+    }
+}
+
+
+sub run {
+    my $self = shift;
+
+    $self->_lift_gas_and_gabs();
+    $self->_update_dnafrags();
+}
+
+
+sub _lift_gas_and_gabs {
+    my $self = shift;
+    
+    my $principal_mlss_id  = $self->param_required('principal_mlss_id');
+    my $component_mlss_ids = $self->param_required('component_mlss_ids');
+    my $magic_number       = '1' . ('0' x $self->param('mlss_padding_n_zeros'));
+
+    # Create the principal MLSS genomic_align_blocks in the correct range
+    my $sql0 = "SELECT MIN(genomic_align_id % $magic_number), MAX(genomic_align_id % $magic_number), MIN(genomic_align_block_id % $magic_number), MAX(genomic_align_block_id % $magic_number), COUNT(*), COUNT(DISTINCT genomic_align_id % $magic_number), COUNT(DISTINCT genomic_align_block_id % $magic_number) FROM genomic_align WHERE method_link_species_set_id = ?";
+    my $sql1 = "INSERT INTO genomic_align_block SELECT (genomic_align_block_id % $magic_number) + ?, $principal_mlss_id, score, perc_id, length, group_id, level_id FROM genomic_align_block WHERE method_link_species_set_id = ?";
+    # Update the genomic_align_ids and genomic_align_block_ids in genomic_align
+    my $sql2 = "UPDATE genomic_align SET genomic_align_block_id = (genomic_align_block_id % $magic_number) + ?, genomic_align_id = (genomic_align_id % $magic_number) + ?, method_link_species_set_id = $principal_mlss_id WHERE method_link_species_set_id = ?";
+    # Remove the component MLSS genomic_align_blocks
+    my $sql3 = "DELETE FROM genomic_align_block WHERE method_link_species_set_id = ?";
+
+    # We really need a transaction to ensure we are not screwing the database
+    my $dbc = $self->compara_dba->dbc;
+    $self->call_within_transaction(sub {
+        my $offset_ga  = $principal_mlss_id * $magic_number;
+        my $offset_gab = $principal_mlss_id * $magic_number;
+        foreach my $mlss_id ( @{$component_mlss_ids} ) {
+            # Get the required information about this component MLSS'
+            # genomic_aligns and genomic_align_blocks
+            my ($min_ga, $max_ga, $min_gab, $max_gab, $tot_count, $safe_ga_count, $safe_gab_count) = $dbc->db_handle->selectrow_array($sql0, undef, $mlss_id);
+            die "No entries found for component mlss_id=$mlss_id\n" unless (defined $min_ga && defined $min_gab);
+            die "genomic_align_id or genomic_align_block_id remainders are not unique\n" if (($tot_count != $safe_ga_count) || ($tot_count != 2*$safe_gab_count));
+            # Lift the genomic_aligns and genomic_align_blocks from the
+            # component MLSS to the principal MLSS
+            print STDERR "Offsets for mlss_id=$mlss_id:\n\tgenomic_align_block_id=$offset_gab\n\tgenomic_align_id=$offset_ga\n";
+            print STDERR (my $nd = $dbc->do($sql1, undef, $offset_gab, $mlss_id)), " rows duplicated in genomic_align_block\n";
+            print STDERR $dbc->do($sql2, undef, $offset_gab, $offset_ga, $mlss_id), " rows of genomic_align redirected to the new entries in genomic_align_block\n";
+            print STDERR (my $nr = $dbc->do($sql3, undef, $mlss_id)), " rows removed from genomic_align_block\n";
+            die "Numbers mismatch: $nd rows duplicated and $nr removed\n" if ($nd != $nr);
+            # Update the offsets
+            $offset_ga  += $max_ga;
+            $offset_gab += $max_gab;
+        }
+    });
+}
+
+
+sub _update_dnafrags {
+    my $self = shift;
+    
+    my $principal_mlss_id  = $self->param_required('principal_mlss_id');
+    
+    # Update the dnafrag_ids in genomic_align from component to the principal
+    my $sql = "UPDATE genomic_align ga JOIN dnafrag d1 USING (dnafrag_id) JOIN dnafrag d2 USING (name) SET ga.dnafrag_id = d2.dnafrag_id WHERE d1.dnafrag_id != d2.dnafrag_id AND method_link_species_set_id = $principal_mlss_id";
+
+    # We really need a transaction to ensure we are not screwing the database
+    my $dbc = $self->compara_dba->dbc;
+    $self->call_within_transaction(sub {
+        print STDERR (my $nr = $dbc->do($sql)), " rows of genomic_align redirected to the principal dnafrags\n";
+        die "No rows where updated\n" unless $nr;
+    });
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/LiftComponentAlignments.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/LiftComponentAlignments.pm
@@ -163,7 +163,7 @@ sub _update_dnafrags {
         foreach my $principal_gdb ( @$genome_dbs ) {
             my $component_gdbs = $principal_gdb->component_genome_dbs;
             foreach my $gdb ( @{$component_gdbs} ) {
-                $nr += $dbc->do($sql, undef, $principal_gdb->dbID, $gdb->dbID, $principal_mlss_id));
+                $nr += $dbc->do($sql, undef, $principal_gdb->dbID, $gdb->dbID, $principal_mlss_id);
             }
         }
         die "No rows where updated\n" unless $nr;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/LiftComponentAlignments.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/LiftComponentAlignments.pm
@@ -80,6 +80,20 @@ sub run {
 
 =head2 _lift_gas_and_gabs
 
+Description : Lifts the genomic_aligns and genomic_align_blocks calculated for
+              the component genomes to their principal genome. To avoid
+              conflicts with foreign keys, it creates the new range of
+              genomic_align_blocks based on the principal MLSS id
+              (method_link_species_set_id * 10**10) and the previously lifted
+              genomic_align_blocks (to avoid collisions), updates the
+              genomic_align_block_ids and method_link_species_set_ids (from
+              the component MLSS id to the principal MLSS id) in the
+              genomic_align table and removes the old genomic_align_blocks.
+              Note that the lifting is performed in a transaction manner. This
+              function is an adaptation of
+              Bio::EnsEMBL::Compara::RunnableDB::PairAligner::SetInternalIdsCollection::_setInternalIds()
+              (first transaction), so these two methods should be kept in sync.
+
 =cut
 
 sub _lift_gas_and_gabs {
@@ -124,6 +138,10 @@ sub _lift_gas_and_gabs {
 
 
 =head2 _update_dnafrags
+
+Description : Updates the dnafrag_ids from the component genomes to their
+              principal genome in genomic_align table. Note that the update is
+              performed in a transaction manner.
 
 =cut
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/LiftComponentAlignments.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/LiftComponentAlignments.pm
@@ -151,7 +151,7 @@ sub _update_dnafrags {
     my $principal_mlss_id  = $self->param_required('principal_mlss_id');
     my $mlss_adaptor = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor();
     my $principal_mlss = $mlss_adaptor->fetch_by_dbID($principal_mlss_id);
-    my $genome_dbs = $principal_mlss->find_pairwise_reference();
+    my @genome_dbs = $principal_mlss->find_pairwise_reference();
     
     # Update the dnafrag_ids in genomic_align from component to the principal
     my $sql = "UPDATE genomic_align ga JOIN dnafrag d1 USING (dnafrag_id) JOIN dnafrag d2 USING (name) SET ga.dnafrag_id = d2.dnafrag_id WHERE d1.genome_db_id = ? AND d2.genome_db_id = ? AND method_link_species_set_id = ?";
@@ -160,7 +160,7 @@ sub _update_dnafrags {
     my $dbc = $self->compara_dba->dbc;
     $self->call_within_transaction(sub {
         my $nr;
-        foreach my $principal_gdb ( @$genome_dbs ) {
+        foreach my $principal_gdb ( @genome_dbs ) {
             my $component_gdbs = $principal_gdb->component_genome_dbs;
             foreach my $gdb ( @{$component_gdbs} ) {
                 $nr += $dbc->do($sql, undef, $principal_gdb->dbID, $gdb->dbID, $principal_mlss_id);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerCodingExonStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerCodingExonStats.pm
@@ -17,39 +17,50 @@ limitations under the License.
 
 =cut
 
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::PairAligner::PairAlignerCodingExonStats
 
-=cut
-
-=head1 SYNOPSIS
-
-$module->fetch_input
-
-$module->run
-
-$module->write_output
-
-=cut
-
 =head1 DESCRIPTION
 
-This module populuates the temporary table 'statistics' with coding exon statistics (matches, mis-matches, insertions and uncovered)
+This module populuates the temporary table 'statistics' with coding exon
+statistics (matches, mis-matches, insertions and uncovered).
+
+=over
+
+=item mlss_id
+
+Mandatory. Method link species set ID.
+
+=item dnafrag_id
+
+Mandatory. DNAFrag ID of one of the genomes involved in the given mlss_id.
+
+=item genome_dumps_dir
+
+Optional. Location of the genome dumps.
+
+=item registry_dbs
+
+Optional. List of registry databases. By default, these are provided by the
+registry configuration file.
+
+=item db_conn
+
+Optional. Compara database url. By default, compara_db is used.
+
+=back
+
+=head1 EXAMPLES
+
+    standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::PairAligner::PairAlignerCodingExonStats \
+        -compara_db $(mysql-ens-compara-prod-8-ensadmin details url jalvarez_shoots_lastz) \
+        -mlss_id 1 -dnafrag_id 1
 
 =head1 APPENDIX
 
 The rest of the documentation details each of the object methods.
-Internal methods are usually preceded with a _
+Internal methods are usually preceded with an underscore (_).
 
 =cut
 
@@ -61,6 +72,7 @@ use warnings;
 use Bio::EnsEMBL::Hive::Utils 'stringify';  # import 'stringify()'
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
 
 sub fetch_input {
   my ($self) = @_;
@@ -78,9 +90,6 @@ sub fetch_input {
   return 1;
 }
 
-=head2 run
-
-=cut
 
 sub run {
   my $self = shift;
@@ -100,7 +109,7 @@ sub run {
   my $dnafrag_adaptor = $compara_dba->get_DnaFragAdaptor;
   my $mlss_adaptor = $compara_dba->get_MethodLinkSpeciesSetAdaptor;
 
-  my $mlss_id = $self->param('mlss_id');
+  my $mlss_id = $self->param_required('mlss_id');
   my $mlss = $mlss_adaptor->fetch_by_dbID($mlss_id);
   $_->db_adaptor->dbc->disconnect_when_inactive(0) for @{ $mlss->species_set->genome_dbs };
 
@@ -213,6 +222,7 @@ sub run {
   return 1;
 }
 
+
 sub write_output {
   my $self = shift;
 
@@ -232,6 +242,7 @@ sub write_output {
   return 1;
 
 }
+
 
 sub get_coding_exon_regions {
   my ($this_slice, $regions) = @_;
@@ -356,5 +367,6 @@ sub restrict_overlapping_genomic_align_blocks {
 
     return $restricted_gabs;
 }
+
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerCodingExonSummary.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerCodingExonSummary.pm
@@ -87,22 +87,9 @@ sub fetch_input {
       }
   }
 
-  my $genome_dbs = $mlss->species_set->genome_dbs;
-  my ($ref_genome_db, $non_ref_genome_db);
-  if (scalar(@{$genome_dbs}) == 1) {
-      # Self-alignment
-      $ref_genome_db = $genome_dbs->[0];
-  } else {
-      if (($genome_dbs->[0]->name eq $mlss->get_value_for_tag('reference_species')) && (!$mlss->has_tag('reference_component')
-          || ($genome_dbs->[0]->genome_component eq $mlss->get_value_for_tag('reference_component')))) {
-          ($ref_genome_db, $non_ref_genome_db) = @$genome_dbs;
-      } else {
-          ($non_ref_genome_db, $ref_genome_db) = @$genome_dbs;
-      }
-  }
-  $non_ref_genome_db ||= $ref_genome_db;
-  $self->param('ref_genome_db', $ref_genome_db);
-  $self->param('non_ref_genome_db', $non_ref_genome_db);
+  my @genome_dbs = $mlss->find_pairwise_reference;
+  $self->param('ref_genome_db', $genome_dbs[0]);
+  $self->param('non_ref_genome_db', $genome_dbs[1]);
 
   return 1;
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerCodingExonSummary.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerCodingExonSummary.pm
@@ -17,29 +17,47 @@ limitations under the License.
 
 =cut
 
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::PairAligner::PairAlignerCodingExonSummary
 
-=cut
-
 =head1 DESCRIPTION
 
-This module updates the method_link_species_set_tag table with pair aligner coding exon statistics from the statistics table
+This module updates the method_link_species_set_tag table with pair aligner
+coding exon statistics from the statistics table.
+
+=over
+
+=item mlss_id
+
+Mandatory. Method link species set ID.
+
+=item method_link_type
+
+Mandatory (if mlss_id missing). Method link type used to retrieve the MLSS of
+the given genome_db_ids.
+
+=item genome_db_ids
+
+Mandatory (if mlss_id missing). List of genome_db_ids used to retrieve their
+MLSS.
+
+=item skip
+
+Optional. Don't run this runnable.
+
+=back
+
+=head1 EXAMPLES
+
+    standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::PairAligner::PairAlignerCodingExonSummary \
+        -compara_db $(mysql-ens-compara-prod-8-ensadmin details url jalvarez_shoots_lastz) \
+        -mlss_id 3
 
 =head1 APPENDIX
 
 The rest of the documentation details each of the object methods.
-Internal methods are usually preceded with a _
+Internal methods are usually preceded with an underscore (_).
 
 =cut
 
@@ -49,6 +67,7 @@ use strict;
 use warnings;
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
 
 sub fetch_input {
   my ($self) = @_;
@@ -69,10 +88,17 @@ sub fetch_input {
   }
 
   my $genome_dbs = $mlss->species_set->genome_dbs;
-  my ($ref_genome_db, $non_ref_genome_db) = @$genome_dbs;
-  unless (($genome_dbs->[0]->name eq $mlss->get_value_for_tag('reference_species'))
-      && (!$mlss->has_tag('reference_component') || ($genome_dbs->[0]->genome_component eq $mlss->get_value_for_tag('reference_component')))) {
-        ($non_ref_genome_db, $ref_genome_db) = @$genome_dbs;
+  my ($ref_genome_db, $non_ref_genome_db);
+  if (scalar(@{$genome_dbs}) == 1) {
+      # Self-alignment
+      $ref_genome_db = $genome_dbs->[0];
+  } else {
+      if (($genome_dbs->[0]->name eq $mlss->get_value_for_tag('reference_species')) && (!$mlss->has_tag('reference_component')
+          || ($genome_dbs->[0]->genome_component eq $mlss->get_value_for_tag('reference_component')))) {
+          ($ref_genome_db, $non_ref_genome_db) = @$genome_dbs;
+      } else {
+          ($non_ref_genome_db, $ref_genome_db) = @$genome_dbs;
+      }
   }
   $non_ref_genome_db ||= $ref_genome_db;
   $self->param('ref_genome_db', $ref_genome_db);
@@ -120,7 +146,6 @@ sub write_output {
   $method_link_species_set->store_tag("non_ref_uncovered", $uncovered);
 
   return 1;
-
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerCodingExonSummary.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerCodingExonSummary.pm
@@ -87,9 +87,9 @@ sub fetch_input {
       }
   }
 
-  my @genome_dbs = $mlss->find_pairwise_reference;
-  $self->param('ref_genome_db', $genome_dbs[0]);
-  $self->param('non_ref_genome_db', $genome_dbs[1]);
+  my ($ref_genome_db, $non_ref_genome_db) = $mlss->find_pairwise_reference;
+  $self->param('ref_genome_db', $ref_genome_db);
+  $self->param('non_ref_genome_db', $non_ref_genome_db);
 
   return 1;
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerCodingExonSummary.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerCodingExonSummary.pm
@@ -88,6 +88,7 @@ sub fetch_input {
   }
 
   my ($ref_genome_db, $non_ref_genome_db) = $mlss->find_pairwise_reference;
+  $non_ref_genome_db //= $ref_genome_db;
   $self->param('ref_genome_db', $ref_genome_db);
   $self->param('non_ref_genome_db', $non_ref_genome_db);
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerStats.pm
@@ -106,6 +106,9 @@ sub fetch_input {
   my ($self) = @_;
 
   return if ($self->param('skip'));
+
+  $self->param_required('bed_dir');
+
   #Find the mlss_id from the method_link_type and genome_db_ids
   my $mlss;
   my $mlss_adaptor = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor;
@@ -218,7 +221,7 @@ sub dump_bed_file {
        $species_arg  .= " --component ".$genome_db->genome_component if $genome_db->genome_component;
     
     #Check if file already exists
-    my $genome_bed_file = $self->param_required('bed_dir') ."/" . $name . "." . $genome_db->dbID . "." . "genome.bed";
+    my $genome_bed_file = $self->param('bed_dir') ."/" . $name . "." . $genome_db->dbID . "." . "genome.bed";
 
     if (-e $genome_bed_file && !(-z $genome_bed_file)) {
 	print "$genome_bed_file already exists and not empty. Not overwriting.\n";

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerStats.pm
@@ -126,26 +126,13 @@ sub fetch_input {
   $self->param('mlss_id', $mlss->dbID);
   $self->param('mlss', $mlss);
 
-  my $genome_dbs = $mlss->species_set->genome_dbs;
-  my ($ref_genome_db, $non_ref_genome_db);
-  if (scalar(@{$genome_dbs}) == 1) {
-      # Self-alignment
-      $ref_genome_db = $genome_dbs->[0];
-  } else {
-      if (($genome_dbs->[0]->name eq $mlss->get_value_for_tag('reference_species')) && (!$mlss->has_tag('reference_component')
-          || ($genome_dbs->[0]->genome_component eq $mlss->get_value_for_tag('reference_component')))) {
-          ($ref_genome_db, $non_ref_genome_db) = @$genome_dbs;
-      } else {
-          ($non_ref_genome_db, $ref_genome_db) = @$genome_dbs;
-      }
-  }
-  $non_ref_genome_db ||= $ref_genome_db;
-  $self->param('ref_genome_db', $ref_genome_db);
-  $self->param('non_ref_genome_db', $non_ref_genome_db);
+  my @genome_dbs = $mlss->find_pairwise_reference;
+  $self->param('ref_genome_db', $genome_dbs[0]);
+  $self->param('non_ref_genome_db', $genome_dbs[1]);
 
   #Create url from db_adaptor
-  my $ref_url = $ref_genome_db->db_adaptor->url;
-  my $non_ref_url = $non_ref_genome_db->db_adaptor->url;
+  my $ref_url = $genome_dbs[0]->db_adaptor->url;
+  my $non_ref_url = $genome_dbs[1]->db_adaptor->url;
 
   $self->param('ref_dbc_url', $ref_url);
   $self->param('non_ref_dbc_url', $non_ref_url);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerStats.pm
@@ -17,39 +17,74 @@ limitations under the License.
 
 =cut
 
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::PairAligner::PairAlignerStats
 
-=cut
-
-=head1 SYNOPSIS
-
-$module->fetch_input
-
-$module->run
-
-$module->write_output
-
-=cut
-
 =head1 DESCRIPTION
 
-This module updates the method_link_species_set_tag table with pair aligner statistics by firstly adding any new bed files to the correct directory and running compare_beds to generate the statistics
+This module updates the method_link_species_set_tag table with pair aligner
+statistics by firstly adding any new bed files to the correct directory and
+running compare_beds to generate the statistics.
+
+=over
+
+=item mlss_id
+
+Mandatory. Method link species set ID.
+
+=item method_link_type
+
+Mandatory (if mlss_id missing). Method link type used to retrieve the MLSS of
+the given genome_db_ids.
+
+=item genome_db_ids
+
+Mandatory (if mlss_id missing). List of genome_db_ids used to retrieve their
+MLSS.
+
+=item bed_dir
+
+Mandatory. Location to dump the BED files.
+
+=item compare_beds
+
+Mandatory. Script to compare the overlap between two BED files to generate
+the stats.
+
+=item create_pair_aligner_page
+
+Mandatory. Script to generate the configuration parameters and coverage for a
+pairwise alignment.
+
+=item dump_features
+
+Mandatory. Script to dump the selected features in to a BED file.
+
+=item output_dir
+
+Optional. Location to dump the feature BED files.
+
+=item skip
+
+Optional. Don't run this runnable.
+
+=back
+
+=head1 EXAMPLES
+
+    standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::PairAligner::PairAlignerStats \
+        -compara_db $(mysql-ens-compara-prod-8-ensadmin details url jalvarez_plants_lastz_polyploid_99) \
+        -mlss_id 9880 -bed_dir /hps/nobackup2/production/ensembl/jalvarez/plants_lastz_polyploid_99/bed_dir \
+        -compare_beds $ENSEMBL_CVS_ROOT_DIR/ensembl-compara/scripts/pipeline/compare_beds.pl \
+        -create_pair_aligner_page $ENSEMBL_CVS_ROOT_DIR/ensembl-compara/scripts/report/create_pair_aligner_page.pl \
+        -dump_features $ENSEMBL_CVS_ROOT_DIR/ensembl-compara/scripts/dumps/dump_features.pl \
+        -output_dir /hps/nobackup2/production/ensembl/jalvarez/plants_lastz_polyploid_99/feature_dumps
 
 =head1 APPENDIX
 
 The rest of the documentation details each of the object methods.
-Internal methods are usually preceded with a _
+Internal methods are usually preceded with an underscore (_).
 
 =cut
 
@@ -61,24 +96,16 @@ use warnings;
 use Bio::EnsEMBL::Hive::DBSQL::DBConnection;
 use Bio::EnsEMBL::Hive::Utils 'stringify';  # import 'stringify()'
 use Bio::EnsEMBL::Utils::URI;
+
 use Bio::EnsEMBL::Compara::Utils::CoreDBAdaptor;
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
-=head2 fetch_input
-
-  Implementation of the Bio::EnsEMBL::Hive::Process interface
-
-=cut
 
 sub fetch_input {
   my ($self) = @_;
 
   return if ($self->param('skip'));
-  #Default directory containing bed files.
-  if (!defined $self->param('bed_dir')) {
-      die ("Must define a location to dump the bed files using the parameter 'bed_dir'");
-  }
   #Find the mlss_id from the method_link_type and genome_db_ids
   my $mlss;
   my $mlss_adaptor = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor;
@@ -97,10 +124,17 @@ sub fetch_input {
   $self->param('mlss', $mlss);
 
   my $genome_dbs = $mlss->species_set->genome_dbs;
-  my ($ref_genome_db, $non_ref_genome_db) = @$genome_dbs;
-  unless (($genome_dbs->[0]->name eq $mlss->get_value_for_tag('reference_species'))
-      && (!$mlss->has_tag('reference_component') || ($genome_dbs->[0]->genome_component eq $mlss->get_value_for_tag('reference_component')))) {
-        ($non_ref_genome_db, $ref_genome_db) = @$genome_dbs;
+  my ($ref_genome_db, $non_ref_genome_db);
+  if (scalar(@{$genome_dbs}) == 1) {
+      # Self-alignment
+      $ref_genome_db = $genome_dbs->[0];
+  } else {
+      if (($genome_dbs->[0]->name eq $mlss->get_value_for_tag('reference_species')) && (!$mlss->has_tag('reference_component')
+          || ($genome_dbs->[0]->genome_component eq $mlss->get_value_for_tag('reference_component')))) {
+          ($ref_genome_db, $non_ref_genome_db) = @$genome_dbs;
+      } else {
+          ($non_ref_genome_db, $ref_genome_db) = @$genome_dbs;
+      }
   }
   $non_ref_genome_db ||= $ref_genome_db;
   $self->param('ref_genome_db', $ref_genome_db);
@@ -119,9 +153,6 @@ sub fetch_input {
   return 1;
 }
 
-=head2 run
-
-=cut
 
 sub run {
   my $self = shift;
@@ -132,18 +163,14 @@ sub run {
 }
 
 
-=head2 write_output
-
-=cut
-
 sub write_output {
   my ($self) = @_;
 
   return if ($self->param('skip'));
 
   #Dump bed files if necessary
-  my ($ref_genome_bed) = $self->dump_bed_file($self->param('ref_genome_db'), $self->param('ref_dbc_url'), $self->param('reg_conf'));
-  my ($non_ref_genome_bed) = $self->dump_bed_file($self->param('non_ref_genome_db'), $self->param('non_ref_dbc_url'), $self->param('reg_conf'));
+  my ($ref_genome_bed) = $self->dump_bed_file($self->param('ref_genome_db'), $self->param('ref_dbc_url'));
+  my ($non_ref_genome_bed) = $self->dump_bed_file($self->param('non_ref_genome_db'), $self->param('non_ref_dbc_url'));
 
   
   #Create statistics
@@ -184,14 +211,14 @@ sub write_output {
 #regions. If a file of that convention already exists, it will not be overwritten.
 #
 sub dump_bed_file {
-    my ($self, $genome_db, $dbc_url, $reg_conf) = @_;
+    my ($self, $genome_db, $dbc_url) = @_;
 
     my $name = $genome_db->_get_unique_name; #get production_name
     my $species_arg   = "--species ".$genome_db->name;
        $species_arg  .= " --component ".$genome_db->genome_component if $genome_db->genome_component;
     
     #Check if file already exists
-    my $genome_bed_file = $self->param('bed_dir') ."/" . $name . "." . $genome_db->dbID . "." . "genome.bed";
+    my $genome_bed_file = $self->param_required('bed_dir') ."/" . $name . "." . $genome_db->dbID . "." . "genome.bed";
 
     if (-e $genome_bed_file && !(-z $genome_bed_file)) {
 	print "$genome_bed_file already exists and not empty. Not overwriting.\n";
@@ -335,5 +362,6 @@ sub run_create_pair_aligner_page {
 
     $self->run_command($cmd, { die_on_failure => 1 });
 }
+
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerStats.pm
@@ -126,13 +126,13 @@ sub fetch_input {
   $self->param('mlss_id', $mlss->dbID);
   $self->param('mlss', $mlss);
 
-  my @genome_dbs = $mlss->find_pairwise_reference;
-  $self->param('ref_genome_db', $genome_dbs[0]);
-  $self->param('non_ref_genome_db', $genome_dbs[1]);
+  my ($ref_genome_db, $non_ref_genome_db) = $mlss->find_pairwise_references;
+  $self->param('ref_genome_db', $ref_genome_db);
+  $self->param('non_ref_genome_db', $non_ref_genome_db);
 
   #Create url from db_adaptor
-  my $ref_url = $genome_dbs[0]->db_adaptor->url;
-  my $non_ref_url = $genome_dbs[1]->db_adaptor->url;
+  my $ref_url = $ref_genome_db->db_adaptor->url;
+  my $non_ref_url = $non_ref_genome_db->db_adaptor->url;
 
   $self->param('ref_dbc_url', $ref_url);
   $self->param('non_ref_dbc_url', $non_ref_url);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerStats.pm
@@ -158,9 +158,9 @@ sub write_output {
 
   return if ($self->param('skip'));
 
-  #Dump bed files if necessary
-  my ($ref_genome_bed) = $self->dump_bed_file($self->param('ref_genome_db'), $self->param('ref_dbc_url'));
-  my ($non_ref_genome_bed) = $self->dump_bed_file($self->param('non_ref_genome_db'), $self->param('non_ref_dbc_url'));
+  # Dump bed files if necessary
+  my $ref_genome_bed     = $self->dump_bed_file($self->param('ref_genome_db'), $self->param('ref_dbc_url'));
+  my $non_ref_genome_bed = $self->dump_bed_file($self->param('non_ref_genome_db'), $self->param('non_ref_dbc_url'));
 
   
   #Create statistics
@@ -218,7 +218,7 @@ sub dump_bed_file {
         $self->run_command($cmd, { die_on_failure => 1 });
     }
 
-    return ($genome_bed_file);
+    return $genome_bed_file;
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/PairAlignerStats.pm
@@ -127,6 +127,7 @@ sub fetch_input {
   $self->param('mlss', $mlss);
 
   my ($ref_genome_db, $non_ref_genome_db) = $mlss->find_pairwise_references;
+  $non_ref_genome_db //= $ref_genome_db;
   $self->param('ref_genome_db', $ref_genome_db);
   $self->param('non_ref_genome_db', $non_ref_genome_db);
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/ParsePairAlignerConf.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/ParsePairAlignerConf.pm
@@ -680,7 +680,7 @@ sub parse_defaults {
                 die "Cannot find tag 'reference_species' for mlss_id $mlss_id" unless $ref_name;
                 my $ref_index = ($mlss_gdbs->[0]->name eq $ref_name) ? 0 : 1;
                 my $ref_gdb   = $mlss_gdbs->[$ref_index];
-                my $non_ref_index = ($ref_index + 1) % 2;
+                my $non_ref_index = 1 - $ref_index;
                 my $non_ref_gdb   = $mlss_gdbs->[$non_ref_index];
                 # To align two polyploid genomes component by component, their
                 # genus has to be the same

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/ParsePairAlignerConf.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/ParsePairAlignerConf.pm
@@ -43,7 +43,7 @@ use warnings;
 
 use File::Path;
 
-use Bio::EnsEMBL::Hive::Utils 'stringify', 'destringify';
+use Bio::EnsEMBL::Hive::Utils qw(stringify destringify);
 use Bio::EnsEMBL::Utils::Exception qw(throw verbose);
 
 use Bio::EnsEMBL::Compara::MethodLinkSpeciesSet;
@@ -922,6 +922,11 @@ sub write_mlss_entry {
     my $ref_name;
     my $name;
 
+    # Create the name of the new MLSS following the format:
+    #     <species1>[.component]-<species2>[.component] method (on <ref_species>[.component])
+    # For instance, a LASTZ_NET PWA of triticum dicoccoides vs triticum turgidum on component
+    # A, being triticum dicoccoides the reference species, the MLSS name would be:
+    #     Tdico.A-Tturg.A lastz-net (on Tdico.A)
     foreach my $gdb ($ref_genome_db, $non_ref_genome_db) {
         my $species_name = $gdb->name;
         $species_name =~ s/\b(\w)/\U$1/g;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/ParsePairAlignerConf.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/ParsePairAlignerConf.pm
@@ -655,7 +655,7 @@ sub parse_defaults {
             my $mlss = $mlss_adaptor->fetch_by_dbID($mlss_id);
             my @mlss_gdbs = $mlss->find_pairwise_reference;
             my @pair;
-            if ($mlss_gdbs[0]->name eq $mlss_gdbs[1]->name) {
+            if (scalar(@mlss_gdbs) == 1) {
                 # Self-alignment
                 if ($mlss_gdbs[0]->is_polyploid) {
                     # To self-align a polyploid genome, align all combinations
@@ -670,11 +670,9 @@ sub parse_defaults {
                         }
                     }
                 } else {
-                    # Pairwise alignments of two components of the same genome
-                    # are handled correctly because we are using both indexes
                     push @pair,
                          {'ref_genome_db'     => $mlss_gdbs[0],
-                          'non_ref_genome_db' => $mlss_gdbs[1]};
+                          'non_ref_genome_db' => $mlss_gdbs[0]};
                 }
             } else {
                 # Pairwise alignment

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/SetInternalIdsCollection.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/SetInternalIdsCollection.pm
@@ -75,6 +75,8 @@ sub run {
 
 
 sub _setInternalIds {
+    # NOTE: the code regarding the first transaction of this function should be kept in sync with
+    # Bio::EnsEMBL::Compara::RunnableDB::PairAligner::LiftComponentAlignments::_lift_gas_and_gabs()
     my $self = shift;
 
     my $mlss_id = $self->param('method_link_species_set_id');

--- a/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
@@ -15,14 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=head1 CONTACT
-
-Please email comments or questions to the public Ensembl
-developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-Questions may also be sent to the Ensembl help desk at
-<http://www.ensembl.org/Help/Contact>.
-
 =head1 DESCRIPTION
 
 This modules contains common methods used when dealing with the
@@ -30,8 +22,6 @@ Compara master database. They can in fact be called on other
 databases too.
 
 - update_dnafrags: updates the DnaFrags of a species
-
-=head1 METHODS
 
 =cut
 
@@ -786,11 +776,7 @@ sub create_self_wga_mlsss {
         # POLYPLOID is the restriction of the alignment on the homoeologues
         my $pp_method = $compara_dba->get_MethodAdaptor->fetch_by_type('POLYPLOID');
         my $pp_mlss = create_mlss($pp_method, $species_set);
-        # Pairwise MLSSs between the components
-        my $sub_aln_mlsss = create_mlsss_on_pairs($aln_method, $gdb->component_genome_dbs);
-        # Those MLSSs should remain internal
-        $_->{_no_release} = 1 for @$sub_aln_mlsss;
-        return [$self_lastz_mlss, $pp_mlss, @$sub_aln_mlsss];
+        return [$self_lastz_mlss, $pp_mlss];
     }
     return [$self_lastz_mlss];
 }

--- a/modules/t/methodLinkSpeciesSet.t
+++ b/modules/t/methodLinkSpeciesSet.t
@@ -39,9 +39,21 @@ my $method_link_species_set;
 ok(defined($multi) and defined($compara_dba));
 
 # Create genome_dbs
-my $gdb1 =  new Bio::EnsEMBL::Compara::GenomeDB(undef, "homo_sapiens", "NCBI36", "9606", "22", "2006-08-Ensembl");
+my $gdb1 =  new Bio::EnsEMBL::Compara::GenomeDB(
+    -name      => 'homo_sapiens',
+    -assembly  => 'NCBI36',
+    -taxon_id  => 9606,
+    -dbID      => 22,
+    -genebuild => '2006-08-Ensembl'
+);
 $gdb1->adaptor($genome_db_adaptor);
-my $gdb2 =  new Bio::EnsEMBL::Compara::GenomeDB(undef, "mus_musculus", "NCBIM36", "10090", "25", "2006-04-Ensembl");
+my $gdb2 =  new Bio::EnsEMBL::Compara::GenomeDB(
+    -name      => 'mus_musculus',
+    -assembly  => 'NCBIM36',
+    -taxon_id  => 10090,
+    -dbID      => 25,
+    -genebuild => '2006-04-Ensembl'
+);
 $gdb2->adaptor($genome_db_adaptor);
 
 #
@@ -97,9 +109,9 @@ subtest "Test Bio::EnsEMBL::Compara::MethodLinkSpeciesSet::new(ALL)", sub {
 
 
 subtest "Test Bio::EnsEMBL::Compara::MethodLinkSpeciesSet::find_pairwise_reference", sub {
-    my @genome_dbs = ($gdb1, $gdb2);
-    is ($method_link_species_set->find_pairwise_reference, @genome_dbs,
-        'Correct genome_dbs and order returned');
+    my $genome_dbs = [$gdb1, $gdb2];
+    my @returned_gdbs = $method_link_species_set->find_pairwise_reference();
+    is_deeply(\@returned_gdbs, $genome_dbs, 'Correct genome_dbs and order returned');
 };
 
 done_testing();

--- a/modules/t/methodLinkSpeciesSet.t
+++ b/modules/t/methodLinkSpeciesSet.t
@@ -31,14 +31,18 @@ my $compara_dba = $multi->get_DBAdaptor( "compara" );
 my $genome_db_adaptor = $compara_dba->get_GenomeDBAdaptor();
   
 my $method_link_species_set_adaptor;
-my $method_link_species_sets;
 my $method_link_species_set;
-my $species;
 
 # 
 # Check premises
 # 
 ok(defined($multi) and defined($compara_dba));
+
+# Create genome_dbs
+my $gdb1 =  new Bio::EnsEMBL::Compara::GenomeDB(undef, "homo_sapiens", "NCBI36", "9606", "22", "2006-08-Ensembl");
+$gdb1->adaptor($genome_db_adaptor);
+my $gdb2 =  new Bio::EnsEMBL::Compara::GenomeDB(undef, "mus_musculus", "NCBIM36", "10090", "25", "2006-04-Ensembl");
+$gdb2->adaptor($genome_db_adaptor);
 
 #
 # Test new method
@@ -50,30 +54,10 @@ subtest "Test Bio::EnsEMBL::Compara::MethodLinkSpeciesSet::new(ALL)", sub {
                                                    -dbID => 1,
                                                    -type => "BLASTZ_NET",
                                                    -class => "GenomicAlignBlock.pairwise_alignment");
-    #
-    #Create genome_dbs
-    #
-    my $gdb1 =  new Bio::EnsEMBL::Compara::GenomeDB(
-                                                    undef,
-                                                    "homo_sapiens",       
-                                                    "NCBI36",
-                                                    "9606",
-                                                    "22",          
-                                                    "2006-08-Ensembl");  
-    $gdb1->adaptor($genome_db_adaptor);
-
-    my $gdb2 =  new Bio::EnsEMBL::Compara::GenomeDB(
-                                                    undef,
-                                                    "mus_musculus",       
-                                                    "NCBIM36",
-                                                    "10090",
-                                                    "25",          
-                                                    "2006-04-Ensembl");  
-    $gdb2->adaptor($genome_db_adaptor);
 
     my $species_set = new Bio::EnsEMBL::Compara::SpeciesSet(-dbID => 30005,
                                                             -genome_dbs => [$gdb1, $gdb2]);
-    
+
     my $mlss_name = "H.sap-M.mus blastz-net (on H.sap)";
     my $mlss_source = "ensembl";
     my $mlss_url;
@@ -109,12 +93,13 @@ subtest "Test Bio::EnsEMBL::Compara::MethodLinkSpeciesSet::new(ALL)", sub {
     my $classification = join(":", map {$_} @{$method_link_species_set->species_set->get_common_classification});
     
     is ($classification, $mlss_classification);
+};
 
+
+subtest "Test Bio::EnsEMBL::Compara::MethodLinkSpeciesSet::find_pairwise_reference", sub {
     my @genome_dbs = ($gdb1, $gdb2);
     is ($method_link_species_set->find_pairwise_reference, @genome_dbs,
-        'Correct genome_dbs and order returned by find_pairwise_reference()');
-
-    done_testing();
+        'Correct genome_dbs and order returned');
 };
 
 done_testing();

--- a/modules/t/methodLinkSpeciesSet.t
+++ b/modules/t/methodLinkSpeciesSet.t
@@ -44,7 +44,7 @@ ok(defined($multi) and defined($compara_dba));
 # Test new method
 #
 
-subtest "Test Bio::EnsEMBL::Compara::DBSQL::MethodLinkSpeciesSet::new(ALL)", sub {
+subtest "Test Bio::EnsEMBL::Compara::MethodLinkSpeciesSet::new(ALL)", sub {
 
     my $method = new Bio::EnsEMBL::Compara::Method(
                                                    -dbID => 1,
@@ -109,6 +109,10 @@ subtest "Test Bio::EnsEMBL::Compara::DBSQL::MethodLinkSpeciesSet::new(ALL)", sub
     my $classification = join(":", map {$_} @{$method_link_species_set->species_set->get_common_classification});
     
     is ($classification, $mlss_classification);
+
+    my @genome_dbs = ($gdb1, $gdb2);
+    is ($method_link_species_set->find_pairwise_reference, @genome_dbs,
+        'Correct genome_dbs and order returned by find_pairwise_reference()');
 
     done_testing();
 };

--- a/modules/t/methodLinkSpeciesSet.t
+++ b/modules/t/methodLinkSpeciesSet.t
@@ -109,6 +109,7 @@ subtest "Test Bio::EnsEMBL::Compara::MethodLinkSpeciesSet::new(ALL)", sub {
 
 
 subtest "Test Bio::EnsEMBL::Compara::MethodLinkSpeciesSet::find_pairwise_reference", sub {
+    $method_link_species_set->add_tag('reference_species', 'homo_sapiens');
     my $genome_dbs = [$gdb1, $gdb2];
     my @returned_gdbs = $method_link_species_set->find_pairwise_reference();
     is_deeply(\@returned_gdbs, $genome_dbs, 'Correct genome_dbs and order returned');

--- a/scripts/pipeline/create_all_mlss.pl
+++ b/scripts/pipeline/create_all_mlss.pl
@@ -22,14 +22,6 @@ use strict;
 
 create_all_mlss.pl
 
-=head1 CONTACT
-
-Please email comments or questions to the public Ensembl
-developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-Questions may also be sent to the Ensembl help desk at
-<http://www.ensembl.org/Help/Contact>.
-
 =head1 DESCRIPTION
 
 This script reads an XML configuration file that describes which analyses
@@ -348,11 +340,6 @@ foreach my $xml_one_vs_all_node (@{$division_node->findnodes('pairwise_alignment
     my $method = $compara_dba->get_MethodAdaptor->fetch_by_type( $xml_one_vs_all_node->getAttribute('method') );
     my $genome_dbs = make_species_set_from_XML_node($xml_one_vs_all_node->getChildrenByTagName('species_set')->[0], $division_genome_dbs);
     while (my $ref_gdb = shift @$genome_dbs) {
-        if ($ref_gdb->is_polyploid) {
-            # We don't do polyploid vs polyploid (yet ?)
-            push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_pairwise_wga_mlsss($compara_dba, $method, $ref_gdb, $_) } for grep {!$_->is_polyploid} @$genome_dbs;
-            next;
-        }
         push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_pairwise_wga_mlsss($compara_dba, $method, $ref_gdb, $_) } for @$genome_dbs;
     }
 }

--- a/scripts/pipeline/populate_new_database.pl
+++ b/scripts/pipeline/populate_new_database.pl
@@ -35,14 +35,6 @@ my $description = q{
 
 populate_new_database.pl
 
-=head1 CONTACT
-
-Please email comments or questions to the public Ensembl
-developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-Questions may also be sent to the Ensembl help desk at
-<http://www.ensembl.org/Help/Contact>.
-
 =head1 DESCRIPTION
 
 This script populates a new database based on the default assemblies
@@ -186,7 +178,6 @@ use Bio::EnsEMBL::Utils::Exception qw(throw warning);
 use Bio::EnsEMBL::Utils::Scalar qw(:assert);
 use Bio::EnsEMBL::Compara::Utils::CopyData qw(:table_copy);
 use Getopt::Long;
-use Data::Dumper;
 
 my $help;
 
@@ -467,6 +458,10 @@ sub get_all_default_genome_dbs {
       my $this_mlss = $method_link_species_set_adaptor->fetch_by_dbID($this_mlss_id);
       foreach my $this_genome_db (@{$this_mlss->species_set->genome_dbs}) {
         $all_species->{$this_genome_db->dbID} = $this_genome_db;
+        # Copy also the components of polyploid genomes
+        if ($this_genome_db->is_polyploid) {
+            $all_species->{$_->dbID} = $_ for @{$this_genome_db->component_genome_dbs};
+        }
       }
     }
     return [values %$all_species];

--- a/scripts/production/batch_lastz.pl
+++ b/scripts/production/batch_lastz.pl
@@ -111,7 +111,7 @@ foreach my $mlss ( @current_lastz_mlsses ) {
     $mlss_job_count{$mlss->dbID}->{analysis}->{dump_nibs} = $filter_dups_job_count;
     $mlss_job_count{$mlss->dbID}->{analysis}->{exon_stats} = $filter_dups_job_count;
 
-    $mlss_job_count{$k}->{all} = sum(values %{ $mlss_job_count{$mlss->dbID}->{analysis} });
+    $mlss_job_count{$mlss->dbID}->{all} = sum(values %{ $mlss_job_count{$mlss->dbID}->{analysis} });
 
 	print_verbose_summary(\%mlss_job_count, $mlss) if ($verbose);
 	print_very_verbose_summary(\%mlss_job_count, $mlss) if ($very_verbose);


### PR DESCRIPTION
Links to tickets [ENSCOMPARASW-2412](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-2412), [ENSCOMPARASW-1878](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-1878) and [ENSCOMPARASW-2020](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-2020).

Main features:
- Two polypoids are aligned by their shared components (by name) only when they belong to the same genus
- The component alignment and lifting is done internally, i.e. only the principal MLSS id is passed to the `PairAligner` pipeline

I have created a division composed by a mix of three polyploid and one non-polyploid plant partial genomes (named sprouts) to **test** every scenario: PWA of two polyploids of the same genus (A _vs_ A, D _vs_ D, ...), PWA of two polyploids of different genus (standard PWA), one polyploid _vs_ one non-polyploid (standard PWA) and a polyploid self-alignment (all _vs_ all components). This is how the pipeline looks now: [mysql://ensro@mysql-ens-compara-prod-8:4618/jalvarez_sprouts_lastz](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-8&port=4618&dbname=jalvarez_sprouts_lastz)
The last job is failing because I didn't pay attention to the regions selected and it seems that the polyploid _vs_ the non-polyploid don't align to each other.