### PR TITLE
JIRA Authentication

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/CreateDCJiraTickets.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/CreateDCJiraTickets.pm
@@ -41,11 +41,11 @@ sub run {
     $self->warning( "Command: " . $command );
 
     unless ( $self->param('dry_run') ) {
-        if (defined $ENV{'USERPW'}) {
+        if (defined $ENV{'JIRA_AUTH_TOKEN'}) {
             $self->run_command($command, { die_on_failure => 1, });
         }
         else {
-            $self->warning( "ENV variable not defined: \$USERPW" );
+            $self->warning( "ERROR: ENV variable not defined: \$JIRA_AUTH_TOKEN. Define with:\nexport JIRA_AUTH_TOKEN=$(echo -n 'user:pass' | openssl base64)" );
         }
     }
 

--- a/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
@@ -77,8 +77,17 @@ sub new {
     $self->{_user} = $user || $ENV{'USER'};
     $self->{_relco} = $relco || $self->{_user};
     $self->{_project} = $project || 'ENSCOMPARASW';
-    # Initialise user's password
-    $self->{_password} = defined $ENV{'USERPW'} ? $ENV{'USERPW'} : $self->_request_password();
+
+    if ( $ENV{'JIRA_AUTH_TOKEN'} ) {
+        # this token should be your 'user:pass' string encoded to base64
+        # export JIRA_AUTH_TOKEN=$(echo -n 'user:pass' | openssl base64)
+        # https://developer.atlassian.com/server/jira/platform/basic-authentication/
+        $self->{_auth_token} = $ENV{'JIRA_AUTH_TOKEN'};
+    } else {
+        # initialise user's password interactively
+        $self->{_password} = $self->_request_password();
+    }
+
     # If any of the following parameters are missing, get them from Compara
     # production environment
     # (https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+Environment)
@@ -644,10 +653,18 @@ sub _http_request {
     $content_data //= {};
     # Create the HTTP request and LWP objects to get the response for the given arguments
     $self->{_logger}->debug("$method Request on $url\n");
-    my $request = HTTP::Request->new($method, $url);
-    $request->authorization_basic($self->{_user}, $self->{_password});
-    # The content data will be sent in JSON format
-    $request->header('Content-Type' => 'application/json');
+    my $auth_token = $ENV{'JIRA_AUTH_TOKEN'};
+    my $request;
+    if ( $self->{_auth_token} ) {
+        print STDERR "Authenticating with token '" . $self->{_auth_token} . "'\n";
+        my $header = ['Authorization' => "Basic " . $self->{_auth_token}, 'Content-Type' => 'application/json'];
+        $request = HTTP::Request->new($method, $url, $header);
+    } else {
+        print STDERR "Authenticating with username and password\n";
+        my $header = ['Content-Type' => 'application/json'];
+        $request = HTTP::Request->new($method, $url, $header);
+        $request->authorization_basic($self->{_user}, $self->{_password});
+    }
     my $json_content = encode_json($content_data);
     $request->content($json_content);
     my $agent    = LWP::UserAgent->new();

--- a/scripts/jira_tickets/create_datacheck_tickets.pl
+++ b/scripts/jira_tickets/create_datacheck_tickets.pl
@@ -167,8 +167,8 @@ sub find_labeled_ticket {
     my $labeled_ticket = $jira_adaptor->fetch_tickets($jql);
 
     # Check that we have actually found the ticket (and only one)
-    die 'Cannot find any ticket with the label "$label"' if (! $labeled_ticket->{total});
-    die 'Found more than one ticket with the label "$label"' if ($labeled_ticket->{total} > 1);
+    die "Cannot find any ticket with the label '$label'" if (! $labeled_ticket->{total});
+    die "Found more than one ticket with the label '$label'" if ($labeled_ticket->{total} > 1);
     print "Found ticket key '" . $labeled_ticket->{issues}->[0]->{key} . "'\n";
 
     return $labeled_ticket->{issues}->[0]->{key};


### PR DESCRIPTION
## Description

Interactions with JIRA using our `Utils::JIRA` adaptor usually requires the user to interactively input their password at runtime. This is not practical when embedding JIRA-related tasks into pipelines. Neither does it feel like a good idea to store passwords in plaintext in environment variables. This PR edits the adaptor to allow us to use an encoded authentication string, providing a slightly more safe method.

https://developer.atlassian.com/server/jira/platform/basic-authentication/

**Related JIRA tickets:**
- https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-3781

## Overview of changes

#### Change #1
- Updates to `Utils::JIRA` to read authentication token from `$ENV{'JIRA_AUTH_TOKEN'}`. The password is only requested if this is not present.
- `_http_request` updated to include token in header where given, or fallback to `basic_authentication` if not

#### Change #2
- updated `CreateDCJiraTickets.pm` to check for `$JIRA_AUTH_TOKEN`, rather than a plaintext password

## Testing
Test run of the `create_datacheck_tickets.pl` script

## Notes
Updated [Production Environment confluence document](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+Environment) to include information about setting the `$JIRA_AUTH_TOKEN` variable.
