### PR TITLE
Run stats after CAFE

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -3267,6 +3267,7 @@ sub core_pipeline_analyses {
                 '1->A' => [
                     'rib_fire_gene_qc',
                     'rib_fire_homology_id_mapping',
+                    'rib_fire_cafe',
                 ],
                 'A->1' => 'rib_group_2'
             },
@@ -3277,7 +3278,6 @@ sub core_pipeline_analyses {
             -flow_into  => {
                 '1->A' => [
                     'rib_fire_dnds',
-                    'rib_fire_cafe',
                     'rib_fire_homology_stats',
                     'rib_fire_hmm_build',
                     'rib_fire_goc'


### PR DESCRIPTION
## Description

In release 100, CAFE stats were missing from the `gene_member_hom_stats` table because the `stats_homologies` step was run before CAFE.

**Related JIRA tickets:**
- ENSCOMPARASW-3100

## Overview of changes
As Carla proposes in the ticket, to ensure CAFE is run before stats it can be moved to `rib_group_1` or stats can be moved to `rib_group_3`. I have done some numbers on those two groups for e100 for vertebrates, and `rib_group_1` took 2h 30m and `rib_group_3` took 8 seconds. Furthermore, CAFE rib took ~37h and the stats rib took ~14h. Thus, I have seen more logical to move CAFE to `rib_group_1` as the group is already in a "similar" time cost.

The new pipeline graph can be found [here](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-8&port=4618&dbname=jalvarez_plants_plants_protein_trees_100).

## Testing
There hasn't been any testing as the change is pretty straightforward and this rib doesn't have any dependencies with the analyses in `rib_group_1`.
