### PR TITLE
Add UPDATE flag to JIRA utils

### DIFF
--- a/conf/pan/jira_recurrent_tickets.json
+++ b/conf/pan/jira_recurrent_tickets.json
@@ -92,6 +92,7 @@
             "summary": "Handover of release DB"
          }
       ],
+      "labels": ["Merge_anchor"],
       "summary": "<Division> Release <version> Database merge and handover"
    },
    {

--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -175,6 +175,7 @@
            "summary": "Handover of ancestral DB"
         }
       ],
+      "labels": ["Merge_anchor"],
       "summary": "<Division> Release <version> Database merge and handover"
    },
    {

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -272,6 +272,7 @@
            "summary": "Handover of ancestral DB"
         }
       ],
+      "labels": ["Merge_anchor"],
       "summary": "<Division> Release <version> Database merge and handover"
    },
    {

--- a/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
@@ -578,7 +578,7 @@ sub _update_ticket {
   Arg[2]      : hashref $content_data - a POST request's content data
   Example     : my $tickets = $jira_adaptor->_post_request(
                     'search', {'jql' => 'project=ENSCOMPARASW', 'maxResults' => 10});
-  Description : Sends an HTTP POST request to the JIRA server and returns the
+  Description : Sends a HTTP POST request to the JIRA server and returns the
                 response
   Return type : arrayref or hashref
   Exceptions  : none

--- a/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
@@ -606,7 +606,7 @@ sub _post_request {
   Example     : my $tickets = $jira_adaptor->_put_request(
                     'issue', 'ENSCOMPARASW-302',
                     {'fields' => {'description' => 'New description'}});
-  Description : Sends an HTTP PUT request to the JIRA server
+  Description : Sends a HTTP PUT request to the JIRA server
   Return type : none
   Exceptions  : none
 

--- a/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
@@ -580,7 +580,7 @@ sub _update_ticket {
                     'search', {'jql' => 'project=ENSCOMPARASW', 'maxResults' => 10});
   Description : Sends a HTTP POST request to the JIRA server and returns the
                 response
-  Return type : arrayref or hashref
+  Return type : hashref for 'issue'; arrayref for 'search' and 'issueLink'
   Exceptions  : none
 
 =cut
@@ -634,7 +634,7 @@ sub _put_request {
                     'POST', 'https://www.ebi.ac.uk/panda/jira/rest/api/latest/issue',
                     {'jql' => 'project=ENSCOMPARASW', 'maxResults' => 10});
   Description : Sends a request to the JIRA server and returns the decoded response
-  Return type : arrayref or hashref
+  Return type : arrayref or hashref (depending on $method and $url)
   Exceptions  : none
 
 =cut

--- a/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
@@ -537,7 +537,7 @@ sub _create_new_ticket {
                 updated
   Example     : $jira_adaptor->_update_ticket('ENSCOMPARASW-352', 'New ticket description', 0);
   Description : Reopens the JIRA ticket, updates its content and removes its
-                previous assingee (unless in dry-mode)
+                previous assignee (unless in dry-mode)
   Return type : none
   Exceptions  : none
 


### PR DESCRIPTION
## Description

In e101 we found out that the DC failure subtasks produce a conflict in our script to automatically create JIRA tickets if new DC failures are raised for a subtest that has failed before in that release and division, as the subtasks only have the subtest as summary. @muffato proposed to move these subtasks as tasks and add an update flag so the DC tickets will be updated if new failures are raised.

**Related JIRA tickets:**
- ENSCOMPARASW-3589

## Overview of changes
#### Change 1
- Make `create_datacheck_tickets.pl` create the DC failues as independent tasks instead of subtasks from a "dc failure file" task. They will all still be linked to the anchor production ticket (as blockers).

#### Change 2
- Add an `--update` flag for the JIRA ticket creation, so those tickets that already exist with the same summary, division and release, instead of being skipped (default behaviour now), will be updated, i.e. their summary will be updated, their previous assignee removed and they will be reopened. This means the ticket has to be `Resolved` or `Closed` to be updated. I have used this as a control to make sure all the previous DC failures are addressed before adding new ones.

## Testing
- The update flag has been tested to make sure it behaves as expected (updating only when the ticket is Resolved/Closed).
- Haven't tested a combination of create + updates to avoid having to track those tickets and remove them.

## Notes
- I'm aware that I have moved quite some code around, but I think the refactoring will be useful in the future if we want to add more features to `JIRA.pm`.
- Once this PR is merged, I will update the instructions at [Final healthchecking and testing](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Final+healthchecking+and+testing) to include the new flag in the commands.
