### PR TITLE
Feature/dependency graph

### DIFF
--- a/conf/pan/jira_recurrent_tickets.json
+++ b/conf/pan/jira_recurrent_tickets.json
@@ -43,17 +43,11 @@
       "component": "Relco tasks",
       "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Intentions+for+release+<version>",
       "subtasks": [{
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::Pan::ProteinTrees_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/ProteinTrees_conf.pm]",
             "summary": "Run the Protein-trees pipeline",
             "name_on_graph": "Protein-trees"
-         },
-         {
-            "assignee": "<RelCo>",
-            "component": "Relco tasks",
-            "description": "[Bio::EnsEMBL::Compara::PipeConfig::Pan::HighConfidenceOrthologs_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/HighConfidenceOrthologs_conf.pm]",
-            "summary": "Run the HighConfidenceOrthologs pipeline",
-            "name_on_graph": "Protein-trees High Confidence Orthologues"
          }
       ],
       "labels": ["Production_anchor"],
@@ -82,11 +76,13 @@
             "summary": "Run the healthchecks"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Testing+the+staging+website#Testingthestagingwebsite-Homologyside",
             "summary": "test the homologies data"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Testing+the+staging+website#Testingthestagingwebsite-Downloads",
             "summary": "test the downloads"

--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -69,40 +69,31 @@
       "component": "Relco tasks",
       "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Intentions+for+release+<version>",
       "subtasks": [{
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::Plants::ProteinTrees_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm]",
             "summary": "Run the Protein-trees pipeline",
             "name_on_graph": "Protein-trees"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "summary": "All LastZ",
             "name_on_graph": "All LastZ"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::Plants::EPOwith2x_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/EPOwith2x_conf.pm]\n\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
             "summary": "Run the Rice EPOwith2x pipeline",
             "name_on_graph": "EPOwith2x:Rice"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::Synteny_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Synteny_conf.pm]",
             "name_on_graph": "Synteny",
             "summary": "Run the Synteny pipeline"
-         },
-         {
-            "component": "Production tasks",
-            "description": "[Bio::EnsEMBL::Compara::PipeConfig::Plants::OrthologQM_Alignment_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/OrthologQM_Alignment_conf.pm]",
-            "summary": "Protein-trees WGA Orthology QC",
-            "name_on_graph": "Protein-trees WGA Orthology QC"
-         },
-         {
-            "assignee": "<RelCo>",
-            "component": "Relco tasks",
-            "description": "[Bio::EnsEMBL::Compara::PipeConfig::Plants::HighConfidenceOrthologs_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/HighConfidenceOrthologs_conf.pm]",
-            "summary": "Run the HighConfidenceOrthologs pipeline",
-            "name_on_graph": "Protein-trees High Confidence Orthologues"
          }
       ],
       "labels": ["Production_anchor"],
@@ -150,25 +141,30 @@
             "summary": "Run the healthchecks"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Relco tasks",
             "summary": "Ask the <Division> team to test the staging server"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Testing+the+staging+website#Testingthestagingwebsite-DNAside",
             "summary": "test the DNA data"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Testing+the+staging+website#Testingthestagingwebsite-Homologyside",
             "summary": "test the homologies data"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Testing+the+staging+website#Testingthestagingwebsite-Downloads",
             "summary": "test the downloads"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Testing+the+staging+website#Testingthestagingwebsite-Documentation&Statistics",
             "summary": "test the documentation and statistics"

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -69,219 +69,143 @@
       "component": "Relco tasks",
       "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Intentions+for+release+<version>",
       "subtasks": [{
-            "component": "Production tasks",
-            "description": "[Bio::EnsEMBL::Compara::PipeConfig::Families_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Families_conf.pm]",
-            "summary": "Run the Family pipeline",
-            "name_on_graph": "Families"
-         },
-         {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::ProteinTrees_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ProteinTrees_conf.pm]",
             "summary": "Run the Protein-trees pipeline",
             "name_on_graph": "Protein-trees:Default vertebrates"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::ncRNAtrees_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ncRNAtrees_conf.pm]",
             "summary": "Run the ncRNA-trees pipeline",
             "name_on_graph": "ncRNA-trees:Default vertebrates"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::MurinaeNcRNAtrees_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MurinaeNcRNAtrees_conf.pm]",
             "summary": "Run the mouse strains ncRNA-trees pipeline",
             "name_on_graph": "ncRNA-trees:Murinae"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::MurinaeProteinTrees_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MurinaeProteinTrees_conf.pm]",
             "summary": "Run the mouse strains Protein-trees pipeline",
             "name_on_graph": "Protein-trees:Murinae"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::SusNcRNAtrees_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/SusNcRNAtrees_conf.pm]",
             "summary": "Run the pig breeds ncRNA-trees pipeline",
             "name_on_graph": "ncRNA-trees:Sus"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::SusProteinTrees_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/SusProteinTrees_conf.pm]",
             "summary": "Run the pig breeds Protein-trees pipeline",
             "name_on_graph": "Protein-trees:Sus"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::StrainsReindexMembers_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsReindexMembers_conf.pm]",
             "summary": "Reindex murinae gene trees",
             "name_on_graph": "Gene-tree reindexing:Murinae"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::StrainsReindexMembers_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsReindexMembers_conf.pm]",
             "summary": "Reindex pig gene trees",
             "name_on_graph": "Gene-tree reindexing:Sus"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
             "summary": "Run the Mammal EPOwith2x pipeline",
             "name_on_graph": "EPOwith2x:Mammals"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
             "summary": "Run the Primates EPOwith2x pipeline",
             "name_on_graph": "EPOwith2x:Primates"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
             "summary": "Run the Pigs EPOwith2x pipeline",
             "name_on_graph": "EPOwith2x:Pigs"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
             "summary": "Run the Fish EPOwith2x pipeline",
             "name_on_graph": "EPOwith2x:Fish"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
             "summary": "Run the Sauropsids EPOwith2x pipeline",
             "name_on_graph": "EPOwith2x:Sauropsids"
          },
          {
-            "component": "Production tasks",
-            "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::MercatorPecan_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MercatorPecan_conf.pm]",
-            "summary": "Run the Amniotes pecan pipeline",
-            "name_on_graph": "Mercator Pecan:Amniotes"
-         },
-         {
-            "component": "Production tasks",
-            "description" : "(!) Only if we have rerun the EPO Primates alignment.\n[Bio::EnsEMBL::Compara::PipeConfig::DumpAncestralAlleles_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAncestralAlleles_conf.pm]",
-            "summary": "Dump the ancestral alleles for the Variation team",
-            "name_on_graph": "Ancestral Alleles"
-         },
-         {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::ImportAltAlleGroupsAsHomologies_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/ImportAltAlleGroupsAsHomologies_conf.pm]",
             "summary": "Import the Alt-allele groups",
             "name_on_graph": "Alt-alleles import"
          },
          {
+             "assignee": "<RelCo>",
              "component": "Production tasks",
              "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+DNA+data#MergetheDNAdata-Patchalignments",
              "summary": "Align the human patches against the primary human assembly",
              "name_on_graph": "Patches against their primary assembly:Human"
          },
          {
+             "assignee": "<RelCo>",
              "component": "Production tasks",
              "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+DNA+data#MergetheDNAdata-Patchalignments",
              "summary": "Align the mouse patches against the primary mouse assembly",
              "name_on_graph": "Patches against their primary assembly:Mouse"
          },
          {
+             "assignee": "<RelCo>",
              "component": "Production tasks",
              "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+DNA+data#MergetheDNAdata-Patchalignments",
              "summary": "Align the zebrafish patches against the primary mouse assembly",
              "name_on_graph": "Patches against their primary assembly:Zebrafish"
          },
          {
-             "component": "Production tasks",
-             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Haplotypes+and+assembly+patches+against+other+species",
-             "summary": "Align the human patches against the other species",
-             "name_on_graph": "Patches against other species:Human"
-         },
-         {
-             "component": "Production tasks",
-             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Haplotypes+and+assembly+patches+against+other+species",
-             "summary": "Align the mouse patches against the other species",
-             "name_on_graph": "Patches against other species:Mouse"
-         },
-         {
-             "component": "Production tasks",
-             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Haplotypes+and+assembly+patches+against+other+species",
-             "summary": "Align the zebrafish patches against the other species",
-             "name_on_graph": "Patches against other species:Zebrafish"
-         },
-         {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "summary": "All LastZ",
             "name_on_graph": "All LastZ"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Age+of+Base",
             "summary": "Age of Base",
             "name_on_graph": "Age of Base:Human"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "[Bio::EnsEMBL::Compara::PipeConfig::Synteny_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Synteny_conf.pm]",
             "name_on_graph": "Synteny",
             "summary": "Run the Synteny pipeline"
-         },
-         {
-            "component": "Production tasks",
-            "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::OrthologQM_Alignment_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/OrthologQM_Alignment_conf.pm]",
-            "summary": "Protein-trees WGA Orthology QC",
-            "name_on_graph": "Protein-trees WGA Orthology QC:Default vertebrates"
-         },
-         {
-            "component": "Production tasks",
-            "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::OrthologQM_Alignment_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/OrthologQM_Alignment_conf.pm]",
-            "summary": "Protein-trees WGA Orthology QC for pig breeds",
-            "name_on_graph": "Protein-trees WGA Orthology QC:Sus"
-         },
-         {
-            "component": "Production tasks",
-            "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::OrthologQM_Alignment_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/OrthologQM_Alignment_conf.pm]",
-            "summary": "ncRNA-trees WGA Orthology QC",
-            "name_on_graph": "ncRNA-trees WGA Orthology QC:Default vertebrates"
-         },
-         {
-            "component": "Production tasks",
-            "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::OrthologQM_Alignment_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/OrthologQM_Alignment_conf.pm]",
-            "summary": "ncRNA-trees WGA Orthology QC for pig breeds",
-            "name_on_graph": "ncRNA-trees WGA Orthology QC:Sus"
-         },
-         {
-            "component": "Relco tasks",
-            "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::HighConfidenceOrthologs_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/HighConfidenceOrthologs_conf.pm]",
-            "summary": "Run the HighConfidenceOrthologs pipeline for protein-coding genes",
-            "name_on_graph": "Protein-trees High Confidence Orthologues:Default vertebrates"
-         },
-         {
-            "component": "Relco tasks",
-            "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::StrainsHighConfidenceOrthologs_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsHighConfidenceOrthologs_conf.pm]",
-            "summary": "Run the mouse strains HighConfidenceOrthologs pipeline for protein-coding genes",
-            "name_on_graph": "Protein-trees High Confidence Orthologues:Murinae"
-         },
-         {
-            "component": "Relco tasks",
-            "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::StrainsHighConfidenceOrthologs_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsHighConfidenceOrthologs_conf.pm]",
-            "summary": "Run the pig breeds HighConfidenceOrthologs pipeline for protein-coding genes",
-            "name_on_graph": "Protein-trees High Confidence Orthologues:Sus"
-         },
-         {
-            "component": "Relco tasks",
-            "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::HighConfidenceOrthologs_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/HighConfidenceOrthologs_conf.pm]",
-            "summary": "Run the HighConfidenceOrthologs pipeline for ncRNAs",
-            "name_on_graph": "ncRNA-trees High Confidence Orthologues:Default vertebrates"
-         },
-         {
-            "component": "Relco tasks",
-            "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::StrainsHighConfidenceOrthologs_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsHighConfidenceOrthologs_conf.pm]",
-            "summary": "Run the mouse strains HighConfidenceOrthologs pipeline for ncRNAs",
-            "name_on_graph": "ncRNA-trees High Confidence Orthologues:Murinae"
-         },
-         {
-            "component": "Relco tasks",
-            "description": "[Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::StrainsHighConfidenceOrthologs_conf|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsHighConfidenceOrthologs_conf.pm]",
-            "summary": "Run the pig breeds HighConfidenceOrthologs pipeline for ncRNAs",
-            "name_on_graph": "ncRNA-trees High Confidence Orthologues:Sus"
          }
       ],
       "labels": ["Production_anchor"],
@@ -329,21 +253,25 @@
             "summary": "Run the healthchecks"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Testing+the+staging+website#Testingthestagingwebsite-DNAside",
             "summary": "test the DNA data"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Testing+the+staging+website#Testingthestagingwebsite-Homologyside",
             "summary": "test the homologies data"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Testing+the+staging+website#Testingthestagingwebsite-Downloads",
             "summary": "test the downloads"
          },
          {
+            "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Testing+the+staging+website#Testingthestagingwebsite-Documentation&Statistics",
             "summary": "test the documentation and statistics"

--- a/scripts/jira_tickets/compara_merged.dot
+++ b/scripts/jira_tickets/compara_merged.dot
@@ -1,25 +1,22 @@
 digraph {
+    rankdir=LR;  # Left-to-right graph instead of top-to-bottom
     "Patches against their primary assembly";
-    "Patches against other species";
 
     "Genome dumps" -> { "Species-tree", "LastZ" };
-    "Species-tree" -> { "EPOwith2x", "Mercator Pecan", "Protein-trees" };
+    "Species-tree" -> { "EPOwith2x", "Protein-trees" };
     "All LastZ" -> "EPOwith2x";
-    "Member loading" -> { "Protein-trees", "ncRNA-trees", "Families", "Gene-tree reindexing", "Alt-alleles import" };
-    "Protein-trees" -> "Protein-trees WGA Orthology QC" [fontsize="8", label="Orthologues and\nhomology_id mapping\nonly"];
-    "ncRNA-trees" -> "ncRNA-trees WGA Orthology QC" [fontsize="8", label="Orthologues and\nhomology_id mapping\nonly"];
-    {"All LastZ", "EPOwith2x"} -> "All alignments for WGA Orthology QC" -> {"Protein-trees WGA Orthology QC", "ncRNA-trees WGA Orthology QC"};
-    {"Protein-trees", "Protein-trees WGA Orthology QC"} -> "Protein-trees High Confidence Orthologues";
-    {"ncRNA-trees", "ncRNA-trees WGA Orthology QC"} -> "ncRNA-trees High Confidence Orthologues";
+    "Member loading" -> { "Protein-trees", "ncRNA-trees", "Gene-tree reindexing", "Alt-alleles import" };
+    {"All LastZ", "EPOwith2x"} -> "All alignments for WGA Orthology QC";
+    "All alignments for WGA Orthology QC" -> "Protein-trees" [fontsize="8", label="Orthologues\nonly"];
+    "All alignments for WGA Orthology QC" -> "ncRNA-trees" [fontsize="8", label="Orthologues\nonly"];
     "LastZ" -> "All LastZ" -> "Synteny";
 
     "Gene-tree reindexing" -> "ncRNA-trees" [style="dashed", dir=none, fontsize="8", label="XOR"];
     "Gene-tree reindexing" -> "Protein-trees" [style="dashed", dir=none, fontsize="8", label="XOR"];
     "EPOwith2x" -> "EPOwith2x" [style="dashed", fontsize="8", label="Anchor\nmapping\nonly", headport="Primates:e", tailport="Mammals:e"];
     "EPOwith2x" -> "EPOwith2x" [style="dashed", fontsize="8", label="Anchor\nmapping\nonly", headport="Pigs:e", tailport="Mammals:e"];
-    "EPOwith2x" -> "Age of Base" [style="dashed", headport="Human:e", tailport="Mammals:w"];
-    "EPOwith2x" -> "Ancestral Alleles" [style="dashed", headport="Vertebrates:w", tailport="Primates:w"];
-    "Protein-trees" -> "Protein-trees" [style="dashed", fontsize="8", xlabel="Orthologues\nonly", headport="Murinae:w", tailport="Default vertebrates:w"];
+    "EPOwith2x" -> "Age of Base" [style="dashed", headport="Human:w", tailport="Mammals:e"];
+    "Protein-trees" -> "Protein-trees" [style="dashed", fontsize="8", label="Orthologues\nonly", headport="Murinae:e", tailport="Default vertebrates:e"];
     "ncRNA-trees" -> "ncRNA-trees" [style="dashed", fontsize="8", label="Orthologues\nonly", headport="Murinae:e", tailport="Default vertebrates:e"];
 
     // Helps laying out the graph


### PR DESCRIPTION
## Description

With the latest update from @CristiGuijarro (see [PR#196](https://github.com/Ensembl/ensembl-compara/pull/196)) and the release freezing for the time being ([link](https://docs.google.com/document/d/1OgPsEOE53htFMQX19XAcf3iA9eFVUsW7rcwqe1OrjbE/edit#heading=h.2qenazl2jq5f)), our dependency graph needed a big update. And here it is!

**Related JIRA tickets:**
- ENSCOMPARASW-3328

## Overview of changes
#### Change 1
- `*-trees WGA Orthology QC` and `*-trees High Confidence Orthologs` pipelines have been merged to their corresponding `*-trees`. The dependencies have been updated accordingly.

#### Change 2
- `Families`, `Mercator-Pecan`, `Ancestral Alleles` and `Patches against other species` pipelines won't be run during the release freezing.

#### Change 3
- From e102 we will have a single RelCo, so to ease their work, all tickets have been assigned to that person.

#### Change 4
- I have changed the direction of the graph from top-down to left-right because I find it more comfortable with our current wide screens.

## Testing
This is how the dependency graph would have looked for e101: https://www.ebi.ac.uk/~jalvarez/graphs/merged_release_graph.html?release=101

## Notes
_More changes were meant to be added (like the update of EPOs and Mercator-Pecan instead of rerunning them), but these tasks have been postponed to e103._
