### PR TITLE
Improved loading of slices from the core database

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/DnaFragAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/DnaFragAdaptor.pm
@@ -339,7 +339,7 @@ sub fetch_all_by_GenomeDB_and_names {
         assert_ref($genome_db, 'Bio::EnsEMBL::Compara::GenomeDB', 'genome_db');
         $genome_db_id = $genome_db->dbID;
         if (!$genome_db_id) {
-            throw("[$genome_db] does not have a dbID");
+            throw($genome_db->toString . " does not have a dbID");
         }
     }
 

--- a/modules/Bio/EnsEMBL/Compara/Utils/CoreDBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/CoreDBAdaptor.pm
@@ -124,8 +124,8 @@ sub pool_one_DBConnection {
   Arg[2]      : (optional) String $genome_component
   Arg[-ATTRIBUTES] (opt)
               : Arrayref of strings. List of the attribute codes to load.
-                If not defined, will load a preselection of attributes known
-                to be necessary to build DnaFrags. Set it to an empty list to
+                to be necessary to build DnaFrags ('codon_table', 'non_ref',
+                and 'sequence_location'). Set it to an empty list to
                 disable loading of any attributes.
   Arg[-RETURN_BATCHES] (opt)
               : Boolean. Make the iterator return batches of slices instead

--- a/modules/Bio/EnsEMBL/Compara/Utils/CoreDBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/CoreDBAdaptor.pm
@@ -195,7 +195,7 @@ sub iterate_toplevel_slices {
     my $slice_builder = sub {
         if ($sth->fetch) {
             my $cs = $csa->fetch_by_dbID($cs_id);
-            if(!$cs) {
+            if (!$cs) {
                 throw("seq_region $name references non-existent coord_system $cs_id.");
             }
             return Bio::EnsEMBL::Slice->new_fast({


### PR DESCRIPTION
## Notes

I have directly pushed the changes to `release/102` as I expect James to shortly merge Ensembl/ensembl-datacheck#294, but since they are important changes, I still want to get a review.

Sorry for the misleading branch names in this pull-request. `experimental/for_master` is in fact currently on par with `release/102`. The most important is that I will be able to do a `git merge` onto `release/102` from it with any suggestions that you make and is committed.

There is 1 commit that is not needed for `release/102` and that I will push on `master` instead. It's currently there: 8df6a819eb79b49dbbeb802ef7669b2bd0f146e0 . You can leave comments on it as well.

## Description

In Ensembl/ensembl-datacheck#285 James added a datacheck version of the Java healthcheck that compares the DnaFrags to the core databases, but there was a caveat: the code was relatively slow and would have taken 6 hours on all vertebrates, so he decided to exclude species that had too many regions. I was not very keen on not testing all species, and took a look at the code (core API) and realised the slowness was coming from the fact the core API doesn't record `seq_region_id` in Slices. Every call like `is_reference()`, `length()`, etc, involves a SQL request to first get the `seq_region_id` plus the one to actually fetch the required information ! Secondly, enabling the datacheck on all species would have severely increased the memory footprint of the datacheck.
My solution is a new function that returns an iterator over the slices (thus keeping the memory consumption low) and fetches all the data (incl. the required attributes) in a small number of queries.

## Overview of changes

#### Change #1

The drive of all this: new `iterate_toplevel_slices` function in modules/Bio/EnsEMBL/Compara/Utils/CoreDBAdaptor.pm

#### Change #2

New iterator functions, which I have put in modules/Bio/EnsEMBL/Compara/Utils/Scalar.pm to batch / un-batch data. Needed by the above to reduce the number of queries.

#### Change #3

Updated `new_from_Slice`, in modules/Bio/EnsEMBL/Compara/DnaFrag.pm, that knows where `iterate_toplevel_slices` has put the extra attributes. It is used by the DataCheck to create a canonical DnaFrag in order to compare the DnaFrag that comes from the database.

#### Change #4

New `fetch_all_by_GenomeDB_and_names` method in modules/Bio/EnsEMBL/Compara/DBSQL/DnaFragAdaptor.pm. Also used by the DataCheck in order to fetch the dnafrags efficiently.

#### Change #5

Use `iterate_toplevel_slices` in `update_dnafrags` (modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm): 8df6a819eb79b49dbbeb802ef7669b2bd0f146e0 . It should run a bit faster, and with less RAM.

## Testing

_How was this tested? Have new unit tests been included?_

I have added unit-tests for everything except `DnaFrag::new_from_Slice`, but this one has been testing by running the datachecks.
