### PR TITLE
Add new mlss_tag for EPO2x

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
@@ -826,6 +826,7 @@ sub create_multiple_wga_mlsss {
         $principal_species = 'gallus_gallus'   if ($mlsss[0]->name =~ /sauropsids/);
         $principal_species = 'oryzias_latipes' if ($mlsss[0]->name =~ /fish/);
         $principal_species = 'sus_scrofa'      if ($mlsss[0]->name =~ /pig/);
+        die "Unexpected EPO_LOW_COVERAGE MLSS: cannot set a principal species\n" unless $principal_species;
         $mlsss[0]->add_tag('principal_species', $principal_species);
     }
        

--- a/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
@@ -817,6 +817,17 @@ sub create_multiple_wga_mlsss {
             $mlss->{_no_release} = $no_release;
         }
     }
+
+    # Add 'principal' species tag in EPO2x alignments for web display purposes
+    if ($method->type =~ /EPO_LOW_COVERAGE/) {
+        my $principal_species;
+        $principal_species = 'homo_sapiens'    if ($mlsss[0]->name =~ /primates/);
+        $principal_species = 'homo_sapiens'    if ($mlsss[0]->name =~ /mammals/);
+        $principal_species = 'gallus_gallus'   if ($mlsss[0]->name =~ /sauropsids/);
+        $principal_species = 'oryzias_latipes' if ($mlsss[0]->name =~ /fish/);
+        $principal_species = 'sus_scrofa'      if ($mlsss[0]->name =~ /pig/);
+        $mlsss[0]->add_tag('principal_species', $principal_species);
+    }
        
     return \@mlsss;
 }

--- a/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
@@ -826,6 +826,7 @@ sub create_multiple_wga_mlsss {
         $principal_species = 'gallus_gallus'   if ($mlsss[0]->name =~ /sauropsids/);
         $principal_species = 'oryzias_latipes' if ($mlsss[0]->name =~ /fish/);
         $principal_species = 'sus_scrofa'      if ($mlsss[0]->name =~ /pig/);
+        $principal_species = 'oryza_sativa'    if ($mlsss[0]->name =~ /rice/);
         die "Unexpected EPO_LOW_COVERAGE MLSS: cannot set a principal species\n" unless $principal_species;
         $mlsss[0]->add_tag('principal_species', $principal_species);
     }


### PR DESCRIPTION
## Description

In e99, a bug was discovered when we added the new pig EPO alignment. This is due to some slightly hacky code in the webcode that selects the 'principal' species in an EPO2x alignment for display purposes.

**Related JIRA tickets:**
- ENSCOMPARASW-3022

## Overview of changes
Added a new tag for the 'principal' species in EPO2x alignments. To avoid more comparisons than those necessary, this tag has been introduced in the `Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_multiple_wga_mlsss` method.

## Testing
No testing performed yet.

## Notes
The value of this tag has been hardcoded as it is unlikely to change frequently.
