### PR TITLE
update the test REST server script to take into account EPO alignment in plant

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/Graph/GenomicAlignTreePhyloXMLWriter.pm
+++ b/modules/Bio/EnsEMBL/Compara/Graph/GenomicAlignTreePhyloXMLWriter.pm
@@ -192,6 +192,12 @@ sub _genomicaligntree_body {
     if ($all_genomic_aligns->[0]->genome_db->name ne "ancestral_sequences") {
       my $gdb = $all_genomic_aligns->[0]->genome_db;
       $self->_write_genome_db($gdb);
+      #add property element to provide the production name
+      $w->dataElement('property', $gdb->name,
+        'datatype' => 'xsd:string',
+        'ref' => 'Compara:genome_db_name',
+        'applies_to' => 'clade'
+      );
     }
 
     if ($compact_alignments) {

--- a/scripts/production/Verify_Compara_REST_Endpoints.pl
+++ b/scripts/production/Verify_Compara_REST_Endpoints.pl
@@ -96,15 +96,17 @@ elsif($division eq "plants"){
     $gene_member_id           = "AT3G52430";
     $gene_tree_id             = "EPlGT00140000000744";
     $alignment_region         = "1:8001-18000:1";
-    $lastz_alignment_region   = $alignment_region;
+    $lastz_alignment_region   = "1:12928-15180";
 
-    $species_1                = "arabidopsis_thaliana";
+    $species_1                = "oryza_sativa";
     $species_2                = "vitis_vinifera";
-    $species_3                = "oryza_barthii";
+    $species_3                = "arabidopsis_thaliana";
 
-    $taxon_1                  = 3702;#arabidopsis_thaliana
+    $taxon_1                  = 39947;#oryza_sativa
     $taxon_2                  = 29760;#vitis_vinifera
-    $taxon_3                  = 65489;#oryza_barthii
+    $taxon_3                  = 3702;#arabidopsis_thaliana
+
+    $species_set_group        = "rice";
 
     $gene_symbol              = "PAD4";
     $homology_type            = 'orthologues';
@@ -112,7 +114,6 @@ elsif($division eq "plants"){
     
     $extra_params             = 'compara=plants';
     $skip_families            = 1;
-    $skip_epo                 = 1;
     $skip_cactus              = 1;
 }
 elsif($division eq 'pan' or $division eq 'pan_homology'){
@@ -490,7 +491,7 @@ try{
         print "\nTesting GET EPO alignment region\/\:species\/\:region \n\n";
     
         my $ext = "/alignment/region/$species_1/$alignment_region?species_set_group=$species_set_group";
-        $ext .= "?$extra_params" if $extra_params;
+        $ext .= ";$extra_params" if $extra_params;
 
         $responseIDGet = $browser->get($server.$ext, { headers => { 'Content-type' => 'application/json' } } );
         ok($responseIDGet->{success}, "Check json validity");
@@ -502,8 +503,8 @@ try{
         $phyloXml = process_phyloXml_get($server.$ext.';content-type=text/x-phyloxml;aligned=0'.($extra_params ? ";$extra_params" : ''));
         #print Dumper $phyloXml;
         ok($phyloXml->{phylogeny}->{clade}->{sequence}->{mol_seq}->{is_aligned} == 0, "Check get alignment region and unaligned sequences");
-    
-        $jsontxt = process_json_get($server."/alignment/region/$species_1/$lastz_alignment_region?content-type=application/json;display_species_set=$species_1".($extra_params ? ";$extra_params" : ''));
+
+        $jsontxt = process_json_get($server."/alignment/region/$species_1/$lastz_alignment_region?content-type=application/json;display_species_set=$species_1;species_set_group=$species_set_group".($extra_params ? ";$extra_params" : ''));
         ok($jsontxt->[0]->{alignments}[0]->{species} eq $species_1, "Check alignment region display_species_set option validity");
     }
     


### PR DESCRIPTION
## Description
The REST testing script was not working on the plant EPO test of the phyloxml output because the access to a species node was not made generic. This has been corrected by making this part generic to any species/divisions.

**Related JIRA tickets:**
- ENSCOMPARASW-3507

## Overview of changes
 The issue was caused by a hard coding of the access to the phyloxml output corresponding to  vertebrates species used for the test.  To solve this problem I have modified and renamed a function that search for the existence of a species production name in the output of a phyloxml. The modified function return now the phyloxml node associated to the species and it is now used used in the part testing EPO REST endpoints making it completely generic to any species/divisions. In addition to this, the EPO phyloxml output has been extended with the with the "property" node containing the production name.

#### Change #1:  Verify_Compara_REST_Endpoints.pl
     #1.1_ rename of the function by fetch_species_node to better describe  its new role: 
     #1.2 make the function fetch_species_node to recursively search for the species node having a given production name
     #1.3 Update the gene tree testing part as it was using the rename function (l346) and add a test for "defined" to test for the existence of the given species 
    #1.4  corrected a small bug in the creation of the REST url for non vertebrate divisions.
    #1.5 Add a call to fetch_species_node in the part of the script testing the EPO phyloxml output. 
  
#### Change #2: GenomicAlignTreePhyloXMLWriter.pm
   #1.1 add the "property" node to the alignment phyloxml output.

## Testing
- test of the extension of the phyloxml output with the property node:
    --> call to the EPO endpoints and look for the existence of the "property" node in the species node: 
/alignment/region/taeniopygia_guttata/3:106040329-106040379?content-type=application/json;species_set_group=sauropsids

- test the rest script:
  --> run the rest test script on all endpoint and and the test was successful if the rest script had no failures. 
   This tested the generic function and the non-regression on the gene tree part of the testing script..

## Notes
_Optional extra information._
