### PR TITLE
New SOP for out-of-the-release production work

### DIFF
--- a/conf/vertebrates/jira_out_of_release_tickets.json
+++ b/conf/vertebrates/jira_out_of_release_tickets.json
@@ -1,0 +1,123 @@
+[
+   {
+      "component": "Relco tasks",
+      "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+setup",
+      "subtasks": [{
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+setup#Productionsetup-Registryconfigurationfile",
+            "summary": "Registry Configuration file"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/pages/viewpage.action?pageId=97126141\n
+*GitHub*: [<Division>/PrepareMasterDatabaseForRelease_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/<Division>/PrepareMasterDatabaseForRelease_conf.pm]\n
+{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::<Division>::PrepareMasterDatabaseForRelease_conf -host mysql-ens-compara-prod-1 -port 4485{code}",
+            "summary": "Prepare the master database"
+         },
+         {
+            "component": "Production tasks",
+            "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+setup#Productionsetup-Genomedumps\n
+*GitHub*: [DumpGenomes_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpGenomes_conf.pm]\n
+{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::DumpGenomes_conf -host mysql-ens-compara-prod-X -port XXXX -division <division>{code}",
+            "summary": "Run the genome dumping pipeline",
+            "name_on_graph": "Genome dumps"
+         },
+         {
+            "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+setup#Productionsetup-LastZbatching",
+            "summary": "Prepare the LastZ batches"
+         },
+         {
+            "component": "Production tasks",
+            "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+setup#Productionsetup-Members\n
+*GitHub*: [<Division>/LoadMembers_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/<Division>/LoadMembers_conf.pm]\n
+{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::<Division>::LoadMembers_conf -host mysql-ens-compara-prod-X -port XXXX{code}",
+            "summary": "Run the member loading pipeline",
+            "name_on_graph": "Member loading"
+         },
+         {
+            "component": "Relco tasks",
+            "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+setup#Productionsetup-Species-tree\n
+*GitHub*: [CreateSpeciesTree_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateSpeciesTree_conf.pm]\n
+{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::CreateSpeciesTree_conf -host mysql-ens-compara-prod-X -port XXXX -output_file $ENSEMBL_CVS_ROOT_DIR/ensembl-compara/conf/<division>/species_tree.branch_len.nw -division <division>{code}",
+            "summary": "Run Create Species Tree pipeline",
+            "name_on_graph": "Species-tree"
+         }
+      ],
+      "summary": "<Division> Pre-release <version> Mouse production setup"
+   },
+   {
+      "component": "Relco tasks",
+      "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Intentions+for+release+<version>",
+      "subtasks": [{
+            "component": "Production tasks",
+            "description": "*GitHub*: [MurinaeNcRNAtrees_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MurinaeNcRNAtrees_conf.pm]\n
+{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::MurinaeNcRNAtrees_conf -host mysql-ens-compara-prod-X -port XXXX -mlss_id <curr_murinae_ncrna_mlss_id>{code}",
+            "summary": "Run the mouse strains ncRNA-trees pipeline",
+            "name_on_graph": "ncRNA-trees:Murinae"
+         },
+         {
+            "component": "Production tasks",
+            "description": "*GitHub*: [MurinaeProteinTrees_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MurinaeProteinTrees_conf.pm]\n
+{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::MurinaeProteinTrees_conf -host mysql-ens-compara-prod-X -port XXXX -mlss_id <curr_murinae_ptree_mlss_id>{code}",
+            "summary": "Run the mouse strains Protein-trees pipeline",
+            "name_on_graph": "Protein-trees:Murinae"
+         },
+         {
+            "component": "Production tasks",
+            "description": "*GitHub*: [EPO_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPO_conf.pm]\n
+{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPO_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name mammals -mlss_id <epo_mlss_id>{code}\n
+(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
+            "summary": "Run the Mammal EPO pipeline",
+            "name_on_graph": "EPO:Mammals"
+         },
+         {
+             "component": "Production tasks",
+             "description": "*GitHub*: [Vertebrates/MercatorPecan_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MercatorPecan_conf.pm]\n
+{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::MercatorPecan_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -mlss_id <pecan_mlss_id>{code}",
+             "summary": "Run the Amniotes pecan pipeline",
+             "name_on_graph": "Mercator Pecan:Amniotes"
+         },
+         {
+             "component": "Production tasks",
+             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+DNA+data#MergetheDNAdata-Patchalignments",
+             "summary": "Align the mouse patches against the primary mouse assembly",
+             "name_on_graph": "Patches against their primary assembly:Mouse"
+         },
+         {
+            "component": "Production tasks",
+            "summary": "All LastZ",
+            "name_on_graph": "All LastZ"
+         },
+         {
+            "component": "Production tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Age+of+Base",
+            "summary": "Age of Base",
+            "name_on_graph": "Age of Base:Human"
+         },
+         {
+            "component": "Production tasks",
+            "description": "*GitHub*: [Synteny_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Synteny_conf.pm]\n
+{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Synteny_conf -host mysql-ens-compara-prod-X -port XXXX -division <division>{code}",
+            "name_on_graph": "Synteny",
+            "summary": "Run the Synteny pipeline"
+         }
+      ],
+      "labels": ["Production_anchor"],
+      "summary": "<Division> Pre-release <version> Mouse production pipelines"
+   },
+   {
+      "component": "Relco tasks",
+      "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Construction+of+the+release+database",
+      "subtasks": [{
+            "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Final+healthchecking+and+testing",
+            "summary": "Run the datachecks"
+         }
+      ],
+      "labels": ["Merge_anchor"],
+      "summary": "<Division> Pre-release <version> Mouse datachecks"
+   }
+]

--- a/conf/vertebrates/mlss_conf.xml
+++ b/conf/vertebrates/mlss_conf.xml
@@ -36,7 +36,7 @@
 
     <!-- Mammals -->
     <!-- Use of "default" collection excludes the mouse strains and the pig breeds -->
-    <!-- NB: we have a CACTUS alignment for mouse strains and an EPO Extended MSA for pig breeds -->
+    <!-- NB: we have an EPO alignment for mouse strains and an EPO Extended MSA for pig breeds -->
     <one_vs_all method="LASTZ_NET" ref_genome="homo_sapiens">
       <species_set in_collection="default">
         <taxonomic_group taxon_name="Eutheria"/>
@@ -428,7 +428,7 @@
     </multiple_alignment>
 
     <!-- Mouse strains -->
-    <multiple_alignment method="CACTUS_HAL">
+    <multiple_alignment method="EPO">
       <species_set name="murinae">
         <!-- As long as we are not able to update this alignment, the species-set must remain the same.
              We cannot use taxonomy-based rules since they would automatically add new species to the set -->

--- a/conf/vertebrates/next_production_reg_conf.pl
+++ b/conf/vertebrates/next_production_reg_conf.pl
@@ -1,0 +1,103 @@
+#!/usr/bin/env perl
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2020] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Release Coordinator, please update this file before starting every release
+# and check the changes back into GIT for everyone's benefit.
+
+# Things that normally need updating are:
+#
+# 1. Release number
+# 2. Check the name prefix of all databases
+# 3. Possibly add entries for core databases that are still on genebuilders' servers
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Registry;
+use Bio::EnsEMBL::Compara::Utils::Registry;
+
+my $next_release = $ENV{'CURR_ENSEMBL_RELEASE'};
+my $curr_release = $next_release - 1;
+my $prev_release = $curr_release - 1;
+
+my $prev_db_suffix = Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX;
+
+# ---------------------- SPECIES TO UPDATE OUT OF THE RELEASE ------------------
+
+my $updated_core_dbs = {
+    'mus_musculus' => [ 'mysql-ens-genebuild-prod-2', 'thibaut_mus_musculus_havana_39' ],
+};
+
+my $prev_core_dbs = {
+    "mus_musculus$prev_db_suffix" => [ 'mysql-ens-vertannot-staging', 'mus_musculus_core_102_38' ],
+};
+
+# ---------------------- CURRENT CORE DATABASES --------------------------------
+
+# All the core databases live on the Vertebrates staging server or our mirror
+# Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-1:4519/$curr_release");
+Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-mirror-1:4240/$curr_release");
+# Remove species that will be updated $next_release
+Bio::EnsEMBL::Compara::Utils::Registry::remove_species( [ keys %$updated_core_dbs ] );
+# Add the correct core database for those species
+Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $updated_core_dbs );
+
+# ---------------------- PREVIOUS CORE DATABASES -------------------------------
+
+# Previous release core databases will be required by PrepareMasterDatabaseForRelease, LoadMembers and Mercator-Pecan
+*Bio::EnsEMBL::Compara::Utils::Registry::load_previous_core_databases = sub {
+    Bio::EnsEMBL::Registry->load_registry_from_db(
+        -host   => 'mysql-ens-mirror-1',
+        -port   => 4240,
+        -user   => 'ensro',
+        -pass   => '',
+        -db_version     => $prev_release,
+        -species_suffix => $prev_db_suffix,
+    );
+    # Do the same with the previous core database
+    Bio::EnsEMBL::Compara::Utils::Registry::remove_species( [ keys %$prev_core_dbs ] );
+    Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $prev_core_dbs );
+};
+
+# ---------------------- COMPARA DATABASE LOCATIONS ----------------------------
+
+# FORMAT: species/alias name => [ host, db_name ]
+my $compara_dbs = {
+    # general compara dbs
+    'compara_master' => [ 'mysql-ens-compara-prod-5', 'jalvarez_compara_master_101' ],
+    'compara_prev'   => [ 'mysql-ens-compara-prod-7', "jalvarez_compara_$curr_release" ],
+};
+
+Bio::EnsEMBL::Compara::Utils::Registry::add_compara_dbas( $compara_dbs );
+
+# ---------------------- NON-COMPARA DATABASES ---------------------------------
+
+my $ancestral_dbs = {
+    'ancestral_prev' => [ 'mysql-ens-compara-prod-1', "ensembl_ancestral_$curr_release" ],
+    'ancestral_curr' => [ 'mysql-ens-compara-prod-1', "ensembl_ancestral_$next_release" ],
+};
+
+Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $ancestral_dbs );
+
+# NCBI taxonomy database (also maintained by production team):
+Bio::EnsEMBL::Compara::Utils::Registry::add_taxonomy_dbas({
+    'ncbi_taxonomy' => [ 'mysql-ens-mirror-1', "ncbi_taxonomy_$curr_release" ],
+});
+
+# ------------------------------------------------------------------------------
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
@@ -142,8 +142,13 @@ sub pipeline_analyses_prep_master_db_for_release {
 
         {   -logic_name => 'update_genome_from_registry_factory',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::PrepareMaster::UpdateGenomesFromRegFactory',
+            -parameters => {
+                'master_db' => $self->o('master_db'),
+            },
             -flow_into  => {
                 '2->A' => [ 'add_species_into_master' ],
+                '3->A' => [ 'retire_species_from_master' ],
+                '5->A' => [ 'verify_genome' ],
                 'A->1' => [ 'sync_metadata' ],
             },
             -rc_name    => '16Gb_job',

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromMetadataFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromMetadataFactory.pm
@@ -52,6 +52,7 @@ sub fetch_input {
     my $allowed_species_file = $self->param('allowed_species_file');
     my $allowed_species;
     if (defined $allowed_species_file && -e $allowed_species_file) {
+        die "The allowed species JSON file ('$allowed_species_file') should not be empty" if -z $allowed_species_file;
         $allowed_species = { map { $_ => 1 } @{ decode_json($self->_slurp($allowed_species_file)) } };
     }
 	# use metadata script to report genomes that need to be updated

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromRegFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromRegFactory.pm
@@ -56,6 +56,7 @@ sub fetch_input {
     # If provided, get the list of allowed species
     my $allowed_species_file = $self->param('allowed_species_file');
     if (defined $allowed_species_file && -e $allowed_species_file) {
+        die "The allowed species JSON file ('$allowed_species_file') should not be empty" if -z $allowed_species_file;
         # Keep only the species included in the allowed list
         my $allowed_species = { map { $_ => 1 } @{ decode_json($self->_slurp($allowed_species_file)) } };
         my @excluded_species = grep { ! exists $allowed_species->{$_} } @{ keys %core_dbas };

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromRegFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromRegFactory.pm
@@ -15,18 +15,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-=pod
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::PrepareMaster::UpdateGenomesFromRegFactory
 
-=head1 SYNOPSIS
+=head1 DESCRIPTION
 
 Returns the list of species/genomes to add to the master database from the core
 databases in the registry file
+
+=head1 EXAMPLES
+
+    standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::PrepareMaster::UpdateGenomesFromRegFactory \
+        -compara_db $(mysql-ens-compara-prod-9-ensadmin details url jalvarez_prep_vertebrates_master_for_rel_103) \
+        -master_db $(mysql-ens-compara-prod-1 details url ensembl_compara_master)
 
 =cut
 
@@ -34,20 +36,70 @@ package Bio::EnsEMBL::Compara::RunnableDB::PrepareMaster::UpdateGenomesFromRegFa
 
 use warnings;
 use strict;
+
 use Bio::EnsEMBL::Registry;
+use Bio::EnsEMBL::Compara::Utils::CoreDBAdaptor;
 
 use base ('Bio::EnsEMBL::Hive::Process');
 
+
 sub fetch_input {
     my $self = shift;
+    # Get the core database adaptors for all the current species specified in the registry
     my $species_list = Bio::EnsEMBL::Registry->get_all_species();
-    $self->param('species_to_update', $species_list);
+    my %core_dbas;
+    foreach my $species_name ( @$species_list ) {
+        my $dba = Bio::EnsEMBL::Registry->get_DBAdaptor($species_name, 'core');
+        $core_dbas{$species_name} = $dba;
+    }
+
+    # If provided, get the list of allowed species
+    my $allowed_species_file = $self->param('allowed_species_file');
+    if (defined $allowed_species_file && -e $allowed_species_file) {
+        # Keep only the species included in the allowed list
+        my $allowed_species = { map { $_ => 1 } @{ decode_json($self->_slurp($allowed_species_file)) } };
+        my @excluded_species = grep { ! exists $allowed_species->{$_} } @{ keys %core_dbas };
+        delete @core_dbas{@excluded_species};
+    }
+
+    my $master_dba = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba( $self->param_required('master_db') );
+    my $current_genomes = $master_dba->get_GenomeDBAdaptor->fetch_all_current();
+    my (@genomes_to_update, @genomes_to_retire, @genomes_to_verify);
+    if ( @$current_genomes ) {
+        foreach my $genome ( @$current_genomes ) {
+            # Never retire ancestral_sequences
+            next if $genome->name eq 'ancestral_sequences';
+            if ( $core_dbas{$genome->name} ) {
+                if ( $genome->assembly eq $core_dbas{$genome->name}->assembly_name ) {
+                    push @genomes_to_verify, $genome->name;
+                } else {
+                    push @genomes_to_update, $genome->name;
+                }
+            } else {
+                # Retire the genomes not included in the registry or the list of allowed species
+                push @genomes_to_retire, $genome->name;
+            }
+        }
+    } else {
+        # We are creating a new compara master dabatase, so all the species have to be added
+        push @genomes_to_update, keys %core_dbas;
+    }
+
+    $self->param('genomes_to_update', \@genomes_to_update);
+    $self->param('genomes_to_retire', \@genomes_to_retire);
+    $self->param('genomes_to_verify', \@genomes_to_verify);
 }
+
 
 sub write_output {
     my $self = shift;
-    my @new_genomes_dataflow = map { {species_name => $_, force => 0} } @{ $self->param('species_to_update') };
-    $self->dataflow_output_id(\@new_genomes_dataflow, 2);
+    my @genomes_to_update = map { {species_name => $_, force => 0} } @{ $self->param('genomes_to_update') };
+    $self->dataflow_output_id(\@genomes_to_update, 2);
+    my @genomes_to_retire = map { {species_name => $_} } @{ $self->param('genomes_to_retire') };
+    $self->dataflow_output_id(\@genomes_to_retire, 3);
+    my @genomes_to_verify = map { {species_name => $_} } @{ $self->param('genomes_to_verify') };
+    $self->dataflow_output_id(\@genomes_to_verify, 5);
 }
+
 
 1;


### PR DESCRIPTION
## Description

New SOP to add genomes to the master database **before** the new production cycle starts to give us extra time to run all the required pipelines affected by the more disruptive species, mainly the fantastic 4.

**Related JIRA tickets:**
- ENSCOMPARASW-3648

## Overview of changes
#### Change 1
- Updated `PrepareMasterDBForRelease` pipeline and `UpdateGenomesFromRegFactory` runnable to handle the registry not only to create new master databases but also to update existing ones as well.

#### Change 2
- Created a new registry configuration file for this task, with the specific information of the species that need to be "pre-updated". I think it is better to keep it separated as its configuration is slightly different (and allows us a better track of the changes). So far this is a basic file, but may need to be extended as we will be using it to run all the production pipelines as well.

#### Change 3
- Added the new JSON file with the mouse-related JIRA tickets to be created and done before/during e103, taking advantage of this new SOP.

## Testing
I have created a copy of vertebrates master database from e101, run the first [Prepare pipeline](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-10&port=4648&dbname=jalvarez_prep_vertebrates_master_for_rel_102a) via the registry updating mouse, and then a [second time using the metadata](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-10&port=4648&dbname=jalvarez_prep_vertebrates_master_for_rel_102b) (adding to the report the mouse was updated as well, to be consistent with the previous changes). No conflicts were raised, just some MLSS and SS ids are "wasted" as they are generated but never actually used in between both runs. Both master databases (after the first run and final) are in `cp5` with names `jalvarez_compara_master_101a` and `jalvarez_compara_master_101`, respectively.

## Notes
As it happens with *Homo sapiens*, every species that has been previously updated via registry needs to have `force = 1` in their job so the analysis `add_species_into_master` doesn't fail.