### PR TITLE
Remove genomes from MSAs (part 1)

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOAncestral.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOAncestral.pm
@@ -1,0 +1,97 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Parts::EPOAncestral
+
+=head1 DESCRIPTION
+
+This is a partial PipeConfig for the creation of a new ancestral database
+required to compute an EPO MSA.
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Parts::EPOAncestral;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;  # For WHEN and INPUT_PLUS
+
+
+sub pipeline_analyses_epo_ancestral {
+    my ($self) = @_;
+    return [
+        {   -logic_name => 'drop_ancestral_db',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::DbCmd',
+            -parameters => {
+                'db_conn'       => '#ancestral_db#',
+                'input_query'   => 'DROP DATABASE IF EXISTS',
+            },
+            -flow_into  => [ 'create_ancestral_db' ],
+        },
+        {   -logic_name => 'create_ancestral_db',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::DbCmd',
+            -parameters => {
+                'db_conn'       => '#ancestral_db#',
+                'input_query'   => 'CREATE DATABASE',
+            },
+            -flow_into  => [ 'create_tables_in_ancestral_db' ],
+        },
+        {   -logic_name => 'create_tables_in_ancestral_db',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::DbCmd',
+            -parameters => {
+                'db_conn'       => '#ancestral_db#',
+                'input_file'    => $self->o('core_schema_sql'),
+            },
+            -flow_into  => [ 'store_ancestral_species_name' ],
+        },
+        {   -logic_name => 'store_ancestral_species_name',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
+            -parameters => {
+                'db_conn'   => '#ancestral_db#',
+                'sql'       => [
+                    'INSERT INTO meta (meta_key, meta_value) VALUES ("species.production_name", "' . $self->o('ancestral_sequences_name') . '")',
+                    'INSERT INTO meta (meta_key, meta_value) VALUES ("species.display_name", "' . $self->o('ancestral_sequences_display_name') . '")',
+                ],
+            },
+            -flow_into  => [ 'find_ancestral_seq_gdb' ],
+        },
+        {   -logic_name => 'find_ancestral_seq_gdb',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ObjectFactory',
+            -parameters => {
+                'compara_db'    => '#master_db#',
+                'call_list'     => [ 'compara_dba', 'get_GenomeDBAdaptor', ['fetch_by_name_assembly', $self->o('ancestral_sequences_name')] ],
+                'column_names2getters'  => { 'master_dbID' => 'dbID' },
+            },
+            -flow_into  => {
+                2   => [ 'store_ancestral_seq_gdb' ],
+            },
+        },
+        {   -logic_name => 'store_ancestral_seq_gdb',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::LoadOneGenomeDB',
+            -parameters => {
+                'locator'   => '#ancestral_db#',
+            },
+        },
+    ];
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EpoLowCoverage.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EpoLowCoverage.pm
@@ -190,8 +190,8 @@ sub pipeline_analyses_epo2x_alignment {
           -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
           -parameters => {
                           'sql' => [
-                              'INSERT INTO method_link_species_set_tag (method_link_species_set_id, tag, value) VALUES (#cs_mlss_id#, "msa_mlss_id", ' . $self->o('low_epo_mlss_id') . ')',
-                              'INSERT INTO method_link_species_set_tag (method_link_species_set_id, tag, value) VALUES (#ce_mlss_id#, "msa_mlss_id", ' . $self->o('low_epo_mlss_id') . ')',
+                              'INSERT INTO method_link_species_set_tag (method_link_species_set_id, tag, value) VALUES (#cs_mlss_id#, "msa_mlss_id", #low_epo_mlss_id#)',
+                              'INSERT INTO method_link_species_set_tag (method_link_species_set_id, tag, value) VALUES (#ce_mlss_id#, "msa_mlss_id", #low_epo_mlss_id#)',
                           ],
                          },
           -flow_into => [ 'set_mlss_tag' ],

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomicAlignBlock/Gerp.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomicAlignBlock/Gerp.pm
@@ -15,17 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::GenomicAlignBlock::Gerp 
@@ -43,11 +32,6 @@ Bio::EnsEMBL::Compara::RunnableDB::GenomicAlignBlock::Gerp
     the program GERP.pl. It then parses the output and writes the constrained
     elements in the constrained_element table and the conserved scores in the 
     conservation_score table
-
-=head1 APPENDIX
-
-The rest of the documentation details each of the object methods. 
-Internal methods are usually preceded with a _
 
 =cut
 
@@ -693,12 +677,13 @@ sub _parse_rates_file {
 sub _build_tree_string {
     my ($self, $genomic_aligns) = @_;
 
-    my $db_tree = $self->compara_dba->get_SpeciesTreeAdaptor->fetch_by_method_link_species_set_id_label($self->param_required('mlss_id'), 'default')->root;
+    my $mlss = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor->fetch_by_dbID($self->param_required('mlss_id'));
+    my $db_tree = $mlss->species_tree->root;
     my $tree = $db_tree->copy();
 
     #if the tree leaves are species names, need to convert these into genome_db_ids
-    my $genome_dbs = $self->compara_dba->get_GenomeDBAdaptor->fetch_all();
-    
+    my $genome_dbs = $mlss->species_set->genome_dbs;
+
     my %leaf_check;
     foreach my $genome_db (@$genome_dbs) {
         if ($genome_db->name ne "ancestral_sequences") {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomicAlignBlock/PopulateNewDatabase.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomicAlignBlock/PopulateNewDatabase.pm
@@ -50,6 +50,8 @@ sub fetch_input {
     push @cmd, '--collection', $self->param('collection') if ( $self->param('collection') && !$self->param('ignore_collection') );
     push @cmd, '--old', $self->param('old_compara_db') if $self->param('old_compara_db');
     push @cmd, '--alignments_only' if $self->param('alignments_only');
+    push @cmd, '--filter_by_mlss' if $self->param('filter_by_mlss');
+    push @cmd, '--skip_gerp' if $self->param('skip_gerp');
 
     # allow for a single mlss_id or multiples as populate_new_database.pl can accept multiple mlsses in the same cmd
     push @cmd, '--mlss', $self->param('mlss_id') if $self->param('mlss_id');

--- a/scripts/pipeline/populate_new_database.pl
+++ b/scripts/pipeline/populate_new_database.pl
@@ -161,6 +161,10 @@ Mainly used by Ensembl Genomes.
 This option triggers a copy of genomic_align(_block) based on the method_link_species_set_id
 instead of the range of genomic_align_id
 
+=item B<--skip_gerp>
+
+Do not store Conservation Score or Constrained Element data.
+
 =back
 
 =head2 OLD DATA
@@ -194,6 +198,7 @@ my $cellular_component = 0;
 my $collection = undef;
 my $filter_by_mlss = 0;
 my $alignments_only = 0;
+my $skip_gerp = 0;
 my $skip_mlsses = [];
 
 GetOptions(
@@ -212,6 +217,7 @@ GetOptions(
     'collection=s' => \$collection,
     'filter_by_mlss' => \$filter_by_mlss,
     'alignments_only' => \$alignments_only,
+    'skip_gerp' => \$skip_gerp,
     'skip_mlss=s@' => \$skip_mlsses,
   );
 
@@ -337,15 +343,20 @@ if ($old_dba and !$skip_data) {
 
 ## Copy DNA-DNA alignments
   copy_dna_to_dna_alignments($old_dba, $new_dba, $all_default_method_link_species_sets);
-  exit(0) if ( $alignments_only );
-## Copy Ancestor dnafrags
-  copy_ancestor_dnafrag($old_dba, $new_dba, $all_default_method_link_species_sets);
-## Copy Synteny data
-  copy_synteny_data($old_dba, $new_dba, $all_default_method_link_species_sets);
-## Copy Constrained elements
-   copy_constrained_elements($old_dba, $new_dba, $all_default_method_link_species_sets);
-## Copy Conservation scores
-   copy_conservation_scores($old_dba, $new_dba, $all_default_method_link_species_sets);
+
+  if ( ! $alignments_only ) {
+      ## Copy Ancestor dnafrags
+      copy_ancestor_dnafrag($old_dba, $new_dba, $all_default_method_link_species_sets);
+      ## Copy Synteny data
+      copy_synteny_data($old_dba, $new_dba, $all_default_method_link_species_sets);
+
+      if ( ! $skip_gerp ) {
+          ## Copy Constrained elements
+          copy_constrained_elements($old_dba, $new_dba, $all_default_method_link_species_sets);
+          ## Copy Conservation scores
+          copy_conservation_scores($old_dba, $new_dba, $all_default_method_link_species_sets);
+      }
+  }
 }
 
 ##END


### PR DESCRIPTION
## Description

This PR introduces changes on certain runnables and pipelines that will be used later on in the new pipeline.

**Related JIRA tickets:**
- ENSCOMPARASW-3065

## Overview of changes
#### Change 1
- The ancestral db creation runnables used in the EPO pipelines has been moved to its own "Parts" now, so it can be directly reused in the pipeline I'm working on.
- I have removed the resource class of the last 2 runnables as for e101 they have required less than 200Mb for any EPO.

#### Change 2
- Added one new flag to `populate_new_database.pl` script to avoid copying the GERPs (it is safer/easier to recompute these than copying and updating them).
- Added this new flag and a preexisting one to `PopulateNewDatabase.pm` runnable so they can be used in pipelines.

#### Change 3
- Made `Gerp` runnable to use only the genomes of the MLSS's species set, instead of all the genomes in the database.

## Testing
I'm using this code in the new pipeline and everything is working as expected.
