### PR TITLE
Embed the WGA Orthology QC and HighConfidence pipelines into the gene-tree pipelines

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeDBsIntoRelease_conf.pm
@@ -99,6 +99,9 @@ sub default_options {
             # Mapping 'db_alias' => Arrayref of table names
             # Example:
             #   'family_db' => [qw(gene_member seq_member sequence)],
+            # Mapping 'db_alias' => Arrayref of table names
+            'ncrna_db'   => [qw(ortholog_quality)],
+            'protein_db' => [qw(ortholog_quality)],
         },
 
    };

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeDBsIntoRelease_conf.pm
@@ -97,9 +97,6 @@ sub default_options {
         # In these databases, ignore these tables
         'ignored_tables'    => {
             # Mapping 'db_alias' => Arrayref of table names
-            # Example:
-            #   'family_db' => [qw(gene_member seq_member sequence)],
-            # Mapping 'db_alias' => Arrayref of table names
             'ncrna_db'   => [qw(ortholog_quality)],
             'protein_db' => [qw(ortholog_quality)],
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/OrthologQM_Alignment_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/OrthologQM_Alignment_conf.pm
@@ -84,6 +84,7 @@ use warnings;
 
 use Bio::EnsEMBL::Hive::Version 2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
+use Bio::EnsEMBL::Compara::PipeConfig::Parts::OrthologQMAlignment;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
 
@@ -125,7 +126,6 @@ sub default_options {
 
         'homology_method_link_types' => ['ENSEMBL_ORTHOLOGUES'],
 
-        # 'alt_aln_dbs'      => [ ],
         'alt_homology_db'  => undef,
         
         # homology_dumps_dir location should be changed to the homology pipeline's workdir if the pipelines are still in progress
@@ -186,120 +186,13 @@ sub pipeline_wide_parameters {
 sub pipeline_analyses {
     my ($self) = @_;
     return [
-        {   -logic_name => 'pair_species',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::PairCollection',
-            -flow_into  => {
-                '2->B' => [ 'select_mlss' ],
-                'B->1' => [ 'ortholog_mlss_factory' ],
-                '3'    => [ 'reset_mlss' ],
-            },
-            -input_ids => [{
-                'species_set_name' => $self->o('species_set_name'),
-                'species_set_id'   => $self->o('species_set_id'),
-                'ref_species'      => $self->o('ref_species'),
-                'species1'         => $self->o('species1'),
-                'species2'         => $self->o('species2'),
-                'compara_db'       => $self->o('compara_db'),
-                'alt_aln_dbs'      => $self->o('alt_aln_dbs'),
-                'master_db'        => $self->o('master_db'),
-                'alt_homology_db'  => $self->o('alt_homology_db'),
-            }],
-            -rc_name    => '500Mb_job',
+        {   -logic_name => 'fire_orth_wga',
+            -input_ids  => [ { } ],
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => 'pair_species',
         },
 
-        {   -logic_name => 'reset_mlss',
-            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
-            -parameters => {
-                'sql' => 'DELETE FROM ortholog_quality WHERE alignment_mlss = #aln_mlss_id#',
-            },
-            -analysis_capacity => 3,
-        },
-
-        {   -logic_name => 'select_mlss',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::SelectMLSS',
-            -parameters => { 'current_release' => $self->o('ensembl_release') },
-            -flow_into  => {
-                1 => [ '?accu_name=alignment_mlsses&accu_address=[]&accu_input_variable=accu_dataflow' ],
-                2 => [ '?accu_name=mlss_db_mapping&accu_address={mlss_id}&accu_input_variable=mlss_db' ],
-            },
-            -rc_name => '500Mb_job',
-            -analysis_capacity => 50,
-        },
-
-        {   -logic_name => 'ortholog_mlss_factory',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::OrthologMLSSFactory',
-            -parameters => {
-                'method_link_types' => $self->o('homology_method_link_types'),
-            },
-            -rc_name    => '500Mb_job',
-            -flow_into  => {
-                '2->A' => [ 'prepare_orthologs' ],
-                'A->1' => [ 'check_file_copy' ],
-            }
-        },
-
-        {   -logic_name => 'prepare_orthologs',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::PrepareOrthologs',
-            -parameters => {
-                'hashed_mlss_id'            => '#expr(dir_revhash(#orth_mlss_id#))expr#',
-                'homology_flatfile'         => '#homology_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.homologies.tsv',
-                'homology_mapping_flatfile' => '#homology_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.homology_id_map.tsv',
-            },
-            -analysis_capacity  =>  50,  # use per-analysis limiter
-            -flow_into => {
-                # these analyses will write to the same file, so a semaphore is required to prevent clashes
-                '3->A' => [ 'reuse_wga_score' ],
-                'A->2' => [ 'calculate_wga_coverage' ],
-            },
-            -rc_name  => '2Gb_job',
-        },
-
-        {   -logic_name => 'calculate_wga_coverage',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::CalculateWGACoverage',
-            -hive_capacity => 30,
-            -batch_size => 10,
-            -flow_into  => {
-                3 => [ '?table_name=ortholog_quality' ],
-                2 => [ 'assign_wga_coverage_score' ],
-            },
-            -rc_name => '2Gb_job',
-        },
-
-        {   -logic_name => 'assign_wga_coverage_score',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::AssignQualityScore',
-            -parameters => {
-                'hashed_mlss_id' => '#expr(dir_revhash(#orth_mlss_id#))expr#',
-                'output_file'    => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv',
-                'reuse_file'     => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga_reuse.tsv',
-            },
-            -rc_name    => '500Mb_job',
-            -hive_capacity     => 400,
-        },
-
-        {   -logic_name => 'reuse_wga_score',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::ReuseWGAScore',
-            -parameters => {
-                'hashed_mlss_id'            => '#expr(dir_revhash(#orth_mlss_id#))expr#',
-                'previous_wga_file'         => '#prev_wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv',
-                'homology_mapping_flatfile' => '#homology_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.homology_id_map.tsv',
-                'output_file'               => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga_reuse.tsv',
-            },
-            -rc_name    => '500Mb_job',
-            -hive_capacity     => 400,
-        },
-
-        {   -logic_name  => 'check_file_copy',
-            -module      => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-            -flow_into   => WHEN( '#homology_dumps_shared_dir#' => 'copy_files_to_shared_loc' ),
-        },
-
-        {   -logic_name => 'copy_files_to_shared_loc',
-            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -parameters => {
-                'cmd'         => q(/bin/bash -c "mkdir -p #homology_dumps_shared_dir# && rsync -rtOp --exclude '*.wga_reuse.tsv' #wga_dumps_dir#/ #homology_dumps_shared_dir#"),
-            },
-        },
-
+        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::OrthologQMAlignment::pipeline_analyses_ortholog_qm_alignment($self) },
     ];
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/OrthologQM_Alignment_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/OrthologQM_Alignment_conf.pm
@@ -179,6 +179,9 @@ sub pipeline_wide_parameters {
         'prev_wga_dumps_dir' => $self->o('prev_wga_dumps_dir'),
         'previous_wga_file'  => defined $self->o('prev_wga_dumps_dir') ? '#prev_wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv' : undef,
 
+        'alt_aln_dbs'        => $self->o('alt_aln_dbs'),
+        'alt_homology_db'   => $self->o('alt_homology_db'),
+
         'homology_dumps_shared_dir' => $self->o('homology_dumps_shared_dir'),
     };
 }

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
@@ -136,7 +136,7 @@ sub pipeline_analyses_ortholog_qm_alignment {
                 'output_file'    => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv',
                 'reuse_file'     => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga_reuse.tsv',
             },
-            -hive_capacity     => 400,
+            -hive_capacity => 400,
         },
 
         {   -logic_name => 'reuse_wga_score',
@@ -147,7 +147,7 @@ sub pipeline_analyses_ortholog_qm_alignment {
                 'homology_mapping_flatfile' => '#homology_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.homology_id_map.tsv',
                 'output_file'               => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga_reuse.tsv',
             },
-            -hive_capacity     => 400,
+            -hive_capacity => 400,
         },
 
         {   -logic_name  => 'check_file_copy',
@@ -161,7 +161,7 @@ sub pipeline_analyses_ortholog_qm_alignment {
         {   -logic_name => 'copy_files_to_shared_loc',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
             -parameters => {
-                'cmd'         => q(/bin/bash -c "mkdir -p #homology_dumps_shared_dir# && rsync -rtOp --exclude '*.wga_reuse.tsv' #wga_dumps_dir#/ #homology_dumps_shared_dir#"),
+                'cmd' => q(/bin/bash -c "mkdir -p #homology_dumps_shared_dir# && rsync -rtOp --exclude '*.wga_reuse.tsv' #wga_dumps_dir#/ #homology_dumps_shared_dir#"),
             },
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
@@ -1,0 +1,171 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=pod
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Parts::OrthologQMAlignment
+
+=head1 DESCRIPTION
+
+This pipeline uses whole genome alignments to calculate the
+coverage of homologous pairs.
+The coverage is calculated on both exonic and intronic regions
+seperately and summarised using a quality_score calculation.
+The average quality_score between both members of the homology
+will be written to the homology table.
+
+=head1 CONTACT
+
+Please email comments or questions to the public Ensembl
+developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+Questions may also be sent to the Ensembl help desk at
+<http://www.ensembl.org/Help/Contact>.
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Parts::OrthologQMAlignment;
+
+
+use strict;
+use warnings;
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
+
+sub pipeline_analyses_ortholog_qm_alignment {
+    my ($self) = @_;
+    return [
+        {   -logic_name => 'pair_species',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::PairCollection',
+            -flow_into  => {
+                '2->B' => [ 'select_mlss' ],
+                'B->1' => [ 'ortholog_mlss_factory' ],
+                '3'    => [ 'reset_mlss' ],
+            },
+            -parameters => {
+                'species_set_name' => $self->o('species_set_name'),
+                'species_set_id'   => '#nonreuse_ss_id#',
+                'ref_species'      => $self->o('ref_species'),
+                'species1'         => $self->o('species1'),
+                'species2'         => $self->o('species2'),
+                'compara_db'       => $self->o('compara_db'),
+                'alt_aln_dbs'      => $self->o('alt_aln_dbs'),
+                'master_db'        => $self->o('master_db'),
+                'alt_homology_db'  => $self->o('alt_homology_db'),
+            },
+        },
+
+        {   -logic_name => 'reset_mlss',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
+            -parameters => {
+                'sql' => 'DELETE FROM ortholog_quality WHERE alignment_mlss = #aln_mlss_id#',
+            },
+            -analysis_capacity => 3,
+        },
+
+        {   -logic_name => 'select_mlss',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::SelectMLSS',
+            -parameters => { 'current_release' => $self->o('ensembl_release') },
+            -flow_into  => {
+                1 => [ '?accu_name=alignment_mlsses&accu_address=[]&accu_input_variable=accu_dataflow' ],
+                2 => [ '?accu_name=mlss_db_mapping&accu_address={mlss_id}&accu_input_variable=mlss_db' ],
+            },
+            -rc_name => '500Mb_job',
+            -analysis_capacity => 50,
+        },
+
+        {   -logic_name => 'ortholog_mlss_factory',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::OrthologMLSSFactory',
+            -parameters => {
+                'method_link_types' => ['ENSEMBL_ORTHOLOGUES'],
+            },
+            -flow_into  => {
+                '2->A' => [ 'prepare_orthologs' => INPUT_PLUS() ],
+                'A->1' => [ 'check_file_copy' ],
+            }
+        },
+
+        {   -logic_name => 'prepare_orthologs',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::PrepareOrthologs',
+            -parameters => {
+                'hashed_mlss_id'            => '#expr(dir_revhash(#orth_mlss_id#))expr#',
+                'homology_flatfile'         => '#homology_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.homologies.tsv',
+                'homology_mapping_flatfile' => '#homology_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.homology_id_map.tsv',
+            },
+            -analysis_capacity  =>  50,  # use per-analysis limiter
+            -flow_into => {
+                # these analyses will write to the same file, so a semaphore is required to prevent clashes
+                '3->A' => [ 'reuse_wga_score' ],
+                'A->2' => { 'calculate_wga_coverage' => INPUT_PLUS() },
+            },
+            -rc_name  => '2Gb_job',
+        },
+
+        {   -logic_name => 'calculate_wga_coverage',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::CalculateWGACoverage',
+            -hive_capacity => 30,
+            -batch_size => 10,
+            -flow_into  => {
+                3 => [ '?table_name=ortholog_quality' ],
+                2 => [ 'assign_wga_coverage_score' ],
+            },
+            -rc_name => '2Gb_job',
+        },
+
+        {   -logic_name => 'assign_wga_coverage_score',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::AssignQualityScore',
+            -parameters => {
+                'hashed_mlss_id' => '#expr(dir_revhash(#orth_mlss_id#))expr#',
+                'output_file'    => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv',
+                'reuse_file'     => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga_reuse.tsv',
+            },
+            -hive_capacity     => 400,
+        },
+
+        {   -logic_name => 'reuse_wga_score',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::ReuseWGAScore',
+            -parameters => {
+                'hashed_mlss_id'            => '#expr(dir_revhash(#orth_mlss_id#))expr#',
+                'previous_wga_file'         => '#prev_wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv',
+                'homology_mapping_flatfile' => '#homology_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.homology_id_map.tsv',
+                'output_file'               => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga_reuse.tsv',
+            },
+            -hive_capacity     => 400,
+        },
+
+        {   -logic_name  => 'check_file_copy',
+            -module      => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -parameters  => { 'orth_wga_complete' => 1, },
+            -flow_into   => {
+                1 => WHEN( '#homology_dumps_shared_dir#' => 'copy_files_to_shared_loc' ),
+            },
+        },
+
+        {   -logic_name => 'copy_files_to_shared_loc',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -parameters => {
+                'cmd'         => q(/bin/bash -c "mkdir -p #homology_dumps_shared_dir# && rsync -rtOp --exclude '*.wga_reuse.tsv' #wga_dumps_dir#/ #homology_dumps_shared_dir#"),
+            },
+        },
+
+    ];
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
@@ -97,7 +97,7 @@ sub pipeline_analyses_ortholog_qm_alignment {
                 'method_link_types' => ['ENSEMBL_ORTHOLOGUES'],
             },
             -flow_into  => {
-                '2->A' => [ 'prepare_orthologs' => INPUT_PLUS() ],
+                '2->A' => { 'prepare_orthologs' => INPUT_PLUS() },
                 'A->1' => [ 'check_file_copy' ],
             }
         },
@@ -155,6 +155,7 @@ sub pipeline_analyses_ortholog_qm_alignment {
             -parameters  => { 'orth_wga_complete' => 1, },
             -flow_into   => {
                 1 => WHEN( '#homology_dumps_shared_dir#' => 'copy_files_to_shared_loc' ),
+                2 => [ '?table_name=pipeline_wide_parameters' ],
             },
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
@@ -154,8 +154,7 @@ sub pipeline_analyses_ortholog_qm_alignment {
             -module      => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -parameters  => { 'orth_wga_complete' => 1, },
             -flow_into   => {
-                1 => WHEN( '#homology_dumps_shared_dir#' => 'copy_files_to_shared_loc' ),
-                2 => [ '?table_name=pipeline_wide_parameters' ],
+                1 => [ WHEN( '#homology_dumps_shared_dir#' => 'copy_files_to_shared_loc' ), '?table_name=pipeline_wide_parameters' ],
             },
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
@@ -80,6 +80,15 @@ sub default_options {
 
     # GOC parameters
         'goc_taxlevels' => ['Panicoideae', 'Oryzinae', 'Pooideae', 'Solanaceae', 'Brassicaceae', 'Malvaceae', 'fabids'],
+
+    # HighConfidenceOrthologs Parameters
+        # In this structure, the "thresholds" are for resp. the GOC score, the WGA coverage and %identity
+        'threshold_levels' => [
+            {
+                'taxa'          => [ 'all' ],
+                'thresholds'    => [ 50, 50, 25 ],
+            },
+        ],
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
@@ -89,6 +89,9 @@ sub default_options {
                 'thresholds'    => [ 50, 50, 25 ],
             },
         ],
+
+        # WGA OrthologQM homology method_link_species_set
+        'homology_method_link_types' => ['ENSEMBL_ORTHOLOGUES', 'ENSEMBL_HOMOEOLOGUES'],
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -45,6 +45,8 @@ use Bio::EnsEMBL::Compara::PipeConfig::Parts::GOC;
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneSetQC;
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneMemberHomologyStats;
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpHomologiesForPosttree;
+use Bio::EnsEMBL::Compara::PipeConfig::Parts::OrthologQMAlignment;
+use Bio::EnsEMBL::Compara::PipeConfig::Parts::HighConfidenceOrthologs;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
 
@@ -251,9 +253,39 @@ sub default_options {
     #default maximum retry count:
         'hive_default_max_retry_count' => 1,
 
+        # parameters for OrthologQMAlignment
+        'species1'         => undef,
+        'species2'         => undef,
+        'species_set_name' => "collection-" . $self->o('collection'),
+        'species_set_id'   => undef,
+        'ref_species'      => undef,
+        # WGA dump directories for OrthologQMAlignment
+        'wga_dumps_dir'      => $self->o('pipeline_dir'),
+        'prev_wga_dumps_dir' => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('prev_release'),
+        # set how many orthologs should be flowed at a time
+        'orth_batch_size'   => 10,
+        # set to 1 when all pairwise and multiple WGA complete
+        'dna_alns_complete' => 0,
+        # populated by the rib_fire_orth_wga when wga analyses finished
+        'orth_wga_complete' => 0,
+
+        # parameters for HighConfidenceOrthologs
+        'threshold_levels'            => [ ],          # division specific
+        'high_confidence_capacity'    => 500,          # how many mlss_ids can be processed in parallel
+        'update_homologies_capacity'  => 30,           # how many homology mlss_ids can be updated in parallel
+        'goc_files_dir'               => $self->o('homology_dumps_dir'),
+        'range_label'                 => $self->o('member_type'),
+
     # connection parameters to various databases:
 
         # Uncomment and update the database locations
+
+        # the dbs required for OrthologQMAlignment alt_aln_dbs can be an array list of alignment dbs
+        'compara_db'      => $self->pipeline_url(),
+        'alt_homology_db' => $self->pipeline_url(),
+        'alt_aln_dbs'     => [
+            'compara_curr',
+        ],
 
         # the master database for synchronization of various ids (use undef if you don't have a master database)
         'master_db' => 'compara_master',
@@ -389,6 +421,18 @@ sub pipeline_create_commands {
 
         $self->pipeline_create_commands_rm_mkdir(['work_dir', 'cluster_dir', 'dump_dir', 'dump_pafs_dir', 'examl_dir', 'tmp_dir', 'fasta_dir', 'plots_dir']),
         $self->pipeline_create_commands_lfs_setstripe('fasta_dir'),
+
+        $self->db_cmd( 'CREATE TABLE ortholog_quality (
+            homology_id              INT NOT NULL,
+            genome_db_id             INT NOT NULL,
+            alignment_mlss           INT NOT NULL,
+            combined_exon_coverage   FLOAT(5,2) NOT NULL,
+            combined_intron_coverage FLOAT(5,2) NOT NULL,
+            quality_score            FLOAT(5,2) NOT NULL,
+            exon_length              INT NOT NULL,
+            intron_length            INT NOT NULL,
+            INDEX (homology_id)
+        )'),
     ];
 }
 
@@ -404,10 +448,15 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'member_db'     => $self->o('member_db'),
         'reuse_db'      => $self->o('prev_rel_db'),
         'mapping_db'    => $self->o('mapping_db'),
+        'alt_aln_dbs'   => $self->o('alt_aln_dbs'),
+
+        'ensembl_release' => $self->o('ensembl_release'),
 
         'reg_conf'      => $self->o('reg_conf'),
         'member_type'   => $self->o('member_type'),
+        'range_label'   => $self->o('range_label'),
 
+        'pipeline_dir'  => $self->o('pipeline_dir'),
         'cluster_dir'   => $self->o('cluster_dir'),
         'fasta_dir'     => $self->o('fasta_dir'),
         'examl_dir'     => $self->o('examl_dir'),
@@ -420,15 +469,30 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'homology_dumps_dir'        => $self->o('homology_dumps_dir'),
         'prev_homology_dumps_dir'   => $self->o('prev_homology_dumps_dir'),
         'homology_dumps_shared_dir' => $self->o('homology_dumps_shared_dir'),
+        'wga_dumps_dir'             => $self->o('wga_dumps_dir'),
+        'prev_wga_dumps_dir'        => $self->o('prev_wga_dumps_dir'),
+
+        'goc_files_dir'      => $self->o('goc_files_dir'),
+        'wga_files_dir'      => $self->o('wga_dumps_dir'),
+        'hashed_mlss_id'     => '#expr(dir_revhash(#mlss_id#))expr#',
+        'goc_file'           => '#goc_files_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.goc.tsv',
+        'wga_file'           => '#wga_files_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.wga.tsv',
+        'previous_wga_file'  => defined $self->o('prev_wga_dumps_dir') ? '#prev_wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv' : undef,
+        'high_conf_file'     => '#pipeline_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.high_conf.tsv',
 
         'clustering_mode'   => $self->o('clustering_mode'),
         'reuse_level'       => $self->o('reuse_level'),
         'goc_threshold'                 => $self->o('goc_threshold'),
+        'threshold_levels'              => $self->o('threshold_levels'),
         'calculate_goc_distribution'    => $self->o('calculate_goc_distribution'),
         'do_homology_id_mapping'        => $self->o('do_homology_id_mapping'),
         'do_jaccard_index'              => $self->o('do_jaccard_index'),
         'binary_species_tree_input_file'   => $self->o('binary_species_tree_input_file'),
         'all_blast_params'          => $self->o('all_blast_params'),
+
+        'orth_batch_size'             => $self->o('orth_batch_size'),
+        'high_confidence_capacity'    => $self->o('high_confidence_capacity'),
+        'update_homologies_capacity'  => $self->o('update_homologies_capacity'),
 
         'use_quick_tree_break'   => $self->o('use_quick_tree_break'),
         'use_notung'   => $self->o('use_notung'),
@@ -442,6 +506,8 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'do_hmm_export'     => $self->o('do_hmm_export'),
         'do_gene_qc'        => $self->o('do_gene_qc'),
         'dbID_range_index'  => $self->o('dbID_range_index'),
+        'dna_alns_complete' => $self->o('dna_alns_complete'), # manually change to 1 when all wgas have finished
+        'orth_wga_complete' => $self->o('orth_wga_complete'), # populated by the rib_fire_orth_wga when wga analyses finished
 
         'mapped_gene_ratio_per_taxon' => $self->o('mapped_gene_ratio_per_taxon'),
     };
@@ -3289,6 +3355,7 @@ sub core_pipeline_analyses {
                     'rib_fire_gene_qc',
                     'rib_fire_homology_id_mapping',
                     'rib_fire_cafe',
+                    'rib_fire_orth_wga',
                 ],
                 'A->1' => 'rib_group_2'
             },
@@ -3313,9 +3380,15 @@ sub core_pipeline_analyses {
                 '1->A' => [
                     'rib_fire_rename_labels',
                     'rib_fire_move_polyploid',
+                    'rib_fire_high_confidence_orths',
                 ],
                 'A->1' => 'floating_rib',
             },
+        },
+
+        {   -logic_name => 'rib_fire_high_confidence_orths',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => WHEN( '#orth_wga_complete#' => [ 'mlss_id_for_high_confidence_factory'] ),
         },
 
         {   -logic_name => 'rib_fire_move_polyploid',
@@ -3517,6 +3590,11 @@ sub core_pipeline_analyses {
             -rc_name => '16Gb_job',
         },
 
+        {   -logic_name => 'rib_fire_orth_wga',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => WHEN( '#dna_alns_complete#'  => [ 'pair_species' ] ),
+        },
+
         {   -logic_name => 'homology_dNdS',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::Homology_dNdS',
             -parameters => {
@@ -3632,6 +3710,8 @@ sub core_pipeline_analyses {
             @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneSetQC::pipeline_analyses_GeneSetQC($self)  },
             @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneMemberHomologyStats::pipeline_analyses_hom_stats($self) },
             @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpHomologiesForPosttree::pipeline_analyses_dump_homologies_posttree($self) },
+            @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::OrthologQMAlignment::pipeline_analyses_ortholog_qm_alignment($self)  },
+            @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::HighConfidenceOrthologs::pipeline_analyses_high_confidence($self) },
     ];
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -259,6 +259,7 @@ sub default_options {
         'species_set_name' => "collection-" . $self->o('collection'),
         'species_set_id'   => undef,
         'ref_species'      => undef,
+        'homology_method_link_types' => ['ENSEMBL_ORTHOLOGUES'],
         # WGA dump directories for OrthologQMAlignment
         'wga_dumps_dir'      => $self->o('homology_dumps_dir'),
         'prev_wga_dumps_dir' => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('prev_release'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -260,13 +260,13 @@ sub default_options {
         'species_set_id'   => undef,
         'ref_species'      => undef,
         # WGA dump directories for OrthologQMAlignment
-        'wga_dumps_dir'      => $self->o('pipeline_dir'),
+        'wga_dumps_dir'      => $self->o('homology_dumps_dir'),
         'prev_wga_dumps_dir' => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('prev_release'),
         # set how many orthologs should be flowed at a time
         'orth_batch_size'   => 10,
         # set to 1 when all pairwise and multiple WGA complete
         'dna_alns_complete' => 0,
-        # populated by the rib_fire_orth_wga when wga analyses finished
+        # populated by the check_file_copy analysis when wga analyses finished
         'orth_wga_complete' => 0,
 
         # parameters for HighConfidenceOrthologs
@@ -478,7 +478,7 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'goc_file'           => '#goc_files_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.goc.tsv',
         'wga_file'           => '#wga_files_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.wga.tsv',
         'previous_wga_file'  => defined $self->o('prev_wga_dumps_dir') ? '#prev_wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv' : undef,
-        'high_conf_file'     => '#pipeline_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.high_conf.tsv',
+        'high_conf_file'     => '#homology_dumps_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.high_conf.tsv',
 
         'clustering_mode'   => $self->o('clustering_mode'),
         'reuse_level'       => $self->o('reuse_level'),
@@ -507,7 +507,7 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'do_gene_qc'        => $self->o('do_gene_qc'),
         'dbID_range_index'  => $self->o('dbID_range_index'),
         'dna_alns_complete' => $self->o('dna_alns_complete'), # manually change to 1 when all wgas have finished
-        'orth_wga_complete' => $self->o('orth_wga_complete'), # populated by the rib_fire_orth_wga when wga analyses finished
+        'orth_wga_complete' => $self->o('orth_wga_complete'), # populated by the check_file_copy analysis when wga analyses finished
 
         'mapped_gene_ratio_per_taxon' => $self->o('mapped_gene_ratio_per_taxon'),
     };

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ProteinTrees_conf.pm
@@ -77,6 +77,23 @@ sub default_options {
 
     # GOC parameters
         'goc_taxlevels'                 => ["Euteleostomi","Ciona"],
+
+    # HighConfidenceOrthologs Parameters
+        # In this structure, the "thresholds" are for resp. the GOC score, the WGA coverage and %identity
+        'threshold_levels' => [
+            {
+                'taxa'          => [ 'Apes', 'Murinae' ],
+                'thresholds'    => [ 75, 75, 80 ],
+            },
+            {
+                'taxa'          => [ 'Mammalia', 'Aves', 'Percomorpha' ],
+                'thresholds'    => [ 75, 75, 50 ],
+            },
+            {
+                'taxa'          => [ 'all' ],
+                'thresholds'    => [ 50, 50, 25 ],
+            },
+        ],
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ncRNAtrees_conf.pm
@@ -70,7 +70,7 @@ sub default_options {
             # Use production names here
             'cafe_species'          => ['danio_rerio', 'taeniopygia_guttata', 'callithrix_jacchus', 'pan_troglodytes', 'homo_sapiens', 'mus_musculus'],
 
-                # HighConfidenceOrthologs Parameters
+        # HighConfidenceOrthologs Parameters
         # In this structure, the "thresholds" are for resp. the GOC score, the WGA coverage and %identity
         'threshold_levels' => [
             {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ncRNAtrees_conf.pm
@@ -69,6 +69,23 @@ sub default_options {
             'do_cafe'  => 1,
             # Use production names here
             'cafe_species'          => ['danio_rerio', 'taeniopygia_guttata', 'callithrix_jacchus', 'pan_troglodytes', 'homo_sapiens', 'mus_musculus'],
+
+                # HighConfidenceOrthologs Parameters
+        # In this structure, the "thresholds" are for resp. the GOC score, the WGA coverage and %identity
+        'threshold_levels' => [
+            {
+                'taxa'          => [ 'Apes', 'Murinae' ],
+                'thresholds'    => [ 75, 75, 80 ],
+            },
+            {
+                'taxa'          => [ 'Mammalia', 'Aves', 'Percomorpha' ],
+                'thresholds'    => [ 75, 75, 50 ],
+            },
+            {
+                'taxa'          => [ 'all' ],
+                'thresholds'    => [ 50, 50, 25 ],
+            },
+        ],
     };
 } 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -163,6 +163,7 @@ sub default_options {
             'species_set_name' => "collection-" . $self->o('collection'),
             'species_set_id'   => undef,
             'ref_species'      => undef,
+            'homology_method_link_types' => ['ENSEMBL_ORTHOLOGUES'],
             # WGA dump directories for OrthologQMAlignment
             'wga_dumps_dir'      => $self->o('homology_dumps_dir'),
             'prev_wga_dumps_dir' => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('prev_release'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -164,13 +164,13 @@ sub default_options {
             'species_set_id'   => undef,
             'ref_species'      => undef,
             # WGA dump directories for OrthologQMAlignment
-            'wga_dumps_dir'      => $self->o('pipeline_dir'),
+            'wga_dumps_dir'      => $self->o('homology_dumps_dir'),
             'prev_wga_dumps_dir' => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('prev_release'),
             # set how many orthologs should be flowed at a time
             'orth_batch_size'   => 10,
             # set to 1 when all pairwise and multiple WGA complete
             'dna_alns_complete' => 0,
-            # populated by the rib_fire_orth_wga when wga analyses finished
+            # populated by the check_file_copy analysis when wga analyses finished
             'orth_wga_complete' => 0,
 
             #Parameters for HighConfidenceOrthologs
@@ -232,7 +232,7 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'goc_file'           => '#goc_files_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.goc.tsv',
         'wga_file'           => '#wga_files_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.wga.tsv',
         'previous_wga_file'  => defined $self->o('prev_wga_dumps_dir') ? '#prev_wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv' : undef,
-        'high_conf_file'     => '#pipeline_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.high_conf.tsv',
+        'high_conf_file'     => '#homology_dumps_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.high_conf.tsv',
 
         'skip_epo'      => $self->o('skip_epo'),
         'epo_db'        => $self->o('epo_db'),
@@ -246,7 +246,7 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'range_label'       => $self->o('range_label'),
 
         'dna_alns_complete' => $self->o('dna_alns_complete'), # manually change to 1 when all wgas have finished
-        'orth_wga_complete' => $self->o('orth_wga_complete'), # populated by the rib_fire_orth_wga when wga analyses finished
+        'orth_wga_complete' => $self->o('orth_wga_complete'), # populated by the check_file_copy analysis when wga analyses finished
 
         'orth_batch_size'             => $self->o('orth_batch_size'),
         'high_confidence_capacity'    => $self->o('high_confidence_capacity'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -43,6 +43,8 @@ use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For WHEN and INPUT_PLU
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::CAFE;
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneMemberHomologyStats;
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpHomologiesForPosttree;
+use Bio::EnsEMBL::Compara::PipeConfig::Parts::OrthologQMAlignment;
+use Bio::EnsEMBL::Compara::PipeConfig::Parts::HighConfidenceOrthologs;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
 
@@ -66,11 +68,19 @@ sub default_options {
         'master_db'   => 'compara_master',
         'member_db'   => 'compara_members',
         'mapping_db'  => 'compara_prev',
+        'prev_rel_db' => 'compara_prev',
         # The following parameter should ideally contain EPO-2X alignments of
         # all the genomes used in the ncRNA-trees. However, due to release
         # coordination considerations, this may not be possible. If so, use the
         # one from the previous release.
         'epo_db'      => 'compara_prev',
+
+        # The dbs required for OrthologQMAlignment alt_aln_dbs can be an array list of alignment dbs
+        'compara_db'      => $self->pipeline_url(),
+        'alt_homology_db' => $self->pipeline_url(),
+        'alt_aln_dbs'     => [
+            'compara_curr',
+        ],
 
     # Parameters to allow merging different runs of the pipeline
         'dbID_range_index'      => 14,
@@ -146,6 +156,30 @@ sub default_options {
             'homology_dumps_dir'       => $self->o('dump_dir'). '/homology_dumps/',
             'homology_dumps_shared_dir' => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('ensembl_release'),
             'prev_homology_dumps_dir' => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('prev_release'),
+
+            # Parameters for OrthologQMAlignment
+            'species1'         => undef,
+            'species2'         => undef,
+            'species_set_name' => "collection-" . $self->o('collection'),
+            'species_set_id'   => undef,
+            'ref_species'      => undef,
+            # WGA dump directories for OrthologQMAlignment
+            'wga_dumps_dir'      => $self->o('pipeline_dir'),
+            'prev_wga_dumps_dir' => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('prev_release'),
+            # set how many orthologs should be flowed at a time
+            'orth_batch_size'   => 10,
+            # set to 1 when all pairwise and multiple WGA complete
+            'dna_alns_complete' => 0,
+            # populated by the rib_fire_orth_wga when wga analyses finished
+            'orth_wga_complete' => 0,
+
+            #Parameters for HighConfidenceOrthologs
+            'threshold_levels'            => [ ],          # division specific
+            'high_confidence_capacity'    => 500,          # how many mlss_ids can be processed in parallel
+            'update_homologies_capacity'  => 30,           # how many homology mlss_ids can be updated in parallel
+            'goc_files_dir'               => $self->o('homology_dumps_dir'),
+            'range_label'                 => $self->o('member_type'),
+
     };
 }
 
@@ -155,6 +189,18 @@ sub pipeline_create_commands {
             @{$self->SUPER::pipeline_create_commands},  # here we inherit creation of database, hive tables and compara tables
 
             $self->pipeline_create_commands_rm_mkdir(['work_dir', 'dump_dir', 'ss_picts_dir']),
+
+            $self->db_cmd( 'CREATE TABLE ortholog_quality (
+                            homology_id              INT NOT NULL,
+                            genome_db_id             INT NOT NULL,
+                            alignment_mlss           INT NOT NULL,
+                            combined_exon_coverage   FLOAT(5,2) NOT NULL,
+                            combined_intron_coverage FLOAT(5,2) NOT NULL,
+                            quality_score            FLOAT(5,2) NOT NULL,
+                            exon_length              INT NOT NULL,
+                            intron_length            INT NOT NULL,
+                            INDEX (homology_id)
+            )'),
     ];
 }
 
@@ -164,14 +210,29 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
     return {
         %{$self->SUPER::pipeline_wide_parameters},          # here we inherit anything from the base class
 
+        'ensembl_release' => $self->o('ensembl_release'),
+
         'mlss_id'       => $self->o('mlss_id'),
         'master_db'     => $self->o('master_db'),
         'member_db'     => $self->o('member_db'),
+        'prev_rel_db'   => $self->o('prev_rel_db'),
+        'alt_aln_dbs'   => $self->o('alt_aln_dbs'),
         'mapping_db'    => $self->o('mapping_db'),
-        
+
+        'pipeline_dir'              => $self->o('pipeline_dir'),
         'homology_dumps_dir'        => $self->o('homology_dumps_dir'),
         'prev_homology_dumps_dir'   => $self->o('prev_homology_dumps_dir'),
         'homology_dumps_shared_dir' => $self->o('homology_dumps_shared_dir'),
+        'wga_dumps_dir'             => $self->o('wga_dumps_dir'),
+        'prev_wga_dumps_dir'        => $self->o('prev_wga_dumps_dir'),
+
+        'goc_files_dir'      => $self->o('goc_files_dir'),
+        'wga_files_dir'      => $self->o('wga_dumps_dir'),
+        'hashed_mlss_id'     => '#expr(dir_revhash(#mlss_id#))expr#',
+        'goc_file'           => '#goc_files_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.goc.tsv',
+        'wga_file'           => '#wga_files_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.wga.tsv',
+        'previous_wga_file'  => defined $self->o('prev_wga_dumps_dir') ? '#prev_wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv' : undef,
+        'high_conf_file'     => '#pipeline_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.high_conf.tsv',
 
         'skip_epo'      => $self->o('skip_epo'),
         'epo_db'        => $self->o('epo_db'),
@@ -181,6 +242,16 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'do_cafe'           => $self->o('do_cafe'),
         'dbID_range_index'  => $self->o('dbID_range_index'),
         'clustering_mode'   => $self->o('clustering_mode'),
+        'threshold_levels'  => $self->o('threshold_levels'),
+        'range_label'       => $self->o('range_label'),
+
+        'dna_alns_complete' => $self->o('dna_alns_complete'), # manually change to 1 when all wgas have finished
+        'orth_wga_complete' => $self->o('orth_wga_complete'), # populated by the rib_fire_orth_wga when wga analyses finished
+
+        'orth_batch_size'             => $self->o('orth_batch_size'),
+        'high_confidence_capacity'    => $self->o('high_confidence_capacity'),
+        'update_homologies_capacity'  => $self->o('update_homologies_capacity'),
+
     }
 }
 
@@ -1219,7 +1290,10 @@ sub core_pipeline_analyses {
         {   -logic_name => 'rib_fire_homology_processing',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => {
-                1 => WHEN('#ref_ortholog_db#' => 'remove_overlapping_homologies', ELSE [ 'homology_stats_factory', 'id_map_mlss_factory' ]),
+                1       => [ 
+                    WHEN('#ref_ortholog_db#' => 'remove_overlapping_homologies', ELSE [ 'homology_stats_factory', 'id_map_mlss_factory' ]),
+                    'rib_fire_orth_wga_and_high_conf',
+                ],
             },
         },
         
@@ -1230,9 +1304,30 @@ sub core_pipeline_analyses {
             },
         },
 
+        {   -logic_name => 'rib_fire_orth_wga_and_high_conf',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => {
+                '1->A'  => 'rib_fire_orth_wga',
+                'A->1'  => 'rib_fire_high_confidence_orths'
+            },
+        },
+
+        {   -logic_name => 'rib_fire_orth_wga',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => WHEN( '#dna_alns_complete#'  => [ 'pair_species' ] ),
+        },
+
+        {   -logic_name => 'rib_fire_high_confidence_orths',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => WHEN( '#orth_wga_complete#' => [ 'mlss_id_for_high_confidence_factory'] ),
+        },
+
         @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::CAFE::pipeline_analyses_cafe_with_full_species_tree($self) },
         @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneMemberHomologyStats::pipeline_analyses_hom_stats($self) },
         @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpHomologiesForPosttree::pipeline_analyses_dump_homologies_posttree($self) },
+        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::OrthologQMAlignment::pipeline_analyses_ortholog_qm_alignment($self)  },
+        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::HighConfidenceOrthologs::pipeline_analyses_high_confidence($self) },
+
     ];
 }
 


### PR DESCRIPTION
## Description

_To further streamline the inference of ortholog quality and confidence metrics._

**Related JIRA tickets:**
- ENSCOMPARASW-3257

## Overview of changes
Parameters needed to be migrated to the protein trees and ncrna trees pipelines and the thresholds for the division specific pipelines in order to incorporate the wga and high confidence pipelines. The High confidence orthologs pipeline only needed to be included in both ncrna and protein tree pipelines. A new `Pipeconfig/Parts/` config file was written to adapt the OrthologQMAlignment pipeline. 

#### Change 1
- New pipeconfig Part: OrthologQMAlignment to be used in both ncrna and protein tree pipelines. This now populates new parameter when complete to prevent HighConfidenceOrthologs from starting if semaphore is released before all pairwise and multiple alignments have completed.

#### Change 2
- All parameters and thresholds for both HighConfidenceOrthologs and OrthologQMAlignment included into the protein trees and ncrna pipeline config files. New parameter to turn OrthologQMAlignment on or off when all pairwise and multiple alignments have finished. 

#### Change 3
- New dummy runnables included to check for whether to run the wga analyses or high confidence analyses.

#### Change 4
- Create table command for the `ortholog_quality` tables in both ncrna and protein tree pipelines.

#### Change 5
- Ignore table parameters for mergedb pipeline to ignore `ortholog_quality` table.

#### Change 6
- Make change to standalone version of WGA pipeline so that it uses new `/Parts/OrthologQMAlignment.pm`

## Testing
Full pipeline runs with both protein trees and ncrna trees:
-- `mysql://ensro@mysql-ens-compara-prod-4:4401/cristig_vertebrates_nctrees_wga_hc_test`
-- `mysql://ensro@mysql-ens-compara-prod-5:4615/cristig_plants_ptrees_wga_hc_test`
-- `mysql://ensro@mysql-ens-compara-prod-5:4615/cristig_wga_standalone_test`
(ncrna trees was used for production e101)

## Notes
