### PR TITLE
Update MLSS config XML file for vertebrates

### DIFF
--- a/conf/vertebrates/mlss_conf.xml
+++ b/conf/vertebrates/mlss_conf.xml
@@ -77,7 +77,8 @@
     <!-- Sauropsids -->
     <one_vs_all method="LASTZ_NET" ref_genome="gallus_gallus">
       <species_set>
-        <taxonomic_group taxon_name="Sauropsida"/>
+        <taxonomic_group taxon_name="Sarcopterygii"/>
+        <taxonomic_group taxon_name="Amniota" exclude="1"/>
         <!-- Remove all the taxa that have a better reference than chicken -->
         <taxonomic_group taxon_name="Iguania" exclude="1"/>
       </species_set>
@@ -86,6 +87,15 @@
     <one_vs_all method="LASTZ_NET" ref_genome="anolis_carolinensis" against="Iguania"/>
 
     <!-- Fishes -->
+    <one_vs_all method="LASTZ_NET" ref_genome="danio_rerio">
+      <species_set>
+        <taxonomic_group taxon_name="Chordata"/>
+        <taxonomic_group taxon_name="Euteleostomi" exclude="1"/>
+        <taxonomic_group taxon_name="Cyclostoma" exclude="1"/>
+        <taxonomic_group taxon_name="Ciona" exclude="1"/>
+      </species_set>
+    </one_vs_all>
+
     <one_vs_all method="LASTZ_NET" ref_genome="oryzias_latipes">
       <species_set>
         <taxonomic_group taxon_name="Actinopterygii"/>

--- a/conf/vertebrates/mlss_conf.xml
+++ b/conf/vertebrates/mlss_conf.xml
@@ -78,7 +78,7 @@
     <one_vs_all method="LASTZ_NET" ref_genome="gallus_gallus">
       <species_set>
         <taxonomic_group taxon_name="Sarcopterygii"/>
-        <taxonomic_group taxon_name="Amniota" exclude="1"/>
+        <taxonomic_group taxon_name="Mammalia" exclude="1"/>
         <!-- Remove all the taxa that have a better reference than chicken -->
         <taxonomic_group taxon_name="Iguania" exclude="1"/>
       </species_set>

--- a/conf/vertebrates/mlss_conf.xml
+++ b/conf/vertebrates/mlss_conf.xml
@@ -4,11 +4,11 @@
   <!-- Collections are species-sets that are needed to define several mlsss -->
   <collections>
 
-    <!-- All chordates except the mouse strains, and the three outgroups -->
+    <!-- All chordates except the mouse strains, pig breeds and the three outgroups -->
     <!-- NB: we have several genomes of the same species, e.g. CHO, NMR -->
     <collection name="default">
       <taxonomic_group taxon_name="Chordata">
-        <!-- But exclude everything below mus_musculus -->
+        <!-- But exclude everything below mus_musculus and sus_scrofa -->
         <ref_for_taxon name="mus_musculus"/>
         <ref_for_taxon name="sus_scrofa"/>
       </taxonomic_group>
@@ -34,98 +34,274 @@
 
   <pairwise_alignments>
 
-    <!-- First, our top four species, which are references for all chordates -->
+    <!-- Mammals -->
+    <!-- Use of "default" collection excludes the mouse strains and the pig breeds -->
+    <!-- NB: we have a CACTUS alignment for mouse strains and an EPO Extended MSA for pig breeds -->
     <one_vs_all method="LASTZ_NET" ref_genome="homo_sapiens">
-      <!-- "default" collection means that the mouse strains are excluded (because only the reference mouse deserves to be aligned to human) -->
       <species_set in_collection="default">
-        <taxonomic_group taxon_name="Chordata"/>
+        <taxonomic_group taxon_name="Mammalia"/>
+        <!-- Remove all the taxa that have a better reference than human -->
+        <taxonomic_group taxon_name="Rodentia" exclude="1"/>
+        <taxonomic_group taxon_name="Feliformia" exclude="1"/>
+        <taxonomic_group taxon_name="Caniformia" exclude="1"/>
+        <taxonomic_group taxon_name="Perissodactyla" exclude="1"/>
+        <taxonomic_group taxon_name="Artiodactyla" exclude="1"/>
+        <taxonomic_group taxon_name="Metatheria" exclude="1"/>
+        <taxonomic_group taxon_name="Prototheria" exclude="1"/>
       </species_set>
     </one_vs_all>
-    <one_vs_all method="LASTZ_NET" ref_genome="mus_musculus" ref_amongst="Chordata">
-      <!-- "default" collection means that the mouse strains are excluded (because we have the Cactus alignment for those) -->
+
+    <one_vs_all method="LASTZ_NET" ref_genome="mus_musculus">
       <species_set in_collection="default">
         <taxonomic_group taxon_name="Rodentia"/>
       </species_set>
     </one_vs_all>
-    <one_vs_all method="LASTZ_NET" ref_genome="gallus_gallus" against="Sauropsida" ref_amongst="Chordata"/>
-    <one_vs_all method="LASTZ_NET" ref_genome="danio_rerio" ref_amongst="Chordata">
-      <species_set>
-        <!-- Include urochordates, cephalochordates, cyclostomes, cartilaginous fishes, ray-finned fishes, coelacanths and lungfishes -->
-        <taxonomic_group taxon_name="Chordata"/>
-        <taxonomic_group taxon_name="Tetrapoda" exclude="1"/>
-      </species_set>
-    </one_vs_all>
 
-    <!-- Pigs: all pigs vs sus_scrofa -->
-    <one_vs_all method="LASTZ_NET" ref_genome="sus_scrofa" against="Sus"/>
+    <one_vs_all method="LASTZ_NET" ref_genome="felis_catus" against="Feliformia"/>
 
-    <!-- Fish -->
-    <one_vs_all method="LASTZ_NET" ref_genome="oryzias_latipes" against="Actinopterygii"/>
+    <one_vs_all method="LASTZ_NET" ref_genome="canis_lupus_familiaris" against="Caniformia"/>
 
-    <!-- Mammals -->
-    <one_vs_all method="LASTZ_NET" ref_genome="monodelphis_domestica" against="Metatheria" ref_amongst="Amniota"/>
-    <one_vs_all method="LASTZ_NET" ref_genome="canis_lupus_familiaris" against="Carnivora" ref_amongst="Eutheria"/>
-    <one_vs_all method="LASTZ_NET" ref_genome="felis_catus" against="Feliformia" ref_amongst="Carnivora"/>
+    <one_vs_all method="LASTZ_NET" ref_genome="equus_caballus" against="Perissodactyla"/>
 
-    <one_vs_all method="LASTZ_NET" ref_genome="bos_taurus" ref_amongst="Eutheria">
+    <one_vs_all method="LASTZ_NET" ref_genome="bos_taurus">
       <species_set in_collection="default">
-        <taxonomic_group taxon_name="Cetartiodactyla"/>
+        <taxonomic_group taxon_name="Artiodactyla"/>
       </species_set>
     </one_vs_all>
 
-    <one_vs_all method="LASTZ_NET" ref_genome="ovis_aries" against="Caprinae" ref_amongst="Cetartiodactyla"/>
+    <one_vs_all method="LASTZ_NET" ref_genome="sus_scrofa" against="Sus"/>
+    <one_vs_all method="LASTZ_NET" ref_genome="monodelphis_domestica" against="Metatheria"/>
+    <one_vs_all method="LASTZ_NET" ref_genome="ornithorhynchus_anatinus" against="Prototheria"/>
+    <pairwise_alignment method="LASTZ_NET" ref_genome="monodelphis_domestica" target_genome="ornithorhynchus_anatinus"/>
+
+    <!-- Sauropsids -->
+    <one_vs_all method="LASTZ_NET" ref_genome="gallus_gallus">
+      <species_set>
+        <taxonomic_group taxon_name="Sauropsida"/>
+        <!-- Remove all the taxa that have a better reference than chicken -->
+        <taxonomic_group taxon_name="Iguania" exclude="1"/>
+      </species_set>
+    </one_vs_all>
+
+    <one_vs_all method="LASTZ_NET" ref_genome="anolis_carolinensis" against="Iguania"/>
+
+    <!-- Fishes -->
+    <one_vs_all method="LASTZ_NET" ref_genome="oryzias_latipes">
+      <species_set>
+        <taxonomic_group taxon_name="Actinopterygii"/>
+      </species_set>
+    </one_vs_all>
 
     <!-- Early vertebrates and other chordates -->
+    <one_vs_all method="LASTZ_NET" ref_genome="xenopus_tropicalis" against="Amphibia"/>
     <one_vs_all method="LASTZ_NET" ref_genome="ciona_intestinalis" against="Ciona" ref_amongst="Cyclostomata"/>
     <one_vs_all method="LASTZ_NET" ref_genome="petromyzon_marinus" against="Cyclostomata" ref_amongst="Ciona"/>
 
-    <!-- These genomes are currently the only ones in their clades, so no alignment within the "against"/"species_set" -->
-    <!-- However they will be aligned against the other reference genomes in "ref_amongst" -->
-    <one_vs_all method="LASTZ_NET" ref_genome="equus_caballus" against="Perissodactyla" ref_amongst="Laurasiatheria"/>
-    <one_vs_all method="LASTZ_NET" ref_genome="sus_scrofa" against="Suina" ref_amongst="Laurasiatheria"/>
-    <one_vs_all method="LASTZ_NET" ref_genome="anolis_carolinensis" against="Lepidosauria" ref_amongst="Sauropsida"/>
-    <one_vs_all method="LASTZ_NET" ref_genome="pelodiscus_sinensis" against="Testudines" ref_amongst="Sauropsida"/>
-    <one_vs_all method="LASTZ_NET" ref_genome="xenopus_tropicalis" against="Amphibia" ref_amongst="Euteleostomi"/>
-    <one_vs_all method="LASTZ_NET" ref_genome="ornithorhynchus_anatinus" against="Prototheria" ref_amongst="Euteleostomi"/>
-    <one_vs_all method="LASTZ_NET" ref_genome="latimeria_chalumnae" ref_amongst="Euteleostomi">
-      <species_set>
-        <!--Coelacanths and lungfishes -->
-        <taxonomic_group taxon_name="Sarcopterygii"/>
-        <taxonomic_group taxon_name="Tetrapoda" exclude="1"/>
-      </species_set>
-    </one_vs_all>
   </pairwise_alignments>
 
   <multiple_alignments>
+
     <!-- Primates -->
-    <multiple_alignment method="EPO+EPO_EXTENDED">
+    <multiple_alignment method="EPO">
+      <species_set name="primates">
+        <genome name="homo_sapiens"/>
+        <genome name="pongo_abelii" assembly="PPYG2"/>
+        <genome name="chlorocebus_sabaeus" assembly="ChlSab1.1"/>
+        <genome name="macaca_fascicularis" assembly="Macaca_fascicularis_5.0"/>
+        <genome name="nomascus_leucogenys" assembly="Nleu_3.0"/>
+        <genome name="microcebus_murinus" assembly="Mmur_3.0"/>
+        <genome name="gorilla_gorilla" assembly="gorGor4"/>
+        <genome name="pan_paniscus" assembly="panpan1.1"/>
+        <genome name="pan_troglodytes" assembly="Pan_tro_3.0"/>
+        <genome name="papio_anubis" assembly="Panu_3.0"/>
+        <genome name="callithrix_jacchus" assembly="ASM275486v1"/>
+        <genome name="theropithecus_gelada" assembly="Tgel_1.0"/>
+        <genome name="macaca_mulatta" assembly="Mmul_10"/>
+      </species_set>
+    </multiple_alignment>
+    <multiple_alignment method="EPO_EXTENDED">
       <species_set name="primates">
         <taxonomic_group taxon_name="Primates"/>
       </species_set>
     </multiple_alignment>
 
     <!-- Mammals, excl. the mouse strains -->
-    <multiple_alignment method="EPO+EPO_EXTENDED" gerp="1">
+    <multiple_alignment method="EPO">
+      <species_set name="mammals" display_name="eutherian mammals">
+        <genome name="homo_sapiens"/>
+        <genome name="mus_musculus"/>
+        <genome name="pongo_abelii" assembly="PPYG2"/>
+        <genome name="loxodonta_africana" assembly="loxAfr3"/>
+        <genome name="oryctolagus_cuniculus" assembly="OryCun2.0"/>
+        <genome name="canis_lupus_familiaris" assembly="CanFam3.1"/>
+        <genome name="ovis_aries" assembly="Oar_v3.1"/>
+        <genome name="chlorocebus_sabaeus" assembly="ChlSab1.1"/>
+        <genome name="rattus_norvegicus" assembly="Rnor_6.0"/>
+        <genome name="mus_spretus" assembly="SPRET_EiJ_v1"/>
+        <genome name="cavia_aperea" assembly="CavAp1.0"/>
+        <genome name="cavia_porcellus" assembly="Cavpor3.0"/>
+        <genome name="microtus_ochrogaster" assembly="MicOch1.0"/>
+        <genome name="macaca_fascicularis" assembly="Macaca_fascicularis_5.0"/>
+        <genome name="nomascus_leucogenys" assembly="Nleu_3.0"/>
+        <genome name="microcebus_murinus" assembly="Mmur_3.0"/>
+        <genome name="gorilla_gorilla" assembly="gorGor4"/>
+        <genome name="pan_paniscus" assembly="panpan1.1"/>
+        <genome name="sus_scrofa" assembly="Sscrofa11.1"/>
+        <genome name="mus_caroli" assembly="CAROLI_EIJ_v1.1"/>
+        <genome name="mus_pahari" assembly="PAHARI_EIJ_v1.1"/>
+        <genome name="cricetulus_griseus_chok1gshd" assembly="CHOK1GS_HDv1"/>
+        <genome name="pan_troglodytes" assembly="Pan_tro_3.0"/>
+        <genome name="papio_anubis" assembly="Panu_3.0"/>
+        <genome name="capra_hircus" assembly="ARS1"/>
+        <genome name="callithrix_jacchus" assembly="ASM275486v1"/>
+        <genome name="panthera_pardus" assembly="PanPar1.0"/>
+        <genome name="felis_catus" assembly="Felis_catus_9.0"/>
+        <genome name="canis_lupus_dingo" assembly="ASM325472v1"/>
+        <genome name="bos_taurus" assembly="ARS-UCD1.2"/>
+        <genome name="equus_caballus" assembly="EquCab3.0"/>
+        <genome name="theropithecus_gelada" assembly="Tgel_1.0"/>
+        <genome name="marmota_marmota_marmota" assembly="marMar2.1"/>
+        <genome name="peromyscus_maniculatus_bairdii" assembly="HU_Pman_2.1"/>
+        <genome name="bos_taurus_hybrid" assembly="UOA_Angus_1"/>
+        <genome name="bos_indicus_hybrid" assembly="UOA_Brahman_1"/>
+        <genome name="macaca_mulatta" assembly="Mmul_10"/>
+        <genome name="canis_lupus_familiarisbasenji" assembly="Basenji_breed-1.1"/>
+        <genome name="canis_lupus_familiarisgreatdane" assembly="UMICH_Zoey_3.1"/>
+        <genome name="rhinolophus_ferrumequinum" assembly="mRhiFer1_v1.p"/>
+        <genome name="lynx_canadensis" assembly="mLynCan4_v1.p"/>
+        <genome name="bos_grunniens" assembly="LU_Bosgru_v3.0"/>
+        <genome name="catagonus_wagneri" assembly="CatWag_v2_BIUU_UCD"/>
+        <genome name="suricata_suricatta" assembly="meerkat_22Aug2017_6uvM2_HiC"/>
+        <genome name="physeter_catodon" assembly="ASM283717v2"/>
+        <genome name="camelus_dromedarius" assembly="CamDro2"/>
+        <genome name="panthera_leo" assembly="PanLeo1.0"/>
+        <genome name="delphinapterus_leucas" assembly="ASM228892v3"/>
+        <genome name="ursus_thibetanus_thibetanus" assembly="ASM966005v1"/>
+        <genome name="zalophus_californianus" assembly="mZalCal1.pri"/>
+        <genome name="cervus_hanglu_yarkandensis" assembly="CEY_v1"/>
+        <genome name="ovis_aries_rambouillet" assembly="Oar_rambouillet_v1.0"/>
+        <genome name="monodon_monoceros" assembly="NGI_Narwhal_1"/>
+        <genome name="balaenoptera_musculus" assembly="mBalMus1.v2"/>
+        <genome name="phocoena_sinus" assembly="mPhoSin1.pri"/>
+        <genome name="capra_hircus_blackbengal" assembly="CVASU_BBG_1.0"/>
+        <genome name="sciurus_vulgaris" assembly="mSciVul1.1"/>
+      </species_set>
+    </multiple_alignment>
+    <multiple_alignment method="EPO_EXTENDED" gerp="1">
       <species_set name="mammals" display_name="eutherian mammals" in_collection="default">
         <taxonomic_group taxon_name="Eutheria"/>
       </species_set>
     </multiple_alignment>
 
     <!-- Sauropsids -->
-    <multiple_alignment method="EPO+EPO_EXTENDED" gerp="1">
+    <multiple_alignment method="EPO">
+      <species_set name="sauropsids">
+        <genome name="gallus_gallus"/>
+        <genome name="anolis_carolinensis" assembly="AnoCar2.0"/>
+        <genome name="meleagris_gallopavo" assembly="Turkey_2.01"/>
+        <genome name="serinus_canaria" assembly="SCA1"/>
+        <genome name="crocodylus_porosus" assembly="CroPor_comp1"/>
+        <genome name="parus_major" assembly="Parus_major1.1"/>
+        <genome name="cyanistes_caeruleus" assembly="cyaCae2"/>
+        <genome name="manacus_vitellinus" assembly="ASM171598v2"/>
+        <genome name="melopsittacus_undulatus" assembly="Melopsittacus_undulatus_6.3"/>
+        <genome name="anas_platyrhynchos_platyrhynchos" assembly="CAU_duck1.0"/>
+        <genome name="junco_hyemalis" assembly="ASM382977v1"/>
+        <genome name="coturnix_japonica" assembly="Coturnix_japonica_2.0"/>
+        <genome name="salvator_merianae" assembly="HLtupMer3"/>
+        <genome name="numida_meleagris" assembly="NumMel1.0"/>
+        <genome name="amazona_collaria" assembly="ASM394721v1"/>
+        <genome name="pseudonaja_textilis" assembly="EBS10Xv2-PRI"/>
+        <genome name="erythrura_gouldiae" assembly="GouldianFinch"/>
+        <genome name="phasianus_colchicus" assembly="ASM414374v1"/>
+        <genome name="aquila_chrysaetos_chrysaetos" assembly="bAquChr1.2"/>
+        <genome name="strigops_habroptila" assembly="bStrHab1_v1.p"/>
+        <genome name="athene_cunicularia" assembly="athCun1"/>
+        <genome name="taeniopygia_guttata" assembly="bTaeGut1_v1.p"/>
+        <genome name="terrapene_carolina_triunguis" assembly="T_m_triunguis-2.0"/>
+        <genome name="varanus_komodoensis" assembly="ASM479886v1"/>
+        <genome name="podarcis_muralis" assembly="PodMur_1.0"/>
+        <genome name="stachyris_ruficeps" assembly="ASM869450v1"/>
+        <genome name="gopherus_evgoodei" assembly="rGopEvg1_v1.p"/>
+        <genome name="camarhynchus_parvulus" assembly="STF_HiC"/>
+        <genome name="anas_platyrhynchos" assembly="ASM874695v1"/>
+        <genome name="chelydra_serpentina" assembly="Chelydra_serpentina-1.0"/>
+        <genome name="cairina_moschata_domestica" assembly="CaiMos1.0"/>
+        <genome name="catharus_ustulatus" assembly="bCatUst1.pri"/>
+        <genome name="naja_naja" assembly="Nana_v5"/>
+        <genome name="malurus_cyaneus_samueli" assembly="mCya_1.0"/>
+        <genome name="otus_sunia" assembly="OtuSun1.0"/>
+        <genome name="falco_tinnunculus" assembly="FalTin1.0"/>
+      </species_set>
+    </multiple_alignment>
+    <multiple_alignment method="EPO_EXTENDED" gerp="1">
       <species_set name="sauropsids">
         <taxonomic_group taxon_name="Sauropsida"/>
       </species_set>
     </multiple_alignment>
 
     <!-- Fishes -->
-    <multiple_alignment method="EPO+EPO_EXTENDED" gerp="1">
+    <multiple_alignment method="EPO">
+      <species_set name="fish">
+        <genome name="danio_rerio"/>
+        <genome name="gasterosteus_aculeatus" assembly="BROADS1"/>
+        <genome name="tetraodon_nigroviridis" assembly="TETRAODON8"/>
+        <genome name="lepisosteus_oculatus" assembly="LepOcu1"/>
+        <genome name="amphiprion_percula" assembly="Nemo_v1"/>
+        <genome name="anabas_testudineus" assembly="fAnaTes1.1"/>
+        <genome name="astatotilapia_calliptera" assembly="fAstCal1.2"/>
+        <genome name="astyanax_mexicanus" assembly="Astyanax_mexicanus-2.0"/>
+        <genome name="cynoglossus_semilaevis" assembly="Cse_v1.0"/>
+        <genome name="gambusia_affinis" assembly="ASM309773v1"/>
+        <genome name="ictalurus_punctatus" assembly="IpCoco_1.2"/>
+        <genome name="mastacembelus_armatus" assembly="fMasArm1.1"/>
+        <genome name="maylandia_zebra" assembly="M_zebra_UMD2a"/>
+        <genome name="mola_mola" assembly="ASM169857v1"/>
+        <genome name="oryzias_latipes_hni" assembly="ASM223471v1"/>
+        <genome name="oryzias_latipes_hsok" assembly="ASM223469v1"/>
+        <genome name="oryzias_melastigma" assembly="Om_v0.7.RACA"/>
+        <genome name="poecilia_reticulata" assembly="Guppy_female_1.0_MT"/>
+        <genome name="scophthalmus_maximus" assembly="ASM318616v1"/>
+        <genome name="seriola_dumerili" assembly="Sdu_1.0"/>
+        <genome name="xiphophorus_couchianus" assembly="Xiphophorus_couchianus-4.0.1"/>
+        <genome name="xiphophorus_maculatus" assembly="X_maculatus-5.0-male"/>
+        <genome name="oryzias_latipes" assembly="ASM223467v1"/>
+        <genome name="parambassis_ranga" assembly="fParRan2.1"/>
+        <genome name="cottoperca_gobio" assembly="fCotGob3.1"/>
+        <genome name="denticeps_clupeoides" assembly="fDenClu1.1"/>
+        <genome name="gouania_willdenowi" assembly="fGouWil2.1"/>
+        <genome name="larimichthys_crocea" assembly="L_crocea_2.0"/>
+        <genome name="erpetoichthys_calabaricus" assembly="fErpCal1.1"/>
+        <genome name="clupea_harengus" assembly="Ch_v2.0.2"/>
+        <genome name="betta_splendens" assembly="fBetSpl5.2"/>
+        <genome name="sparus_aurata" assembly="fSpaAur1.1"/>
+        <genome name="salmo_salar" assembly="ICSASG_v2"/>
+        <genome name="sphaeramia_orbicularis" assembly="fSphaOr1.1"/>
+        <genome name="salarias_fasciatus" assembly="fSalaFa1.1"/>
+        <genome name="echeneis_naucrates" assembly="fEcheNa1.1"/>
+        <genome name="takifugu_rubripes" assembly="fTakRub1.2"/>
+        <genome name="scleropages_formosus" assembly="fSclFor1.1"/>
+        <genome name="oreochromis_niloticus" assembly="O_niloticus_UMD_NMBU"/>
+        <genome name="myripristis_murdjan" assembly="fMyrMur1.1"/>
+        <genome name="salmo_trutta" assembly="fSalTru1.1"/>
+        <genome name="oryzias_javanicus" assembly="OJAV_1.1"/>
+        <genome name="oncorhynchus_tshawytscha" assembly="Otsh_v1.0"/>
+        <genome name="carassius_auratus" assembly="ASM336829v1"/>
+        <genome name="oncorhynchus_mykiss" assembly="Omyk_1.0"/>
+        <genome name="esox_lucius" assembly="Eluc_v4"/>
+        <genome name="dicentrarchus_labrax" assembly="seabass_V1.0"/>
+        <genome name="cyclopterus_lumpus" assembly="fCycLum1.pri"/>
+        <genome name="nothobranchius_furzeri" assembly="Nfu_20140520"/>
+        <genome name="oncorhynchus_kisutch" assembly="Okis_V2"/>
+      </species_set>
+    </multiple_alignment>
+    <multiple_alignment method="EPO_EXTENDED" gerp="1">
       <species_set name="fish">
         <taxonomic_group taxon_name="Actinopterygii"/>
       </species_set>
     </multiple_alignment>
 
-    <!-- Pigs -->
+    <!-- Pig breeds -->
     <!-- Special case: base EPO should remain internal/unreleased, but should still be updated -->
     <multiple_alignment method="EPO" no_release="1">
       <species_set name="pig_breeds" display_name="pig breeds">
@@ -141,12 +317,106 @@
         <taxonomic_group taxon_name="Eutheria"/> <!-- everything in the collection -->
       </species_set>
     </multiple_alignment>
-    
 
     <!-- Amniotes, excl. mouse strains -->
+    <!-- NB: this MSA can only stay the same or decrease in number of species -->
     <multiple_alignment method="PECAN" gerp="1">
-      <species_set name="amniotes" display_name="amniota vertebrates" in_collection="default">
-        <taxonomic_group taxon_name="Amniota" only_good_for_alignment="1"/>
+      <species_set name="amniotes" display_name="amniota vertebrates">
+        <genome name="homo_sapiens" assembly="GRCh38"/>
+        <genome name="gallus_gallus" assembly="GRCg6a"/>
+        <genome name="pongo_abelii" assembly="PPYG2"/>
+        <genome name="loxodonta_africana" assembly="loxAfr3"/>
+        <genome name="oryctolagus_cuniculus" assembly="OryCun2.0"/>
+        <genome name="anolis_carolinensis" assembly="AnoCar2.0"/>
+        <genome name="meleagris_gallopavo" assembly="Turkey_2.01"/>
+        <genome name="mus_musculus" assembly="GRCm38"/>
+        <genome name="canis_lupus_familiaris" assembly="CanFam3.1"/>
+        <genome name="ovis_aries" assembly="Oar_v3.1"/>
+        <genome name="chlorocebus_sabaeus" assembly="ChlSab1.1"/>
+        <genome name="rattus_norvegicus" assembly="Rnor_6.0"/>
+        <genome name="mus_spretus" assembly="SPRET_EiJ_v1"/>
+        <genome name="cavia_aperea" assembly="CavAp1.0"/>
+        <genome name="cavia_porcellus" assembly="Cavpor3.0"/>
+        <genome name="microtus_ochrogaster" assembly="MicOch1.0"/>
+        <genome name="macaca_fascicularis" assembly="Macaca_fascicularis_5.0"/>
+        <genome name="nomascus_leucogenys" assembly="Nleu_3.0"/>
+        <genome name="microcebus_murinus" assembly="Mmur_3.0"/>
+        <genome name="gorilla_gorilla" assembly="gorGor4"/>
+        <genome name="pan_paniscus" assembly="panpan1.1"/>
+        <genome name="sus_scrofa" assembly="Sscrofa11.1"/>
+        <genome name="mus_caroli" assembly="CAROLI_EIJ_v1.1"/>
+        <genome name="mus_pahari" assembly="PAHARI_EIJ_v1.1"/>
+        <genome name="cricetulus_griseus_chok1gshd" assembly="CHOK1GS_HDv1"/>
+        <genome name="pan_troglodytes" assembly="Pan_tro_3.0"/>
+        <genome name="papio_anubis" assembly="Panu_3.0"/>
+        <genome name="capra_hircus" assembly="ARS1"/>
+        <genome name="callithrix_jacchus" assembly="ASM275486v1"/>
+        <genome name="panthera_pardus" assembly="PanPar1.0"/>
+        <genome name="felis_catus" assembly="Felis_catus_9.0"/>
+        <genome name="canis_lupus_dingo" assembly="ASM325472v1"/>
+        <genome name="bos_taurus" assembly="ARS-UCD1.2"/>
+        <genome name="equus_caballus" assembly="EquCab3.0"/>
+        <genome name="serinus_canaria" assembly="SCA1"/>
+        <genome name="crocodylus_porosus" assembly="CroPor_comp1"/>
+        <genome name="parus_major" assembly="Parus_major1.1"/>
+        <genome name="cyanistes_caeruleus" assembly="cyaCae2"/>
+        <genome name="manacus_vitellinus" assembly="ASM171598v2"/>
+        <genome name="melopsittacus_undulatus" assembly="Melopsittacus_undulatus_6.3"/>
+        <genome name="anas_platyrhynchos_platyrhynchos" assembly="CAU_duck1.0"/>
+        <genome name="junco_hyemalis" assembly="ASM382977v1"/>
+        <genome name="theropithecus_gelada" assembly="Tgel_1.0"/>
+        <genome name="coturnix_japonica" assembly="Coturnix_japonica_2.0"/>
+        <genome name="marmota_marmota_marmota" assembly="marMar2.1"/>
+        <genome name="salvator_merianae" assembly="HLtupMer3"/>
+        <genome name="numida_meleagris" assembly="NumMel1.0"/>
+        <genome name="peromyscus_maniculatus_bairdii" assembly="HU_Pman_2.1"/>
+        <genome name="bos_taurus_hybrid" assembly="UOA_Angus_1"/>
+        <genome name="bos_indicus_hybrid" assembly="UOA_Brahman_1"/>
+        <genome name="monodelphis_domestica" assembly="ASM229v1"/>
+        <genome name="macaca_mulatta" assembly="Mmul_10"/>
+        <genome name="amazona_collaria" assembly="ASM394721v1"/>
+        <genome name="canis_lupus_familiarisbasenji" assembly="Basenji_breed-1.1"/>
+        <genome name="pseudonaja_textilis" assembly="EBS10Xv2-PRI"/>
+        <genome name="erythrura_gouldiae" assembly="GouldianFinch"/>
+        <genome name="canis_lupus_familiarisgreatdane" assembly="UMICH_Zoey_3.1"/>
+        <genome name="rhinolophus_ferrumequinum" assembly="mRhiFer1_v1.p"/>
+        <genome name="phasianus_colchicus" assembly="ASM414374v1"/>
+        <genome name="lynx_canadensis" assembly="mLynCan4_v1.p"/>
+        <genome name="aquila_chrysaetos_chrysaetos" assembly="bAquChr1.2"/>
+        <genome name="strigops_habroptila" assembly="bStrHab1_v1.p"/>
+        <genome name="bos_grunniens" assembly="LU_Bosgru_v3.0"/>
+        <genome name="athene_cunicularia" assembly="athCun1"/>
+        <genome name="catagonus_wagneri" assembly="CatWag_v2_BIUU_UCD"/>
+        <genome name="suricata_suricatta" assembly="meerkat_22Aug2017_6uvM2_HiC"/>
+        <genome name="physeter_catodon" assembly="ASM283717v2"/>
+        <genome name="taeniopygia_guttata" assembly="bTaeGut1_v1.p"/>
+        <genome name="terrapene_carolina_triunguis" assembly="T_m_triunguis-2.0"/>
+        <genome name="camelus_dromedarius" assembly="CamDro2"/>
+        <genome name="varanus_komodoensis" assembly="ASM479886v1"/>
+        <genome name="podarcis_muralis" assembly="PodMur_1.0"/>
+        <genome name="stachyris_ruficeps" assembly="ASM869450v1"/>
+        <genome name="panthera_leo" assembly="PanLeo1.0"/>
+        <genome name="gopherus_evgoodei" assembly="rGopEvg1_v1.p"/>
+        <genome name="ornithorhynchus_anatinus" assembly="mOrnAna1.p.v1"/>
+        <genome name="delphinapterus_leucas" assembly="ASM228892v3"/>
+        <genome name="camarhynchus_parvulus" assembly="STF_HiC"/>
+        <genome name="anas_platyrhynchos" assembly="ASM874695v1"/>
+        <genome name="ursus_thibetanus_thibetanus" assembly="ASM966005v1"/>
+        <genome name="chelydra_serpentina" assembly="Chelydra_serpentina-1.0"/>
+        <genome name="zalophus_californianus" assembly="mZalCal1.pri"/>
+        <genome name="cervus_hanglu_yarkandensis" assembly="CEY_v1"/>
+        <genome name="cairina_moschata_domestica" assembly="CaiMos1.0"/>
+        <genome name="catharus_ustulatus" assembly="bCatUst1.pri"/>
+        <genome name="naja_naja" assembly="Nana_v5"/>
+        <genome name="ovis_aries_rambouillet" assembly="Oar_rambouillet_v1.0"/>
+        <genome name="malurus_cyaneus_samueli" assembly="mCya_1.0"/>
+        <genome name="monodon_monoceros" assembly="NGI_Narwhal_1"/>
+        <genome name="otus_sunia" assembly="OtuSun1.0"/>
+        <genome name="balaenoptera_musculus" assembly="mBalMus1.v2"/>
+        <genome name="phocoena_sinus" assembly="mPhoSin1.pri"/>
+        <genome name="falco_tinnunculus" assembly="FalTin1.0"/>
+        <genome name="capra_hircus_blackbengal" assembly="CVASU_BBG_1.0"/>
+        <genome name="sciurus_vulgaris" assembly="mSciVul1.1"/>
       </species_set>
     </multiple_alignment>
 
@@ -185,11 +455,9 @@
   <assembly_patches>
     <genome name="homo_sapiens"/>
     <genome name="mus_musculus"/>
+    <genome name="gallus_gallus"/>
+    <genome name="danio_rerio"/>
   </assembly_patches>
-
-  <families>
-    <family collection="default"/>
-  </families>
 
   <gene_trees>
     <protein_trees collection="default"/>

--- a/conf/vertebrates/mlss_conf.xml
+++ b/conf/vertebrates/mlss_conf.xml
@@ -39,15 +39,12 @@
     <!-- NB: we have a CACTUS alignment for mouse strains and an EPO Extended MSA for pig breeds -->
     <one_vs_all method="LASTZ_NET" ref_genome="homo_sapiens">
       <species_set in_collection="default">
-        <taxonomic_group taxon_name="Mammalia"/>
+        <taxonomic_group taxon_name="Eutheria"/>
         <!-- Remove all the taxa that have a better reference than human -->
         <taxonomic_group taxon_name="Rodentia" exclude="1"/>
-        <taxonomic_group taxon_name="Feliformia" exclude="1"/>
-        <taxonomic_group taxon_name="Caniformia" exclude="1"/>
+        <taxonomic_group taxon_name="Carnivora" exclude="1"/>
         <taxonomic_group taxon_name="Perissodactyla" exclude="1"/>
         <taxonomic_group taxon_name="Artiodactyla" exclude="1"/>
-        <taxonomic_group taxon_name="Metatheria" exclude="1"/>
-        <taxonomic_group taxon_name="Prototheria" exclude="1"/>
       </species_set>
     </one_vs_all>
 
@@ -57,11 +54,7 @@
       </species_set>
     </one_vs_all>
 
-    <one_vs_all method="LASTZ_NET" ref_genome="felis_catus" against="Feliformia"/>
-
-    <one_vs_all method="LASTZ_NET" ref_genome="canis_lupus_familiaris" against="Caniformia"/>
-
-    <one_vs_all method="LASTZ_NET" ref_genome="equus_caballus" against="Perissodactyla"/>
+    <one_vs_all method="LASTZ_NET" ref_genome="canis_lupus_familiaris" against="Carnivora"/>
 
     <one_vs_all method="LASTZ_NET" ref_genome="bos_taurus">
       <species_set in_collection="default">
@@ -69,10 +62,15 @@
       </species_set>
     </one_vs_all>
 
+    <one_vs_all method="LASTZ_NET" ref_genome="equus_caballus" against="Perissodactyla"/>
     <one_vs_all method="LASTZ_NET" ref_genome="sus_scrofa" against="Sus"/>
-    <one_vs_all method="LASTZ_NET" ref_genome="monodelphis_domestica" against="Metatheria"/>
-    <one_vs_all method="LASTZ_NET" ref_genome="ornithorhynchus_anatinus" against="Prototheria"/>
-    <pairwise_alignment method="LASTZ_NET" ref_genome="monodelphis_domestica" target_genome="ornithorhynchus_anatinus"/>
+
+    <one_vs_all method="LASTZ_NET" ref_genome="monodelphis_domestica">
+      <species_set in_collection="default">
+        <taxonomic_group taxon_name="Metatheria"/>
+        <taxonomic_group taxon_name="Prototheria"/>
+      </species_set>
+    </one_vs_all>
 
     <!-- Sauropsids -->
     <one_vs_all method="LASTZ_NET" ref_genome="gallus_gallus">
@@ -80,11 +78,11 @@
         <taxonomic_group taxon_name="Sarcopterygii"/>
         <taxonomic_group taxon_name="Mammalia" exclude="1"/>
         <!-- Remove all the taxa that have a better reference than chicken -->
-        <taxonomic_group taxon_name="Iguania" exclude="1"/>
+        <taxonomic_group taxon_name="Amphibia" exclude="1"/>
       </species_set>
     </one_vs_all>
 
-    <one_vs_all method="LASTZ_NET" ref_genome="anolis_carolinensis" against="Iguania"/>
+    <one_vs_all method="LASTZ_NET" ref_genome="xenopus_tropicalis" against="Amphibia"/>
 
     <!-- Fish -->
     <one_vs_all method="LASTZ_NET" ref_genome="danio_rerio">
@@ -103,7 +101,6 @@
     </one_vs_all>
 
     <!-- Early vertebrates and other chordates -->
-    <one_vs_all method="LASTZ_NET" ref_genome="xenopus_tropicalis" against="Amphibia"/>
     <one_vs_all method="LASTZ_NET" ref_genome="ciona_intestinalis" against="Ciona" ref_amongst="Cyclostomata"/>
     <one_vs_all method="LASTZ_NET" ref_genome="petromyzon_marinus" against="Cyclostomata" ref_amongst="Ciona"/>
 
@@ -146,7 +143,7 @@
         <genome name="canis_lupus_familiaris" assembly="CanFam3.1"/>
         <genome name="ovis_aries" assembly="Oar_v3.1"/>
         <genome name="chlorocebus_sabaeus" assembly="ChlSab1.1"/>
-        <genome name="rattus_norvegicus" assembly="Rnor_6.0"/>
+        <genome name="rattus_norvegicus"/>
         <genome name="mus_spretus" assembly="SPRET_EiJ_v1"/>
         <genome name="cavia_aperea" assembly="CavAp1.0"/>
         <genome name="cavia_porcellus" assembly="Cavpor3.0"/>
@@ -167,7 +164,7 @@
         <genome name="panthera_pardus" assembly="PanPar1.0"/>
         <genome name="felis_catus" assembly="Felis_catus_9.0"/>
         <genome name="canis_lupus_dingo" assembly="ASM325472v1"/>
-        <genome name="bos_taurus" assembly="ARS-UCD1.2"/>
+        <genome name="bos_taurus"/>
         <genome name="equus_caballus" assembly="EquCab3.0"/>
         <genome name="theropithecus_gelada" assembly="Tgel_1.0"/>
         <genome name="marmota_marmota_marmota" assembly="marMar2.1"/>
@@ -275,7 +272,7 @@
         <genome name="seriola_dumerili" assembly="Sdu_1.0"/>
         <genome name="xiphophorus_couchianus" assembly="Xiphophorus_couchianus-4.0.1"/>
         <genome name="xiphophorus_maculatus" assembly="X_maculatus-5.0-male"/>
-        <genome name="oryzias_latipes" assembly="ASM223467v1"/>
+        <genome name="oryzias_latipes"/>
         <genome name="parambassis_ranga" assembly="fParRan2.1"/>
         <genome name="cottoperca_gobio" assembly="fCotGob3.1"/>
         <genome name="denticeps_clupeoides" assembly="fDenClu1.1"/>

--- a/conf/vertebrates/mlss_conf.xml
+++ b/conf/vertebrates/mlss_conf.xml
@@ -86,12 +86,12 @@
 
     <one_vs_all method="LASTZ_NET" ref_genome="anolis_carolinensis" against="Iguania"/>
 
-    <!-- Fishes -->
+    <!-- Fish -->
     <one_vs_all method="LASTZ_NET" ref_genome="danio_rerio">
       <species_set>
         <taxonomic_group taxon_name="Chordata"/>
         <taxonomic_group taxon_name="Euteleostomi" exclude="1"/>
-        <taxonomic_group taxon_name="Cyclostoma" exclude="1"/>
+        <taxonomic_group taxon_name="Cyclostomata" exclude="1"/>
         <taxonomic_group taxon_name="Ciona" exclude="1"/>
       </species_set>
     </one_vs_all>
@@ -250,7 +250,7 @@
       </species_set>
     </multiple_alignment>
 
-    <!-- Fishes -->
+    <!-- Fish -->
     <multiple_alignment method="EPO">
       <species_set name="fish">
         <genome name="danio_rerio"/>

--- a/scripts/pipeline/compara_db_config.rng
+++ b/scripts/pipeline/compara_db_config.rng
@@ -52,6 +52,9 @@
         <element name="genome" blockly:blockName="Genome">
           <attribute name="name" blockly:blockName="Name"/>
           <optional>
+            <attribute name="assembly" blockly:blockName="Assembly"/>
+          </optional>
+          <optional>
             <attribute name="exclude" blockly:blockName="Exclude those genomes">
               <choice>
                 <value blockly:blockName="Yes">1</value>
@@ -222,6 +225,9 @@
           <oneOrMore>
             <element name="genome" blockly:blockName="Genome">
               <attribute name="name" blockly:blockName="Name"/>
+              <optional>
+                <attribute name="assembly" blockly:blockName="Assembly"/>
+              </optional>
             </element>
           </oneOrMore>
         </element>
@@ -232,6 +238,9 @@
           <oneOrMore>
             <element name="genome" blockly:blockName="Genome">
               <attribute name="name" blockly:blockName="Name"/>
+              <optional>
+                <attribute name="assembly" blockly:blockName="Assembly"/>
+              </optional>
             </element>
           </oneOrMore>
         </element>

--- a/scripts/pipeline/create_all_mlss.pl
+++ b/scripts/pipeline/create_all_mlss.pl
@@ -181,8 +181,13 @@ my @mlsss;
 sub find_genome_from_xml_node_attribute {
     my ($xml_node, $attribute_name, $assembly_name) = @_;
     my $species_name = $xml_node->getAttribute($attribute_name);
-    my $species_assembly = $xml_node->getAttribute($assembly_name) if (defined $assembly_name && $xml_node->hasAttribute($assembly_name));
-    my $gdb = $genome_dba->fetch_by_name_assembly($species_name, $species_assembly) || throw("Cannot find $species_name in the available list of GenomeDBs");
+    my $gdb;
+    if (defined $assembly_name && $xml_node->hasAttribute($assembly_name)) {
+        my $species_assembly = $xml_node->getAttribute($assembly_name);
+        $gdb = $genome_dba->fetch_by_name_assembly($species_name, $species_assembly) || throw("Cannot find $species_name (assembly $species_assembly) in the available list of GenomeDBs");
+    } else {
+        $gdb = $genome_dba->fetch_by_name_assembly($species_name) || throw("Cannot find $species_name in the available list of GenomeDBs");
+    }
     die "Cannot find any current genomes matching '$species_name'. Please check that this name is still correct" unless (defined $assembly_name || $gdb->is_current);
     return $gdb;
 }


### PR DESCRIPTION
## Description

Update MLSS config XML file for vertebrates to match the coming changes in our frozen production.

**Related JIRA tickets:**
- ENSCOMPARASW-3329
- ENSCOMPARASW-3071

## Overview of changes
#### Change 1
- Removed `Mercator-Pecan` and `Families` MLSSs.

#### Change 2
- Selected a single reference species per genome for LastZ (based on the best LastZ alignment chosen in each EPO Extended for e101).

#### Change 3
- Accept the species assembly too to define a specific genome version to be included in the EPOs and Mercator-Pecan (if updated, these genomes should be removed). Leave the references without assembly for the EPOs so they will be marked to be rerun automatically.

## Testing
`create_all_mlss.pl` script run successfully (in dry mode).