### PR TITLE
WGA and GOC distribution moved from highConf pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/SelectMLSS.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/SelectMLSS.pm
@@ -207,6 +207,13 @@ sub _map_mlss_to_db {
 
 	# check all have been mapped
 	foreach my $this_mlss_id ( @$mlsses ) {
+        my $mlss_adap = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor;
+        unless ( $mlss_db_mapping{$this_mlss_id} ) {
+            my $this_mlss = $mlss_adap->fetch_by_dbID($this_mlss_id);
+            if ( $this_mlss ) {
+                $mlss_db_mapping{$this_mlss->dbID} = $self->param('master_db');
+            }
+        }
 		die "MLSS $this_mlss_id can't be found in the given alignment databases\n" unless ( $mlss_db_mapping{$this_mlss_id} );
 	}
 	return \%mlss_db_mapping;

--- a/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
@@ -38,6 +38,7 @@ our @EXPORT_OK;
 
 @EXPORT_OK = qw(
     map_row_to_header
+    parse_flatfile_into_hash
 );
 %EXPORT_TAGS = (
   all     => [@EXPORT_OK]
@@ -71,6 +72,30 @@ sub map_row_to_header {
         $row->{$head_cols[$i]} = $cols[$i];
     }
     return $row;
+}
+
+=head2 parse_flatfile_into_hash
+
+    A two column file is parsed into $column_1->$column_2
+
+=cut
+
+sub parse_flatfile_into_hash {
+    my ($self, $filename, $filter) = @_;
+
+    my %flatfile_hash;
+    open(my $fh, '<', $filename) or die "Cannot open $filename for reading";
+    my $header = <$fh>;
+    while ( my $line = <$fh> ) {
+        chomp $line;
+        my ( $id, $val ) = split(/\s+/, $line);
+        next if $val eq '';
+        next if $filter && ! $self->match_range_filter($id, $filter);
+        $flatfile_hash{$id} = $val;
+    }
+    close $fh;
+
+    return \%flatfile_hash;
 }
 
 1;


### PR DESCRIPTION
## Description

_Both the WGA coverage and GOC score distributions were being written and calculated in the HighConfidence pipeline, which, for plants at least, meant that only homologies considered `is_high_confidence` were having distributions computed ._

**Related JIRA tickets:**
- ENSCOMPARASW-2751

## Overview of changes
_WGA distribution analysis has been moved to the WGA pipeline: OrthologQM_Alignment_conf and GOC distributions moved to the GeneOrderConservation runnable to be analysed in the ProteinTrees_conf pipeline._

#### Change #[1](https://github.com/Ensembl/ensembl-compara/pull/178/commits/1ad4e2caeafc6410b19f26df4e9415a3014634fe)
- _The `n_wga_distribution` write distribution was moved to analysis assign_wga_coverage_score_. 

#### Change #[2](https://github.com/Ensembl/ensembl-compara/pull/178/commits/1ad4e2caeafc6410b19f26df4e9415a3014634fe)
- _The `n_goc_distribution` write distribution was moved to the `GeneOrderConservation` runnable._

## Testing
_The tested pipelines can be found here: `mysql://ensro@mysql-ens-compara-prod-5:4615/cristig_wga_dist_test` and `mysql://ensro@mysql-ens-compara-prod-5:4615/cristig_goc_test`. Additional to protein pipeline to check passing of correct parameters, the GOC distributions were tested in standalone mode also._

## Notes
_All mention of thresholds in WGA and GOC pipelines removed, because the thresholds are only used in the HighConfidence pipeline._
