### PR TITLE
Improve Utils/CopyData.pm and populate_new_database.pl

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/DBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/DBAdaptor.pm
@@ -298,5 +298,21 @@ sub get_division {
 }
 
 
+=head2 get_table_engine
+
+  Arg[1]      : string $table - table name
+  Example     : $dba->get_table_engine('meta');
+  Description : Returns the table's engine for the given DBAdaptor.
+  Returns     : string
+  Exceptions  : none
+
+=cut
+
+sub get_table_engine {
+    my ($self, $table) = @_;
+    return $self->dbc->db_handle->selectrow_hashref("SHOW TABLE STATUS WHERE Name = '$table'")->{Engine};
+}
+
+
 1;
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeDBsIntoRelease_conf.pm
@@ -193,7 +193,7 @@ sub pipeline_analyses {
             -parameters    => {
                 'dest_db_conn'  => '#curr_rel_db#',
                 'mode'          => 'ignore',
-                'skip_disable_keys' => 1,
+                'skip_disable_vars' => 1,
             },
             -hive_capacity => $self->o('copying_capacity'),
         },

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/CopyMembersByGenomeDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/CopyMembersByGenomeDB.pm
@@ -92,8 +92,7 @@ sub _copy_data_wrapper {
 
     # The extra arguments tell copy_data *not* to disable and enable keys
     # since there is too little data to copy to make it worth
-    my $rows = copy_data($from_dbc, $to_dbc, $table, $input_query, undef, 'skip_disable_keys', 0, $self->debug);
-    $self->warning("Copied over $rows rows of the $table table for genome_db_id=$genome_db_id");
+    copy_data($from_dbc, $to_dbc, $table, $input_query, undef, 'skip_disable_vars', $self->debug);
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/CopyTable.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/CopyTable.pm
@@ -43,7 +43,7 @@ sub param_defaults {
         %{ $self->SUPER::param_defaults() },
 
         'mode' => 'ignore',
-        'skip_disable_keys' => 0,
+        'skip_disable_vars' => 0,
     };
 }
 
@@ -59,7 +59,7 @@ sub run {
 	my $to_str   = $to_dbc->host . '/' . $to_dbc->dbname;
 	$self->warning("Copying $table_name from $from_str to $to_str");
 
-	copy_table( $from_dbc, $to_dbc, $table_name, undef, $replace, $self->param('skip_disable_keys'), $self->debug );
+	copy_table( $from_dbc, $to_dbc, $table_name, undef, $replace, $self->param('skip_disable_vars'), $self->debug );
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoLowCoverage/ImportAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoLowCoverage/ImportAlignment.pm
@@ -160,7 +160,7 @@ sub importAlignment {
 
     copy_data($self->param('from_dbc'), $self->compara_dba->dbc,
               "genomic_align_tree",
-              $gat_sql, 1, 'skip_disable_vars', $self->debug);
+              $gat_sql, 1, 0, $self->debug);
     print "\n\n" if $self->debug;
 
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoLowCoverage/ImportAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoLowCoverage/ImportAlignment.pm
@@ -113,23 +113,23 @@ sub importAlignment {
     }
 
     #Copy the species_set_header
-    my $ssh_rows = copy_data($self->param('from_dbc'), $self->compara_dba->dbc,
+    copy_data($self->param('from_dbc'), $self->compara_dba->dbc,
 	      "species_set_header",
 	      "SELECT species_set_header.* FROM species_set_header JOIN method_link_species_set USING (species_set_id) WHERE method_link_species_set_id = $mlss_id",
-          0, 0, 0, $self->debug);
+          0, 0, $self->debug);
     print "\n\n" if $self->debug;
 
     #Copy the method_link_species_set
-    my $mlss_rows = copy_table($self->param('from_dbc'), $self->compara_dba->dbc,
+    copy_table($self->param('from_dbc'), $self->compara_dba->dbc,
 	      "method_link_species_set",
 	      "method_link_species_set_id = $mlss_id");
     print "\n\n" if $self->debug;
 
     #Copy the species_set
-    my $ss_rows = copy_data($self->param('from_dbc'), $self->compara_dba->dbc,
+    copy_data($self->param('from_dbc'), $self->compara_dba->dbc,
 	      "species_set",
 	      "SELECT species_set.* FROM species_set JOIN method_link_species_set USING (species_set_id) WHERE method_link_species_set_id = $mlss_id",
-          0, 0, 0, $self->debug);
+          0, 0, $self->debug);
     print "\n\n" if $self->debug;
 
     #copy genomic_align_block table
@@ -139,9 +139,9 @@ sub importAlignment {
     } else {
         $gab_sql = "SELECT * FROM genomic_align_block WHERE method_link_species_set_id = $mlss_id";
     }
-    my $gab_rows = copy_data($self->param('from_dbc'), $self->compara_dba->dbc,
+    copy_data($self->param('from_dbc'), $self->compara_dba->dbc,
               "genomic_align_block",
-              $gab_sql, 0, 0, 0, $self->debug);
+              $gab_sql, 0, 0, $self->debug);
     print "\n\n" if $self->debug;
 
     #copy genomic_align_tree table
@@ -158,9 +158,9 @@ sub importAlignment {
                     "ORDER BY node_id DESC";
     }
 
-    my $gat_rows = copy_data($self->param('from_dbc'), $self->compara_dba->dbc,
+    copy_data($self->param('from_dbc'), $self->compara_dba->dbc,
               "genomic_align_tree",
-              $gat_sql, 1, 0, 'ignore_fks', $self->debug);
+              $gat_sql, 1, 'skip_disable_vars', $self->debug);
     print "\n\n" if $self->debug;
 
 
@@ -176,9 +176,9 @@ sub importAlignment {
                     " FROM genomic_align JOIN dnafrag USING (dnafrag_id)".
                     " WHERE method_link_species_set_id = $mlss_id $ancestral_dbID_constraint";
     }
-    my $ga_rows = copy_data($self->param('from_dbc'), $self->compara_dba->dbc,
+    copy_data($self->param('from_dbc'), $self->compara_dba->dbc,
               "genomic_align",
-              $ga_sql, 1, 0, 0, $self->debug);
+              $ga_sql, 1, 0, $self->debug);
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Families/CopyUniprotData.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Families/CopyUniprotData.pm
@@ -75,8 +75,7 @@ sub _sql_copy{
   my $from_dbc        = $self->param('reuse_dba')->dbc;
   my $to_dbc          = $self->compara_dba->dbc;
 
-  my $rows = copy_data($from_dbc, $to_dbc, $table, $input_query, undef, 'skip_disable_keys', 0, $self->debug);
-  $self->warning("Copied over $rows rows of uniprot members from the $table table ");
+  copy_data($from_dbc, $to_dbc, $table, $input_query, undef, 'skip_disable_vars', $self->debug);
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/Utils/CopyData.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/CopyData.pm
@@ -91,8 +91,6 @@ our @EXPORT_OK;
     copy_data_with_foreign_keys_by_constraint
     clear_copy_data_cache
     copy_data
-    copy_data_in_binary_mode
-    copy_data_in_text_mode
     copy_data_pp
     copy_table
     bulk_insert
@@ -106,12 +104,7 @@ our @EXPORT_OK;
   'all'         => [@EXPORT_OK]
 );
 
-use constant MAX_FILE_SIZE_FOR_MYSQLIMPORT => 10_000_000;   # How much space can we safely assume is available on /tmp
 use constant MAX_STATEMENT_LENGTH => 1_000_000;             # Related to MySQL's "max_allowed_packet" parameter
-use constant MAX_ROWS_WHILE_CONNECTED => 100_000;           # Heuristics: reading/writing that amount of rows is going to take some time, so disconnect from the other database if possible
-
-use Data::Dumper;
-use File::Temp qw/tempfile/;
 
 use Bio::EnsEMBL::Utils::Iterator;
 use Bio::EnsEMBL::Utils::Scalar qw(check_ref assert_ref);
@@ -270,38 +263,6 @@ sub clear_copy_data_cache {
 }
 
 
-=head2 _has_binary_column
-
-  Example     : _has_binary_column($dbc, 'genomic_align_block');
-  Description : Tells whether the table has a binary column
-  Returntype  : Boolean
-  Exceptions  : none
-  Caller      : general
-  Status      : Stable
-
-=cut
-
-sub _has_binary_column {
-    my ($dbc, $table_name) = @_;
-
-    assert_ref($dbc, 'Bio::EnsEMBL::DBSQL::DBConnection', 'dbc');
-    return $dbc->{"_has_binary_column__${table_name}"} if exists $dbc->{"_has_binary_column__${table_name}"};
-
-    my $sth = $dbc->db_handle->column_info($dbc->dbname, undef, $table_name, '%');
-    $sth->execute;
-    my $all_rows = $sth->fetchall_arrayref;
-    my $binary_mode = 0;
-    foreach my $this_col (@$all_rows) {
-        if (($this_col->[5] =~ /BINARY$/) or ($this_col->[5] =~ /BLOB$/) or ($this_col->[5] eq "BIT")) {
-            $binary_mode = 1;
-            last;
-        }
-    }
-    $dbc->{"_has_binary_column__${table_name}"} = $binary_mode;
-    return $binary_mode;
-}
-
-
 =head2 copy_data
 
   Arg[1]      : Bio::EnsEMBL::DBSQL::DBConnection $from_dbc
@@ -309,17 +270,15 @@ sub _has_binary_column {
   Arg[3]      : string $table_name
   Arg[4]      : string $query
   Arg[5]      : (opt) boolean $replace (default: false)
-  Arg[6]      : (opt) boolean $skip_disable_keys (default: false)
-  Arg[7]      : (opt) boolean $ignore_foreign_keys (default: false)
+  Arg[6]      : (opt) boolean $skip_disable_vars (default: false)
   Arg[7]      : (opt) boolean $debug (default: false)
 
-  Description : Copy the output of the query to this table using chunks of $index_name
-  Return      : Integer - The number of rows copied over
+  Description : Copy the output of the query to this table
 
 =cut
 
 sub copy_data {
-    my ($from_dbc, $to_dbc, $table_name, $query, $replace, $skip_disable_keys, $ignore_fks, $debug) = @_;
+    my ($from_dbc, $to_dbc, $table_name, $query, $replace, $skip_disable_vars, $debug) = @_;
 
     assert_ref($from_dbc, 'Bio::EnsEMBL::DBSQL::DBConnection', 'from_dbc');
     assert_ref($to_dbc, 'Bio::EnsEMBL::DBSQL::DBConnection', 'to_dbc');
@@ -327,175 +286,7 @@ sub copy_data {
     unless (defined $table_name && defined $query) {
         die "table_name and query are mandatory parameters";
     };
-
-    print "Copying data in table $table_name\n" if $debug;
-
-    unless ($skip_disable_keys) {
-        #speed up writing of data by disabling keys, write the data, then enable
-        print "DISABLE KEYS\n" if $debug;
-        $to_dbc->do("ALTER TABLE `$table_name` DISABLE KEYS");
-    }
-
-    my $rows;
-    if ( $ignore_fks ) {
-        $rows = copy_data_pp($from_dbc, $to_dbc, $table_name, $query, $replace, $ignore_fks, $debug);
-    } elsif (_has_binary_column($from_dbc, $table_name)) {
-        $rows = copy_data_in_binary_mode($from_dbc, $to_dbc, $table_name, $query, $replace, $debug);
-    } else {
-        $rows = copy_data_in_text_mode($from_dbc, $to_dbc, $table_name, $query, $replace, $debug);
-    }
-
-    unless ($skip_disable_keys) {
-        # this can take a lot of time
-        print "ENABLE KEYS\n" if $debug;
-        $to_dbc->do("ALTER TABLE `$table_name` ENABLE KEYS");
-    }
-    return $rows;
-}
-
-
-=head2 _escape
-
-  Description : Helper function that escapes some special characters.
-
-=cut
-
-sub _escape {
-    my $s = shift;
-    return '\N' unless defined $s;
-    $s =~ s/\n/\\\n/g;
-    $s =~ s/\t/\\\t/g;
-    return $s;
-}
-
-
-=head2 copy_data_in_text_mode
-
-  Description : A specialized version of copy_data() for tables that don't have
-                any binary data and can be loaded with mysqlimport.
-
-=cut
-
-sub copy_data_in_text_mode {
-    my ($from_dbc, $to_dbc, $table_name, $query, $replace, $ignore_fks, $debug) = @_;
-
-    assert_ref($from_dbc, 'Bio::EnsEMBL::DBSQL::DBConnection', 'from_dbc');
-    assert_ref($to_dbc, 'Bio::EnsEMBL::DBSQL::DBConnection', 'to_dbc');
-
-    $from_dbc->reconnect() unless $from_dbc->db_handle->ping;
-    $to_dbc->reconnect() unless $to_dbc->db_handle->ping;
-
-    my $user = $to_dbc->username;
-    my $pass = $to_dbc->password;
-    my $host = $to_dbc->host;
-    my $port = $to_dbc->port;
-    my $dbname = $to_dbc->dbname;
-
-    print "Query: $query\n" if $debug;
-    my $sth = $from_dbc->prepare($query, { 'mysql_use_result' => 1 });
-    $sth->execute();
-    my $curr_row;
-
-    my $total_rows = 0;
-    do {
-        my ($fh, $filename) = tempfile("${table_name}.XXXXXX", TMPDIR => 1, UNLINK => 0);
-        my $nrows = 0;
-        my $file_size = 0;
-        # The order of the condition is important: we don't want to discard a row
-        while (($file_size < MAX_FILE_SIZE_FOR_MYSQLIMPORT) and ($curr_row = $sth->fetchrow_arrayref)) {
-            my $row = join("\t", map {_escape($_)} @$curr_row) . "\n";
-            print $fh $row;
-            $file_size += length($row);
-            $nrows++;
-            $to_dbc->disconnect_if_idle if $nrows >= MAX_ROWS_WHILE_CONNECTED;
-        }
-        close($fh);
-        unless ($curr_row) {
-            $sth->finish;
-            $from_dbc->disconnect_if_idle if $nrows >= MAX_ROWS_WHILE_CONNECTED;
-        }
-        if ($nrows) {
-            my @cmd = ('mysqlimport', "-h$host", "-P$port", "-u$user", $pass ? ("-p$pass") : (), '--local', '--lock-tables', $replace ? '--replace' : '--ignore', $dbname, $filename);
-            Bio::EnsEMBL::Compara::Utils::RunCommand->new_and_exec(\@cmd, { die_on_failure => 1, debug => $debug });
-            print "Inserted $nrows rows in $table_name\n" if $debug;
-            $total_rows += $nrows;
-        }
-        unlink($filename);
-    } while ($curr_row);
-    return $total_rows;
-}
-
-
-=head2 copy_data_in_binary_mode
-
-  Description : A specialized version of copy_data() for tables that have binary
-                data, using mysqldump.
-
-=cut
-
-sub copy_data_in_binary_mode {
-    my ($from_dbc, $to_dbc, $table_name, $query, $replace, $debug) = @_;
-
-    assert_ref($from_dbc, 'Bio::EnsEMBL::DBSQL::DBConnection', 'from_dbc');
-    assert_ref($to_dbc, 'Bio::EnsEMBL::DBSQL::DBConnection', 'to_dbc');
-
-    print " ** WARNING ** Copying table $table_name in binary mode, this requires write access.\n";
-    print " ** WARNING ** The original table will be temporarily renamed as original_$table_name.\n";
-    print " ** WARNING ** An auxiliary table named temp_$table_name will also be created.\n";
-    print " ** WARNING ** You may have to undo this manually if the process crashes.\n\n";
-
-    my $start_time  = time();
-
-    $from_dbc->reconnect() unless $from_dbc->db_handle->ping;
-
-    my $count = $from_dbc->sql_helper->execute_single_result(
-        -SQL => "SELECT COUNT(*) FROM $table_name",
-    );
-
-    ## EXIT CONDITION
-    return unless !$count;
-
-    ## Copy data into a aux. table
-    $from_dbc->do("CREATE TABLE temp_$table_name $query");
-
-    ## Change table names (mysqldump will keep the table name, hence we need to do this)
-    $from_dbc->do("ALTER TABLE $table_name RENAME original_$table_name");
-    $from_dbc->do("ALTER TABLE temp_$table_name RENAME $table_name");
-
-    ## mysqldump data
-    ## disable/enable keys is managed in copy_data, so here we can just skip this
-    copy_table($from_dbc, $to_dbc, $table_name, undef, $replace, 'skip_disable_keys', $debug);
-
-    ## Undo table names change
-    $from_dbc->do("DROP TABLE $table_name");
-    $from_dbc->do("ALTER TABLE original_$table_name RENAME $table_name");
-
-    return $count;
-}
-
-
-=head2 copy_table
-
-  Arg[1]      : Bio::EnsEMBL::DBSQL::DBConnection $from_dbc
-  Arg[2]      : Bio::EnsEMBL::DBSQL::DBConnection $to_dbc
-  Arg[3]      : string $table_name
-  Arg[4]      : (opt) string $where_filter
-  Arg[5]      : (opt) boolean $replace (default: false)
-  Arg[6]      : (opt) boolean $skip_disable_keys (default: false)
-  Arg[7]      : (opt) boolean $debug (default: false)
-
-  Description : Copy the table (either all of it or a subset).
-                The main optional argument is $where_filter, which allows to select a portion of
-                the table. Note: the filter must be valid on the table alone, and does not support
-                JOINs. If you need the latter, use copy_data()
-
-=cut
-
-sub copy_table {
-    my ($from_dbc, $to_dbc, $table_name, $where_filter, $replace, $skip_disable_keys, $debug) = @_;
-
-    assert_ref($from_dbc, 'Bio::EnsEMBL::DBSQL::DBConnection', 'from_dbc');
-    assert_ref($to_dbc, 'Bio::EnsEMBL::DBSQL::DBConnection', 'to_dbc');
+    my $load_query = "LOAD DATA LOCAL INFILE '/dev/stdin' " . ($replace ? 'REPLACE' : 'IGNORE' ) . " INTO TABLE $table_name";
 
     print "Copying data in table $table_name\n" if $debug;
 
@@ -511,16 +302,92 @@ sub copy_table {
     my $to_port = $to_dbc->port;
     my $to_dbname = $to_dbc->dbname;
 
+    # Check the column information: if there is at least one binary column, alter the given query and the
+    # LOAD DATA query to handle the binary columns accordingly
+    my $sth = $from_dbc->db_handle->column_info($from_dbname, undef, $table_name, '%');
+    my $columns_info = $sth->fetchall_arrayref;
+    my $binary_mode = 0;
+    my (@select_cols, @load_cols, @set_exprs);
+    foreach my $col ( @$columns_info ) {
+        if ($col->[5] =~ /(^BIT|BLOB|BINARY)$/) {
+            $binary_mode = 1;
+            push @select_cols, "HEX($table_name." . $col->[3] . ")";
+            push @load_cols, "@" . $col->[3];
+            push @set_exprs, $col->[3] . " = UNHEX(@" . $col->[3] . ")";
+        } else {
+            push @select_cols, "$table_name." . $col->[3];
+            push @load_cols, $col->[3];
+        }
+    }
+    if ($binary_mode) {
+        # Replace the wildcard by the list of columns (including the HEX-ing of the binary ones)
+        my $select_cols = join(', ', @select_cols);
+        $query =~ s/($table_name\.|)\*/$select_cols/;
+        # Make LOAD DATA aware of which columns to UNHEX
+        $load_query .= sprintf(" (%s) SET %s", join(', ', @load_cols), join(', ', @set_exprs));
+    }
+
+    # Get table's engine to optimise the copy process
+    my $table_engine;
+    unless ($skip_disable_vars) {
+        $table_engine = $to_dbc->db_handle->selectrow_hashref("SHOW TABLE STATUS WHERE Name = '$table_name'")->{Engine};
+        # Speed up writing of data by disabling certain variables, write the data, then enable them back
+        print "DISABLE VARIABLES\n" if $debug;
+        if ($table_engine eq 'MyISAM') {
+            $to_dbc->do("ALTER TABLE `$table_name` DISABLE KEYS");
+        } else {
+            $to_dbc->do("SET AUTOCOMMIT = 0");
+            $to_dbc->do("SET FOREIGN_KEY_CHECKS = 0");
+            $to_dbc->do("SET UNIQUE_CHECKS = 0");
+        }
+    }
+
+    # Disconnect from the databases before copying the table
+    $from_dbc->disconnect_if_idle();
+    $to_dbc->disconnect_if_idle();
+
     my $start_time  = time();
-    my $insert_mode = $replace ? '--replace' : '--insert-ignore';
+    my $cmd = "mysql --host=$from_host --port=$from_port --user=$from_user " . ($from_pass ? "--password=$from_pass" : '') .
+        " --max_allowed_packet=1024M $from_dbname -e \"$query\" --quick --silent --skip-column-names " .
+        "| mysql --host=$to_host --port=$to_port --user=$to_user " . ($to_pass ? "--password=$to_pass" : '') . " $to_dbname -e \"$load_query\"";
+    Bio::EnsEMBL::Compara::Utils::RunCommand->new_and_exec($cmd, { die_on_failure => 1, debug => $debug });
+    print "total time: " . (time - $start_time) . " s\n" if $debug;
 
-    my $cmd = "mysqldump -h$from_host -P$from_port -u$from_user ".($from_pass ? "-p$from_pass" : '')." $insert_mode -t $from_dbname $table_name ".
-        ($where_filter ? "-w '$where_filter'" : "")." ".
-        ($skip_disable_keys ? "--skip-disable-keys" : "")." ".
-        "| mysql   -h$to_host   -P$to_port   -u$to_user   ".($to_pass ? "-p$to_pass" : '')." $to_dbname";
-    Bio::EnsEMBL::Compara::Utils::RunCommand->new_and_exec($cmd, { die_on_failure => 1, use_bash_pipefail => 1, debug => $debug });
+    unless ($skip_disable_vars) {
+        print "ENABLE VARIABLES\n" if $debug;
+        if ($table_engine eq 'MyISAM') {
+            $to_dbc->do("ALTER TABLE `$table_name` ENABLE KEYS");
+        } else {
+            $to_dbc->do("SET AUTOCOMMIT = 1");
+            $to_dbc->do("SET FOREIGN_KEY_CHECKS = 1");
+            $to_dbc->do("SET UNIQUE_CHECKS = 1");
+        }
+    }
+}
 
-    print "time " . (time - $start_time) . "\n" if $debug;
+
+=head2 copy_table
+
+  Arg[1]      : Bio::EnsEMBL::DBSQL::DBConnection $from_dbc
+  Arg[2]      : Bio::EnsEMBL::DBSQL::DBConnection $to_dbc
+  Arg[3]      : string $table_name
+  Arg[4]      : (opt) string $where_filter
+  Arg[5]      : (opt) boolean $replace (default: false)
+  Arg[6]      : (opt) boolean $skip_disable_vars (default: false)
+  Arg[7]      : (opt) boolean $debug (default: false)
+
+  Description : Copy the table (either all of it or a subset).
+                The main optional argument is $where_filter, which allows to select a portion of
+                the table. Note: the filter must be valid on the table alone, and does not support
+                JOINs. If you need the latter, use copy_data()
+
+=cut
+
+sub copy_table {
+    my ($from_dbc, $to_dbc, $table_name, $where_filter, $replace, $skip_disable_vars, $debug) = @_;
+
+    my $query = "SELECT * FROM $table_name" . ($where_filter ? " WHERE $where_filter" : '');
+    copy_data($from_dbc, $to_dbc, $table_name, $query, $replace, $skip_disable_vars, $debug);
 }
 
 
@@ -548,6 +415,12 @@ sub copy_data_pp {
 
     assert_ref($from_dbc, 'Bio::EnsEMBL::DBSQL::DBConnection', 'from_dbc');
     assert_ref($to_dbc, 'Bio::EnsEMBL::DBSQL::DBConnection', 'to_dbc');
+
+    unless (defined $table_name && defined $query) {
+        die "table_name and query are mandatory parameters";
+    };
+
+    print "Copying data in table $table_name\n" if $debug;
 
     my $sth = $from_dbc->prepare($query, { 'mysql_use_result' => 1 });
     $sth->execute();
@@ -663,4 +536,3 @@ sub bulk_insert_iterator {
 
 
 1;
- 

--- a/scripts/pipeline/copy_data.pl
+++ b/scripts/pipeline/copy_data.pl
@@ -980,10 +980,6 @@ sub copy_conservation_scores {
 
   if ($count) {
     ## Other scores are in the from database.
-    print " ** WARNING **\n";
-    print " ** WARNING ** Copying only part of the data in the conservation_score table\n";
-    print " ** WARNING ** This process might be very slow.\n";
-    print " ** WARNING **\n";
     copy_data($from_dbc, $to_dbc,
         "conservation_score",
         "SELECT cs.genomic_align_block_id+$fix, window_size, position, expected_score, diff_score".
@@ -994,10 +990,6 @@ sub copy_conservation_scores {
       );
   } elsif ($fix) {
     ## These are the only scores but need to fix them.
-    print " ** WARNING **\n";
-    print " ** WARNING ** Copying in 'fix' mode\n";
-    print " ** WARNING ** This process might be very slow.\n";
-    print " ** WARNING **\n";
     copy_data($from_dbc, $to_dbc,
         "conservation_score",
         "SELECT cs.genomic_align_block_id+$fix, window_size, position, expected_score, diff_score".

--- a/scripts/pipeline/populate_new_database.pl
+++ b/scripts/pipeline/populate_new_database.pl
@@ -636,7 +636,7 @@ sub copy_all_dnafrags {
   assert_ref($to_dba, 'Bio::EnsEMBL::Compara::DBSQL::DBAdaptor', 'to_dba');
 
   # Keys are disabled / enabled only once for the whole loop
-  my $df_engine = $new_dba->dbc->db_handle->selectrow_hashref("SHOW TABLE STATUS WHERE Name = 'dnafrag'")->{Engine};
+  my $df_engine = $new_dba->get_table_engine('dnafrag');
   $new_dba->dbc->do("ALTER TABLE `dnafrag` DISABLE KEYS") if $df_engine eq 'MyISAM';
 
   my $n = 0;
@@ -720,9 +720,9 @@ sub copy_dna_to_dna_alignments {
   my ($old_dba, $new_dba, $method_link_species_sets) = @_;
 
   # Keys are disabled / enabled only once for the whole loop
-  my $gab_engine = $new_dba->dbc->db_handle->selectrow_hashref("SHOW TABLE STATUS WHERE Name = 'genomic_align_block'")->{Engine};
-  my $ga_engine = $new_dba->dbc->db_handle->selectrow_hashref("SHOW TABLE STATUS WHERE Name = 'genomic_align'")->{Engine};
-  my $gat_engine = $new_dba->dbc->db_handle->selectrow_hashref("SHOW TABLE STATUS WHERE Name = 'genomic_align_tree'")->{Engine};
+  my $gab_engine = $new_dba->get_table_engine('genomic_align_block');
+  my $ga_engine = $new_dba->get_table_engine('genomic_align');
+  my $gat_engine = $new_dba->get_table_engine('genomic_align_tree');
   $new_dba->dbc->do("ALTER TABLE `genomic_align_block` DISABLE KEYS") if $gab_engine eq 'MyISAM';
   $new_dba->dbc->do("ALTER TABLE `genomic_align` DISABLE KEYS") if $ga_engine eq 'MyISAM';
   $new_dba->dbc->do("ALTER TABLE `genomic_align_tree` DISABLE KEYS") if $gat_engine eq 'MyISAM';
@@ -811,8 +811,8 @@ sub copy_synteny_data {
   my ($old_dba, $new_dba, $method_link_species_sets) = @_;
 
   # Keys are disabled / enabled only once for the whole loop
-  my $sr_engine = $new_dba->dbc->db_handle->selectrow_hashref("SHOW TABLE STATUS WHERE Name = 'synteny_region'")->{Engine};
-  my $dfr_engine = $new_dba->dbc->db_handle->selectrow_hashref("SHOW TABLE STATUS WHERE Name = 'dnafrag_region'")->{Engine};
+  my $sr_engine = $new_dba->get_table_engine('synteny_region');
+  my $dfr_engine = $new_dba->get_table_engine('dnafrag_region');
   $new_dba->dbc->do("ALTER TABLE `synteny_region` DISABLE KEYS") if $sr_engine eq 'MyISAM';
   $new_dba->dbc->do("ALTER TABLE `dnafrag_region` DISABLE KEYS") if $dfr_engine eq 'MyISAM';
 
@@ -845,7 +845,7 @@ sub copy_constrained_elements {
   my ($old_dba, $new_dba, $method_link_species_sets) = @_;
 
   # Keys are disabled / enabled only once for the whole loop
-  my $ce_engine = $new_dba->dbc->db_handle->selectrow_hashref("SHOW TABLE STATUS WHERE Name = 'constrained_element'")->{Engine};
+  my $ce_engine = $new_dba->get_table_engine('constrained_element');
   $new_dba->dbc->do("ALTER TABLE `constrained_element` DISABLE KEYS") if $ce_engine eq 'MyISAM';
 
   foreach my $this_method_link_species_set (@$method_link_species_sets) {
@@ -886,7 +886,7 @@ sub copy_conservation_scores {
   my ($old_dba, $new_dba, $method_link_species_sets) = @_;
 
   # Keys are disabled / enabled only once for the whole loop
-  my $cs_engine = $new_dba->dbc->db_handle->selectrow_hashref("SHOW TABLE STATUS WHERE Name = 'conservation_score'")->{Engine};
+  my $cs_engine = $new_dba->get_table_engine('conservation_score');
   $new_dba->dbc->do("ALTER TABLE `conservation_score` DISABLE KEYS") if $cs_engine eq 'MyISAM';
   my $conservation_score_fetch_sth = $old_dba->dbc->prepare("SELECT * FROM conservation_score".
       " WHERE genomic_align_block_id >= ? AND genomic_align_block_id < ? LIMIT 1");
@@ -909,4 +909,3 @@ sub copy_conservation_scores {
 
   $new_dba->dbc->do("ALTER TABLE `conservation_score` ENABLE KEYS") if $cs_engine eq 'MyISAM';
 }
-


### PR DESCRIPTION
## Description

Our script `populate_new_database.pl` didn't work as expected during e101, with several `server has gone away` errors midway through the copy process. Furthermore, this script is quite slow and any improvements in its performance would be much appreciated.

**Related JIRA tickets:**
- ENSCOMPARASW-3542

## Overview of changes

Performance improvements have been added based on the destination table's engine in `populate_new_database.pl` script and `copy_data` method.

#### Change 1
- Regarding the disconnection issues in `populate_new_database.pl`, `disconnect_if_idle` methods have been added to the `copy_data` method.

#### Change 2
- `LOAD DATA` has been proven to be much faster than an INSERT of multiple values in both MyISAM and InnoDB tables. Furthermore, I have found a data transfer method via `mysql` that works for both binary and non-binary columns. Thus, all the `copy_data_*` methods have been removed and only `copy_data` has remained as a global approach.

#### Change 3
- `copy_data` does not return the number of rows inserted any more.

#### Change 4
- `copy_table` is now based on `copy_data`, as the latter allows more configuration than the former, so the code can be reused.

## Testing
Regarding performance, my preliminary tests have shown that the query + `LOAD DATA` approach provides a reduction of at least 35% on the time cost. For instance, copying the `constrained_element` table (e100) to a new empty table took 45 minutes with the old code, less than 18 minutes with the proposed update, and for `gene_tree_node_tag`, from 16 minutes to 9 minutes.

However, I have tested thoroughly that both `copy_data` and `copy_table` work, but not the rest of the changes.

## Notes
- All the runnables and pipeline configs that use `Utils/CopyData.pm` have been updated accordingly.
- This solution only addresses part of the problem mentioned in the JIRA ticket. More work should be done in the future.