### PR TITLE
Remove core dependencies in LastZ pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/Production/Analysis/AlignmentChains.pm
+++ b/modules/Bio/EnsEMBL/Compara/Production/Analysis/AlignmentChains.pm
@@ -79,9 +79,8 @@ sub run_chains {
     mkdir $target_nib_dir;
 
     my $target_chunks = $self->param('target_chunks');
-    foreach my $nm (keys %{$target_chunks}) {
-      my $target = $target_chunks->{$nm};
-      my $target_name = $target->dnafrag->name;
+    foreach my $target_name (keys %{$target_chunks}) {
+      my $target = $target_chunks->{$target_name};
 
       $target->dump_chunks_to_fasta_file("$target_nib_dir/$target_name.fa");
 

--- a/modules/Bio/EnsEMBL/Compara/Production/Analysis/AlignmentChains.pm
+++ b/modules/Bio/EnsEMBL/Compara/Production/Analysis/AlignmentChains.pm
@@ -26,8 +26,6 @@ package Bio::EnsEMBL::Compara::Production::Analysis::AlignmentChains;
 use warnings ;
 use strict;
 
-use Bio::SeqIO;
-
 use Bio::EnsEMBL::Utils::Exception qw(throw);
 use Bio::EnsEMBL::DnaDnaAlignFeature;
 
@@ -68,18 +66,7 @@ sub run_chains {
     $query_nib_dir = "$work_dir/query_nib";
     mkdir $query_nib_dir;
 
-    my $seqio = Bio::SeqIO->new(-format => 'fasta',
-                                -file   => ">$query_nib_dir/$query_name.fa");   
-
-    # prevent extensive disconnections when fetching sequence length etc.
-    my $query_slice = $self->param('query_slice');
-    $query_slice->adaptor()->dbc->prevent_disconnect( sub {
-
-    $seqio->write_seq($query_slice); 
-
-    } );
-
-    $seqio->close;
+    $self->param('query_chunk')->dump_chunks_to_fasta_file("$query_nib_dir/$query_name.fa");
     
     $self->run_command([$self->param_required('faToNib_exe'), "$query_nib_dir/$query_name.fa", "$query_nib_dir/$query_name.nib"], { die_on_failure => 1 });
     push @nib_files, "$query_nib_dir/$query_name.nib";
@@ -91,16 +78,13 @@ sub run_chains {
     $target_nib_dir =  "$work_dir/target_nib";
     mkdir $target_nib_dir;
 
-    my $target_slices = $self->param('target_slices');
-    foreach my $nm (keys %{$target_slices}) {
-      my $target = $target_slices->{$nm};
-      my $target_name = $target->seq_region_name;
-      
-      my $seqio =  Bio::SeqIO->new(-format => 'fasta',
-                                -file   => ">$target_nib_dir/$target_name.fa");
-      $seqio->write_seq($target);
-      $seqio->close; 
-      
+    my $target_chunks = $self->param('target_chunks');
+    foreach my $nm (keys %{$target_chunks}) {
+      my $target = $target_chunks->{$nm};
+      my $target_name = $target->dnafrag->name;
+
+      $target->dump_chunks_to_fasta_file("$target_nib_dir/$target_name.fa");
+
       $self->run_command([$self->param_required('faToNib_exe'), "$target_nib_dir/$target_name.fa", "$target_nib_dir/$target_name.nib"], { die_on_failure => 1 });
       push @nib_files, "$target_nib_dir/$target_name.nib";
     }

--- a/modules/Bio/EnsEMBL/Compara/Production/DnaFragChunk.pm
+++ b/modules/Bio/EnsEMBL/Compara/Production/DnaFragChunk.pm
@@ -273,8 +273,7 @@ sub dump_chunks_to_fasta_file {
 
 =head2 dump_loc_file
 
-  Arg [1]     : (Optional) string - base directory path. By default, the current
-                working directory.
+  Arg [1]     : string - base directory path
   Example     : $chunk->dump_loc_file('/tmp');
   Description : Returns a unique filepath for this DnaFragChunk.
   Returntype  : String
@@ -283,7 +282,9 @@ sub dump_chunks_to_fasta_file {
 
 sub dump_loc_file {
     my $self = shift;
-    my $basedir = shift // cwd();
+    my $basedir = shift;
+
+    die "Base directory path required" unless $basedir;
 
     my $sub_dir  = dir_revhash($self->dbID);
     my $filename = sprintf('chunk_%s.fa', $self->dbID);

--- a/modules/Bio/EnsEMBL/Compara/Production/DnaFragChunk.pm
+++ b/modules/Bio/EnsEMBL/Compara/Production/DnaFragChunk.pm
@@ -110,7 +110,6 @@ sub fetch_masked_sequence {
   
   return undef unless($self->dnafrag);
   return undef unless($self->dnafrag->genome_db);
-  return undef unless(my $dba = $self->dnafrag->genome_db->db_adaptor);
 
   printf("getting %smasked sequence...\n", $self->masking ? $self->masking . ' ' : 'un') if $self->{debug};
 

--- a/modules/Bio/EnsEMBL/Compara/Production/DnaFragChunk.pm
+++ b/modules/Bio/EnsEMBL/Compara/Production/DnaFragChunk.pm
@@ -50,6 +50,8 @@ sub new {
   $self->dnafrag_start($start)                 if($start);
   $self->dnafrag_end($end)                     if($end);
   $self->dnafrag_chunk_set_id($dnafrag_chunk_set_id) if ($dnafrag_chunk_set_id);
+  # DnaFragChunk does not include the concept of strand, so set it to 1
+  $self->dnafrag_strand(1);
   return $self;
 }
 

--- a/modules/Bio/EnsEMBL/Compara/Production/DnaFragChunkSet.pm
+++ b/modules/Bio/EnsEMBL/Compara/Production/DnaFragChunkSet.pm
@@ -265,8 +265,7 @@ sub dump_to_fasta_file {
 
 =head2 dump_loc_file
 
-  Arg [1]     : (Optional) string - base directory path. By default, the current
-                working directory.
+  Arg [1]     : string - base directory path
   Example     : $chunk_set->dump_loc_file('/tmp');
   Description : Returns a unique filepath for this DnaFragChunkSet.
   Returntype  : String
@@ -275,7 +274,9 @@ sub dump_to_fasta_file {
 
 sub dump_loc_file {
     my $self = shift;
-    my $basedir = shift // cwd();
+    my $basedir = shift;
+
+    die "Base directory path required" unless $basedir;
 
     my $sub_dir  = dir_revhash($self->dbID);
     my $filename = sprintf('chunk_set_%s.fa', $self->dbID);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/ChunkAndGroupDna.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/ChunkAndGroupDna.pm
@@ -135,7 +135,6 @@ sub create_chunks {
     } else {
         my $dnafrag_list = $dnafrag_dba->fetch_all_by_GenomeDB(
             $genome_db,
-            -COORD_SYSTEM_NAME  => 'toplevel',
             -IS_REFERENCE       => $self->param('include_non_reference') ? undef : 1,
             -CELLULAR_COMPONENT => $self->param('only_cellular_component'),
         );

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/ParsePairAlignerConf.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/ParsePairAlignerConf.pm
@@ -605,7 +605,7 @@ sub parse_defaults {
                     # of two different components without repetition
                     # Sort components alphabetically so the same order is
                     # followed in every PWA
-                    my @components = sort {$a cmp $b} @{$mlss_gdbs[0]->component_genome_dbs};
+                    my @components = sort @{$mlss_gdbs[0]->component_genome_dbs};
                     while (my $gdb1 = shift @components) {
                         foreach my $gdb2 ( @components ) {
                             push @pair,
@@ -629,7 +629,7 @@ sub parse_defaults {
                     my %non_ref_components = map { $_->genome_component => $_ } @{$mlss_gdbs[1]->component_genome_dbs};
                     # Sort components alphabetically so the same order is
                     # followed in every PWA
-                    my @components = sort {$a cmp $b} keys %ref_components;
+                    my @components = sort keys %ref_components;
                     # Ignore the components that are not present in both genomes
                     foreach my $cpnt ( @components ) {
                         if (exists $non_ref_components{$cpnt}) {


### PR DESCRIPTION
## Description

Related with previous work on PR#168, we are trying to remove all the dependencies (that can be removed) in this pipeline from Core dbs, using our genome dumps instead. @muffato detected a few more cases (mentioned [here](https://github.com/Ensembl/ensembl-compara/pull/168#discussion_r358552815)) that have been now removed.

**Related JIRA tickets:**
- ENSCOMPARASW-3302

## Overview of changes
Removed the core dependencies in `alignment_chains` analysis. For that I have used the `DnaFragChunk` class (instead of just Locus) to also take advantage of the method `dump_chunks_to_fasta_file()`, which saves a lot of memory requirements without affecting its performance significantly (in my test there was a ~5% increment).

A few more minor details have been addressed too.

## Testing
I have generated two LastZ pipelines for CITest, one with the previous code (mysql://ensro@mysql-ens-compara-prod-10:4648/jalvarez_citest_lastz_default) and one with the new one (mysql://ensro@mysql-ens-compara-prod-10:4648/jalvarez_citest_lastz_update). Before running `alignment_chains` analysis, I removed the core dbs from the registry, and for the updated code I also removed the locators from the `genome_db` table. All jobs have finished succesfully. I manually checked one nib file from the same job and both pipelines generated the same `.fa` file.

## Notes
The `genomic_align` and `genomic_align_block` tables present differences, but I'm not sure if this is due to the update or the reproducibility of this analysis.
