### PR TITLE
FindMLSSUnderTaxa to include homoeologs for highconf

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/FindMLSSUnderTaxa.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/FindMLSSUnderTaxa.pm
@@ -42,14 +42,26 @@ sub fetch_input {
 
     my $gdb_adaptor         = $self->compara_dba->get_GenomeDBAdaptor;
     my $ncbi_adaptor        = $self->compara_dba->get_NCBITaxonAdaptor;
-    my $all_orthology_mlsss = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor->fetch_all_by_method_link_type('ENSEMBL_ORTHOLOGUES');
+    my @method_link_types   = qw( ENSEMBL_ORTHOLOGUES ENSEMBL_HOMOEOLOGUES );
+
+    my @all_orthology_mlsss;
+
+    foreach my $method_link_type (@method_link_types) {
+        push @all_orthology_mlsss, @{ $self->compara_dba->get_MethodLinkSpeciesSetAdaptor->fetch_all_by_method_link_type($method_link_type) };
+    }
 
     # Lookup table for the mlsss that haven't matched any taxa (yet)
     my %mlss_per_gdbs;
-    foreach my $mlss (@$all_orthology_mlsss) {
+    foreach my $mlss (@all_orthology_mlsss) {
         my ($gdb1, $gdb2) = @{ $mlss->species_set->genome_dbs };
-        $mlss_per_gdbs{$gdb1->dbID."_".$gdb2->dbID} = $mlss;
-        $mlss_per_gdbs{$gdb2->dbID."_".$gdb1->dbID} = $mlss;
+        # There is only one genome_db in each homoeolog mlss species_set
+        if ( scalar @{ $mlss->species_set->genome_dbs } == 1 ) {
+            $mlss_per_gdbs{$gdb1->dbID} = $mlss;
+        }
+        else {
+            $mlss_per_gdbs{$gdb1->dbID."_".$gdb2->dbID} = $mlss;
+            $mlss_per_gdbs{$gdb2->dbID."_".$gdb1->dbID} = $mlss;
+        }
     }
 
     # Process each level and each taxon sequentially
@@ -62,6 +74,11 @@ sub fetch_input {
 
             # Iterate over all the pairs of genome_db_id
             while (my $gdb_id1 = shift @{$genome_db_ids}) {
+                # First check for homoeolog mlss which only has one genome_db_id
+                if ( $mlss_per_gdbs{$gdb_id1} ) {
+                    my $mlss = $mlss_per_gdbs{$gdb_id1};
+                    push @output_ids, { 'mlss_id' => $mlss->dbID, 'threshold_index' => $i };
+                }
                 foreach my $gdb_id2 (@{$genome_db_ids}) {
                     my $key12 = ($gdb_id1).'_'.($gdb_id2);
                     my $key21 = ($gdb_id2).'_'.($gdb_id1);


### PR DESCRIPTION
## Description

_GOC scores have been missing for homoeologues in the release database since release/100._

**Related JIRA tickets:**
- ENSCOMPARASW-3607

## Overview of changes
`fetch_input` was altered to allow homoeolog mlsss:

- `ENSEMBL_HOMOEOLOGUES` was added as a `method_link` alongside `ENSEMBL_ORTHOLOGUES`.
- For each homoeologues/polyploid `species_set` only one genome is expected, so this was accounted for.
- The single genome mlsss were added for the dataflow output.

## Testing
This was tested in both plants and vertebrates individual HighConfidenceOrthologs pipelines, firstly to check the missing GOC mlsss were picked up on, and secondly to check it didn't break vertebrates which don't have homoeologues.

## Notes
The GOC scores for the homoeologues exist in the homology dump flatfiles, so they are computed. FindMLSSUnderTaxa.pm was only checking for orthologues. Since the HighConfidenceOrthologs pipeline now writes the GOC scores directly to the database, it needed to look for homoeologues too.
