### PR TITLE
Developement for the migration of pan compara to compara

### DIFF
--- a/conf/pan/production_reg_conf.pl
+++ b/conf/pan/production_reg_conf.pl
@@ -86,7 +86,7 @@ Bio::EnsEMBL::Compara::Utils::Registry::add_compara_dbas( $compara_dbs );
 # NCBI taxonomy database (also maintained by production team):
 Bio::EnsEMBL::Compara::Utils::Registry::add_taxonomy_dbas({
     'ncbi_taxonomy' => [ 'mysql-ens-sta-1', 'ncbi_taxonomy' ],
-    });
+});
 
 # -------------------------------------------------------------------
 

--- a/conf/pan/production_reg_conf.pl
+++ b/conf/pan/production_reg_conf.pl
@@ -1,0 +1,99 @@
+#!/usr/bin/env perl
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2019] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Release Coordinator, please update this file before starting every release
+# and check the changes back into GIT for everyone's benefit.
+
+# Things that normally need updating are:
+#
+# 1. Release number
+# 2. Check the name prefix of all databases
+# 3. Possibly add entries for core databases that are still on genebuilders' servers
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Registry;
+use Bio::EnsEMBL::Compara::Utils::Registry;
+
+my $curr_release = $ENV{'CURR_ENSEMBL_RELEASE'};
+my $prev_release = $curr_release - 1;
+my $curr_eg_release = $curr_release - 53;
+my $prev_eg_release = $curr_eg_release - 1;
+
+# ---------------------- CURRENT CORE DATABASES----------------------------------
+
+# most cores are on EG servers, but some are on ensembl's vertannot-staging
+Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertannot-staging:4573/$curr_release");
+Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-3:4160/$curr_release");
+#Bio::EnsEMBL::Registry->remove_DBAdaptor('saccharomyces_cerevisiae', 'core'); # never use EG's version of yeast
+
+# ---------------------- PREVIOUS CORE DATABASES---------------------------------
+
+# previous release core databases will be required by PrepareMasterDatabaseForRelease and LoadMembers only
+# !!! COMMENT THIS SECTION OUT FOR ALL OTHER PIPELINES (for speed) !!!
+#my $suffix_separator = '__cut_here__';
+#Bio::EnsEMBL::Registry->load_registry_from_db(
+#    -host   => 'mysql-ens-mirror-3',
+#    -port   => 4275,
+#    -user   => 'ensro',
+#    -pass   => '',
+#    -db_version     => $prev_release,
+#    -species_suffix => $suffix_separator.$prev_release,
+#);
+#Bio::EnsEMBL::Registry->remove_DBAdaptor('saccharomyces_cerevisiae'.$suffix_separator.$prev_release, 'core'); # never use EG's version of yeast
+#Bio::EnsEMBL::Registry->load_registry_from_db(
+#    -host   => 'mysql-ens-mirror-1',
+#    -port   => 4240,
+#    -user   => 'ensro',
+#    -pass   => '',
+#    -db_version     => $prev_release,
+#    -species_suffix => $suffix_separator.$prev_release,
+#);
+#------------------------COMPARA DATABASE LOCATIONS----------------------------------
+
+
+my $compara_dbs = {
+    # general compara dbs
+    'compara_master' => [ 'mysql-ens-compara-prod-7', 'ensembl_compara_master_pan' ],
+   # 'compara_curr'   => [ 'mysql-ens-compara-prod-5', "ensembl_compara_plants_${curr_eg_release}_${curr_release}" ],
+   # 'compara_prev'   => [ 'mysql-ens-compara-prod-5', "ensembl_compara_plants_${prev_eg_release}_${prev_release}" ],
+
+    # homology dbs
+    #'compara_members'  => [ 'mysql-ens-compara-prod-5', 'cristig_plants_load_members_99'  ],
+    #'compara_ptrees'   => [ 'mysql-ens-compara-prod-3', 'cristig_default_plants_protein_trees_99' ],
+    #'ptrees_prev'      => [ 'mysql-ens-compara-prod-5', 'jalvarez_default_plants_protein_trees_98' ],
+
+    # LASTZ dbs
+    #'lastz' => [ 'mysql-ens-compara-prod-5', 'cristig_plants_lastz_batch1_99' ],
+
+    # synteny
+    #compara_syntenies' => [ 'mysql-ens-compara-prod-1', 'cristig_plants_synteny_99' ],
+};
+
+Bio::EnsEMBL::Compara::Utils::Registry::add_compara_dbas( $compara_dbs );
+
+# ----------------------NON-COMPARA DATABASES------------------------
+
+# NCBI taxonomy database (also maintained by production team):
+Bio::EnsEMBL::Compara::Utils::Registry::add_taxonomy_dbas({
+        'ncbi_taxonomy' => [ 'mysql-ens-sta-1', 'ncbi_taxonomy' ],
+    });
+
+# -------------------------------------------------------------------
+
+1;

--- a/conf/pan/production_reg_conf.pl
+++ b/conf/pan/production_reg_conf.pl
@@ -85,7 +85,7 @@ Bio::EnsEMBL::Compara::Utils::Registry::add_compara_dbas( $compara_dbs );
 
 # NCBI taxonomy database (also maintained by production team):
 Bio::EnsEMBL::Compara::Utils::Registry::add_taxonomy_dbas({
-    'ncbi_taxonomy' => [ 'mysql-ens-sta-1', 'ncbi_taxonomy' ],
+    'ncbi_taxonomy' => [ 'mysql-ens-sta-1', "ncbi_taxonomy_${curr_release}" ],
 });
 
 # -------------------------------------------------------------------

--- a/conf/pan/production_reg_conf.pl
+++ b/conf/pan/production_reg_conf.pl
@@ -32,7 +32,7 @@ use Bio::EnsEMBL::Compara::Utils::Registry;
 
 my $curr_release = $ENV{'CURR_ENSEMBL_RELEASE'};
 my $prev_release = $curr_release - 1;
-my $curr_eg_release = $curr_release - 53;
+my $curr_eg_release = $ENV{'CURR_EG_RELEASE'};
 my $prev_eg_release = $curr_eg_release - 1;
 
 # ---------------------- CURRENT CORE DATABASES----------------------------------
@@ -70,15 +70,13 @@ Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-3:4
 my $compara_dbs = {
     # general compara dbs
     'compara_master' => [ 'mysql-ens-compara-prod-7', 'ensembl_compara_master_pan' ],
-   # 'compara_curr'   => [ 'mysql-ens-compara-prod-7', "ensembl_compara_pan_homology_${curr_eg_release}_${curr_release}" ],
-   # 'compara_prev'   => [ 'mysql-ens-compara-prod-7', "ensembl_compara_pan_homolog_${prev_eg_release}_${prev_release}" ],
+    # 'compara_curr'   => [ 'mysql-ens-compara-prod-7', "ensembl_compara_pan_homology_${curr_eg_release}_${curr_release}" ],
+    # 'compara_prev'   => [ 'mysql-ens-compara-prod-7', "ensembl_compara_pan_homolog_${prev_eg_release}_${prev_release}" ],
 
     # homology dbs
     #'compara_members'  => [ '', ''  ],
     #'compara_ptrees'   => [ '', '' ],
     #'ptrees_prev'      => [ 'mysql-ens-compara-prod-7', 'dthybert_pan_protein_trees_99' ],
-
-
 };
 
 Bio::EnsEMBL::Compara::Utils::Registry::add_compara_dbas( $compara_dbs );
@@ -87,7 +85,7 @@ Bio::EnsEMBL::Compara::Utils::Registry::add_compara_dbas( $compara_dbs );
 
 # NCBI taxonomy database (also maintained by production team):
 Bio::EnsEMBL::Compara::Utils::Registry::add_taxonomy_dbas({
-        'ncbi_taxonomy' => [ 'mysql-ens-sta-1', 'ncbi_taxonomy' ],
+    'ncbi_taxonomy' => [ 'mysql-ens-sta-1', 'ncbi_taxonomy' ],
     });
 
 # -------------------------------------------------------------------

--- a/conf/pan/production_reg_conf.pl
+++ b/conf/pan/production_reg_conf.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2019] EMBL-European Bioinformatics Institute
+# Copyright [2016-2020] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,19 +70,15 @@ Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-3:4
 my $compara_dbs = {
     # general compara dbs
     'compara_master' => [ 'mysql-ens-compara-prod-7', 'ensembl_compara_master_pan' ],
-   # 'compara_curr'   => [ 'mysql-ens-compara-prod-5', "ensembl_compara_plants_${curr_eg_release}_${curr_release}" ],
-   # 'compara_prev'   => [ 'mysql-ens-compara-prod-5', "ensembl_compara_plants_${prev_eg_release}_${prev_release}" ],
+   # 'compara_curr'   => [ 'mysql-ens-compara-prod-7', "ensembl_compara_pan_homology_${curr_eg_release}_${curr_release}" ],
+   # 'compara_prev'   => [ 'mysql-ens-compara-prod-7', "ensembl_compara_pan_homolog_${prev_eg_release}_${prev_release}" ],
 
     # homology dbs
-    #'compara_members'  => [ 'mysql-ens-compara-prod-5', 'cristig_plants_load_members_99'  ],
-    #'compara_ptrees'   => [ 'mysql-ens-compara-prod-3', 'cristig_default_plants_protein_trees_99' ],
-    #'ptrees_prev'      => [ 'mysql-ens-compara-prod-5', 'jalvarez_default_plants_protein_trees_98' ],
+    #'compara_members'  => [ '', ''  ],
+    #'compara_ptrees'   => [ '', '' ],
+    #'ptrees_prev'      => [ 'mysql-ens-compara-prod-7', 'dthybert_pan_protein_trees_99' ],
 
-    # LASTZ dbs
-    #'lastz' => [ 'mysql-ens-compara-prod-5', 'cristig_plants_lastz_batch1_99' ],
 
-    # synteny
-    #compara_syntenies' => [ 'mysql-ens-compara-prod-1', 'cristig_plants_synteny_99' ],
 };
 
 Bio::EnsEMBL::Compara::Utils::Registry::add_compara_dbas( $compara_dbs );

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/PrepareMasterDatabaseForRelease_conf.pm
@@ -15,8 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::PipeConfig::Pan::PrepareMasterDatabaseForRelease_conf

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/PrepareMasterDatabaseForRelease_conf.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2019] EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -53,7 +53,8 @@ sub default_options {
 
         'division'               => 'pan',
         'additional_species'     => {
-            'vertebrates' => ['xenopus_tropicalis',
+            'vertebrates' => [
+                              'xenopus_tropicalis',
                               'pongo_abelii',
                               'pan_troglodytes',
                               'mus_musculus',
@@ -63,8 +64,10 @@ sub default_options {
                               'gallus_gallus',
                               'danio_rerio',
                               'ciona_savignyi',
-                              'anolis_carolinensis',],
-            'protist'     => ['thecamonas_trahens_atcc_50062_gca_000142905',
+                              'anolis_carolinensis'
+                              ],
+            'protist'     => [
+                              'thecamonas_trahens_atcc_50062_gca_000142905',
                               'tetrahymena_thermophila',
                               'plasmodium_falciparum',
                               'phytophthora_infestans',
@@ -76,8 +79,10 @@ sub default_options {
                               'emiliania_huxleyi',
                               'dictyostelium_discoideum',
                               'cryptomonas_paramecium_gca_000194455',
-                              'bigelowiella_natans'],
-            'plants'      => ['vitis_vinifera',
+                              'bigelowiella_natans'
+                              ],
+            'plants'      => [
+                              'vitis_vinifera',
                               'solanum_lycopersicum',
                               'selaginella_moellendorffii',
                               'physcomitrella_patens',
@@ -87,8 +92,10 @@ sub default_options {
                               'chlamydomonas_reinhardtii',
                               'brachypodium_distachyon',
                               'arabidopsis_thaliana',
-                              'amborella_trichopoda'],
-            'metazoa'     => ['zootermopsis_nevadensis',
+                              'amborella_trichopoda'
+                              ],
+            'metazoa'     => [
+                              'zootermopsis_nevadensis',
                               'trichoplax_adhaerens',
                               'tribolium_castaneum',
                               'tetranychus_urticae',
@@ -111,15 +118,19 @@ sub default_options {
                               'apis_mellifera',
                               'anopheles_gambiae',
                               'amphimedon_queenslandica',
-                              'aedes_aegypti_lvpagwg'],
-            'fungi'       => ['zymoseptoria_tritici',
+                              'aedes_aegypti_lvpagwg'
+                              ],
+            'fungi'       => [
+                              'zymoseptoria_tritici',
                               'ustilago_maydis',
                               'schizosaccharomyces_pombe',
                               'saccharomyces_cerevisiae',
                               'puccinia_graminis',
                               'neurospora_crassa',
-                              'aspergillus_nidulans'],
-            'bacteria'    => ['yersinia_pestis_biovar_microtus_str_91001',
+                              'aspergillus_nidulans'
+                              ],
+            'bacteria'    => [
+                              'yersinia_pestis_biovar_microtus_str_91001',
                               'xanthomonas_campestris_pv_campestris_str_atcc_33913',
                               'wolbachia_endosymbiont_of_drosophila_melanogaster',
                               'vibrio_fischeri_es114',
@@ -241,7 +252,8 @@ sub default_options {
                               'aeropyrum_pernix_k1',
                               'aeromonas_hydrophila_subsp_hydrophila_atcc_7966',
                               'actinobacillus_pleuropneumoniae_serovar_5b_str_l20',
-                              'acinetobacter_baumannii_aye']
+                              'acinetobacter_baumannii_aye'
+                              ]
         },
     };
 }

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/PrepareMasterDatabaseForRelease_conf.pm
@@ -1,0 +1,249 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Pan::PrepareMasterDatabaseForRelease_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Pan::PrepareMasterDatabaseForRelease_conf -host mysql-ens-compara-prod-X -port XXXX
+
+=head1 DESCRIPTION
+
+Prepare Pan master database for next release. Please, refer to the parent
+class for further information.
+
+WARNING: the previous reports and backups will be removed if the pipeline is
+initialised again for the same division and release.
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Pan::PrepareMasterDatabaseForRelease_conf;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::PrepareMasterDatabaseForRelease_conf');
+
+sub default_options {
+    my ($self) = @_;
+
+    return {
+        %{$self->SUPER::default_options},   # inherit the generic ones
+
+        'division'               => 'pan',
+        'additional_species'     => {
+            'vertebrates' => ['xenopus_tropicalis',
+                              'pongo_abelii',
+                              'pan_troglodytes',
+                              'mus_musculus',
+                              'monodelphis_domestica',
+                              'homo_sapiens',
+                              'gasterosteus_aculeatus',
+                              'gallus_gallus',
+                              'danio_rerio',
+                              'ciona_savignyi',
+                              'anolis_carolinensis',],
+            'protist'     => ['thecamonas_trahens_atcc_50062_gca_000142905',
+                              'tetrahymena_thermophila',
+                              'plasmodium_falciparum',
+                              'phytophthora_infestans',
+                              'phaeodactylum_tricornutum',
+                              'monosiga_brevicollis_mx1_gca_000002865',
+                              'leishmania_major',
+                              'guillardia_theta',
+                              'giardia_lamblia',
+                              'emiliania_huxleyi',
+                              'dictyostelium_discoideum',
+                              'cryptomonas_paramecium_gca_000194455',
+                              'bigelowiella_natans'],
+            'plants'      => ['vitis_vinifera',
+                              'solanum_lycopersicum',
+                              'selaginella_moellendorffii',
+                              'physcomitrella_patens',
+                              'oryza_sativa',
+                              'marchantia_polymorpha',
+                              'cyanidioschyzon_merolae',
+                              'chlamydomonas_reinhardtii',
+                              'brachypodium_distachyon',
+                              'arabidopsis_thaliana',
+                              'amborella_trichopoda'],
+            'metazoa'     => ['zootermopsis_nevadensis',
+                              'trichoplax_adhaerens',
+                              'tribolium_castaneum',
+                              'tetranychus_urticae',
+                              'strongylocentrotus_purpuratus',
+                              'strigamia_maritima',
+                              'stegodyphus_mimosarum',
+                              'schistosoma_mansoni',
+                              'pediculus_humanus',
+                              'octopus_bimaculoides',
+                              'nematostella_vectensis',
+                              'mnemiopsis_leidyi',
+                              'lottia_gigantea',
+                              'lingula_anatina',
+                              'helobdella_robusta',
+                              'heliconius_melpomene',
+                              'drosophila_melanogaster',
+                              'daphnia_pulex',
+                              'caenorhabditis_elegans',
+                              'brugia_malayi',
+                              'apis_mellifera',
+                              'anopheles_gambiae',
+                              'amphimedon_queenslandica',
+                              'aedes_aegypti_lvpagwg'],
+            'fungi'       => ['zymoseptoria_tritici',
+                              'ustilago_maydis',
+                              'schizosaccharomyces_pombe',
+                              'saccharomyces_cerevisiae',
+                              'puccinia_graminis',
+                              'neurospora_crassa',
+                              'aspergillus_nidulans'],
+            'bacteria'    => ['yersinia_pestis_biovar_microtus_str_91001',
+                              'xanthomonas_campestris_pv_campestris_str_atcc_33913',
+                              'wolbachia_endosymbiont_of_drosophila_melanogaster',
+                              'vibrio_fischeri_es114',
+                              'vibrio_cholerae_o1_biovar_el_tor_str_n16961',
+                              'ureaplasma_parvum_serovar_3_str_atcc_700970',
+                              'treponema_pallidum_subsp_pallidum_str_nichols',
+                              'thermus_thermophilus_hb8',
+                              'thermotoga_maritima_msb8',
+                              'thermosynechococcus_elongatus_bp_1',
+                              'thermoplasma_acidophilum_dsm_1728',
+                              'thermofilum_pendens_hrk_5',
+                              'thermodesulfovibrio_yellowstonii_dsm_11347',
+                              'thermococcus_kodakarensis_kod1',
+                              'thermanaerovibrio_acidaminovorans_dsm_6589',
+                              'synechocystis_sp_pcc_6803',
+                              'sulfolobus_solfataricus_p2',
+                              'streptomyces_coelicolor_a3_2_',
+                              'streptococcus_pneumoniae_tigr4',
+                              'stenotrophomonas_maltophilia_k279a',
+                              'staphylococcus_aureus_subsp_aureus_n315',
+                              'sinorhizobium_meliloti_1021',
+                              'shigella_dysenteriae_sd197',
+                              'shewanella_oneidensis_mr_1',
+                              'salmonella_enterica_subsp_enterica_serovar_typhimurium_str_lt2',
+                              'salinibacter_ruber_dsm_13855',
+                              'rickettsia_prowazekii_str_madrid_e',
+                              'rhodospirillum_rubrum_atcc_11170',
+                              'rhodopirellula_baltica_sh_1',
+                              'rhodobacter_sphaeroides_2_4_1',
+                              'rhizobium_leguminosarum_bv_viciae_3841',
+                              'ralstonia_solanacearum_gmi1000',
+                              'pyrococcus_horikoshii_ot3',
+                              'pyrobaculum_aerophilum_str_im2',
+                              'pseudomonas_aeruginosa_mpao1_p2',
+                              'proteus_mirabilis_hi4320',
+                              'propionibacterium_acnes_kpa171202',
+                              'prochlorococcus_marinus_subsp_marinus_str_ccmp1375',
+                              'prevotella_intermedia_17',
+                              'porphyromonas_gingivalis_w83',
+                              'pasteurella_multocida_subsp_multocida_str_pm70',
+                              'paracoccus_denitrificans_pd1222',
+                              'nostoc_punctiforme_pcc_73102',
+                              'nitrosopumilus_maritimus_scm1',
+                              'neisseria_meningitidis_z2491',
+                              'natronomonas_pharaonis_dsm_2160',
+                              'nanoarchaeum_equitans_kin4_m',
+                              'myxococcus_xanthus_dk_1622',
+                              'mycoplasma_pneumoniae_m129',
+                              'mycobacterium_tuberculosis_h37rv',
+                              'moraxella_catarrhalis_7169',
+                              'moorella_thermoacetica_atcc_39073',
+                              'microcystis_aeruginosa_nies_843',
+                              'micrococcus_luteus_nctc_2665',
+                              'methanothermobacter_thermautotrophicus_str_delta_h',
+                              'methanospirillum_hungatei_jf_1',
+                              'methanosarcina_acetivorans_c2a',
+                              'methanopyrus_kandleri_av19',
+                              'methanococcus_maripaludis_s2',
+                              'methanocaldococcus_jannaschii_dsm_2661',
+                              'methanobrevibacter_smithii_atcc_35061',
+                              'methanobacterium_formicicum_dsm_3637',
+                              'mesoplasma_florum_l1',
+                              'mannheimia_haemolytica_serotype_a2_str_ovine',
+                              'lysinibacillus_sphaericus_c3_41',
+                              'listeria_monocytogenes_egd_e',
+                              'leuconostoc_mesenteroides_subsp_mesenteroides_atcc_8293',
+                              'leptospira_interrogans_serovar_lai_str_56601',
+                              'legionella_pneumophila_str_paris',
+                              'lactococcus_lactis_subsp_lactis_il1403',
+                              'lactobacillus_plantarum_wcfs1',
+                              'klebsiella_pneumoniae_subsp_pneumoniae_mgh_78578',
+                              'hyperthermus_butylicus_dsm_5456',
+                              'helicobacter_pylori_26695',
+                              'haloferax_volcanii_ds2',
+                              'halobacterium_salinarum_r1',
+                              'haloarcula_marismortui_atcc_43049',
+                              'haemophilus_influenzae_rd_kw20',
+                              'gloeobacter_violaceus_pcc_7421',
+                              'geobacter_sulfurreducens_pca',
+                              'gardnerella_vaginalis_0288e',
+                              'fusobacterium_nucleatum_subsp_nucleatum_atcc_25586',
+                              'francisella_tularensis_subsp_tularensis_schu_s4',
+                              'flavobacterium_psychrophilum_jip02_86',
+                              'escherichia_coli_str_k_12_substr_mg1655',
+                              'enterococcus_faecalis_v583',
+                              'enterobacter_cloacae_subsp_cloacae_atcc_13047',
+                              'dictyoglomus_turgidum_dsm_6724',
+                              'desulfovibrio_vulgaris_str_hildenborough',
+                              'deinococcus_radiodurans_r1',
+                              'coxiella_burnetii_rsa_493',
+                              'corynebacterium_glutamicum_atcc_13032',
+                              'clostridium_botulinum_a_str_hall',
+                              'clostridioides_difficile_630',
+                              'citrobacter_freundii_4_7_47cfaa',
+                              'chloroflexus_aurantiacus_j_10_fl',
+                              'chlorobium_tepidum_tls',
+                              'chlamydia_trachomatis_d_uw_3_cx',
+                              'cenarchaeum_symbiosum_a',
+                              'caulobacter_crescentus_cb15',
+                              'candidatus_koribacter_versatilis_ellin345',
+                              'candidatus_korarchaeum_cryptofilum_opf8',
+                              'campylobacter_jejuni_subsp_jejuni_nctc_11168_atcc_700819',
+                              'burkholderia_pseudomallei_1710b',
+                              'buchnera_aphidicola_str_aps_acyrthosiphon_pisum_',
+                              'brucella_abortus_bv_1_str_9_941',
+                              'bradyrhizobium_diazoefficiens_usda_110',
+                              'borrelia_burgdorferi_b31',
+                              'bordetella_pertussis_tohama_i',
+                              'bifidobacterium_longum_ncc2705',
+                              'bartonella_henselae_str_houston_1',
+                              'bacteroides_thetaiotaomicron_vpi_5482',
+                              'bacillus_subtilis_subsp_subtilis_str_168',
+                              'azotobacter_vinelandii_dj',
+                              'archaeoglobus_fulgidus_dsm_4304',
+                              'aquifex_aeolicus_vf5',
+                              'anaplasma_phagocytophilum_str_hz',
+                              'agrobacterium_fabrum_str_c58',
+                              'aggregatibacter_actinomycetemcomitans_d11s_1',
+                              'aeropyrum_pernix_k1',
+                              'aeromonas_hydrophila_subsp_hydrophila_atcc_7966',
+                              'actinobacillus_pleuropneumoniae_serovar_5b_str_l20',
+                              'acinetobacter_baumannii_aye']
+        },
+    };
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromMetadataFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromMetadataFactory.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2019] EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ sub fetch_input {
 	my $genome_db_adaptor = $self->get_cached_compara_dba('master_db')->get_GenomeDBAdaptor;
 
 	# use metadata script to report genomes that need to be updated
-	my ($genomes_to_update, $renamed_genomes, $genomes_with_assembly_patches) = $self->fetch_genome_report($release, $division);
+    my ($genomes_to_update, $renamed_genomes, $genomes_with_assembly_patches, $updated_annotations) = $self->fetch_genome_report($release, $division);
 
     # prepare renaming SQL cmds
     my @rename_cmds;
@@ -67,36 +67,38 @@ sub fetch_input {
 	my $list_cmd = "perl $list_genomes_script $metadata_script_options";
 	my @release_genomes = $self->get_command_output($list_cmd);
 	chomp @release_genomes;
-	if ($division ne "pan"){
-    die "No genomes reported for release" unless @release_genomes;
-	}
+
+    #if pan do not die becasue the list of species used in pan is
+    #exclusively described in param('additional_species')
+    if ($division ne "pan"){
+        die "No genomes reported for release" unless @release_genomes;
+    }
 
     # check if additional species have been defined and include them
     # in the appropriate data structures
-  	if ( $self->param('additional_species') ) {
+    if ( $self->param('additional_species') ) {
         my $additional_species = $self->param('additional_species');
         foreach my $additional_div ( keys %$additional_species ) {
             # first, add them to the release_genomes
             my @add_species_for_div = @{$additional_species->{$additional_div}};
             push( @release_genomes, @add_species_for_div );
-
-						# check for each additonal species in each division that the productioin name is correct
-						$metadata_script_options = "\$(mysql-ens-meta-prod-1 details script) --release $release --division $additional_div";
-						$list_cmd = "perl $list_genomes_script $metadata_script_options";
-						my @additional_release_genomes = $self->get_command_output($list_cmd);
-						chomp @additional_release_genomes;
-						my %additional_genome = map {$_ => 1} @additional_release_genomes;
-						foreach my $genome (@add_species_for_div) {
-							  if (not exists($additional_genome{$genome})){
-										die "'$genome' from division $additional_div does not exist in the metadata database!\n";
-								}
-						}
-
+            # check for each additonal species in each division that the productioin name is correct
+            $metadata_script_options = "\$(mysql-ens-meta-prod-1 details script) --release $release --division $additional_div";
+            $list_cmd = "perl $list_genomes_script $metadata_script_options";
+            my @additional_release_genomes = $self->get_command_output($list_cmd);
+            chomp @additional_release_genomes;
+            my %additional_genome = map {$_ => 1} @additional_release_genomes;
+            foreach my $genome (@add_species_for_div) {
+                if (not exists($additional_genome{$genome})){
+                    die "'$genome' from division $additional_div does not exist in the metadata database!\n";
+                }
+            }
             # check if they've been updated this release too
-            my ($updated_add_species, $renamed_add_species, $patched_add_species) = $self->fetch_genome_report($release, $additional_div);
+            my ($updated_add_species, $renamed_add_species, $patched_add_species, $updated_gen_add_species) = $self->fetch_genome_report($release, $additional_div);
             foreach my $add_species_name ( @add_species_for_div ) {
                 push( @$genomes_to_update, $add_species_name ) if grep { $add_species_name eq $_ } @$updated_add_species;
                 push( @$genomes_with_assembly_patches, $add_species_name ) if grep { $add_species_name eq $_ } @$patched_add_species;
+                push( @$updated_annotations, $add_species_name ) if grep { $add_species_name eq $_ } @$updated_gen_add_species;
                 if (my $old_name = $renamed_add_species->{$add_species_name}) {
                     # We have the new name in the PipeConfig. Still need to update the database
                     push @rename_cmds, "UPDATE genome_db SET name = '$add_species_name' WHERE name = '$old_name' AND first_release IS NOT NULL AND last_release IS NULL";
@@ -119,6 +121,9 @@ sub fetch_input {
 
     print "GENOMES_WITH_ASSEMBLY_PATCHES!! ";
     print Dumper $genomes_with_assembly_patches;
+
+    print "GENOMES_WITH_UPDATED_ANNOTATION!! ";
+    print Dumper $updated_annotations;
 
     # check that there have been no changes in dnafrags vs core slices
     my %g2update = map { $_ => 1 } @$genomes_to_update;
@@ -147,6 +152,7 @@ sub fetch_input {
 
     $self->param('genomes_to_update', $genomes_to_update);
     $self->param('genomes_with_assembly_patches', $genomes_with_assembly_patches);
+    $self->param('genomes_with_updated_annotation', $updated_annotations);
 	$self->param('genomes_to_retire', \@to_retire);
 }
 
@@ -164,6 +170,11 @@ sub write_output {
 
     my @patched_genomes_dataflow = map { {species_name => $_} } @{ $self->param('genomes_with_assembly_patches') };
     $self->dataflow_output_id( \@patched_genomes_dataflow, 5 );
+
+    $self->_spurt(
+        $self->param_required('annotation_file'),
+        join("\n", @{$self->param('genomes_with_updated_annotation')}),
+    );
 }
 
 sub fetch_genome_report {
@@ -188,6 +199,7 @@ sub fetch_genome_report {
 
     my @new_genomes = keys %{$decoded_meta_report->{new_genomes}};
     my %renamed_genomes = map { $_->{name} => $_->{old_name} } values %{$decoded_meta_report->{renamed_genomes}};
+    my @updated_annotations = map {$_->{name}} @{$decoded_meta_report->{updated_annotations}};
 
     my @genomes_with_assembly_patches;
     my @updated_assemblies;
@@ -203,7 +215,7 @@ sub fetch_genome_report {
         push @updated_assemblies, $genome;
     }
 
-    return ([@new_genomes, @updated_assemblies], \%renamed_genomes, \@genomes_with_assembly_patches);
+    return ([@new_genomes, @updated_assemblies], \%renamed_genomes, \@genomes_with_assembly_patches, \@updated_annotations);
 }
 
 1;


### PR DESCRIPTION
## Overview of changes
      conf/pan/production_reg_conf.pl with edition of the pan compara master
      .../PipeConfig/Pan/PrepareMasterDatabaseForRelease_conf.pm: it includes the list of genome treated by pan compara
      .../RunnableDB/PrepareMaster/UpdateGenomesFromMetadataFactory.pm : it includes modification to take into account that pan does not take the list of genome
      from the service metadata but only from the list defined in PrepareMasterDatabaseForRelease_conf.pm
      The modification implement as well a test that the genome is present in the master database . this work for all divisions.

## Description
This development implement changes related to the migration of pan compara to the compara team. In this change the dividaion pan take the list of genome require from a list of genome defined in the PrepareMasterDatabaseForRelease_conf.pm. The master /UpdateGenomesFromMetadataFactory.pm runnable has also been modified to take into account this specificity of pan compara and to test that the genome production name defined in the config file is present in the meta data database.

**Related JIRA tickets:**
- ENSCOMPARASW-2817

## Overview of changes

#### Change #1
 conf/pan/production_reg_conf.pl with edition of the pan compara master
      .../PipeConfig/Pan/PrepareMasterDatabaseForRelease_conf.pm: it includes the list of genome treated by pan compara

#### Change #2
.../RunnableDB/PrepareMaster/UpdateGenomesFromMetadataFactory.pm : 
    -   it includes modification to take into account that pan does not take the list of genome from the service metadata but only from the list defined in PrepareMasterDatabaseForRelease_conf.pm
    -   implementation of a test that the genome is present in the master database . this work for all divisions.

## Testing
I tested the following cases:
 -  test that the modification work with plants as a non regression test and genome are checked: ok
 - test that if division incorrect it die as a non regression test:ok
 - test if division is plants and there is a typo in the list of genome then it die: ok
 - test if division is pan and there is a typo in the list of genome then it die: ok

## Notes
I used this as a base for doing the tests:
env CURR_ENSEMBL_RELEASE=99 standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::PrepareMaster::UpdateGenomesFromMetadataFactory -additional_species "{'vertebrates' => ['homo_sapiens','caenorhabditis_elegans','ciona_savignyi','drosophila_melanogaster','saccharomyces_cerevisiae']}" -list_genomes_script /homes/dthybert/workbench/master/ensembl-metadata/misc_scripts/get_list_genomes_for_division.pl -report_genomes_script /homes/dthybert/workbench/master/ensembl-metadata/misc_scripts/report_genomes.pl -division plants -release 99 -master_db compara_master -reg_conf /homes/dthybert/workbench/master/ensembl-compara/conf/plants/production_reg_conf.pl -work_dir /homes/dthybert/workbench/outTest/ -debug 9


