### PR TITLE
updated plant reference genomes for pairwise genome alignments

### DIFF
--- a/conf/plants/mlss_conf.xml
+++ b/conf/plants/mlss_conf.xml
@@ -36,14 +36,14 @@
         </species_set>
     </all_vs_all> -->
 
-    <!-- Triticeae all v all, DFW work, excl. T.urartu -->
+    <!-- Triticeae all v all, DFW work, excl. T.urartu, downscaling
     <all_vs_all method="LASTZ_NET">
         <species_set>
-          <taxonomic_group taxon_name="Triticeae"/>
-          <!-- Because not k-mer masked -->
+          <taxonomic_group taxon_name="Triticeae"/> -->
+          <!-- Because not k-mer masked 
           <genome name="triticum_urartu" exclude="1" />
         </species_set>
-    </all_vs_all>
+    </all_vs_all> --> 
 
   </pairwise_alignments>
 
@@ -68,7 +68,7 @@
   <!-- wheat, DFW work -->
   <self_alignments>
     <genome name="triticum_aestivum"/>
-    <genome name="triticum_dicoccoides"/>
+    <!-- <genome name="triticum_dicoccoides"/> downscaling -->
   </self_alignments>
 
   <gene_trees>


### PR DESCRIPTION
## Description

As requested by @JAlvarezJarreta , we have updated the reference genomes for plant pairwise genome alignments (master branch). Now there's only one for all land plants with the exception of some wheat and rice tasks related to funded projects DFW & PanOryza

As we discussed with @dthybert, the DFW grant is still live, as will the PanOryza grant sometime after the summer: https://www.ebi.ac.uk/seqdb/confluence/display/EnsGen/PanOryza
That means we will have to do new wheat & rice tasks in the next 18 months, mostly gene trees among cultivars. 

We comment out the wheat alignments for the time being, but we cannot rule them out completely for the next couple of years @gnaamati
