### PR TITLE
Alignment dbs to be taken from accu

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/CalculateWGACoverage.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/CalculateWGACoverage.pm
@@ -106,7 +106,6 @@ sub fetch_input {
         foreach my $orth ( @orth_info ) {
 
             my ($orth_dnafrags, $orth_ranges) = $self->_orth_dnafrags($orth);
-            my @aln_mlss_ids  = @{ $self->param_required( 'aln_mlss_ids' ) };
 
             my $s1_dnafrag = $dnafrag_adaptor->fetch_by_dbID( $orth_dnafrags->[0]->{id} );
             my $s2_dnafrag = $dnafrag_adaptor->fetch_by_dbID( $orth_dnafrags->[1]->{id} );


### PR DESCRIPTION
## Description

Currently the pipeline starts by copying all the relevant alignments to the local database so that the load is contained on just one server. Since that was implemented the pipeline has been changed to use a tailored SQL query to fetch the alignments between two regions.There is no need to copy the alignments any more, since the load is less. The pipeline can use the production alignment databases directly, thus (1) spreading the load across many servers and (2) removing a significant overhead of the pipeline.

**Related JIRA tickets:**
- ENSCOMPARASW-2802

## Overview of changes
The `select_mlss` analysis already collects alignment mlss_ids and links them to the correct alignment dbs, written to the pipeline `accu` table. The changes in the `calculate_wga_coverage` and `assign_wga_coverage_score` take this into account, and instead of using the pipeline db copies (for which the unnecessary analyses have been removed), they connect to the production alignment dbs that are listed in the pipeline conf.

#### Change no.1
- DB copy analyses and hard-coded `alignment_db` parameter removed from analyses. 

#### Change no.2
- The `calculate_wga_coverage` analysis now takes the associated db to `mlss_id` from the `accu` table in the pipeline db in `fetch_input` and `run`. Because generally there are fewer alignment `mlss_ids` to `orth_info` elements, so it seems like a better idea when connecting to multiple db adaptors, or something like that.

#### Change no.3
- The alignment db from `accu` stuff needed to be done in the `assign_wga_coverage_score` analysis also.

## Testing
Working pipeline here: `mysql://ensro@mysql-ens-compara-prod-7:4617/cristig_wga_aln_dbs_test`

## Notes
This PR is related to  ENSCOMPARASW-3257.
