### PR TITLE
Add "Epic Link" parameter for JIRA tickets

### DIFF
--- a/scripts/jira_tickets/create_compara_release_JIRA_tickets.pl
+++ b/scripts/jira_tickets/create_compara_release_JIRA_tickets.pl
@@ -22,6 +22,9 @@ use Getopt::Long;
 
 use Bio::EnsEMBL::Compara::Utils::JIRA;
 
+# Epic JIRA Ticket ID for Production taks
+use constant EPIC_TICKET_ID => 'ENSCOMPARASW-3572';
+
 main();
 
 sub main {
@@ -76,7 +79,12 @@ sub main {
     die 'Aborted by user. Please rerun with correct parameters.' if ( $response ne 'y' );
 
     # Create JIRA tickets
-    my $subtask_keys = $jira_adaptor->create_tickets(-JSON_FILE => $tickets_json, -DRY_RUN => $dry_run, -DEFAULT_PRIORITY => 'Blocker');
+    my $subtask_keys = $jira_adaptor->create_tickets(
+        -JSON_FILE        => $tickets_json,
+        -DEFAULT_PRIORITY => 'Blocker',
+        -EPIC_LINK        => EPIC_TICKET_ID(),
+        -DRY_RUN          => $dry_run,
+    );
     printf("Created %d top-level tickets.\n", scalar(@$subtask_keys));
 }
 


### PR DESCRIPTION
## Description

We want production tickets to be linked to the Epic Ticket ENSCOMPARASW-3572, so a new parameter needs to be added to `JIRA.pm`.

**Related JIRA tickets:**
- ENSCOMPARASW-3723

## Overview of changes
#### Change 1
- Make `JIRA.pm` be able to link any new ticket (provided it is not a sub-task) to an existing Epic JIRA ticket. Sub-task tickets inherit the epic link from their parent task

#### Change 2
- Link all production/relco tickets to Epic ENSCOMPARASW-3572.

## Testing
All production tickets for e102 were created without being linked to the Epic and this update in `JIRA.pm` was used to update the tickets (with certain modifications in the "update method" to perform that task).
