### PR TITLE
New feature rice MSA for production

### DIFF
--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -81,6 +81,12 @@
          },
          {
             "component": "Production tasks",
+            "description": "[Bio::EnsEMBL::Compara::PipeConfig::Plants::EPOwith2x_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/EPOwith2x_conf.pm]",
+            "summary": "Run the Rice EPOwith2x pipeline",
+            "name_on_graph": "EPOwith2x:Rice"
+         },
+         {
+            "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::Synteny_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Synteny_conf.pm]",
             "name_on_graph": "Synteny",
             "summary": "Run the Synteny pipeline"

--- a/conf/plants/mlss_conf.xml
+++ b/conf/plants/mlss_conf.xml
@@ -54,6 +54,23 @@
 
   </pairwise_alignments>
 
+  <multiple_alignments>
+    <!-- Rice -->
+    <multiple_alignment method="EPO">
+      <species_set name="rice">
+        <taxonomic_group taxon_name="Oryza" only_good_for_alignment="1"/>
+        <genome name="oryza_brachyantha" exclude="1"/>
+        <genome name="oryza_punctata" exclude="1"/>
+      </species_set>
+    </multiple_alignment>
+    <multiple_alignment method="EPO_LOW_COVERAGE">
+      <species_set name="rice">
+        <taxonomic_group taxon_name="Oryza"/>
+      </species_set>
+    </multiple_alignment>
+
+  </multiple_alignments>
+
   <self_alignments>
     <genome name="triticum_aestivum"/>
     <genome name="triticum_dicoccoides"/>

--- a/conf/plants/production_reg_conf.pl
+++ b/conf/plants/production_reg_conf.pl
@@ -83,6 +83,13 @@ my $compara_dbs = {
 
     # synteny
     'compara_syntenies' => [ 'mysql-ens-compara-prod-1', 'cristig_plants_synteny_99' ],
+
+    # EPO dbs
+    ## rice
+    'rice_epo'         => [ 'mysql-ens-compara-prod-5', 'cristig_rice_epo_test5' ],
+    #'rice_epo_prev'    => [ 'mysql-ens-compara-prod-5', 'cristig_rice_epo_test5' ],
+    'rice_epo_low'     => [ 'mysql-ens-compara-prod-5', 'cristig_rice_epo_low_coverage_test' ],
+    'rice_epo_anchors' => [ 'mysql-ens-compara-prod-5', 'cristig_generate_anchors_rice_99' ],
 };
 
 Bio::EnsEMBL::Compara::Utils::Registry::add_compara_dbas( $compara_dbs );

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/EPO_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/EPO_conf.pm
@@ -1,0 +1,53 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Plants::EPO_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Plants::EPO_conf.pm -host mysql-ens-compara-prod-X -port XXXX \
+        -division $COMPARA_DIV -species_set_name <species_set_name> -mlss_id <curr_epo_mlss_id>
+
+=head1 DESCRIPTION
+
+This PipeConfig file gives defaults for mapping (using exonerate at the moment)
+anchors to a set of target genomes (dumped text files).
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Plants::EPO_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::EPO_conf');
+
+sub default_options {
+    my ($self) = @_;
+
+    return {
+        %{$self->SUPER::default_options},
+        'enredo_params'     => ' --min-score 0 --max-gap-length 200000 --max-path-dissimilarity 4 --min-length 2000 --min-regions 2 --min-anchors 3 --max-ratio 3 --simplify-graph 7 --bridges -o ',
+        'division'          => 'plants',
+    };
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/EPOwith2x_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/EPOwith2x_conf.pm
@@ -1,0 +1,56 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Plants::EPOwith2x_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Plants::EPOwith2x_conf.pm -host mysql-ens-compara-prod-X -port XXXX \
+        -division $COMPARA_DIV -species_set_name <species_set_name> -low_epo_mlss_id <id> -high_epo_mlss_id <id>
+
+=head1 DESCRIPTION
+
+    This pipeline runs EPO and EPO2x together. For more information on each pipeline, see their respective PipeConfig files:
+    - Bio::EnsEMBL::Compara::PipeConfig::EPO_conf
+    - Bio::EnsEMBL::Compara::PipeConfig::EpoLowCoverage_conf
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Plants::EPOwith2x_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf');
+
+sub default_options {
+    my ($self) = @_;
+
+    return {
+        %{$self->SUPER::default_options},
+
+        'enredo_params'     => ' --min-score 0 --max-gap-length 200000 --max-path-dissimilarity 4 --min-length 2000 --min-regions 2 --min-anchors 3 --max-ratio 3 --simplify-graph 7 --bridges -o ',
+        'run_gerp'          => 0,
+        'division'          => 'plants',
+    };
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomicAlignBlock/SetGerpNeutralRate.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomicAlignBlock/SetGerpNeutralRate.pm
@@ -74,7 +74,7 @@ sub fetch_input {
 
     my $mlss = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor->fetch_by_dbID($self->param_required('mlss_id'));
 
-    if (($mlss->name =~ /(sauropsid|bird)/i) || ($self->dbc && ($self->dbc->dbname =~ /(sauropsid|bird)/i))) {
+    if (($mlss->name =~ /(sauropsid|bird|plant|rice)/i) || ($self->dbc && ($self->dbc->dbname =~ /(sauropsid|bird|plant|rice)/i))) {
         # A bit of institutional knowledge. This value was found to be
         # better years ago, at at time we only had 3 birds
         # MM: in Mar 2019, on the 34-sauropsids alignment, this threshold


### PR DESCRIPTION
## Description

_A new feature for rice multiple alignment would be greatly appreciated by the plant community._

**Related JIRA tickets:**
- ENSCOMPARASW-1728
- ENSCOMPARASW-2685

## Overview of changes
-_Updated xml configuration for plants to allow rice EPO_
-_Updated jira ticket creation in json config file for production to include rice EPO_
-_Updated production_reg_conf to include rice epo dbs_
-_Parameter alteration specific to plants_

#### Change #1
-_Altered the parameters for epo anchors so gerp_neutral_rate defaults to the same as sauropsids_

#### Change #2
-_Altered the enredo --min-length parameters in the EPO pipeline from 10,000 to 2,000 in new plant specific EPOwith2x_conf_

## Testing
_This was tested by running multiple pipelines with varying parameters and comparing the alignments stored in pipeline dbs. Testing unit not necessary because the code has not changed except for parameters_

## Notes
_Additional docs in confluence_