### PR TITLE
Feature/seq loc attrib

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DnaFrag.pm
+++ b/modules/Bio/EnsEMBL/Compara/DnaFrag.pm
@@ -223,7 +223,6 @@ sub new_from_Slice {
         'genome_db_id' => $genome_db->dbID,
         '_codon_table_id' => $codon_table_id || 1,
         '_cellular_component' => $cellular_component,
-        '_sequence_location' => $sequence_location,
     } );
 }
 
@@ -472,26 +471,6 @@ sub codon_table_id {
     return $self->{'_codon_table_id'};
 }
 
-=head2 sequence_location
-
-  Arg [1]    : none
-  Example    : $sequence_location = $dnafrag->sequence_location();
-  Description: Returns the cellular compartment in which this dnafrag
-               is located. For example if this dnafrag is from a
-               chloroplast_chromosome this will be sequence_location
-               attribute.
-  Returntype : string
-  Exceptions : none
-  Caller     : general
-  Status     : Stable
-
-=cut
-
-sub sequence_location {
-  my $self = shift;
-  $self->{'_sequence_location'} = shift if @_;
-  return $self->{'_sequence_location'};
-}
 
 =head2 slice
 

--- a/modules/Bio/EnsEMBL/Compara/DnaFrag.pm
+++ b/modules/Bio/EnsEMBL/Compara/DnaFrag.pm
@@ -200,7 +200,8 @@ sub new_from_Slice {
     my $codon_table_id;
     $codon_table_id = $attrib->value() if $attrib;
     my ($seq_loc) = @{ $slice->get_all_Attributes('sequence_location') };
-    my $sequence_location = $seq_loc->value() if $seq_loc;
+    my $sequence_location;
+    $sequence_location = $seq_loc->value() if $seq_loc;
 
     my %seq_loc_to_cell_component = ( 'nuclear_chromosome' => 'NUC', 'mitochondrial_chromosome' => 'MT', 'chloroplast_chromosome' => 'PT' );
     my $cellular_component = 'NUC';

--- a/modules/Bio/EnsEMBL/Compara/DnaFrag.pm
+++ b/modules/Bio/EnsEMBL/Compara/DnaFrag.pm
@@ -199,17 +199,18 @@ sub new_from_Slice {
     my ($attrib) = @{ $slice->get_all_Attributes('codon_table') };
     my $codon_table_id;
     $codon_table_id = $attrib->value() if $attrib;
+    my ($seq_loc) = @{ $slice->get_all_Attributes('sequence_location') };
+    my $sequence_location = $seq_loc->value() if $seq_loc;
 
-    my %name_to_cellular_component = ( 'MT' => 'MT', 'CHRM' => 'MT', 'PT' => 'PT' );
+    my %seq_loc_to_cell_component = ( 'nuclear_chromosome' => 'NUC', 'mitochondrial_chromosome' => 'MT', 'chloroplast_chromosome' => 'PT' );
     my $cellular_component = 'NUC';
-    if (exists $name_to_cellular_component{uc $slice->seq_region_name}) {
-        $cellular_component = $name_to_cellular_component{uc $slice->seq_region_name};
-    } else {
-        foreach my $synonym (@{$slice->get_all_synonyms}) {
-            if (exists $name_to_cellular_component{uc $synonym->name}) {
-                $cellular_component = $name_to_cellular_component{uc $synonym->name};
-                last;
-            }
+
+    if ($sequence_location) {
+        if (exists $seq_loc_to_cell_component{$sequence_location}) {
+            $cellular_component = $seq_loc_to_cell_component{$sequence_location};
+        }
+        else {
+            $cellular_component = 'OTHER';
         }
     }
 
@@ -222,6 +223,7 @@ sub new_from_Slice {
         'genome_db_id' => $genome_db->dbID,
         '_codon_table_id' => $codon_table_id || 1,
         '_cellular_component' => $cellular_component,
+        '_sequence_location' => $sequence_location,
     } );
 }
 
@@ -470,6 +472,26 @@ sub codon_table_id {
     return $self->{'_codon_table_id'};
 }
 
+=head2 sequence_location
+
+  Arg [1]    : none
+  Example    : $sequence_location = $dnafrag->sequence_location();
+  Description: Returns the cellular compartment in which this dnafrag
+               is located. For example if this dnafrag is from a
+               chloroplast_chromosome this will be sequence_location
+               attribute.
+  Returntype : string
+  Exceptions : none
+  Caller     : general
+  Status     : Stable
+
+=cut
+
+sub sequence_location {
+  my $self = shift;
+  $self->{'_sequence_location'} = shift if @_;
+  return $self->{'_sequence_location'};
+}
 
 =head2 slice
 

--- a/sql/patch_101_102_b.sql
+++ b/sql/patch_101_102_b.sql
@@ -1,0 +1,28 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2020] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_101_102_a.sql
+#
+# Title: Update schema version.
+#
+# Description:
+#   Include "OTHER" as possible cellular_component value.
+
+ALTER table dnafrag
+  MODIFY COLUMN cellular_component ENUM ('NUC', 'MT', 'PT', 'OTHER') DEFAULT 'NUC' NOT NULL;
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_101_102_b.sql|enum_other');

--- a/sql/patch_101_102_b.sql
+++ b/sql/patch_101_102_b.sql
@@ -13,9 +13,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-# patch_101_102_a.sql
+# patch_101_102_b.sql
 #
-# Title: Update schema version.
+# Title: Add OTHER enum to cellular_component.
 #
 # Description:
 #   Include "OTHER" as possible cellular_component value.

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -617,7 +617,7 @@ CREATE TABLE synteny_region (
 @column genome_db_id       External reference to genome_db_id in the @link genome_db table
 @column coord_system_name  Refers to the coord system in which this dnafrag has been defined
 @column is_reference       Boolean, whether dnafrag is reference (1) or non-reference (0) eg haplotype
-@column cellular_component Either "NUC", "MT" or "PT". Represents which genome the dnafrag is part of
+@column cellular_component Either "NUC", "MT", "PT" or "OTHER". Represents which organelle genome the dnafrag is part of
 @column codon_table_id     Integer. The numeric identifier of the codon-table that applies to this dnafrag (https://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi)
 
 @see genomic_align_block
@@ -630,7 +630,7 @@ CREATE TABLE dnafrag (
   name                        varchar(255) DEFAULT '' NOT NULL,
   genome_db_id                int(10) unsigned NOT NULL, # FK genome_db.genome_db_id
   coord_system_name           varchar(40) DEFAULT '' NOT NULL,
-  cellular_component          ENUM('NUC', 'MT', 'PT') DEFAULT 'NUC' NOT NULL,
+  cellular_component          ENUM('NUC', 'MT', 'PT', 'OTHER') DEFAULT 'NUC' NOT NULL,
   is_reference                tinyint(1) DEFAULT 1 NOT NULL,
   codon_table_id              tinyint(2) unsigned DEFAULT 1 NOT NULL,
 
@@ -2255,3 +2255,6 @@ INSERT INTO meta (species_id, meta_key, meta_value) VALUES (NULL, 'schema_type',
 # Patch identifier
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_101_102_a.sql|schema_version');
+
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_101_102_b.sql|enum_other');


### PR DESCRIPTION
## Description

MT and PT sequences are now to be identified through a sequence attribute named sequence_location instead of name / synonyms.

**Related JIRA tickets:**
- ENSCOMPARASW-3468

## Overview of changes
Instead of mapping `seq_region_name` to either `NUC`, `MT` or `PT` and `synonym` if that doesn't match, we check the `sequence_location` attrib `value`.

#### Change 1
- Map the possible enum `cellular_component` values to the `sequence_location` attribute. If an attrib `value` for `sequence_location` is not defined, then the default is to assign `NUC`.

#### Change 2
-  Currently with only `MT`, `PT` and `NUC` in our schema, as a possible `cellular_component` , we need to add `OTHER` as an enum value to the column for the schema, until we know what we will do with the other organelles from the other divisions in the future. Whilst technically `PT` could account for all plastids, in this case it only maps to `chloroplast_chromosome` and other plastids will be assigned `OTHER`.

## Testing
Unit tests for dnafrag.pm and MasterDatabase.pm prior to Travis, then Travis

## Notes
We may want to include all possible organelles as unique `cellular_components` in the future and swap out `OTHER`. `OTHER` is the quick fix for the uncertain future.
