### PR TITLE
Add '-wait_for' instructions in lastz pipeline to fix flow bugs

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAligner_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAligner_conf.pm
@@ -353,7 +353,7 @@ sub core_pipeline_analyses {
  	    },
  	    {  -logic_name => 'create_filter_duplicates_jobs', #factory
  	       -module     => 'Bio::EnsEMBL::Compara::RunnableDB::PairAligner::CreateFilterDuplicatesJobs',
- 	       -wait_for =>  [ 'update_max_alignment_length_before_FD' ],
+ 	       -wait_for =>  [ 'update_max_alignment_length_before_FD', 'check_no_partial_gabs', 'create_pair_aligner_jobs', $self->o('pair_aligner_logic_name') ],
 	        -flow_into => {
 			       2 => { 'filter_duplicates' => INPUT_PLUS() },
 			     },
@@ -469,7 +469,7 @@ sub core_pipeline_analyses {
 			       1 => [ 'remove_inconsistencies_after_net' ],
 			       2 => [ 'alignment_nets' ],
 			      },
-            -wait_for => [ 'update_max_alignment_length_after_chain' ],
+            -wait_for => [ 'update_max_alignment_length_after_chain', 'create_alignment_chains_jobs', 'remove_inconsistencies_after_chain' ],
 	       -rc_name => '1Gb_job',
  	    },
  	    {  -logic_name => 'alignment_nets',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAligner_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAligner_conf.pm
@@ -469,7 +469,7 @@ sub core_pipeline_analyses {
 			       1 => [ 'remove_inconsistencies_after_net' ],
 			       2 => [ 'alignment_nets' ],
 			      },
-            -wait_for => [ 'update_max_alignment_length_after_chain', 'create_alignment_chains_jobs', 'remove_inconsistencies_after_chain' ],
+            -wait_for => [ 'update_max_alignment_length_after_chain', 'create_alignment_chains_jobs', 'remove_inconsistencies_after_chain', 'alignment_chains' ],
 	       -rc_name => '1Gb_job',
  	    },
  	    {  -logic_name => 'alignment_nets',


### PR DESCRIPTION
## Description

The LASTZ pipeline is running things out of order. This is because the semaphores and `wait_for` s in the LASTZ pipeline are not set up correctly. Here I add a few more `wait_for` s to solve the issue.

**Related JIRA tickets:**
- ENSCOMPARASW-3471

## Overview of changes

#### Change 1
- `create_filter_duplicates_jobs` now waiting for both `create_pair_aligner_jobs` and `check_no_partial_gabs` and `lastz` 

#### Change 2
- `create_alignment_nets_jobs` now waiting for both `create_alignment_chains_jobs` and `remove_inconsistencies_after_chain`

## Testing
_[Pipeline here.](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-7&port=4617&dbname=cristig_lastz_wait_for_tests)_ 
