### PR TITLE
Feature/on demand previous registry

### DIFF
--- a/conf/pan/production_reg_conf.pl
+++ b/conf/pan/production_reg_conf.pl
@@ -52,34 +52,37 @@ Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
 # ---------------------- PREVIOUS CORE DATABASES---------------------------------
 
 # previous release core databases will be required by PrepareMasterDatabaseForRelease and LoadMembers only
-# !!! COMMENT THIS SECTION OUT FOR ALL OTHER PIPELINES (for speed) !!!
-#my $suffix_separator = '__cut_here__';
-#Bio::EnsEMBL::Registry->load_registry_from_db(
-#    -host   => 'mysql-ens-mirror-1',
-#    -port   => 4240,
-#    -user   => 'ensro',
-#    -pass   => '',
-#    -db_version     => $prev_release,
-#    -species_suffix => $suffix_separator.$prev_release,
-#);
-#Bio::EnsEMBL::Registry->remove_DBAdaptor('saccharomyces_cerevisiae'.$suffix_separator.$prev_release, 'core'); # never use Vertebrates' version of yeast
-#Bio::EnsEMBL::Registry->load_registry_from_db(
-#    -host   => 'mysql-ens-mirror-3',
-#    -port   => 4275,
-#    -user   => 'ensro',
-#    -pass   => '',
-#    -db_version     => $prev_release,
-#    -species_suffix => $suffix_separator.$prev_release,
-#);
-# Bacteria server: all species used in Pan happen to be in this database
-#Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
-#    -host   => 'mysql-ens-mirror-4',
-#    -port   => 4495,
-#    -user   => 'ensro',
-#    -pass   => '',
-#    -dbname => "bacteria_0_collection_core_${prev_eg_release}_${prev_release}_1",
-#    -species_suffix => $suffix_separator.$prev_release,
-#);
+*Bio::EnsEMBL::Compara::Utils::Registry::load_previous_core_databases = sub {
+    my $release_number  = shift;
+    my $species_suffix  = Bio::EnsEMBL::Compara::Utils::Registry::SUFFIX_SEPARATOR.$release_number;
+
+    Bio::EnsEMBL::Registry->load_registry_from_db(
+        -host   => 'mysql-ens-mirror-1',
+        -port   => 4240,
+        -user   => 'ensro',
+        -pass   => '',
+        -db_version     => $release_number,
+        -species_suffix => $species_suffix,
+    );
+    Bio::EnsEMBL::Registry->remove_DBAdaptor('saccharomyces_cerevisiae'.$species_suffix, 'core'); # never use Vertebrates' version of yeast
+    Bio::EnsEMBL::Registry->load_registry_from_db(
+        -host   => 'mysql-ens-mirror-3',
+        -port   => 4275,
+        -user   => 'ensro',
+        -pass   => '',
+        -db_version     => $release_number,
+        -species_suffix => $species_suffix,
+    );
+    # Bacteria server: all species used in Pan happen to be in this database
+    Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
+        -host   => 'mysql-ens-mirror-4',
+        -port   => 4495,
+        -user   => 'ensro',
+        -pass   => '',
+        -dbname => "bacteria_0_collection_core_".($release_number-53)."_${release_number}_1",
+        -species_suffix => $species_suffix,
+    );
+};
 
 #------------------------COMPARA DATABASE LOCATIONS----------------------------------
 

--- a/conf/pan/production_reg_conf.pl
+++ b/conf/pan/production_reg_conf.pl
@@ -59,26 +59,23 @@ Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
 
 # previous release core databases will be required by PrepareMasterDatabaseForRelease and LoadMembers only
 *Bio::EnsEMBL::Compara::Utils::Registry::load_previous_core_databases = sub {
-    my $release_number  = shift;
-    my $species_suffix  = Bio::EnsEMBL::Compara::Utils::Registry::SUFFIX_SEPARATOR.$release_number;
-
     Bio::EnsEMBL::Registry->load_registry_from_db(
         -host   => 'mysql-ens-mirror-1',
         -port   => 4240,
         -user   => 'ensro',
         -pass   => '',
-        -db_version     => $release_number,
-        -species_suffix => $species_suffix,
+        -db_version     => $prev_release,
+        -species_suffix => Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX,
     );
-    Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species, $species_suffix);
-    Bio::EnsEMBL::Compara::Utils::Registry::remove_multi(undef, $species_suffix);
+    Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species, Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX);
+    Bio::EnsEMBL::Compara::Utils::Registry::remove_multi(undef, Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX);
     Bio::EnsEMBL::Registry->load_registry_from_db(
         -host   => 'mysql-ens-mirror-3',
         -port   => 4275,
         -user   => 'ensro',
         -pass   => '',
-        -db_version     => $release_number,
-        -species_suffix => $species_suffix,
+        -db_version     => $prev_release,
+        -species_suffix => Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX,
     );
     # Bacteria server: all species used in Pan happen to be in this database
     Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
@@ -86,8 +83,8 @@ Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
         -port   => 4495,
         -user   => 'ensro',
         -pass   => '',
-        -dbname => "bacteria_0_collection_core_".($release_number-53)."_${release_number}_1",
-        -species_suffix => $species_suffix,
+        -dbname => "bacteria_0_collection_core_${prev_eg_release}_${prev_release}_1",
+        -species_suffix => Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX,
     );
 };
 

--- a/conf/pan/production_reg_conf.pl
+++ b/conf/pan/production_reg_conf.pl
@@ -35,10 +35,25 @@ my $prev_release = $curr_release - 1;
 my $curr_eg_release = $ENV{'CURR_EG_RELEASE'};
 my $prev_eg_release = $curr_eg_release - 1;
 
+
+## To avoid warnings
+sub cleanup_adaptors_from_vertebrates_server {
+    my $species_suffix = shift;
+    foreach my $s (qw(saccharomyces_cerevisiae drosophila_melanogaster caenorhabditis_elegans)) {
+        foreach my $g (qw(core otherfeatures variation funcgen)) {
+            Bio::EnsEMBL::Registry->remove_DBAdaptor("${s}${species_suffix}", $g);
+        }
+    }
+    foreach my $g (qw(ontology taxonomy)) {
+        Bio::EnsEMBL::Registry->remove_DBAdaptor("multi${species_suffix}", $g);
+    }
+}
+
+
 # ---------------------- CURRENT CORE DATABASES----------------------------------
 
 Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-1:4519/$curr_release");
-Bio::EnsEMBL::Registry->remove_DBAdaptor('saccharomyces_cerevisiae');    # never use Vertebrates' version of yeast
+cleanup_adaptors_from_vertebrates_server('');
 Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-3:4160/$curr_release");
 # Bacteria server: all species used in Pan happen to be in this database
 Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
@@ -64,7 +79,7 @@ Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
         -db_version     => $release_number,
         -species_suffix => $species_suffix,
     );
-    Bio::EnsEMBL::Registry->remove_DBAdaptor('saccharomyces_cerevisiae'.$species_suffix, 'core'); # never use Vertebrates' version of yeast
+    cleanup_adaptors_from_vertebrates_server($species_suffix);
     Bio::EnsEMBL::Registry->load_registry_from_db(
         -host   => 'mysql-ens-mirror-3',
         -port   => 4275,

--- a/conf/plants/production_reg_conf.pl
+++ b/conf/plants/production_reg_conf.pl
@@ -35,6 +35,9 @@ my $prev_release = $curr_release - 1;
 my $curr_eg_release = $curr_release - 53;
 my $prev_eg_release = $curr_eg_release - 1;
 
+# Species found on both vertebrates and non-vertebrates servers
+my @overlap_species = qw(saccharomyces_cerevisiae drosophila_melanogaster caenorhabditis_elegans);
+
 # ---------------------- CURRENT CORE DATABASES----------------------------------
 
 # Use our mirror (which has all the databases)
@@ -42,7 +45,10 @@ Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertann
 
 # Or use the official staging servers
 #Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-3:4160/$curr_release");
-#Bio::EnsEMBL::Registry->remove_DBAdaptor('saccharomyces_cerevisiae', 'core'); # never use EG's version of yeast
+# and remove the NV version of the shared species
+#Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species);
+#Bio::EnsEMBL::Compara::Utils::Registry::remove_multi();
+# before loading the V version
 #Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-1:4519/$curr_release");
 
 # ---------------------- PREVIOUS CORE DATABASES---------------------------------
@@ -58,7 +64,9 @@ Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertann
 #    -db_version     => $prev_release,
 #    -species_suffix => $suffix_separator.$prev_release,
 #);
-#Bio::EnsEMBL::Registry->remove_DBAdaptor('saccharomyces_cerevisiae'.$suffix_separator.$prev_release, 'core'); # never use EG's version of yeast
+# Never use EG's version of yeast & co
+#Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species, $suffix_separator.$prev_release);
+#Bio::EnsEMBL::Compara::Utils::Registry::remove_multi($suffix_separator.$prev_release);
 #Bio::EnsEMBL::Registry->load_registry_from_db(
 #    -host   => 'mysql-ens-mirror-1',
 #    -port   => 4240,

--- a/conf/plants/production_reg_conf.pl
+++ b/conf/plants/production_reg_conf.pl
@@ -37,8 +37,10 @@ my $prev_eg_release = $curr_eg_release - 1;
 
 # ---------------------- CURRENT CORE DATABASES----------------------------------
 
-# most cores are on EG servers, but some are on ensembl's vertannot-staging
+# Use our mirror (which has all the databases)
 Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertannot-staging:4573/$curr_release");
+
+# Or use the official staging servers
 #Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-3:4160/$curr_release");
 #Bio::EnsEMBL::Registry->remove_DBAdaptor('saccharomyces_cerevisiae', 'core'); # never use EG's version of yeast
 

--- a/conf/plants/production_reg_conf.pl
+++ b/conf/plants/production_reg_conf.pl
@@ -43,6 +43,7 @@ Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertann
 # Or use the official staging servers
 #Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-3:4160/$curr_release");
 #Bio::EnsEMBL::Registry->remove_DBAdaptor('saccharomyces_cerevisiae', 'core'); # never use EG's version of yeast
+#Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-1:4519/$curr_release");
 
 # ---------------------- PREVIOUS CORE DATABASES---------------------------------
 

--- a/conf/plants/production_reg_conf.pl
+++ b/conf/plants/production_reg_conf.pl
@@ -45,10 +45,10 @@ Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertann
 
 # Or use the official staging servers
 #Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-3:4160/$curr_release");
-# and remove the NV version of the shared species
+# and remove the Non-Vertebrates version of the shared species
 #Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species);
 #Bio::EnsEMBL::Compara::Utils::Registry::remove_multi();
-# before loading the V version
+# before loading the Vertebrates version
 #Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-1:4519/$curr_release");
 
 # ---------------------- PREVIOUS CORE DATABASES---------------------------------

--- a/conf/plants/production_reg_conf.pl
+++ b/conf/plants/production_reg_conf.pl
@@ -54,27 +54,26 @@ Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertann
 # ---------------------- PREVIOUS CORE DATABASES---------------------------------
 
 # previous release core databases will be required by PrepareMasterDatabaseForRelease and LoadMembers only
-# !!! COMMENT THIS SECTION OUT FOR ALL OTHER PIPELINES (for speed) !!!
-#my $suffix_separator = '__cut_here__';
-#Bio::EnsEMBL::Registry->load_registry_from_db(
-#    -host   => 'mysql-ens-mirror-3',
-#    -port   => 4275,
-#    -user   => 'ensro',
-#    -pass   => '',
-#    -db_version     => $prev_release,
-#    -species_suffix => $suffix_separator.$prev_release,
-#);
-# Never use EG's version of yeast & co
-#Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species, $suffix_separator.$prev_release);
-#Bio::EnsEMBL::Compara::Utils::Registry::remove_multi($suffix_separator.$prev_release);
-#Bio::EnsEMBL::Registry->load_registry_from_db(
-#    -host   => 'mysql-ens-mirror-1',
-#    -port   => 4240,
-#    -user   => 'ensro',
-#    -pass   => '',
-#    -db_version     => $prev_release,
-#    -species_suffix => $suffix_separator.$prev_release,
-#);
+*Bio::EnsEMBL::Compara::Utils::Registry::load_previous_core_databases = sub {
+    Bio::EnsEMBL::Registry->load_registry_from_db(
+        -host   => 'mysql-ens-mirror-3',
+        -port   => 4275,
+        -user   => 'ensro',
+        -pass   => '',
+        -db_version     => $prev_release,
+        -species_suffix => Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX,
+    );
+    Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species, Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX);
+    Bio::EnsEMBL::Compara::Utils::Registry::remove_multi(undef, Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX);
+    Bio::EnsEMBL::Registry->load_registry_from_db(
+        -host   => 'mysql-ens-mirror-1',
+        -port   => 4240,
+        -user   => 'ensro',
+        -pass   => '',
+        -db_version     => $prev_release,
+        -species_suffix => Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX,
+    );
+};
 #------------------------COMPARA DATABASE LOCATIONS----------------------------------
 
 

--- a/conf/vertebrates/production_reg_conf.pl
+++ b/conf/vertebrates/production_reg_conf.pl
@@ -49,21 +49,17 @@ Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertann
 
 # ---------------------- PREVIOUS CORE DATABASES---------------------------------
 
-# previous release core databases will ONLY be required by:
-#   * PrepareMasterDatabaseForRelease_conf
-#   * LoadMembers_conf
-#   * MercatorPecan_conf
-# !!! COMMENT THIS SECTION OUT FOR ALL OTHER PIPELINES (for speed) !!!
-
-# my $suffix_separator = '__cut_here__';
-# Bio::EnsEMBL::Registry->load_registry_from_db(
-#   -host           => 'mysql-ens-mirror-1',
-#   -port           => 4240,
-#   -user           => 'ensro',
-#   -pass           => '',
-#   -db_version     => $prev_release,
-#   -species_suffix => $suffix_separator.$prev_release,
-# );
+# previous release core databases will be required by PrepareMasterDatabaseForRelease, LoadMembers and MercatorPecan
+*Bio::EnsEMBL::Compara::Utils::Registry::load_previous_core_databases = sub {
+    Bio::EnsEMBL::Registry->load_registry_from_db(
+        -host   => 'mysql-ens-mirror-1',
+        -port   => 4240,
+        -user   => 'ensro',
+        -pass   => '',
+        -db_version     => $prev_release,
+        -species_suffix => Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX,
+    );
+};
 
 #------------------------COMPARA DATABASE LOCATIONS----------------------------------
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
@@ -251,7 +251,6 @@ sub pipeline_analyses {
                 # 'registry_dbs'      => $self->o('prev_core_sources_locs'),
                 'do_not_reuse_list' => $self->o('do_not_reuse_list'),
                 'reuse_db'          => '#reuse_member_db#',
-                'current_release'   => $self->o('ensembl_release'),
             },
             -hive_capacity => $self->o('loadmembers_capacity'),
             -rc_name => '2Gb_job',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MercatorPecan_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MercatorPecan_conf.pm
@@ -244,7 +244,6 @@ sub pipeline_analyses {
             -parameters => {
 		        'reuse_db'          => $self->o('reuse_db'),
 		        'do_not_reuse_list' => $self->o('do_not_reuse_list'),
-                'current_release'   => $self->o('ensembl_release'),
             },
             -hive_capacity => $self->o('reuse_capacity'),
             -flow_into => {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/CheckGenomeReusability.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/CheckGenomeReusability.pm
@@ -150,8 +150,7 @@ sub fetch_input {
             
             # now use the registry to find the previous release core database candidate:
             Bio::EnsEMBL::Registry->no_version_check(1);
-            my $prev_release = $self->param_required('current_release') - 1;
-            $prev_core_dba = $self->param('prev_core_dba', Bio::EnsEMBL::Compara::Utils::Registry::get_previous_core_DBAdaptor($species_name, $prev_release));
+            $prev_core_dba = $self->param('prev_core_dba', Bio::EnsEMBL::Compara::Utils::Registry::get_previous_core_DBAdaptor($species_name));
 
         } else {
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/CheckGenomeReusability.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/CheckGenomeReusability.pm
@@ -47,10 +47,10 @@ use Scalar::Util qw(looks_like_number);
 
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Compara::GenomeDB;
+use Bio::EnsEMBL::Compara::Utils::Registry;
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
-my $suffix_separator = '__cut_here__';
 
 sub param_defaults {
     my $self = shift;
@@ -151,7 +151,7 @@ sub fetch_input {
             # now use the registry to find the previous release core database candidate:
             Bio::EnsEMBL::Registry->no_version_check(1);
             my $prev_release = $self->param_required('current_release') - 1;
-            $prev_core_dba = $self->param('prev_core_dba', Bio::EnsEMBL::Registry->get_DBAdaptor($species_name.$suffix_separator.$prev_release, 'core'));
+            $prev_core_dba = $self->param('prev_core_dba', Bio::EnsEMBL::Compara::Utils::Registry::get_previous_core_DBAdaptor($species_name, $prev_release));
 
         } else {
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/LoadAssemblyPatches.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/LoadAssemblyPatches.pm
@@ -53,10 +53,9 @@ sub write_output {
 
   my $compara_dba = $self->compara_dba;
   my $genome_db   = $self->param('genome_db');
-  my $release     = $self->param_required('release');
   my $report_file = $self->param_required('work_dir') . '/assembly_patches.' . $self->param_required('species_name') . '.txt';
 
-  Bio::EnsEMBL::Compara::Utils::MasterDatabase::load_assembly_patches($compara_dba, $genome_db, $release, $report_file);
+  Bio::EnsEMBL::Compara::Utils::MasterDatabase::load_assembly_patches($compara_dba, $genome_db, $report_file);
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
@@ -410,7 +410,6 @@ sub load_lrgs {
 sub load_assembly_patches {
     my $compara_dba = shift;
     my $genome_db   = shift;
-    my $release     = shift;
     my $report_file = shift;
 
     die "Patches are only available for GRC species" unless $genome_db->assembly =~ /^GRC/;
@@ -423,8 +422,7 @@ sub load_assembly_patches {
     my @curr_patches_seq_region_ids = map { $_->[1] } @$curr_patches;
     my %curr_patches_by_name = map { $_->[0] => {seq_region_id => $_->[1], date => $_->[2]} } @$curr_patches;
 
-    # $release = $species_db->dbc->db_version;
-    my $prev_species_db = Bio::EnsEMBL::Compara::Utils::Registry::get_previous_core_DBAdaptor($genome_db->name, $release-1);
+    my $prev_species_db = Bio::EnsEMBL::Compara::Utils::Registry::get_previous_core_DBAdaptor($genome_db->name);
     my $prev_patches_sth = $prev_species_db->dbc->prepare($find_patches_sql);
     $prev_patches_sth->execute;
     my $prev_patches = $prev_patches_sth->fetchall_arrayref;

--- a/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
@@ -35,6 +35,7 @@ use Bio::EnsEMBL::Utils::IO qw/:spurt/;
 
 use Bio::EnsEMBL::Compara::Method;
 use Bio::EnsEMBL::Compara::MethodLinkSpeciesSet;
+use Bio::EnsEMBL::Compara::Utils::Registry;
 
 use Data::Dumper;
 $Data::Dumper::Maxdepth=3;
@@ -407,14 +408,10 @@ sub load_lrgs {
 =cut
 
 sub load_assembly_patches {
-    # my ($compara_dba, $genome_db, $release, $report_file) = @_;
     my $compara_dba = shift;
     my $genome_db   = shift;
     my $release     = shift;
     my $report_file = shift;
-
-    my($suffix_separator) = rearrange([qw(SUFFIX_SEPARATOR)], @_);
-    $suffix_separator = '__cut_here__' unless $suffix_separator;
 
     die "Patches are only available for GRC species" unless $genome_db->assembly =~ /^GRC/;
     my $find_patches_sql = "SELECT s.name, s.seq_region_id, a.value FROM seq_region s JOIN seq_region_attrib a USING(seq_region_id) JOIN attrib_type t USING(attrib_type_id) WHERE t.code IN ('patch_fix', 'patch_novel')";
@@ -427,7 +424,7 @@ sub load_assembly_patches {
     my %curr_patches_by_name = map { $_->[0] => {seq_region_id => $_->[1], date => $_->[2]} } @$curr_patches;
 
     # $release = $species_db->dbc->db_version;
-    my $prev_species_db = Bio::EnsEMBL::Registry->get_DBAdaptor($genome_db->name.$suffix_separator.($release-1), 'core');
+    my $prev_species_db = Bio::EnsEMBL::Compara::Utils::Registry::get_previous_core_DBAdaptor($genome_db->name, $release-1);
     my $prev_patches_sth = $prev_species_db->dbc->prepare($find_patches_sql);
     $prev_patches_sth->execute;
     my $prev_patches = $prev_patches_sth->fetchall_arrayref;

--- a/modules/Bio/EnsEMBL/Compara/Utils/Registry.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Registry.pm
@@ -60,7 +60,7 @@ use Bio::EnsEMBL::Utils::Argument qw(rearrange);
 use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
 use Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyDBAdaptor;
 
-use constant SUFFIX_SEPARATOR => '__cut_here__';
+use constant PREVIOUS_DATABASE_SUFFIX => '__previous_database__';
 
 my %ports;
 my %rw_users;
@@ -114,21 +114,19 @@ sub load_collection_core_database {
 
 =head2 load_previous_core_databases_if_needed
 
-  Arg[1]      : Integer $release_number
-  Example     : Bio::EnsEMBL::Compara::Utils::Registry::load_previous_core_databases_if_needed($current_release-1);
+  Example     : Bio::EnsEMBL::Compara::Utils::Registry::load_previous_core_databases_if_needed();
   Description : Wrapper around load_previous_core_databases to only call it once
   Returntype  : none
   Exceptions  : none
 
 =cut
 
-my %loaded_previous;
+my $loaded_previous;
 sub load_previous_core_databases_if_needed {
-    my ($release_number) = @_;
     return unless defined &load_previous_core_databases;
-    return if $loaded_previous{$release_number};
-    load_previous_core_databases(@_);
-    $loaded_previous{$release_number} = 1;
+    return if $loaded_previous;
+    load_previous_core_databases();
+    $loaded_previous = 1;
 }
 
 
@@ -275,9 +273,8 @@ sub add_dbas {
 =head2 get_previous_core_DBAdaptor
 
   Arg[1]      : String $species_name. Name of the species
-  Arg[2]      : Integer $release_number. Release number
-  Example     : Bio::EnsEMBL::Compara::Utils::Registry::get_previous_core_DBAdaptor('homo_sapiens', 98);
-  Description : Returns the DBAdaptor of the species in the required release. The Registry for that release
+  Example     : Bio::EnsEMBL::Compara::Utils::Registry::get_previous_core_DBAdaptor('homo_sapiens');
+  Description : Returns the DBAdaptor of the species in the previous release. The Registry for that release
                 will automatically be populated using load_previous_core_databases
   Returntype  : Bio::EnsEMBL::DBSQL::DBAdaptor
   Exceptions  : none
@@ -285,9 +282,9 @@ sub add_dbas {
 =cut
 
 sub get_previous_core_DBAdaptor {
-    my ($species_name, $release_number) = @_;
-    Bio::EnsEMBL::Compara::Utils::Registry::load_previous_core_databases_if_needed($release_number);
-    return Bio::EnsEMBL::Registry->get_DBAdaptor($species_name . SUFFIX_SEPARATOR . $release_number, 'core');
+    my $species_name = shift;
+    Bio::EnsEMBL::Compara::Utils::Registry::load_previous_core_databases_if_needed();
+    return Bio::EnsEMBL::Registry->get_DBAdaptor($species_name . PREVIOUS_DATABASE_SUFFIX, 'core');
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/Utils/Registry.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Registry.pm
@@ -132,6 +132,57 @@ sub load_previous_core_databases_if_needed {
 }
 
 
+=head2 remove_species
+
+  Arg[1]      : Arrayref of species names $species_names.
+  Arg[2]      : String $species_suffix (optional, defaults to '')
+  Example     : Bio::EnsEMBL::Compara::Utils::Registry::remove_species(['saccharomyces_cerevisiae']);
+                Bio::EnsEMBL::Compara::Utils::Registry::remove_species(['saccharomyces_cerevisiae', 'drosophila_melanogaster'], '__cut_here__99');
+  Description : Remove the given species from the Registry
+  Returntype  : none
+  Exceptions  : none
+
+=cut
+
+sub remove_species {
+    my $species_names = shift;
+    my $species_suffix = shift;
+
+    $species_suffix //= '';
+
+    foreach my $name (@$species_names) {
+        foreach my $group (qw(core otherfeatures variation funcgen)) {
+            Bio::EnsEMBL::Registry->remove_DBAdaptor("${name}${species_suffix}", $group);
+        }
+    }
+}
+
+
+=head2 remove_multi
+
+  Arg[1]      : Arrayref of group names $groups. Optional, defaults to all groups
+  Arg[2]      : String $species_suffix (optional, defaults to '')
+  Example     : Bio::EnsEMBL::Compara::Utils::Registry::remove_multi();
+                Bio::EnsEMBL::Compara::Utils::Registry::remove_multi(undef, '__cut_here__99');
+  Description : Remove the given species from the Registry
+  Returntype  : none
+  Exceptions  : none
+
+=cut
+
+sub remove_multi {
+    my $groups = shift;
+    my $species_suffix = shift;
+
+    $groups //= [qw(compara metadata ontology production stable_ids taxonomy)];
+    $species_suffix //= '';
+
+    foreach my $group (@$groups) {
+        Bio::EnsEMBL::Registry->remove_DBAdaptor("multi${species_suffix}", $group);
+    }
+}
+
+
 =head2 add_core_dbas
 
   Example     : Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $core_dbs );

--- a/scripts/pipeline/update_master_db.pl
+++ b/scripts/pipeline/update_master_db.pl
@@ -154,7 +154,6 @@ my %genome_db_names = map {$_->name => 1} @{$genome_db_adaptor->fetch_all};
 
 foreach my $db_adaptor (@{Bio::EnsEMBL::Registry->get_all_DBAdaptors(-GROUP => 'core')}) {
 
-    next if $db_adaptor->species =~ /__cut_here__/;
     next if $db_adaptor->dbc->dbname =~ /^ensembl_ancestral_/;
     next if $db_adaptor->dbc->dbname =~ /_ancestral_core_/;
 


### PR DESCRIPTION
## Description

I want to avoid having to uncomment / comment out the bit in `production_reg_conf.pl` that loads the previous core databases into the Registry.

## Overview of changes

Here I wrap this part of the code in a function that belongs to our `Utils::Registry` and I add helper methods in `Utils::Registry` to search for a previous core database and do the loading automatically (just once) when needed. I have updated `CheckGenomeReusability.pm` and `Utils/MasterDatabase.pm` to use the new interface.

The new interface is still compatible with "old-style" production_reg_conf files (as long as they use the `__cut_here__` string and the correct version number).

You don't need to review these two functions as they serve another purpose.
- `cleanup_adaptors_from_vertebrates_server` in `production_reg_conf.pl`
- `load_collection_core_database` in `Utils::Registry`

## Testing

This is the code I've used during the Pan-Compara production.

## Further thoughts

Doing this made it more apparent (to me) that we do `$release` minus 1 in many places, but since we only ever load one set of previous core databases, what about using a fixed suffix like `__previous_database` ? Then it's up to the production_reg_conf to load the required previous version, and consumers ( `CheckGenomeReusability.pm` and `Utils/MasterDatabase.pm`) don't need to bother about checking the release number.
