### PR TITLE
WGA "All in one"

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
@@ -91,58 +91,26 @@ sub pipeline_analyses_ortholog_qm_alignment {
                 'method_link_types' => $self->o('homology_method_link_types'),
             },
             -flow_into  => {
-                '2->A' => { 'prepare_orthologs' => INPUT_PLUS() },
+                '2->A' => { 'calculate_wga_coverage' => INPUT_PLUS() },
                 'A->1' => [ 'check_file_copy' ],
             }
         },
 
-        {   -logic_name => 'prepare_orthologs',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::PrepareOrthologs',
+        {   -logic_name => 'calculate_wga_coverage',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::WGACoverage',
             -parameters => {
                 'hashed_mlss_id'            => '#expr(dir_revhash(#orth_mlss_id#))expr#',
                 'homology_flatfile'         => '#homology_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.homologies.tsv',
                 'homology_mapping_flatfile' => '#homology_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.homology_id_map.tsv',
+                'previous_wga_file'         => '#prev_wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv',
+                'reuse_file'                => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga_reuse.tsv',
+                'output_file'               => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv',
             },
             -analysis_capacity  =>  50,  # use per-analysis limiter
-            -flow_into => {
-                # these analyses will write to the same file, so a semaphore is required to prevent clashes
-                '3->A' => [ 'reuse_wga_score' ],
-                'A->2' => { 'calculate_wga_coverage' => INPUT_PLUS() },
-            },
-            -rc_name  => '2Gb_job',
-        },
-
-        {   -logic_name => 'calculate_wga_coverage',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::CalculateWGACoverage',
-            -hive_capacity => 30,
-            -batch_size => 10,
             -flow_into  => {
                 3 => [ '?table_name=ortholog_quality' ],
-                2 => [ 'assign_wga_coverage_score' ],
             },
             -rc_name => '2Gb_job',
-        },
-
-        {   -logic_name => 'assign_wga_coverage_score',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::AssignQualityScore',
-            -parameters => {
-                'hashed_mlss_id' => '#expr(dir_revhash(#orth_mlss_id#))expr#',
-                'output_file'    => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv',
-                'reuse_file'     => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga_reuse.tsv',
-            },
-            -rc_name    => '500Mb_job',
-            -hive_capacity => 400,
-        },
-
-        {   -logic_name => 'reuse_wga_score',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::ReuseWGAScore',
-            -parameters => {
-                'hashed_mlss_id'            => '#expr(dir_revhash(#orth_mlss_id#))expr#',
-                'previous_wga_file'         => '#prev_wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv',
-                'homology_mapping_flatfile' => '#homology_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.homology_id_map.tsv',
-                'output_file'               => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga_reuse.tsv',
-            },
-            -hive_capacity => 400,
         },
 
         {   -logic_name  => 'check_file_copy',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
@@ -106,7 +106,7 @@ sub pipeline_analyses_ortholog_qm_alignment {
                 'reuse_file'                => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga_reuse.tsv',
                 'output_file'               => '#wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv',
             },
-            -analysis_capacity  =>  50,  # use per-analysis limiter
+            -analysis_capacity  =>  140,  # use per-analysis limiter
             -flow_into  => {
                 3 => [ '?table_name=ortholog_quality' ],
             },

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/AssignQualityScore.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/AssignQualityScore.pm
@@ -110,7 +110,7 @@ sub write_output {
         my $dba = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba($aln_db);
         my $mlss = $dba->get_MethodLinkSpeciesSetAdaptor->fetch_by_dbID($aln_mlss_id);
         print "Writing n_${member_type}_wga_score to the database\n" if $self->debug;
-        $self->write_n_tag($mlss, "${member_type}_wga", \%max_quality);
+        write_n_tag($mlss, "${member_type}_wga", \%max_quality);
         print "Tag: n_${member_type}_wga_score written!\n\n" if $self->debug;
         $dba->dbc->disconnect_if_idle();
     }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/AssignQualityScore.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/AssignQualityScore.pm
@@ -44,7 +44,6 @@ use strict;
 use warnings;
 use Data::Dumper;
 use File::Basename;
-use Bio::EnsEMBL::Compara::Utils::FlatFile qw(map_row_to_header);
 use Bio::EnsEMBL::Compara::Utils::DistributionTag qw(write_n_tag);
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/ReuseWGAScore.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/ReuseWGAScore.pm
@@ -40,7 +40,7 @@ sub write_output {
 
     my $previous_wga_file = $self->param('previous_wga_file');
     my $homology_map_file = $self->param('homology_mapping_flatfile');
-    my $output_file       = $self->param('output_file');
+    my $output_file       = $self->param('reuse_file');
     $self->run_command( "mkdir -p " . dirname($output_file)) unless -d dirname($output_file);
 
     # parse homology id map

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/WGACoverage.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/WGACoverage.pm
@@ -40,7 +40,8 @@ use Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::CalculateWGACoverage;
 use Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::ReuseWGAScore;
 use Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::AssignQualityScore;
 
-use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+# Need to use these as parent classes to allow their functions to be called with $self->
+use base ('Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::PrepareOrthologs', 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::CalculateWGACoverage');
 
 sub fetch_input {
     my $self = shift;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/WGACoverage.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/OrthologQM/WGACoverage.pm
@@ -1,0 +1,107 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::WGACoverage
+
+=head1 SYNOPSIS
+
+Wrapper around all the Runnables that compute the WGA coverage score to
+compute everything within one job.
+
+See those for a description of the algorithm and their input parameters.
+
+Below, "IN" and "OUT" represent the job parameters that are used and set.
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::WGACoverage;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::PrepareOrthologs;
+use Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::CalculateWGACoverage;
+use Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::ReuseWGAScore;
+use Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::AssignQualityScore;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+sub fetch_input {
+    my $self = shift;
+
+    # IN: species1_id
+    # IN: species2_id
+    # IN: homology_flatfile
+    # IN: previous_wga_file
+    # IN: homology_mapping_flatfile
+    # IN: new_alignment
+    # IN: alt_homology_db
+    # OUT: orth_objects
+    # OUT: reuse
+    # OUT: member_info
+    Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::PrepareOrthologs::fetch_input($self);
+}
+
+sub run {
+    my $self = shift;
+
+    # IN: member_info
+    # IN: orth_objects
+    # OUT: orth_info
+    Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::PrepareOrthologs::run($self);
+
+    # IN: orth_info
+    # IN: aln_mlss_ids
+    # IN: alt_homology_db
+    # IN: mlss_db_mapping
+    # OUT: aln_ranges
+    Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::CalculateWGACoverage::fetch_input($self);
+
+    # IN: orth_info
+    # IN: mlss_db_mapping
+    # IN: aln_ranges
+    # OUT: orth_ids
+    # OUT: qual_summary
+    # OUT: max_quality
+    Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::CalculateWGACoverage::run($self);
+}
+
+sub write_output {
+    my $self = shift;
+
+    if ( $self->param('reuse') ){
+        # IN: previous_wga_file
+        # IN: homology_mapping_flatfile
+        # IN: reuse_file (for writing)
+        Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::ReuseWGAScore::write_output($self);
+    }
+
+    # IN: max_quality
+    # IN: member_type
+    # IN: mlss_db_mapping
+    # IN: aln_mlss_ids
+    # IN: output_file
+    # IN: reuse_file (for reading)
+    Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::AssignQualityScore::write_output($self);
+
+    # If we want to record the scores in the ortholog_quality table
+    #$self->dataflow_output_id( $self->param('qual_summary'), 3 );
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/Utils/DistributionTag.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/DistributionTag.pm
@@ -48,7 +48,7 @@ our @EXPORT_OK;
 =cut
 
 sub write_n_tag {
-    my ($self, $mlss, $label, $scores) = @_;
+    my ($mlss, $label, $scores) = @_;
 
     my %distrib_hash;
     foreach my $score ( values %$scores ) {


### PR DESCRIPTION
## Description

The per-mlss_id work of WGA pipeline is split over four analyses, with a lot of data being transferred between them: homologies, coordinates, scores, etc. If you look at the runtime stats, `assign_wga_coverage_score.fetch_input` takes almost 40% of the total runtime, just fetching the scores. Some overhead take is not listed here, for instance, eHive fetching job parameters before the job starts.

```
+---------------------------+------------------------+----------------------+-------------------------+
| logic_name                | avg_input_msec_per_job | avg_run_msec_per_job | avg_output_msec_per_job |
+---------------------------+------------------------+----------------------+-------------------------+
| prepare_orthologs         |                 227613 |                  342 |                    2725 |
| calculate_wga_coverage    |                1770726 |               772603 |                   10888 |
| assign_wga_coverage_score |                1815250 |                    0 |                    2720 |
| reuse_wga_score           |                      0 |                    0 |                     514 |
+---------------------------+------------------------+----------------------+-------------------------+
```

My idea was to speed this up by combining those Runnables into 1.

## Overview of changes

I have created a new "Frankenstein" Runnable that calls all existing four Runnables. The advantage is that almost no changes are required in the existing Runnables, so the history will still be normally accessible.

I have benchmarked the new Runnable and the optimal capacity is 140, making it run in 7 hours in total (15 min per mlss_id) on e102 data. In the real database (`carlac_default_vertebrates_protein_trees_102`) it took 48 min per mlss_id the first time I looked at it (mid July) and now it seems to have taken 131 min per mlss_id, so maybe it was rerun since ? Anyway, the Frankenstein code is faster.

## Testing

No unit tests, but I have run the pipeline
