### PR TITLE
New wrapper scripts that take a registry configuration file

### DIFF
--- a/scripts/production/backup_master.pl
+++ b/scripts/production/backup_master.pl
@@ -41,9 +41,8 @@ URL of the database to dump.
 
 =item B<[--reg_conf registry_configuration_file]>
 
-The Bio::EnsEMBL::Registry configuration file. If none given and no URL is
-given, the one set in ENSEMBL_REGISTRY will be used if defined, if not
-~/.ensembl_init will be used.
+The Bio::EnsEMBL::Registry configuration file. Must be given to refer to
+the database by registry name (alias) instead of a URL.
 
 =item B<[--reg_type reg_type]>
 

--- a/scripts/production/backup_master.pl
+++ b/scripts/production/backup_master.pl
@@ -112,6 +112,11 @@ unless ($url or $reg_conf) {
     exit 1;
 }
 
+if ($url and $reg_alias) {
+    print "\nERROR: Both --url and --reg_alias are defined. Don't know which one to use\n\n";
+    exit 1;
+}
+
 if ($reg_conf) {
     Bio::EnsEMBL::Registry->load_all($reg_conf);
 }

--- a/scripts/production/backup_master.pl
+++ b/scripts/production/backup_master.pl
@@ -1,0 +1,133 @@
+#!/usr/bin/env perl
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2020] EMBL-European Bioinformatics Institute
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+=head1 NAME
+
+backup_master.pl
+
+=head1 DESCRIPTION
+
+This script is a wrapper around sudo and mysqldump to dump the master database,
+taking its location from a production_reg_conf file.
+
+=head1 SYNOPSIS
+
+  perl backup_master.pl $COMPARA_REG compara_curr -group compara
+
+  perl backup_master.pl \
+    --reg_conf registry_configuration_file --reg_alias compara_curr
+
+=head1 ARGUMENTS
+
+The script reads these arguments and passes the other ones straight to run-configurable-testrunner.sh
+
+=head2 DATABASE SETUP
+
+=over
+
+=item B<[--url mysql://user[:passwd]@host[:port]/dbname]>
+
+URL of the database to test.
+
+=item B<[--reg_conf registry_configuration_file]>
+
+The Bio::EnsEMBL::Registry configuration file. If none given and no URL is
+given, the one set in ENSEMBL_REGISTRY will be used if defined, if not
+~/.ensembl_init will be used.
+
+=item B<[--reg_type reg_type]>
+
+The "type" or "group" under which the database is to be found in the Registry.
+
+=item B<[--reg_alias|--reg_name name]>
+
+The name or "species" under which the database is to be found in the Registry.
+Defaults to "compara_master".
+
+=back
+
+=head2 DUMP SETUP
+
+=over
+
+=item B<[--dump_path /path/to_dumps]>
+
+Where to store the dumps. Defaults to the shared warehouse directory.
+
+=item B<[--label str]>
+
+Label to add to the file name
+
+=back
+
+=cut
+
+use strict;
+use warnings;
+
+use Getopt::Long;
+use POSIX qw(strftime);
+
+use Bio::EnsEMBL::Registry;
+
+use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
+use Bio::EnsEMBL::Compara::Utils::Registry;
+
+my ($url, $reg_conf, $reg_type, $reg_alias);
+my ($dump_path, $label);
+
+# Arguments parsing
+GetOptions(
+    'url=s'                         => \$url,
+    'reg_conf|regfile|reg_file=s'   => \$reg_conf,
+    'reg_type=s'                    => \$reg_type,
+    'reg_alias|regname|reg_name=s'  => \$reg_alias,
+    'dump_path=s'                   => \$dump_path,
+    'label=s'                       => \$label,
+) or die "Error in command line arguments\n";
+
+if (@ARGV) {
+    die "ERROR: There are invalid arguments on the command-line: ". join(" ", @ARGV). "\n";
+}
+
+unless ($url or ($reg_conf and $reg_alias)) {
+    print "\nNeither --url nor --reg_conf and --reg_alias are defined. Some of those are needed to refer to the database being tested\n\n";
+    exit 1;
+}
+
+if ($reg_conf) {
+    Bio::EnsEMBL::Registry->load_all($reg_conf);
+}
+my $dba = $url
+    ? Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->new( -URL => $url )
+    : Bio::EnsEMBL::Registry->get_DBAdaptor( $reg_alias || 'compara_master', $reg_type || 'compara' );
+
+my $division = $dba->get_division;
+
+my @params = (
+    '--host'    => $dba->dbc->host,
+    '--port'    => $dba->dbc->port,
+    '--user'    => 'ensro',
+);
+
+$dump_path ||= '/nfs/production/panda/ensembl/warehouse/compara/master_db_dumps';
+
+my $date = strftime '%Y%m%d', localtime;
+my $dump_name = "ensembl_compara_master_${division}.${date}" . ($label ? ".$label" : ''). ".sql";
+
+my $cmd = join(' ', 'mysqldump', @params, $dba->dbc->dbname, '>', "$dump_path/$dump_name");
+print "Executing: $cmd\n\n";
+exec('sudo', -u => 'compara_ensembl', '/bin/bash', -c => $cmd);

--- a/scripts/production/backup_master.pl
+++ b/scripts/production/backup_master.pl
@@ -108,7 +108,7 @@ if (@ARGV) {
 }
 
 unless ($url or $reg_conf) {
-    print "\nNeither --url nor --reg_conf are defined. Some of those are needed to refer to the database being dumped\n\n";
+    print "\nERROR: Neither --url nor --reg_conf are defined. Some of those are needed to refer to the database being dumped\n\n";
     exit 1;
 }
 

--- a/scripts/production/backup_master.pl
+++ b/scripts/production/backup_master.pl
@@ -25,9 +25,9 @@ taking its location from a production_reg_conf file.
 
 =head1 SYNOPSIS
 
-  perl backup_master.pl --reg_conf $COMPARA_REG_PATH
+    perl backup_master.pl --reg_conf $COMPARA_REG_PATH
 
-  perl backup_master.pl $COMPARA_REG compara_master --label "pre100"
+    perl backup_master.pl $COMPARA_REG compara_master --label "pre100"
 
 =head1 ARGUMENTS
 

--- a/scripts/production/backup_master.pl
+++ b/scripts/production/backup_master.pl
@@ -37,7 +37,7 @@ taking its location from a production_reg_conf file.
 
 =item B<[--url mysql://user[:passwd]@host[:port]/dbname]>
 
-URL of the database to test.
+URL of the database to dump.
 
 =item B<[--reg_conf registry_configuration_file]>
 
@@ -73,7 +73,7 @@ backup as yourself.
 
 =item B<[--label str]>
 
-Label to add to the file name
+Label to append to the dump file name.
 
 =back
 
@@ -109,7 +109,7 @@ if (@ARGV) {
 }
 
 unless ($url or $reg_conf) {
-    print "\nNeither --url nor --reg_conf are defined. Some of those are needed to refer to the database being tested\n\n";
+    print "\nNeither --url nor --reg_conf are defined. Some of those are needed to refer to the database being dumped\n\n";
     exit 1;
 }
 

--- a/scripts/production/backup_master.pl
+++ b/scripts/production/backup_master.pl
@@ -108,8 +108,8 @@ if (@ARGV) {
     die "ERROR: There are invalid arguments on the command-line: ". join(" ", @ARGV). "\n";
 }
 
-unless ($url or ($reg_conf and $reg_alias)) {
-    print "\nNeither --url nor --reg_conf and --reg_alias are defined. Some of those are needed to refer to the database being tested\n\n";
+unless ($url or $reg_conf) {
+    print "\nNeither --url nor --reg_conf are defined. Some of those are needed to refer to the database being tested\n\n";
     exit 1;
 }
 

--- a/scripts/production/backup_master.pl
+++ b/scripts/production/backup_master.pl
@@ -25,14 +25,11 @@ taking its location from a production_reg_conf file.
 
 =head1 SYNOPSIS
 
-  perl backup_master.pl $COMPARA_REG compara_curr -group compara
+  perl backup_master.pl --reg_conf $COMPARA_REG_PATH
 
-  perl backup_master.pl \
-    --reg_conf registry_configuration_file --reg_alias compara_curr
+  perl backup_master.pl $COMPARA_REG compara_master --label "pre100"
 
 =head1 ARGUMENTS
-
-The script reads these arguments and passes the other ones straight to run-configurable-testrunner.sh
 
 =head2 DATABASE SETUP
 
@@ -51,6 +48,7 @@ given, the one set in ENSEMBL_REGISTRY will be used if defined, if not
 =item B<[--reg_type reg_type]>
 
 The "type" or "group" under which the database is to be found in the Registry.
+Defaults to "compara".
 
 =item B<[--reg_alias|--reg_name name]>
 

--- a/scripts/production/enable_mysql_keys.sh
+++ b/scripts/production/enable_mysql_keys.sh
@@ -16,12 +16,12 @@
 # limitations under the License.
 
 
-[ $# -ne 2 ] && { echo "Usage: $0 mysql-server database_name"; exit 1; }
+[ $# -ne 4 ] && { echo "Usage: $0 --host=mysql-server --port=port --user=user database_name"; exit 1; }
 
 set -euo pipefail
 
-"$1" "$2" --column-names=false -e "SHOW FULL TABLES WHERE TABLE_TYPE = 'BASE TABLE'" | cut -f1 | while read table; do
+mysql "$@" --column-names=false -e "SHOW FULL TABLES WHERE TABLE_TYPE = 'BASE TABLE'" | cut -f1 | while read -r table; do
     echo "$table"
-    "$1" "$2" -e "ALTER TABLE $2.$table ENABLE KEYS"
+    mysql "$@" -e "ALTER TABLE $table ENABLE KEYS"
 done
 

--- a/scripts/production/patch_database.pl
+++ b/scripts/production/patch_database.pl
@@ -93,7 +93,7 @@ if (@ARGV) {
 }
 
 unless ($url or ($reg_conf and $reg_alias)) {
-    print "\nNeither --url nor --reg_conf and --reg_alias are defined. Some of those are needed to refer to the database being patched\n\n";
+    print "\nERROR: Neither --url nor --reg_conf and --reg_alias are defined. Some of those are needed to refer to the database being patched\n\n";
     exit 1;
 }
 
@@ -108,7 +108,7 @@ unless ($schema_patcher) {
     die "Need to give the --schema_patcher option or set the ENSEMBL_CVS_ROOT_DIR environment variable to use the default" unless $ENV{ENSEMBL_CVS_ROOT_DIR};
     $schema_patcher = $ENV{ENSEMBL_CVS_ROOT_DIR} . '/ensembl/misc-scripts/schema_patcher.pl';
 }
-die "'$schema_patcher' is not a valid executable" unless -x $schema_patcher;
+die "ERROR: '$schema_patcher' is not a valid executable" unless -x $schema_patcher;
 
 
 if ($dba->dbc->user eq 'ensro') {

--- a/scripts/production/patch_database.pl
+++ b/scripts/production/patch_database.pl
@@ -25,10 +25,7 @@ taking connection details from a production_reg_conf file.
 
 =head1 SYNOPSIS
 
-  perl patch_database.pl $COMPARA_REG compara_curr -group compara
-
-  perl patch_database.pl \
-    --reg_conf registry_configuration_file --reg_alias compara_curr
+  perl patch_database.pl $COMPARA_REG compara_prev
 
 =head1 ARGUMENTS
 

--- a/scripts/production/patch_database.pl
+++ b/scripts/production/patch_database.pl
@@ -25,7 +25,7 @@ taking connection details from a production_reg_conf file.
 
 =head1 SYNOPSIS
 
-  perl patch_database.pl $COMPARA_REG compara_prev
+    perl patch_database.pl $COMPARA_REG compara_prev
 
 =head1 ARGUMENTS
 

--- a/scripts/production/patch_database.pl
+++ b/scripts/production/patch_database.pl
@@ -46,6 +46,7 @@ given, the one set in ENSEMBL_REGISTRY will be used if defined, if not
 =item B<[--reg_type reg_type]>
 
 The "type" or "group" under which the database is to be found in the Registry.
+Defaults to "compara".
 
 =item B<[--reg_alias|--reg_name name]>
 

--- a/scripts/production/patch_database.pl
+++ b/scripts/production/patch_database.pl
@@ -39,9 +39,8 @@ URL of the database to patch.
 
 =item B<[--reg_conf registry_configuration_file]>
 
-The Bio::EnsEMBL::Registry configuration file. If none given and no URL is
-given, the one set in ENSEMBL_REGISTRY will be used if defined, if not
-~/.ensembl_init will be used.
+The Bio::EnsEMBL::Registry configuration file. Must be given to refer to
+the database by registry name (alias) instead of a URL.
 
 =item B<[--reg_type reg_type]>
 

--- a/scripts/production/patch_database.pl
+++ b/scripts/production/patch_database.pl
@@ -97,6 +97,11 @@ unless ($url or ($reg_conf and $reg_alias)) {
     exit 1;
 }
 
+if ($url and $reg_alias) {
+    print "\nERROR: Both --url and --reg_alias are defined. Don't know which one to use\n\n";
+    exit 1;
+}
+
 if ($reg_conf) {
     Bio::EnsEMBL::Registry->load_all($reg_conf);
 }

--- a/scripts/production/patch_database.pl
+++ b/scripts/production/patch_database.pl
@@ -1,0 +1,131 @@
+#!/usr/bin/env perl
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2020] EMBL-European Bioinformatics Institute
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+=head1 NAME
+
+patch_database.pl
+
+=head1 DESCRIPTION
+
+This script is a wrapper around ensembl's schema_patcher.pl to run it
+taking connection details from a production_reg_conf file.
+
+=head1 SYNOPSIS
+
+  perl patch_database.pl $COMPARA_REG compara_curr -group compara
+
+  perl patch_database.pl \
+    --reg_conf registry_configuration_file --reg_alias compara_curr
+
+=head1 ARGUMENTS
+
+=head2 DATABASE SETUP
+
+=over
+
+=item B<[--url mysql://user[:passwd]@host[:port]/dbname]>
+
+URL of the database to test.
+
+=item B<[--reg_conf registry_configuration_file]>
+
+The Bio::EnsEMBL::Registry configuration file. If none given and no URL is
+given, the one set in ENSEMBL_REGISTRY will be used if defined, if not
+~/.ensembl_init will be used.
+
+=item B<[--reg_type reg_type]>
+
+The "type" or "group" under which the database is to be found in the Registry.
+
+=item B<[--reg_alias|--reg_name name]>
+
+The name or "species" under which the database is to be found in the Registry.
+
+=back
+
+=head2 SCHEMA PATCHER SETUP
+
+=over
+
+=item B<[--schema_patcher /path/to/schema_patcher.pl]>
+
+The path to schema_patcher.pl. If not given a default will be
+formed using the ENSEMBL_CVS_ROOT_DIR environment variable.
+
+=back
+
+=cut
+
+use strict;
+use warnings;
+
+use Getopt::Long;
+
+use Bio::EnsEMBL::Registry;
+
+use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
+use Bio::EnsEMBL::Compara::Utils::Registry;
+
+my ($url, $reg_conf, $reg_type, $reg_alias);
+my ($schema_patcher);
+
+# Arguments parsing
+GetOptions(
+    'url=s'                         => \$url,
+    'reg_conf|regfile|reg_file=s'   => \$reg_conf,
+    'reg_type=s'                    => \$reg_type,
+    'reg_alias|regname|reg_name=s'  => \$reg_alias,
+    'schema_patcher=s'              => \$schema_patcher,
+) or die "Error in command line arguments\n";
+
+if (@ARGV) {
+    die "ERROR: There are invalid arguments on the command-line: ". join(" ", @ARGV). "\n";
+}
+
+unless ($url or ($reg_conf and $reg_alias)) {
+    print "\nNeither --url nor --reg_conf and --reg_alias are defined. Some of those are needed to refer to the database being tested\n\n";
+    exit 1;
+}
+
+if ($reg_conf) {
+    Bio::EnsEMBL::Registry->load_all($reg_conf);
+}
+my $dba = $url
+    ? Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->new( -URL => $url )
+    : Bio::EnsEMBL::Registry->get_DBAdaptor( $reg_alias, $reg_type || 'compara' );
+
+unless ($schema_patcher) {
+    die "Need to give the --schema_patcher option or set the ENSEMBL_CVS_ROOT_DIR environment variable to use the default" unless $ENV{ENSEMBL_CVS_ROOT_DIR};
+    $schema_patcher = $ENV{ENSEMBL_CVS_ROOT_DIR} . '/ensembl/misc-scripts/schema_patcher.pl';
+}
+die "'$schema_patcher' is not a valid executable" unless -x $schema_patcher;
+
+
+if ($dba->dbc->user eq 'ensro') {
+    warn "Switching to the ensadmin user\n";
+}
+
+my @params = (
+    '--host'    => $dba->dbc->host,
+    '--port'    => $dba->dbc->port,
+    '--user'    => Bio::EnsEMBL::Compara::Utils::Registry::get_rw_user($dba->dbc->host),
+    '--pass'    => Bio::EnsEMBL::Compara::Utils::Registry::get_rw_pass($dba->dbc->host),
+    '--database'    => $dba->dbc->dbname,
+);
+
+print "Executing: ", join(" ", $schema_patcher, @params), "\n\n";
+
+exec($schema_patcher, @params);

--- a/scripts/production/patch_database.pl
+++ b/scripts/production/patch_database.pl
@@ -116,11 +116,11 @@ if ($dba->dbc->user eq 'ensro') {
 }
 
 my @params = (
-    '--host'    => $dba->dbc->host,
-    '--port'    => $dba->dbc->port,
-    '--user'    => Bio::EnsEMBL::Compara::Utils::Registry::get_rw_user($dba->dbc->host),
-    '--pass'    => Bio::EnsEMBL::Compara::Utils::Registry::get_rw_pass($dba->dbc->host),
-    '--database'    => $dba->dbc->dbname,
+    '--host'     => $dba->dbc->host,
+    '--port'     => $dba->dbc->port,
+    '--user'     => Bio::EnsEMBL::Compara::Utils::Registry::get_rw_user($dba->dbc->host),
+    '--pass'     => Bio::EnsEMBL::Compara::Utils::Registry::get_rw_pass($dba->dbc->host),
+    '--database' => $dba->dbc->dbname,
 );
 
 print "Executing: ", join(" ", $schema_patcher, @params), "\n\n";

--- a/scripts/production/patch_database.pl
+++ b/scripts/production/patch_database.pl
@@ -35,7 +35,7 @@ taking connection details from a production_reg_conf file.
 
 =item B<[--url mysql://user[:passwd]@host[:port]/dbname]>
 
-URL of the database to test.
+URL of the database to patch.
 
 =item B<[--reg_conf registry_configuration_file]>
 
@@ -93,7 +93,7 @@ if (@ARGV) {
 }
 
 unless ($url or ($reg_conf and $reg_alias)) {
-    print "\nNeither --url nor --reg_conf and --reg_alias are defined. Some of those are needed to refer to the database being tested\n\n";
+    print "\nNeither --url nor --reg_conf and --reg_alias are defined. Some of those are needed to refer to the database being patched\n\n";
     exit 1;
 }
 

--- a/scripts/production/run_datachecks.pl
+++ b/scripts/production/run_datachecks.pl
@@ -1,0 +1,159 @@
+#!/usr/bin/env perl
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2020] EMBL-European Bioinformatics Institute
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+=head1 NAME
+
+run_datachecks.pl
+
+=head1 DESCRIPTION
+
+This script is a wrapper around ensembl-datacheck's eponym script which
+accepts our production_reg_conf-based configuration and automatically sets
+the connection details of the database being tested and the previous one.
+
+=head1 SYNOPSIS
+
+  perl run_datachecks.pl $COMPARA_REG compara_curr -group compara
+
+  perl run_datachecks.pl \
+    --reg_conf registry_configuration_file --reg_alias compara_curr \
+    -name CompareMSANames
+
+=head1 ARGUMENTS
+
+The script reads these arguments and passes the other ones straight to run_datachecks.pl
+
+=head2 DATABASE SETUP
+
+=over
+
+=item B<[--url mysql://user[:passwd]@host[:port]/dbname]>
+
+URL of the database to test.
+
+=item B<[--reg_conf registry_configuration_file]>
+
+The Bio::EnsEMBL::Registry configuration file. If none given and no URL is
+given, the one set in ENSEMBL_REGISTRY will be used if defined, if not
+~/.ensembl_init will be used.
+
+=item B<[--reg_type reg_type]>
+
+The "type" or "group" under which the database is to be found in the Registry.
+
+=item B<[--reg_alias|--reg_name name]>
+
+The name or "species" under which the database is to be found in the Registry.
+Defaults to "compara_curr"
+
+=item B<[--prev_url mysql://user[:passwd]@host[:port]/dbname]>
+
+URL of the previous database.
+
+=item B<[--prev_alias|--prev_reg_name name]>
+
+The name or "species" under which the previous database is to be found in the Registry.
+Defaults to "compara_prev"
+
+=back
+
+=head2 DATACHECK SETUP
+
+=over
+
+=item B<[--dc-runner /path/to/run_datachecks.pl]>
+
+The path to the run_datachecks.pl of ensembl-datacheck. If not given a
+default will be formed using the ENSEMBL_CVS_ROOT_DIR environment variable.
+
+=back
+
+=cut
+
+use strict;
+use warnings;
+
+use Getopt::Long qw(:config pass_through);
+
+use Bio::EnsEMBL::Registry;
+
+use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
+use Bio::EnsEMBL::Compara::Utils::Registry;
+
+my ($url, $reg_conf, $reg_type, $reg_alias);
+my ($prev_url, $prev_alias);
+my ($dc_runner);
+
+# Arguments parsing
+GetOptions(
+    'url=s'                         => \$url,
+    'reg_conf|regfile|reg_file=s'   => \$reg_conf,
+    'reg_type=s'                    => \$reg_type,
+    'reg_alias|regname|reg_name=s'  => \$reg_alias,
+    'prev_url=s'                    => \$prev_url,
+    'prev_alias|prev_reg_name=s'    => \$prev_alias,
+    'dc-runner=s'                   => \$dc_runner,
+);
+
+unless (($url and $prev_url) or $reg_conf) {
+    print "\nWithout the registry, both --url and --prev_url must be given\n\n";
+    exit 1;
+}
+
+unless ($dc_runner) {
+    die "Need to give the --dc-runner option or set the ENSEMBL_CVS_ROOT_DIR environment variable to use the default" unless $ENV{ENSEMBL_CVS_ROOT_DIR};
+    $dc_runner = $ENV{ENSEMBL_CVS_ROOT_DIR} . '/ensembl-datacheck/scripts/run_datachecks.pl';
+}
+die "'$dc_runner' is not a valid executable" unless -x $dc_runner;
+
+if ($reg_conf) {
+    Bio::EnsEMBL::Registry->load_all($reg_conf);
+}
+my $dba = $url
+    ? Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->new( -URL => $url )
+    : Bio::EnsEMBL::Registry->get_DBAdaptor( $reg_alias || 'compara_curr', $reg_type || 'compara' );
+
+# Common parameters
+my @params = (
+    '--host'    => $dba->dbc->host,
+    '--port'    => $dba->dbc->port,
+    '--user'    => 'ensro',             # Fallback to ensro to ensure we don't write to it by accident
+    '--dbname'  => $dba->dbc->dbname,
+);
+
+if ($reg_conf) {
+    push @params, (
+        '--registry_file'   => $reg_conf,
+    );
+}
+
+if ($prev_url) {
+    die "Both --prev_url and --prev_alias were given. Please choose !" if $prev_alias;
+    push @params, (
+        '--old_server_uri' => $prev_url,
+    );
+} else {
+    $prev_alias ||= 'compara_prev';
+    my $prev_dba = Bio::EnsEMBL::Registry->get_DBAdaptor( $prev_alias, $reg_type || 'compara' );
+    die "Cannot find the alias '$prev_alias' in the Registry" unless $prev_dba;
+    push @params, (
+        '--old_server_uri' => $prev_dba->url,
+    );
+}
+
+print "Executing: ", join(" ", $dc_runner, @params, @ARGV), "\n\n";
+
+exec($dc_runner, @params, @ARGV);

--- a/scripts/production/run_datachecks.pl
+++ b/scripts/production/run_datachecks.pl
@@ -20,7 +20,7 @@ run_datachecks.pl
 
 =head1 DESCRIPTION
 
-This script is a wrapper around ensembl-datacheck's eponym script which
+This script is a wrapper around ensembl-datacheck's eponym script that
 accepts our production_reg_conf-based configuration and automatically sets
 the connection details of the database being tested and the previous one.
 
@@ -65,7 +65,7 @@ URL of the previous database.
 =item B<[--prev_alias|--prev_reg_name name]>
 
 The name or "species" under which the previous database is to be found in the Registry.
-Defaults to "compara_prev"
+Defaults to "compara_prev".
 
 =back
 

--- a/scripts/production/run_datachecks.pl
+++ b/scripts/production/run_datachecks.pl
@@ -46,9 +46,8 @@ URL of the database to test.
 
 =item B<[--reg_conf registry_configuration_file]>
 
-The Bio::EnsEMBL::Registry configuration file. If none given and no URL is
-given, the one set in ENSEMBL_REGISTRY will be used if defined, if not
-~/.ensembl_init will be used.
+The Bio::EnsEMBL::Registry configuration file. Must be given to refer to
+one of the databases by registry name (alias) instead of URLs.
 
 =item B<[--reg_type reg_type]>
 

--- a/scripts/production/run_datachecks.pl
+++ b/scripts/production/run_datachecks.pl
@@ -26,11 +26,11 @@ the connection details of the database being tested and the previous one.
 
 =head1 SYNOPSIS
 
-  perl run_datachecks.pl $COMPARA_REG compara_curr -group compara
+    perl run_datachecks.pl $COMPARA_REG compara_curr --group compara
 
-  perl run_datachecks.pl \
-    --reg_conf registry_configuration_file --reg_alias compara_curr \
-    -name CompareMSANames
+    perl run_datachecks.pl \
+        --reg_conf registry_configuration_file --reg_alias compara_curr \
+        --name CompareMSANames
 
 =head1 ARGUMENTS
 

--- a/scripts/production/run_datachecks.pl
+++ b/scripts/production/run_datachecks.pl
@@ -53,6 +53,7 @@ given, the one set in ENSEMBL_REGISTRY will be used if defined, if not
 =item B<[--reg_type reg_type]>
 
 The "type" or "group" under which the database is to be found in the Registry.
+Defaults to "compara".
 
 =item B<[--reg_alias|--reg_name name]>
 

--- a/scripts/production/run_datachecks.pl
+++ b/scripts/production/run_datachecks.pl
@@ -108,7 +108,7 @@ GetOptions(
 );
 
 unless (($url and $prev_url) or ($reg_conf and $reg_alias)) {
-    print "\nThe script requires either URLs (--url, --prev_url) or a registry configuration (--reg_conf, --reg_alias, --prev_alias).\n\n";
+    print "\nERROR: The script requires either URLs (--url, --prev_url) or a registry configuration (--reg_conf, --reg_alias, --prev_alias).\n\n";
     exit 1;
 }
 
@@ -116,7 +116,7 @@ unless ($dc_runner) {
     die "Need to give the --dc-runner option or set the ENSEMBL_CVS_ROOT_DIR environment variable to use the default" unless $ENV{ENSEMBL_CVS_ROOT_DIR};
     $dc_runner = $ENV{ENSEMBL_CVS_ROOT_DIR} . '/ensembl-datacheck/scripts/run_datachecks.pl';
 }
-die "'$dc_runner' is not a valid executable" unless -x $dc_runner;
+die "ERROR: '$dc_runner' is not a valid executable" unless -x $dc_runner;
 
 if ($reg_conf) {
     Bio::EnsEMBL::Registry->load_all($reg_conf);
@@ -147,7 +147,7 @@ if ($prev_url) {
 } else {
     $prev_alias ||= 'compara_prev';
     my $prev_dba = Bio::EnsEMBL::Registry->get_DBAdaptor( $prev_alias, $reg_type || 'compara' );
-    die "Cannot find the alias '$prev_alias' in the Registry" unless $prev_dba;
+    die "ERROR: Cannot find the alias '$prev_alias' in the Registry" unless $prev_dba;
     push @params, (
         '--old_server_uri' => $prev_dba->url,
     );

--- a/scripts/production/run_datachecks.pl
+++ b/scripts/production/run_datachecks.pl
@@ -112,6 +112,16 @@ unless (($url and $prev_url) or ($reg_conf and $reg_alias)) {
     exit 1;
 }
 
+if ($url and $reg_alias) {
+    print "\nERROR: Both --url and --reg_alias are defined. Don't know which one to use\n\n";
+    exit 1;
+}
+
+if ($prev_url and $prev_alias) {
+    print "\nERROR: Both --prev_url and --prev_alias are defined. Don't know which one to use\n\n";
+    exit 1;
+}
+
 unless ($dc_runner) {
     die "Need to give the --dc-runner option or set the ENSEMBL_CVS_ROOT_DIR environment variable to use the default" unless $ENV{ENSEMBL_CVS_ROOT_DIR};
     $dc_runner = $ENV{ENSEMBL_CVS_ROOT_DIR} . '/ensembl-datacheck/scripts/run_datachecks.pl';
@@ -140,7 +150,6 @@ if ($reg_conf) {
 }
 
 if ($prev_url) {
-    die "Both --prev_url and --prev_alias were given. Please choose !" if $prev_alias;
     push @params, (
         '--old_server_uri' => $prev_url,
     );

--- a/scripts/production/run_datachecks.pl
+++ b/scripts/production/run_datachecks.pl
@@ -57,7 +57,6 @@ The "type" or "group" under which the database is to be found in the Registry.
 =item B<[--reg_alias|--reg_name name]>
 
 The name or "species" under which the database is to be found in the Registry.
-Defaults to "compara_curr"
 
 =item B<[--prev_url mysql://user[:passwd]@host[:port]/dbname]>
 
@@ -108,8 +107,8 @@ GetOptions(
     'dc-runner=s'                   => \$dc_runner,
 );
 
-unless (($url and $prev_url) or $reg_conf) {
-    print "\nWithout the registry, both --url and --prev_url must be given\n\n";
+unless (($url and $prev_url) or ($reg_conf and $reg_alias)) {
+    print "\nThe script requires either URLs (--url, --prev_url) or a registry configuration (--reg_conf, --reg_alias, --prev_alias).\n\n";
     exit 1;
 }
 
@@ -122,9 +121,9 @@ die "'$dc_runner' is not a valid executable" unless -x $dc_runner;
 if ($reg_conf) {
     Bio::EnsEMBL::Registry->load_all($reg_conf);
 }
-my $dba = $url
-    ? Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->new( -URL => $url )
-    : Bio::EnsEMBL::Registry->get_DBAdaptor( $reg_alias || 'compara_curr', $reg_type || 'compara' );
+my $dba = $reg_alias
+    ? Bio::EnsEMBL::Registry->get_DBAdaptor( $reg_alias, $reg_type || 'compara' )
+    : Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->new( -URL => $url );
 
 # Common parameters
 my @params = (

--- a/scripts/production/run_datachecks.pl
+++ b/scripts/production/run_datachecks.pl
@@ -127,15 +127,15 @@ my $dba = $reg_alias
 
 # Common parameters
 my @params = (
-    '--host'    => $dba->dbc->host,
-    '--port'    => $dba->dbc->port,
-    '--user'    => 'ensro',             # Fallback to ensro to ensure we don't write to it by accident
-    '--dbname'  => $dba->dbc->dbname,
+    '--host'   => $dba->dbc->host,
+    '--port'   => $dba->dbc->port,
+    '--user'   => 'ensro',             # Fallback to ensro to ensure we don't write to it by accident
+    '--dbname' => $dba->dbc->dbname,
 );
 
 if ($reg_conf) {
     push @params, (
-        '--registry_file'   => $reg_conf,
+        '--registry_file' => $reg_conf,
     );
 }
 

--- a/scripts/production/run_healthchecks.pl
+++ b/scripts/production/run_healthchecks.pl
@@ -46,13 +46,13 @@ URL of the database to test.
 
 =item B<[--reg_conf registry_configuration_file]>
 
-The Bio::EnsEMBL::Registry configuration file. If none given and no URL is
-given, the one set in ENSEMBL_REGISTRY will be used if defined, if not
-~/.ensembl_init will be used.
+The Bio::EnsEMBL::Registry configuration file. Must be given to refer to
+one of the databases by registry name (alias) instead of URLs.
 
 =item B<[--reg_type reg_type]>
 
 The "type" or "group" under which the database is to be found in the Registry.
+Defaults to "compara".
 
 =item B<[--reg_alias|--reg_name name]>
 

--- a/scripts/production/run_healthchecks.pl
+++ b/scripts/production/run_healthchecks.pl
@@ -125,6 +125,11 @@ unless ($url or ($reg_conf and $reg_alias)) {
     exit 1;
 }
 
+if ($url and $reg_alias) {
+    print "\nERROR: Both --url and --reg_alias are defined. Don't know which one to use\n\n";
+    exit 1;
+}
+
 if ($reg_conf) {
     Bio::EnsEMBL::Registry->load_all($reg_conf);
 }


### PR DESCRIPTION
## Description

This is to to make our SOPs more generic, and be able to use our usual `production_reg_conf.pl` instead of having to provide the database name and server.

This removes the need to have separate instructions for Vertebrates (mysql-ens-compara-prod-1 ensembl_compara_XX), Plants (mysql-ens-compara-prod-5 ensembl_compara_plants_XX_YY) and Pan (given `$COMPARA_DIV` doesn't match)

## Overview of changes

The three new scripts are mostly wrappers around existing scripts (from other repos) that are not `production_reg_conf`-aware. 

`scripts/production/enable_mysql_keys.sh` is implemented differently. I've made it work with `db_cmd.pl`, e.g.
```
db_cmd.pl $COMPARA_REG compara_curr -executable $ENSEMBL_CVS_ROOT_DIR/ensembl-compara/scripts/production/enable_mysql_keys.sh
```

## Testing

I have tested each script by running it.

## Notes
_Optional extra information._
