### PR TITLE
DBConnection switch to hive & move consistency removal after filter dups

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/FilterDuplicates.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/FilterDuplicates.pm
@@ -92,7 +92,7 @@ sub fetch_input {
 sub run
 {
   my $self = shift;
-  $self->filter_duplicates;
+  $self->call_within_transaction( sub { $self->filter_duplicates } );
 }
 
 
@@ -187,8 +187,9 @@ sub filter_duplicates {
       my $sql_gab_to_exec = $sql_gab . "(" . join(",", @gab_ids) . ")";
       my $sql_ga_to_exec = $sql_ga . "(" . join(",", @gab_ids) . ")";
  
+      my $dbc = Bio::EnsEMBL::Hive::DBSQL::DBConnection->new(-dbconn => $self->compara_dba->dbc);
       foreach my $sql ($sql_ga_to_exec,$sql_gab_to_exec) {
- 	  my $sth = $self->compara_dba->dbc->prepare($sql);
+ 	  my $sth = $dbc->prepare($sql);
  	  $sth->execute;
  	  $sth->finish;
        }


### PR DESCRIPTION
## Description

_There were partial blocks in `genomic_align_block` and not in `genomic_align`, caused by incomplete queries in the `filter_duplicates`._

**Related JIRA tickets:**
- ENSCOMPARASW-3262

## Overview of changes

- _Connection changed to hive connection for `filter_duplicates` and method called under a transaction._
- _Added `remove_partial_blocks` analysis after `filter_duplicates_net`._

## Testing
_Tested on `mlss_id` 1537 of `e100` which was a culprit previously: `mysql://ensro@mysql-ens-compara-prod-7:4617/cristig_filter_dups_1573`._

## Notes
_Neither one of the transaction or e-hive dbconnection fixes the issue alone and the `remove_partial_blocks` analysis is required to clean up. However the issue is resolved by the use of all three as overkill._
