### PR TITLE
plant species topology for release/102

### DIFF
--- a/conf/plants/species_tree.topology.nw
+++ b/conf/plants/species_tree.topology.nw
@@ -252,7 +252,7 @@
         )rosids,
         ( 
          )
-		  beta_vulgaris
+          beta_vulgaris
          )Chenopodiaceae,
         )Caryophyllales,
         (

--- a/conf/plants/species_tree.topology.nw
+++ b/conf/plants/species_tree.topology.nw
@@ -247,7 +247,16 @@
           )Anacardiaceae,
          )malvids,
         )rosids,
-        beta_vulgaris,
+        ( 
+         )
+		  beta_vulgaris
+         )Chenopodiaceae,
+        )Caryophyllales,
+        (
+         (
+          kalanchoe_fedtschenkoi
+         )Crassulaceae,
+        )Saxifragales,
        )Pentapetalae,
       )Mesangiospermae,
      )Magnoliophyta,

--- a/conf/plants/species_tree.topology.nw
+++ b/conf/plants/species_tree.topology.nw
@@ -201,6 +201,9 @@
            populus_trichocarpa,
           )Malpighiales,
           (
+           quercus_lobata
+          )Fagales,
+          (
            cucumis_sativus,
            cucumis_melo,
            citrullus_lanatus,

--- a/conf/plants/species_tree.topology.nw
+++ b/conf/plants/species_tree.topology.nw
@@ -251,7 +251,7 @@
          )malvids,
         )rosids,
         ( 
-         )
+         (
           beta_vulgaris
          )Chenopodiaceae,
         )Caryophyllales,

--- a/conf/plants/species_tree.topology.nw
+++ b/conf/plants/species_tree.topology.nw
@@ -226,7 +226,10 @@
             camelina_sativa_G1,
             camelina_sativa_G2,
             camelina_sativa_G3,
-           )Camelina,
+           )Camelina, 
+           (
+            eutrema_salsugineum
+           )Eutrema,
           )Brassicaceae,
           (
            corchorus_capsularis,

--- a/conf/plants/species_tree.topology.nw
+++ b/conf/plants/species_tree.topology.nw
@@ -201,7 +201,7 @@
            populus_trichocarpa,
           )Malpighiales,
           (
-           quercus_lobata
+           quercus_lobata,
           )Fagales,
           (
            cucumis_sativus,
@@ -231,7 +231,7 @@
             camelina_sativa_G3,
            )Camelina, 
            (
-            eutrema_salsugineum
+            eutrema_salsugineum,
            )Eutrema,
           )Brassicaceae,
           (
@@ -252,12 +252,12 @@
         )rosids,
         ( 
          (
-          beta_vulgaris
+          beta_vulgaris,
          )Chenopodiaceae,
         )Caryophyllales,
         (
          (
-          kalanchoe_fedtschenkoi
+          kalanchoe_fedtschenkoi,
          )Crassulaceae,
         )Saxifragales,
        )Pentapetalae,


### PR DESCRIPTION
## Description

This is the updated Newick file with the topology of plant species as of release 49/102.
It includes only 3 new species. This should serve as well as the list of plant species for this Compara production cycle @JAlvarezJarreta @dthybert 
The new UK wheat cultivars are not included yet as these still have lift-over annotation and we prefer to wait until their de novo annotation is in place @gnaamati 