### PR TITLE
NcRNA_trees homology mlss_id factory replaced

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/HomologyAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/HomologyAdaptor.pm
@@ -703,4 +703,11 @@ sub update_wga_coverage {
   return $self;
 }
 
+sub count_by_mlss_id {
+    my ($self, $mlss_id) = @_;
+
+    $self->bind_param_generic_fetch($mlss_id, SQL_INTEGER);
+    return $self->generic_count('method_link_species_set_id=?');
+}
+
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpHomologiesForPosttree.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpHomologiesForPosttree.pm
@@ -42,9 +42,13 @@ sub pipeline_analyses_dump_homologies_posttree {
     my ($self) = @_;
     return [
         {   -logic_name => 'homology_dumps_mlss_id_factory',
-            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::MLSSIDFactory',
             -parameters => {
-                'inputquery' => 'SELECT method_link_species_set_id AS mlss_id, COUNT(*) as exp_line_count FROM homology GROUP BY method_link_species_set_id',
+                'methods'    => {
+                    'ENSEMBL_PARALOGUES'    => 2,
+                    'ENSEMBL_ORTHOLOGUES'   => 2,
+                },
+                'line_count' => 1,
             },
             -flow_into => {
                 2 => [ 'dump_per_mlss_homologies_tsv' ],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -1204,21 +1204,8 @@ sub core_pipeline_analyses {
         {   -logic_name => 'rib_fire_homology_dumps',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => {
-                '1->A' => 'mlss_id_factory_for_homology_dumps',
+                '1->A' => 'homology_dumps_mlss_id_factory',
                 'A->1' => 'rib_fire_homology_processing',
-            },
-        },
-
-        {   -logic_name => 'mlss_id_factory_for_homology_dumps',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::MLSSIDFactory',
-            -parameters => {
-                'methods'   => {
-                    'ENSEMBL_ORTHOLOGUES'   => 2,
-                    'ENSEMBL_PARALOGUES'    => 2,
-                },
-            },
-            -flow_into => {
-                2 => [ 'dump_per_mlss_homologies_tsv' ],
             },
         },
 
@@ -1241,10 +1228,6 @@ sub core_pipeline_analyses {
         @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneMemberHomologyStats::pipeline_analyses_hom_stats($self) },
         @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpHomologiesForPosttree::pipeline_analyses_dump_homologies_posttree($self) },
     ];
-}
-
-sub analyses_to_remove {
-    return ['homology_dumps_mlss_id_factory'];
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -1204,8 +1204,21 @@ sub core_pipeline_analyses {
         {   -logic_name => 'rib_fire_homology_dumps',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => {
-                '1->A' => 'homology_dumps_mlss_id_factory',
+                '1->A' => 'mlss_id_factory_for_homology_dumps',
                 'A->1' => 'rib_fire_homology_processing',
+            },
+        },
+
+        {   -logic_name => 'mlss_id_factory_for_homology_dumps',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::MLSSIDFactory',
+            -parameters => {
+                'methods'   => {
+                    'ENSEMBL_ORTHOLOGUES'   => 2,
+                    'ENSEMBL_PARALOGUES'    => 2,
+                },
+            },
+            -flow_into => {
+                2 => [ 'dump_per_mlss_homologies_tsv' ],
             },
         },
 
@@ -1228,6 +1241,10 @@ sub core_pipeline_analyses {
         @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneMemberHomologyStats::pipeline_analyses_hom_stats($self) },
         @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpHomologiesForPosttree::pipeline_analyses_dump_homologies_posttree($self) },
     ];
+}
+
+sub analyses_to_remove {
+    return ['homology_dumps_mlss_id_factory'];
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/MLSSIDFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/MLSSIDFactory.pm
@@ -97,10 +97,9 @@ sub _get_line_count {
         $adaptor = $self->compara_dba->get_SyntenyRegionAdaptor;
     }
     else {
-        return;
+        die "_get_line_count does not support method: " . $mlss->method->type;
     }
-
-    my $allitems = $adaptor->fetch_all_by_MethodLinkSpeciesSet($mlss);
-    return scalar(@$allitems);
+    my $line_count = $adaptor->count_by_mlss_id($mlss->dbID);
+    return $line_count;
 }
 1;


### PR DESCRIPTION
## Description

_The homology_dumps_mlss_id_factory was using analyses from the protein tree `Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpHomologiesForPosttree`  which did not fit with the rest of the pipeline, causing conflict further along with the homologies that were dumped and the stats that depend on those dumps._

**Related JIRA tickets:**
- ENSCOMPARASW-3077

## Overview of changes
_Give details of what changes were required to solve the problem. Break into sections if applicable._

#### Change #180
- _The_ `homology_dumps_mlss_id_factory` _was replaced with_ `Bio::EnsEMBL::Compara::RunnableDB::MLSSIDFactory`

#### Change #180
- `Bio::EnsEMBL::Compara::RunnableDB::MLSSIDFactory` _was altered to _

## Testing
_This was tested in Standalone mode for different scenarios:_
```
- { 'methods' => {  'SYNTENY' => 2 },  'line_count' => 1 } 
- { 'methods' => {  'SYNTENY' => 2 } }
- { 'methods' => {  'ENSEMBL_ORTHOLOGUES' => 2 }, 'line_count' => 1 }
- { 'methods' => {  'ENSEMBL_ORTHOLOGUES' => 2 } }
- { 'methods' => {  'ENSEMBL_PARALOGUES' => 2 }, 'line_count' => 1 }
- { 'methods' => {  'ENSEMBL_PARALOGUES' => 2 } }
- { 'methods' => {  'LASTZ_NET'  => 2 }, 'line_count' => 1 }
```


## Notes
_There are 3 separate analyses for mlss_id factory in the_ `rib_fire_homology_dumps`. _There doesn't need to be. But in this case I have just swapped out the one analysis, so everything else remains the same._
