### PR TITLE
MIsc. WGA improvements

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/OrthologQM_Alignment_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/OrthologQM_Alignment_conf.pm
@@ -182,6 +182,7 @@ sub pipeline_wide_parameters {
         'gene_dumps_dir'     => $self->o('gene_dumps_dir'),
 
         'compara_db'         => $self->o('compara_db'),
+        'master_db'          => $self->o('master_db'),
         'alt_aln_dbs'        => $self->o('alt_aln_dbs'),
         'alt_homology_db'   => $self->o('alt_homology_db'),
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/OrthologQM_Alignment_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/OrthologQM_Alignment_conf.pm
@@ -140,6 +140,8 @@ sub default_options {
     };
 }
 
+sub no_compara_schema {}    # Tell the base class not to create the Compara tables in the database
+
 =head2 pipeline_create_commands
 
 	Description: create tables for writing data to

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/OrthologQM_Alignment_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/OrthologQM_Alignment_conf.pm
@@ -196,7 +196,13 @@ sub pipeline_analyses {
     my ($self) = @_;
     return [
         {   -logic_name => 'fire_orth_wga',
-            -input_ids  => [ { } ],
+            -input_ids  => [ {
+                'species_set_name' => $self->o('species_set_name'),
+                'species_set_id'   => $self->o('species_set_id'),
+                'ref_species'      => $self->o('ref_species'),
+                'species1'         => $self->o('species1'),
+                'species2'         => $self->o('species2'),
+            } ],
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => 'pair_species',
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
@@ -51,13 +51,6 @@ sub pipeline_analyses_ortholog_qm_alignment {
                 'B->1' => [ 'ortholog_mlss_factory' ],
                 '3'    => [ 'reset_mlss' ],
             },
-            -parameters => {
-                'species_set_name' => $self->o('species_set_name'),
-                'species_set_id'   => $self->o('species_set_id'),
-                'ref_species'      => $self->o('ref_species'),
-                'species1'         => $self->o('species1'),
-                'species2'         => $self->o('species2'),
-            },
         },
 
         {   -logic_name => 'reset_mlss',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
@@ -57,7 +57,6 @@ sub pipeline_analyses_ortholog_qm_alignment {
                 'ref_species'      => $self->o('ref_species'),
                 'species1'         => $self->o('species1'),
                 'species2'         => $self->o('species2'),
-                'master_db'        => $self->o('master_db'),
             },
         },
 
@@ -73,7 +72,6 @@ sub pipeline_analyses_ortholog_qm_alignment {
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::SelectMLSS',
             -parameters => {
                 'current_release' => $self->o('ensembl_release'),
-                'master_db'       => $self->o('master_db'),
             },
             -flow_into  => {
                 1 => [ '?accu_name=alignment_mlsses&accu_address=[]&accu_input_variable=accu_dataflow' ],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
@@ -57,9 +57,7 @@ sub pipeline_analyses_ortholog_qm_alignment {
                 'ref_species'      => $self->o('ref_species'),
                 'species1'         => $self->o('species1'),
                 'species2'         => $self->o('species2'),
-                'alt_aln_dbs'      => $self->o('alt_aln_dbs'),
                 'master_db'        => $self->o('master_db'),
-                'alt_homology_db'  => $self->o('alt_homology_db'),
             },
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -284,8 +284,6 @@ sub default_options {
         # Uncomment and update the database locations
 
         # the dbs required for OrthologQMAlignment alt_aln_dbs can be an array list of alignment dbs
-        'compara_db'      => $self->pipeline_url(),
-        'alt_homology_db' => $self->pipeline_url(),
         'alt_aln_dbs'     => [
             'compara_curr',
         ],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -256,11 +256,7 @@ sub default_options {
         'hive_default_max_retry_count' => 1,
 
         # parameters for OrthologQMAlignment
-        'species1'         => undef,
-        'species2'         => undef,
-        'species_set_name' => "collection-" . $self->o('collection'),
-        'species_set_id'   => undef,
-        'ref_species'      => undef,
+        'wga_species_set_name'       => "collection-" . $self->o('collection'),
         'homology_method_link_types' => ['ENSEMBL_ORTHOLOGUES'],
         # WGA dump directories for OrthologQMAlignment
         'wga_dumps_dir'      => $self->o('homology_dumps_dir'),
@@ -3618,7 +3614,7 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'rib_fire_orth_wga',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-            -flow_into  => WHEN( '#dna_alns_complete#'  => [ 'pair_species' ] ),
+            -flow_into  => WHEN( '#dna_alns_complete#'  => { 'pair_species' => {'species_set_name' => $self->o('wga_species_set_name')}, } ),
         },
 
         {   -logic_name => 'homology_dNdS',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -77,8 +77,6 @@ sub default_options {
         'epo_db'      => 'compara_prev',
 
         # The dbs required for OrthologQMAlignment alt_aln_dbs can be an array list of alignment dbs
-        'compara_db'      => $self->pipeline_url(),
-        'alt_homology_db' => $self->pipeline_url(),
         'alt_aln_dbs'     => [
             'compara_curr',
         ],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -158,11 +158,7 @@ sub default_options {
             'prev_homology_dumps_dir'   => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('prev_release'),
 
             # Parameters for OrthologQMAlignment
-            'species1'         => undef,
-            'species2'         => undef,
-            'species_set_name' => "collection-" . $self->o('collection'),
-            'species_set_id'   => undef,
-            'ref_species'      => undef,
+            'wga_species_set_name'       => "collection-" . $self->o('collection'),
             'homology_method_link_types' => ['ENSEMBL_ORTHOLOGUES'],
             # WGA dump directories for OrthologQMAlignment
             'wga_dumps_dir'      => $self->o('homology_dumps_dir'),
@@ -1312,7 +1308,7 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'rib_fire_orth_wga',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-            -flow_into  => WHEN( '#dna_alns_complete#'  => [ 'pair_species' ] ),
+            -flow_into  => WHEN( '#dna_alns_complete#'  => { 'pair_species' => {'species_set_name' => $self->o('wga_species_set_name')}, } ),
         },
 
         {   -logic_name => 'rib_fire_high_confidence_orths',


### PR DESCRIPTION
## Description

Follow up of #196, made of several things I noticed while working on #229. I would have made the comments in #196 but I didn't get the chance to review it.

First of all, note that I have already pushed two bugfixes on `release/103`: ce71c75d918a5e206e07111816e3670da3c2dbcd and cf543b0ae5547682ba840dda388faeb027c29780

## Overview of changes

The commit messages are self-explanatory, but for clarity, here is a summary

#### Change n°1
- Don't need to define `compara_db` and `alt_homology_db` since by default the pipeline will default to the current database. Also having these defined means that the Runnable will open _another_ connection to the database, leaving the first one open and unused.

#### Change n°2
- Don't create the Compara tables in the standalone pipeline

#### Change n°3
- Moved parameters outside of the analysis, thus limiting what options pipelines that include WGA need to have

## Testing

I have run the (standalone) pipeline in #229
