### PR TITLE
Plants downscaling

### DIFF
--- a/conf/plants/mlss_conf.xml
+++ b/conf/plants/mlss_conf.xml
@@ -19,6 +19,7 @@
     </collection>
 
     <!-- Rice species tree including nearest grass relative -->
+    <!-- used to compute branch lengths for EPO below -->
     <collection name="rice-with-outgroup" no_release="1">
       <taxonomic_group taxon_name="Oryza"/>
       <genome name="leersia_perrieri"/>

--- a/conf/plants/mlss_conf.xml
+++ b/conf/plants/mlss_conf.xml
@@ -7,7 +7,7 @@
     <!-- All species except the triticum aestivum strains -->
     <collection name="default">
       <taxonomic_group taxon_name="Viridiplantae">
-        <!-- But exclude everything below triticum_aestivum -->
+        <!-- But exclude everything below triticum_aestivum ie cultivars, etc-->
         <ref_for_taxon name="triticum_aestivum"/>
       </taxonomic_group>
       <taxonomic_group taxon_name="Rhodophyta"/>
@@ -28,48 +28,29 @@
 
   <pairwise_alignments>
 
-    <!-- First, our top 3 species, which are references for all land plants -->
+    <!-- By default use Arabidopsis thaliana for land plants -->
     <one_vs_all method="LASTZ_NET" ref_genome="arabidopsis_thaliana">
-      <species_set in_collection="default">
+      <species_set>
         <taxonomic_group taxon_name="Embryophyta"/>
-      </species_set>
-    </one_vs_all>
-    <one_vs_all method="LASTZ_NET" ref_genome="vitis_vinifera">
-      <species_set in_collection="default">
-        <taxonomic_group taxon_name="Embryophyta"/>
-      </species_set>
-    </one_vs_all>
-    <one_vs_all method="LASTZ_NET" ref_genome="oryza_sativa">
-      <species_set in_collection="default">
-        <taxonomic_group taxon_name="Embryophyta"/>
+        <taxonomic_group taxon_name="Asterids" exclude="1"/>
+        <taxonomic_group taxon_name="Fabids" exclude="1"/>
+        <taxonomic_group taxon_name="Liliopsida" exclude="1"/>
       </species_set>
     </one_vs_all>
 
-    <!-- More reference species, but within smaller clades -->
-    <one_vs_all method="LASTZ_NET" ref_genome="medicago_truncatula" against="fabids"/>
-    <one_vs_all method="LASTZ_NET" ref_genome="brachypodium_distachyon">
-      <species_set in_collection="default">
-        <taxonomic_group taxon_name="Triticeae"/>
-      </species_set>
-    </one_vs_all>
-    <one_vs_all method="LASTZ_NET" ref_genome="solanum_lycopersicum" against="asterids"/>
-    <one_vs_all method="LASTZ_NET" ref_genome="theobroma_cacao_criollo" against="malvids"/>
+    <!-- Reference species for specific clades -->
+    <one_vs_all method="LASTZ_NET" ref_genome="solanum_lycopersicum" against="Asterids"/>
+    <one_vs_all method="LASTZ_NET" ref_genome="medicago_truncatula" against="Fabids"/>
+    <one_vs_all method="LASTZ_NET" ref_genome="oryza_sativa" against="Liliopsida"/>
 
-    <!-- Vigna all v all -->
+    <!-- Triticeae all v all, DFW work, downscaling
     <all_vs_all method="LASTZ_NET">
       <species_set in_collection="default">
-        <taxonomic_group taxon_name="Vigna"/>
-      </species_set>
-    </all_vs_all>
-
-    <!-- Triticeae all v all, excl. T.urartu -->
-    <all_vs_all method="LASTZ_NET">
-      <species_set in_collection="default">
-        <taxonomic_group taxon_name="Triticeae"/>
-        <!-- Because not k-mer masked -->
+        <taxonomic_group taxon_name="Triticeae"/> -->
+        <!-- Because not k-mer masked 
         <genome name="triticum_urartu" exclude="1" />
       </species_set>
-    </all_vs_all>
+    </all_vs_all> -->
 
   </pairwise_alignments>
 
@@ -90,6 +71,7 @@
 
   </multiple_alignments>
 
+  <!-- DFW work -->
   <self_alignments>
     <genome name="triticum_aestivum"/>
     <genome name="triticum_dicoccoides"/>

--- a/scripts/pipeline/compara_db_config.rng
+++ b/scripts/pipeline/compara_db_config.rng
@@ -114,6 +114,14 @@
         <element name="collections" blockly:blockName="Collections">
           <oneOrMore>
             <element name="collection" blockly:blockName="Collection definition">
+              <optional>
+                <attribute name="no_release" blockly:blockName="No release">
+                  <choice>
+                    <value blockly:blockName="Yes">1</value>
+                    <value blockly:blockName="No">0</value>
+                  </choice>
+                </attribute>
+              </optional>
               <ref name="new_named_species_set"/>
             </element>
           </oneOrMore>


### PR DESCRIPTION
## Description

As requested by @JAlvarezJarreta , we have updated the reference genomes for plant pairwise genome alignments. Now there's only one for all land plants.

As we discussed with @dthybert, the DFW grant is still live, as will the PanOryza grant sometime after the summer: https://www.ebi.ac.uk/seqdb/confluence/display/EnsGen/PanOryza

That means we will have to do new wheat & rice tasks in the next 18 months, mostly cultivar gene trees. We comment out the wheat alignments for the time being, but we cannot rule them out completely for the next couple of years @gnaamati 