### PR TITLE
Changes to facilitate new feature: rice multiple alignment

### DIFF
--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -81,6 +81,18 @@
          },
          {
             "component": "Production tasks",
+            "description": "[Bio::EnsEMBL::Compara::PipeConfig::EPO_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPO_conf.pm]\n\n",
+            "summary": "Run the Rice EPO pipeline",
+            "name_on_graph": "EPO:Rice"
+         },
+         {
+            "component": "Production tasks",
+            "description": "[Bio::EnsEMBL::Compara::PipeConfig::EpoLowCoverage_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EpoLowCoverage_conf.pm]\n\n",
+            "summary": "Run the Rice EPO 2x pipeline",
+            "name_on_graph": "EPO2x:Rice"
+         },
+         {
+            "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::Synteny_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Synteny_conf.pm]",
             "name_on_graph": "Synteny",
             "summary": "Run the Synteny pipeline"

--- a/conf/plants/production_reg_conf.pl
+++ b/conf/plants/production_reg_conf.pl
@@ -30,10 +30,10 @@ use warnings;
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Compara::Utils::Registry;
 
-my $curr_release = $ENV{'CURR_ENSEMBL_RELEASE'};
-my $prev_release = $curr_release - 1;
-my $curr_eg_release = $curr_release - 53;
-my $prev_eg_release = $curr_eg_release - 1;
+my $curr_release = $ENV{'CURR_ENSEMBL_RELEASE'}-1;
+my $prev_release = $curr_release - 2;
+my $curr_eg_release = $curr_release - 54;
+my $prev_eg_release = $curr_eg_release - 2;
 
 # ---------------------- CURRENT CORE DATABASES----------------------------------
 
@@ -74,7 +74,7 @@ my $compara_dbs = {
     'compara_prev'   => [ 'mysql-ens-compara-prod-5', "ensembl_compara_plants_${prev_eg_release}_${prev_release}" ],
 
     # homology dbs
-    'compara_members'  => [ 'mysql-ens-compara-prod-5', 'cristig_plants_load_members_99'  ],
+    'compara_members'  => [ 'mysql-ens-compara-prod-5', 'cristig_plants_load_members_99' ],
     'compara_ptrees'   => [ 'mysql-ens-compara-prod-3', 'cristig_default_plants_protein_trees_99' ],
     'ptrees_prev'      => [ 'mysql-ens-compara-prod-5', 'jalvarez_default_plants_protein_trees_98' ],
 
@@ -83,6 +83,14 @@ my $compara_dbs = {
 
     # synteny
     'compara_syntenies' => [ 'mysql-ens-compara-prod-1', 'cristig_plants_synteny_99' ],
+    
+    #EPO anchors
+    'rice_epo_anchors' => [ 'mysql-ens-compara-prod-5', 'cristig_generate_anchors_rice_99' ],
+    
+    #EPO
+    'rice_epo'     => [ 'mysql-ens-compara-prod-5', 'cristig_rice_epo_test5' ],
+    'rice_epo_low' => [ 'mysql-ens-compara-prod-5', 'cristig_rice_epo_low_coverage_test' ],
+    
 };
 
 Bio::EnsEMBL::Compara::Utils::Registry::add_compara_dbas( $compara_dbs );

--- a/conf/plants/production_reg_conf.pl
+++ b/conf/plants/production_reg_conf.pl
@@ -30,10 +30,10 @@ use warnings;
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Compara::Utils::Registry;
 
-my $curr_release = $ENV{'CURR_ENSEMBL_RELEASE'}-1;
-my $prev_release = $curr_release - 2;
-my $curr_eg_release = $curr_release - 54;
-my $prev_eg_release = $curr_eg_release - 2;
+my $curr_release = $ENV{'CURR_ENSEMBL_RELEASE'};
+my $prev_release = $curr_release - 1;
+my $curr_eg_release = $curr_release - 53;
+my $prev_eg_release = $curr_eg_release - 1;
 
 # ---------------------- CURRENT CORE DATABASES----------------------------------
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EPO_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EPO_conf.pm
@@ -67,7 +67,7 @@ sub default_options {
 
         # Executable parameters
         'mapping_params'    => { bestn=>11, gappedextension=>"no", softmasktarget=>"no", percent=>75, showalignment=>"no", model=>"affine:local", },
-        'enredo_params'     => ' --min-score 0 --max-gap-length 200000 --max-path-dissimilarity 4 --min-length 10000 --min-regions 2 --min-anchors 3 --max-ratio 3 --simplify-graph 7 --bridges -o ',
+        'enredo_params'     => ' --min-score 0 --max-gap-length 200000 --max-path-dissimilarity 4 --min-length 2000 --min-regions 2 --min-anchors 3 --max-ratio 3 --simplify-graph 7 --bridges -o ',
         'gerp_window_sizes' => [1,10,100,500], #gerp window sizes
 
         # Dump directory

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomicAlignBlock/SetGerpNeutralRate.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomicAlignBlock/SetGerpNeutralRate.pm
@@ -74,7 +74,7 @@ sub fetch_input {
 
     my $mlss = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor->fetch_by_dbID($self->param_required('mlss_id'));
 
-    if (($mlss->name =~ /(sauropsid|bird)/i) || ($self->dbc && ($self->dbc->dbname =~ /(sauropsid|bird)/i))) {
+    if (($mlss->name =~ /(sauropsid|bird|plant|rice)/i) || ($self->dbc && ($self->dbc->dbname =~ /(sauropsid|bird|plant|rice)/i))) {
         # A bit of institutional knowledge. This value was found to be
         # better years ago, at at time we only had 3 birds
         # MM: in Mar 2019, on the 34-sauropsids alignment, this threshold


### PR DESCRIPTION
## Description

_A new feature for rice multiple alignment would be greatly appreciated by the plant community._

**Related JIRA tickets:**
- ENSCOMPARASW-1728
- ENSCOMPARASW-2685

## Overview of changes
-_Updated xml configuration for plants to allow rice EPO_
-_Updated jira ticket creation in json config file for production to include rice EPO_
-_Updated production_reg_conf to include rice epo dbs_
-_Parameter alteration specific to plants_

#### Change #1
-_Altered the parameters for epo anchors so gerp_neutral_rate defaults to the same as sauropsids_

#### Change #2
-_Altered the enredo --min-length parameters in the EPO pipeline from 10,000 to 2,000_

## Testing
_This was tested by running multiple pipelines with varying parameters and comparing the alignments stored in pipeline dbs. Testing unit not necessary because the code has not changed except for parameters_

## Notes
_Additional docs in confluence_
