### PR TITLE
Back compatibility for collection

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/MethodLinkSpeciesSetAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/MethodLinkSpeciesSetAdaptor.pm
@@ -635,7 +635,11 @@ sub fetch_by_method_link_type_species_set_name {
     my ($self, $method_link_type, $species_set_name) = @_;
 
     my $species_set_adaptor = $self->db->get_SpeciesSetAdaptor;
+    my $alt_ss_name = $species_set_name =~ /^collection-/ ? substr($species_set_name, 11) : "collection-" . $species_set_name;
+
     my $all_species_sets = $species_set_adaptor->fetch_all_by_name($species_set_name);
+    my $alt_species_sets = $species_set_adaptor->fetch_all_by_name($alt_ss_name);
+    push @$all_species_sets, @$alt_species_sets;
 
     my $method = $self->db->get_MethodAdaptor->fetch_by_type($method_link_type);
 


### PR DESCRIPTION
## Description

Backwards compatibility for mice in the rest GET end point for `get_alignment` breaks `pig_breeds` in `e101` where the name of the `species_set` is `collection-pig_breeds`.

**Related JIRA tickets:**
- ENSCOMPARASW-3604

## Overview of changes
The method `fetch_by_method_link_type_species_set_name` that is used by the REST API to collect the genome alignments by `species_set` name will now check `species_sets` with both `collection-` in the name and without. 

## Testing
_The method was tested to ensure it returns an appropriate mlss against the `e101` release database for the `pig_breeds` `EPO_EXTENDED` method type._

## Notes
A patch has already been approved and merged for `e101` before it could be closed ([#401](https://github.com/Ensembl/staging-patches/pull/401)), which makes this a little redundant for `e101` now, but it will work for future cases, we don't really know what will happen beyond `e102` if `pig_breeds` `EPO_EXTENDED` is recalculated. A fix can be put in place to remove the `collection-` removal from the `GenomicAlignment.pm` `get_alignment()` method in the `ensembl-rest` repository, although with this fix in place, I am not sure if that is necessary? This fix does not work for `e100` where the `species_set_name` is `collection-sus`.
