### PR TITLE
Datacheck analysis added to LoadMembers

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
@@ -514,9 +514,24 @@ sub core_pipeline_analyses {
                 mode            => 'members_globally',
             },
             %hc_analysis_params,
-            -flow_into          => WHEN(
-                            '#load_uniprot_members#' => 'save_uniprot_release_date',
-                            ),
+            -flow_into          => {
+                '2->A' => WHEN( '#load_uniprot_members#' => 'save_uniprot_release_date' ),
+                'A->1' => [ 'dc_members_enums' ],
+            },
+        },
+
+        {   -logic_name      => 'dc_members_enums',
+            -module          => 'Bio::EnsEMBL::Compara::RunnableDB::RunDataChecks',
+            -parameters      => {
+                'datacheck_names'  => ['BlankEnums'],
+                'work_dir'         => $self->o('work_dir'),
+                'history_file'     => '#work_dir#/datacheck.compara_load_members.history.json',
+                'output_file'      => '#work_dir#/datacheck.compara_load_members.tap.txt',
+                'failures_fatal'   => 1,
+                'pdbname'          => $self->o('pipeline_name'),
+                'dbtype'           => 'compara',
+            },
+            -max_retry_count => 0,
         },
 
 # ---------------------------------------------[load UNIPROT members for Family pipeline]------------------------------------------------------------

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
@@ -516,11 +516,11 @@ sub core_pipeline_analyses {
             %hc_analysis_params,
             -flow_into          => {
                 '2->A' => WHEN( '#load_uniprot_members#' => 'save_uniprot_release_date' ),
-                'A->1' => [ 'dc_sequences_and_enums' ],
+                'A->1' => [ 'datachecks' ],
             },
         },
 
-        {   -logic_name      => 'dc_sequences_and_enums',
+        {   -logic_name      => 'datachecks',
             -module          => 'Bio::EnsEMBL::Compara::RunnableDB::RunDataChecks',
             -parameters      => {
                 'datacheck_names'  => ['BlankEnums', 'CheckSequenceTable'],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
@@ -516,14 +516,14 @@ sub core_pipeline_analyses {
             %hc_analysis_params,
             -flow_into          => {
                 '2->A' => WHEN( '#load_uniprot_members#' => 'save_uniprot_release_date' ),
-                'A->1' => [ 'dc_members_enums' ],
+                'A->1' => [ 'dc_sequences_and_enums' ],
             },
         },
 
-        {   -logic_name      => 'dc_members_enums',
+        {   -logic_name      => 'dc_sequences_and_enums',
             -module          => 'Bio::EnsEMBL::Compara::RunnableDB::RunDataChecks',
             -parameters      => {
-                'datacheck_names'  => ['BlankEnums'],
+                'datacheck_names'  => ['BlankEnums', 'CheckSequenceTable'],
                 'work_dir'         => $self->o('work_dir'),
                 'history_file'     => '#work_dir#/datacheck.compara_load_members.history.json',
                 'output_file'      => '#work_dir#/datacheck.compara_load_members.tap.txt',


### PR DESCRIPTION
## Description

_Sometimes the cores are handed over without adequate checks, so when loaded we can end up with empty enum fields when we should not._

**Related JIRA tickets:**
- ENSCOMPARASW-3543

## Overview of changes
_A new analysis was included to run at the end of the pipeline and check for empty fields using the BlankEnums datacheck._

#### Change #1
- Added semaphore in pipeline to flow to new `datachecks` from `hc_members_globally`.

#### Change #2
- Plugged in compara `RunDataChecks.pm` runnable with necessary parameters.

## Testing
CITest pipeline [here](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-7&port=4617&dbname=cristig_citest_load_members_101) (test pass, then manual intervention in db to cause failure and correct failure reported)

## Notes

