### PR TITLE
WGA and GOC distribution moved from highConf pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/OrthologQM_Alignment_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/OrthologQM_Alignment_conf.pm
@@ -321,6 +321,7 @@ sub pipeline_analyses {
                 'hashed_mlss_id' => '#expr(dir_revhash(#orth_mlss_id#))expr#',
                 'output_file'    => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv',
                 'reuse_file'     => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga_reuse.tsv',
+                'alignment_db'   => $self->pipeline_url,
             },
             -hive_capacity     => 400,
         },

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/FlagHighConfidenceOrthologs.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/FlagHighConfidenceOrthologs.pm
@@ -39,7 +39,7 @@ use warnings;
 use POSIX qw(floor);
 use File::Basename;
 
-use Bio::EnsEMBL::Compara::Utils::FlatFile qw(map_row_to_header);
+use Bio::EnsEMBL::Compara::Utils::FlatFile qw(map_row_to_header parse_flatfile_into_hash);
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
@@ -108,8 +108,8 @@ sub write_output {
     $self->run_command( "mkdir -p " . dirname($output_file)) unless -e dirname($output_file);
 
     my ( $wga_coverage, $goc_scores );
-    $wga_coverage = $self->_parse_flatfile_into_hash($wga_file, $range_filter) if $wga_file && -e $wga_file;;
-    $goc_scores   = $self->_parse_flatfile_into_hash($goc_file, $range_filter) if $goc_file && -e $goc_file;
+    $wga_coverage = $self->parse_flatfile_into_hash($wga_file, $range_filter) if $wga_file && -e $wga_file;
+    $goc_scores   = $self->parse_flatfile_into_hash($goc_file, $range_filter) if $goc_file && -e $goc_file;
 
     open(my $hfh, '<', $homology_file) or die "Cannot open $homology_file for reading";
     open(my $ofh, '>', $output_file  ) or die "Cannot open $output_file for writing";
@@ -163,15 +163,15 @@ sub write_output {
 
     # More stats for the metrics that were used for this mlss_id
     if ( defined $external_conditions->{goc_score} ) {
-        $self->_write_distribution($mlss, 'goc', $external_conditions->{goc_score}, $goc_scores);
+        $self->_write_threshold_scores($mlss, 'goc', $external_conditions->{goc_score}, $goc_scores);
     }
     if ( defined $external_conditions->{wga_coverage} ) {
         # unlike goc, wga is calculated on both protein and ncrna - add the range_label to ensure mergeability
-        $self->_write_distribution($mlss, "${range_label}wga", $external_conditions->{wga_coverage}, $wga_coverage);
+        $self->_write_threshold_scores($mlss, "${range_label}wga", $external_conditions->{wga_coverage}, $wga_coverage);
     }
 }
 
-sub _write_distribution {
+sub _write_threshold_scores {
     my ($self, $mlss, $label, $threshold, $scores) = @_;
 
     my %distrib_hash;
@@ -183,8 +183,6 @@ sub _write_distribution {
     my $n_tot = 0;
     my $n_over_threshold = 0;
     foreach my $distrib_score ( keys %distrib_hash ) {
-        my $tag = sprintf('n_%s_%s', $label, $distrib_score // 'null');
-        $mlss->store_tag($tag, $distrib_hash{$distrib_score});
         $n_tot += $distrib_hash{$distrib_score};
         if ((defined $distrib_score) and ($distrib_score > $threshold)) {
             $n_over_threshold += $distrib_hash{$distrib_score};
@@ -223,24 +221,6 @@ sub _lines_in_file {
     my @wc_out = split( /\s+/, $self->get_command_output("wc -l $filename") );
     my $wc_l   = shift @wc_out;
     return $wc_l - 1; # account for header line
-}
-
-sub _parse_flatfile_into_hash {
-    my ($self, $filename, $filter) = @_;
-
-    my %flatfile_hash;
-    open(my $fh, '<', $filename) or die "Cannot open $filename for reading";
-    my $header = <$fh>;
-    while ( my $line = <$fh> ) {
-        chomp $line;
-        my ( $id, $val ) = split(/\s+/, $line);
-        next if $val eq '';
-        next if $filter && ! $self->_match_range_filter($id, $filter);
-        $flatfile_hash{$id} = $val;
-    }
-    close $fh;
-
-    return \%flatfile_hash;
 }
 
 sub _match_range_filter {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/FlagHighConfidenceOrthologs.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/FlagHighConfidenceOrthologs.pm
@@ -39,7 +39,7 @@ use warnings;
 use POSIX qw(floor);
 use File::Basename;
 
-use Bio::EnsEMBL::Compara::Utils::FlatFile qw(map_row_to_header parse_flatfile_into_hash);
+use Bio::EnsEMBL::Compara::Utils::FlatFile qw(map_row_to_header parse_flatfile_into_hash match_range_filter);
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
@@ -125,7 +125,7 @@ sub write_output {
         );
 
         if ( $range_filter ) {
-            next unless $self->_match_range_filter($homology_id, $range_filter);
+            next unless $self->match_range_filter($homology_id, $range_filter);
         }
 
         # decide if homology is high confidence
@@ -221,22 +221,6 @@ sub _lines_in_file {
     my @wc_out = split( /\s+/, $self->get_command_output("wc -l $filename") );
     my $wc_l   = shift @wc_out;
     return $wc_l - 1; # account for header line
-}
-
-sub _match_range_filter {
-    my ($self, $id, $filter) = @_;
-
-    my $match = 0;
-    foreach my $range ( @$filter ) {
-        die "Bad range declaration: at least one value expected, 0 found." unless defined $range->[0];
-        if ( defined $range->[1] ) {
-            $match = 1 if $id >= $range->[0] && $id <= $range->[1];
-        } else {
-            $match = 1 if $id >= $range->[0];
-        }
-    }
-
-    return $match;
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/GeneOrderConservation.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/GeneOrderConservation.pm
@@ -39,6 +39,7 @@ use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
 use Data::Dumper;
 
 use Bio::EnsEMBL::Compara::Utils::FlatFile qw(map_row_to_header);
+use Bio::EnsEMBL::Compara::Utils::DistributionTag qw(write_n_tag);
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
@@ -173,10 +174,10 @@ sub write_output {
     
     my $goc_scores  = $self->param('goc_scores');
     my $output_file = $self->param('output_file');
-    my $mlss        = $self->param_required('mlss');
+    my $mlss        = $self->param('mlss');
 
     print "Writing n_goc_score to the database\n" if $self->debug;
-    $self->_write_n_tag($mlss, 'goc', $goc_scores);
+    $self->write_n_tag($mlss, 'goc', $goc_scores);
     print "Tag: n_goc_score written!\n\n" if $self->debug;
 
     if ( $output_file ) {
@@ -463,23 +464,6 @@ sub _split_polyploid_goc {
             }
             $self->complete_early("Got ENSEMBL_ORTHOLOGUES on polyploids, so dataflowed 1 job per component genome_db\n");
         }
-    }
-}
-
-sub _write_n_tag {
-    my ($self, $mlss, $label, $scores) = @_;
-
-    my %distrib_hash;
-    foreach my $score ( values %$scores ) {
-        my $floor_score = int($score/25)*25;
-        $distrib_hash{$floor_score} += 1;
-    }
-
-    my $n_tot = 0;
-    my $n_over_threshold = 0;
-    foreach my $distrib_score ( keys %distrib_hash ) {
-        my $tag = sprintf('n_%s_%s', $label, $distrib_score // 'null');
-        $mlss->store_tag($tag, $distrib_hash{$distrib_score});
     }
 }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/GeneOrderConservation.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/GeneOrderConservation.pm
@@ -121,6 +121,7 @@ sub fetch_input {
       
     $self->param('gene_member_strand', \%gene_member_strand);
     $self->param('neighbourhood', \%neighbourhood);
+    $self->param('mlss', $mlss);
 }
 
 sub run {
@@ -172,6 +173,11 @@ sub write_output {
     
     my $goc_scores  = $self->param('goc_scores');
     my $output_file = $self->param('output_file');
+    my $mlss        = $self->param_required('mlss');
+
+    print "Writing n_goc_score to the database\n" if $self->debug;
+    $self->_write_n_tag($mlss, 'goc', $goc_scores);
+    print "Tag: n_goc_score written!\n\n" if $self->debug;
 
     if ( $output_file ) {
         print "Writing GOC scores to output file $output_file\n" if $self->debug;
@@ -457,6 +463,23 @@ sub _split_polyploid_goc {
             }
             $self->complete_early("Got ENSEMBL_ORTHOLOGUES on polyploids, so dataflowed 1 job per component genome_db\n");
         }
+    }
+}
+
+sub _write_n_tag {
+    my ($self, $mlss, $label, $scores) = @_;
+
+    my %distrib_hash;
+    foreach my $score ( values %$scores ) {
+        my $floor_score = int($score/25)*25;
+        $distrib_hash{$floor_score} += 1;
+    }
+
+    my $n_tot = 0;
+    my $n_over_threshold = 0;
+    foreach my $distrib_score ( keys %distrib_hash ) {
+        my $tag = sprintf('n_%s_%s', $label, $distrib_score // 'null');
+        $mlss->store_tag($tag, $distrib_hash{$distrib_score});
     }
 }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/PrepareOrthologs.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/PrepareOrthologs.pm
@@ -154,7 +154,7 @@ sub write_output {
         $self->dataflow_output_id( {orth_mlss_id => $self->param('orth_mlss_id')}, 3 ); # to reuse_wga_score
     }
 
-    $self->dataflow_output_id( { orth_info => $self->param('orth_info') }, 2 ); # to calculate_coverage
+    $self->dataflow_output_id( { orth_info => $self->param('orth_info'), aln_mlss_ids => $self->param('aln_mlss_ids') }, 2 ); # to calculate_coverage
 }
 
 =head2 _nonreusable_homologies

--- a/modules/Bio/EnsEMBL/Compara/Utils/DistributionTag.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/DistributionTag.pm
@@ -1,0 +1,67 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::Utils::DistributionTag
+
+=head1 DESCRIPTION
+
+Utility methods for writing distribution tags
+
+=cut
+
+package Bio::EnsEMBL::Compara::Utils::DistributionTag;
+
+use strict;
+use warnings;
+use base qw(Exporter);
+
+our %EXPORT_TAGS;
+our @EXPORT_OK;
+
+@EXPORT_OK = qw(
+    write_n_tag
+);
+%EXPORT_TAGS = (
+    all => [@EXPORT_OK]
+);
+
+=head2 write_n_tag
+
+    Write the n_label_distribution tags for homology scores
+
+=cut
+
+sub write_n_tag {
+    my ($self, $mlss, $label, $scores) = @_;
+
+    my %distrib_hash;
+    foreach my $score ( values %$scores ) {
+        my $floor_score = int($score/25)*25;
+        $distrib_hash{$floor_score} += 1;
+    }
+
+    my $n_tot = 0;
+    my $n_over_threshold = 0;
+    foreach my $distrib_score ( keys %distrib_hash ) {
+        my $tag = sprintf('n_%s_%s', $label, $distrib_score // 'null');
+        $mlss->store_tag($tag, $distrib_hash{$distrib_score});
+    }
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
@@ -38,6 +38,7 @@ our @EXPORT_OK;
 
 @EXPORT_OK = qw(
     map_row_to_header
+    parse_flatfile_into_hash
 );
 %EXPORT_TAGS = (
   all     => [@EXPORT_OK]
@@ -71,6 +72,30 @@ sub map_row_to_header {
         $row->{$head_cols[$i]} = $cols[$i];
     }
     return $row;
+}
+
+=head2 parse_flatfile_into_hash
+
+    A two column file is parsed into $column_1->$column_2
+
+=cut
+
+sub parse_flatfile_into_hash {
+    my ($self, $filename, $filter) = @_;
+
+    my %flatfile_hash;
+    open(my $fh, '<', $filename) or die "Cannot open $filename for reading";
+    my $header = <$fh>;
+    while ( my $line = <$fh> ) {
+        chomp $line;
+        my ( $id, $val ) = split(/\s+/, $line);
+        next if $val eq '';
+        next if $filter && ! $self->match_range_filter($id, $filter);
+        $flatfile_hash{$id} = $val;
+    }
+    close $fh;
+
+    return \%flatfile_hash;
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
@@ -39,6 +39,7 @@ our @EXPORT_OK;
 @EXPORT_OK = qw(
     map_row_to_header
     parse_flatfile_into_hash
+    match_range_filter
 );
 %EXPORT_TAGS = (
   all     => [@EXPORT_OK]
@@ -96,6 +97,28 @@ sub parse_flatfile_into_hash {
     close $fh;
 
     return \%flatfile_hash;
+}
+
+=head2 match_range_filter
+
+    Range filter to collect appropriate ncrna or protein ids
+
+=cut
+
+sub match_range_filter {
+    my ($self, $id, $filter) = @_;
+
+    my $match = 0;
+    foreach my $range ( @$filter ) {
+        die "Bad range declaration: at least one value expected, 0 found." unless defined $range->[0];
+        if ( defined $range->[1] ) {
+            $match = 1 if $id >= $range->[0] && $id <= $range->[1];
+        } else {
+            $match = 1 if $id >= $range->[0];
+        }
+    }
+
+    return $match;
 }
 
 1;

--- a/modules/t/PrepareOrthologs.t
+++ b/modules/t/PrepareOrthologs.t
@@ -56,14 +56,14 @@ $exp_dataflow = { orth_info => [
     { id => 102, gene_members => [ [9263637, 134], [9274269, 150] ]},
     { id => 103, gene_members => [ [9263633, 134], [9284238, 150] ]},
 ],
-    aln_mlss_ids => 54321,
+    aln_mlss_ids => [54321],
 };
 
 standaloneJob(
 	'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::PrepareOrthologs', # module
 	{ # input param hash
         'orth_mlss_id'      => '12345',
-        'aln_mlss_ids'      => '54321',
+        'aln_mlss_ids'      => ['54321'],
 		'species1_id'       => '150',
 		'species2_id'       => '134',
 		'compara_db'        => $compara_db,
@@ -90,14 +90,14 @@ my $prev_compara_db = $dbc_prev->url;
 my $exp_dataflow_2 = { orth_info => [
     { id => 101, gene_members => [ [9263633, 134], [9274269, 150] ]}
 ],
-    aln_mlss_ids => 54321,
+    aln_mlss_ids => [54321],
 };
 
 standaloneJob(
 	'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::PrepareOrthologs', # module
 	{ # input param hash
         'orth_mlss_id'      => '12345',
-        'aln_mlss_ids'      => '54321',
+        'aln_mlss_ids'      => ['54321'],
 		'species1_id'       => '150',
 		'species2_id'       => '134',
 		'compara_db'        => $compara_db,
@@ -131,7 +131,7 @@ standaloneJob(
 	'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::PrepareOrthologs', # module
 	{ # input param hash
         'orth_mlss_id'      => '12345',
-        'aln_mlss_ids'      => '54321',
+        'aln_mlss_ids'      => ['54321'],
 		'species1_id'       => '150',
 		'species2_id'       => '134',
 		'compara_db'        => $compara_db,

--- a/modules/t/PrepareOrthologs.t
+++ b/modules/t/PrepareOrthologs.t
@@ -55,12 +55,15 @@ $exp_dataflow = { orth_info => [
     { id => 101, gene_members => [ [9263633, 134], [9274269, 150] ]},
     { id => 102, gene_members => [ [9263637, 134], [9274269, 150] ]},
     { id => 103, gene_members => [ [9263633, 134], [9284238, 150] ]},
-]};
+],
+    aln_mlss_ids => 54321,
+};
 
 standaloneJob(
 	'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::PrepareOrthologs', # module
 	{ # input param hash
         'orth_mlss_id'      => '12345',
+        'aln_mlss_ids'      => '54321',
 		'species1_id'       => '150',
 		'species2_id'       => '134',
 		'compara_db'        => $compara_db,
@@ -86,12 +89,15 @@ my $prev_compara_db = $dbc_prev->url;
 
 my $exp_dataflow_2 = { orth_info => [
     { id => 101, gene_members => [ [9263633, 134], [9274269, 150] ]}
-]};
+],
+    aln_mlss_ids => 54321,
+};
 
 standaloneJob(
 	'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::PrepareOrthologs', # module
 	{ # input param hash
         'orth_mlss_id'      => '12345',
+        'aln_mlss_ids'      => '54321',
 		'species1_id'       => '150',
 		'species2_id'       => '134',
 		'compara_db'        => $compara_db,
@@ -125,6 +131,7 @@ standaloneJob(
 	'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::PrepareOrthologs', # module
 	{ # input param hash
         'orth_mlss_id'      => '12345',
+        'aln_mlss_ids'      => '54321',
 		'species1_id'       => '150',
 		'species2_id'       => '134',
 		'compara_db'        => $compara_db,


### PR DESCRIPTION
## Description

_Both the WGA coverage and GOC score n tags were being written and calculated in the HighConfidence pipeline, which, for plants at least, meant that only homologies considered `is_high_confidence` were having distributions computed ._

**Related JIRA tickets:**
- ENSCOMPARASW-2751

## Overview of changes
_WGA distribution analysis has been moved to the WGA pipeline: OrthologQM_Alignment_conf and GOC distributions moved to the GeneOrderConservation runnable to be analysed in the ProteinTrees_conf pipeline._

#### Change #[1](https://github.com/Ensembl/ensembl-compara/pull/178/commits/1ad4e2caeafc6410b19f26df4e9415a3014634fe)
- _The `n_wga_score` write tag was moved to analysis assign_wga_coverage_score. This meant having to pass a parameter through PrepareOrthologues.pm and CalculateWGACoverage.pm, and connection to an alignment db. I have not made a decision on how we pass the alignment_db, or which dbs we use, I am saving that for another ticket_. 

#### Change #[2](https://github.com/Ensembl/ensembl-compara/pull/178/commits/1ad4e2caeafc6410b19f26df4e9415a3014634fe)
- _The `n_goc_score` write tag was moved to the `GeneOrderConservation` runnable._

## Testing
_The tested pipeline for wga can be found here: `mysql://ensro@mysql-ens-compara-prod-5:4615/cristig_wga_dist_test`. The GOC n_goc_score tags were tested in standalone mode._

## Notes
_parse_flat_file_into_hash_ was moved to the FlatFiles.pm utils for use with other runnables.
