### PR TITLE
Feature/homology annotation

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -233,6 +233,7 @@ sub resource_classes_multi_thread {
         '4Gb_2c_job'   => { 'LSF' => ['-C0 -n 2 -M4000 -R"span[hosts=1] select[mem>4000] rusage[mem=4000]"', $reg_requirement] },
         '8Gb_2c_job'   => { 'LSF' => ['-C0 -n 2 -M8000 -R"span[hosts=1] select[mem>8000] rusage[mem=8000]"', $reg_requirement] },
 
+        '500Mb_4c_job' => {'LSF' => ['-n 4 -C0 -M500   -R"select[mem>500]   rusage[mem=500]   span[hosts=1]"', $reg_requirement] },
         '1Gb_4c_job'   => {'LSF' => ['-n 4 -C0 -M1000  -R"select[mem>1000]  rusage[mem=1000]  span[hosts=1]"', $reg_requirement] },
         '2Gb_4c_job'   => {'LSF' => ['-n 4 -C0 -M2000  -R"select[mem>2000]  rusage[mem=2000]  span[hosts=1]"', $reg_requirement] },
         '4Gb_4c_job'   => {'LSF' => ['-n 4 -C0 -M4000  -R"select[mem>4000]  rusage[mem=4000]  span[hosts=1]"', $reg_requirement] },
@@ -264,6 +265,9 @@ sub resource_classes_multi_thread {
         '64Gb_64c_job' => {'LSF' => ['-n 64 -C0 -M64000 -R"select[mem>64000] rusage[mem=64000] span[hosts=1]"', $reg_requirement] },
         '128Gb_64c_job' => {'LSF' => ['-n 64 -C0 -M128000 -R"select[mem>128000] rusage[mem=128000] span[hosts=1]"', $reg_requirement] },
         '256Gb_64c_job' => {'LSF' => ['-n 64 -C0 -M256000 -R"select[mem>256000] rusage[mem=256000] span[hosts=1]"', $reg_requirement] },
+
+        '500Mb_4c_20min_job' => {'LSF' => ['-n 4 -C0 -M500  -W 0:20 -R"select[mem>500]   rusage[mem=500]   span[hosts=1]"', $reg_requirement] },
+        '2Gb_4c_20min_job'   => {'LSF' => ['-n 4 -C0 -M2000 -W 0:20 -R"select[mem>2000]  rusage[mem=2000]  span[hosts=1]"', $reg_requirement] },
 
         '8Gb_4c_mpi'   => {'LSF' => ['-q mpi-rh74 -n 4  -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=4]"', $reg_requirement] },
         '8Gb_8c_mpi'   => {'LSF' => ['-q mpi-rh74 -n 8  -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=8]"', $reg_requirement] },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -115,6 +115,7 @@ sub executable_locations {
         'cmbuild_exe'               => $self->check_exe_in_cellar('infernal/1.1.2/bin/cmbuild'),
         'cmsearch_exe'              => $self->check_exe_in_cellar('infernal/1.1.2/bin/cmsearch'),
         'codeml_exe'                => $self->check_exe_in_cellar('paml43/4.3.0/bin/codeml'),
+        'diamond_exe'               => $self->check_exe_in_cellar('diamond'),
         'enredo_exe'                => $self->check_exe_in_cellar('enredo/0.5.0/bin/enredo'),
         'erable_exe'                => $self->check_exe_in_cellar('erable/1.0/bin/erable'),
         'esd2esi_exe'               => $self->check_exe_in_cellar('exonerate24/2.4.0/bin/esd2esi'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
@@ -82,7 +82,8 @@ sub default_options {
         'hc_priority'              => -10,
 
         'num_sequences_per_blast_job'   => 200,
-        'all_blast_params'              => [ 35, 50, '--max-hsps 1 --matrix PAM70 --threads 4 -b1 -c1 --sensitive', '1e-6' ],
+        'blast_params'              => '--max-hsps 1 --threads 4 -b1 -c1 --sensitive',
+        'evalue_limit'              => '1e-6',
     };
 }
 
@@ -105,7 +106,8 @@ sub pipeline_wide_parameters {  # These parameter values are visible to all anal
         'master_db'        => $self->o('master_db'),
         'output_db'        => $self->o('output_db'),
         'species_set_id'   => $self->o('species_set_id'),
-        'all_blast_params' => $self->o('all_blast_params'),
+        'blast_params'     => $self->o('all_blast_params'),
+        'evalue_limit'     => $self->o('evalue_limit'),
         'fasta_dir'        => $self->o('fasta_dir'),
     };
 }
@@ -130,12 +132,6 @@ sub core_pipeline_analyses {
             -analysis_capacity  => $self->o('decision_capacity'),
             -priority           => $self->o('hc_priority'),
             -batch_size         => 20,
-    );
-
-    my %blastp_parameters = (
-        'blast_bin_dir'         => $self->o('blast_bin_dir'),
-        'blast_params'          => "#expr( #all_blast_params#->[#param_index#]->[2])expr#",
-        'evalue_limit'          => "#expr( #all_blast_params#->[#param_index#]->[3])expr#",
     );
 
     return [

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
@@ -81,8 +81,8 @@ sub default_options {
         'decision_capacity'        => 150,
         'hc_priority'              => -10,
 
-        'num_sequences_per_blast_job'   => 50,
-        'all_blast_params'              => [ 35, 50, '-seg no -max_hsps 1 -use_sw_tback -num_threads 1 -matrix PAM70 -word_size 2', '1e-6' ],
+        'num_sequences_per_blast_job'   => 200,
+        'all_blast_params'              => [ 35, 50, '--max-hsps 1 --matrix PAM70 --threads 4 -b1 -c1 --sensitive', '1e-6' ],
     };
 }
 
@@ -144,12 +144,12 @@ sub core_pipeline_analyses {
         {   -logic_name => 'backbone_fire_blast',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into     => {
-                '1->A' => [ 'blast_factory' ],
+                '1->A' => [ 'diamond_factory' ],
                 'A->1' => [ 'do_something_with_paf_table' ],
             },
         },
 
-        {   -logic_name => 'blast_factory',
+        {   -logic_name => 'diamond_factory',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::BlastFactory',
             -parameters => {
                 'species_set_id'    => $self->o('species_set_id'),
@@ -158,7 +158,7 @@ sub core_pipeline_analyses {
             -rc_name       => '500Mb_job',
             -hive_capacity => $self->o('blast_factory_capacity'),
             -flow_into     => {
-                '2' => { 'blastp_unannotated' => INPUT_PLUS() }
+                '2' => { 'diamond_blastp' => INPUT_PLUS() }
             },
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
@@ -35,7 +35,7 @@ use Bio::EnsEMBL::Hive::Version 2.5;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For WHEN and INPUT_PLUS
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::CopyNCBIandGenomeDB;
-use Bio::EnsEMBL::Compara::PipeConfig::Parts::BLASTpAgainstRef;
+use Bio::EnsEMBL::Compara::PipeConfig::Parts::DiamondAgainstRef;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
 
@@ -167,7 +167,7 @@ sub core_pipeline_analyses {
         },
 
         @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::CopyNCBIandGenomeDB::pipeline_analyses_copy_ncbi_and_genome_db($self) },
-        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::BLASTpAgainstRef::pipeline_analyses_blastp_against_refdb($self) },
+        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::DiamondAgainstRef::pipeline_analyses_diamond_against_refdb($self) },
     ];
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
@@ -110,6 +110,13 @@ sub pipeline_wide_parameters {  # These parameter values are visible to all anal
     };
 }
 
+sub resource_classes {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::resource_classes('include_multi_threaded')},  # inherit the standard resource classes, incl. multi-threaded
+    };
+}
+
 sub core_pipeline_analyses {
     my ($self) = @_;
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DiamondAgainstRef.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DiamondAgainstRef.pm
@@ -1,0 +1,111 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Parts::DiamondAgainstRef
+
+=head1 DESCRIPTION
+
+    This is a partial PipeConfig to Diamond search a member_id list against given blast_db
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Parts::DiamondAgainstRef;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf; # For WHEN and INPUT_PLUS
+
+sub default_options {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::default_options},
+    }
+}
+
+sub pipeline_analyses_diamond_against_refdb {
+    my ($self) = @_;
+
+    my %blastp_parameters = (
+        'blast_bin_dir' => $self->o('blast_bin_dir'),
+        'blast_params'  => "#expr(#all_blast_params#->[2])expr#",
+        'evalue_limit'  => "#expr(#all_blast_params#->[3])expr#",
+        'blast_db'      => $self->o('blast_db'),
+    );
+
+    return [
+        {   -logic_name         => 'diamond_blastp',
+            -module             => 'Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::DiamondBlastp',
+            -parameters         => {
+                %blastp_parameters,
+            },
+            -rc_name       => '500Mb_6_hour_job',
+            -flow_into => {
+               -1 => [ 'diamond_blastp_himem' ],  # MEMLIMIT
+               -2 => 'break_batch',
+            },
+            -hive_capacity => $self->o('blastpu_capacity'),
+        },
+
+        {   -logic_name         => 'diamond_blastp_himem',
+            -module             => 'Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::DiamondBlastp',
+            -parameters         => {
+                %blastp_parameters,
+            },
+            -rc_name       => '2Gb_6_hour_job',
+            -flow_into => {
+               -2 => 'break_batch',
+            },
+            -priority      => 20,
+            -hive_capacity => $self->o('blastpu_capacity'),
+        },
+
+        {   -logic_name         => 'break_batch',
+            -module             => 'Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::BreakBlastBatch',
+            -flow_into  => {
+                2 => 'diamond_blastp_no_runlimit',
+            }
+        },
+
+        {   -logic_name         => 'diamond_blastp_no_runlimit',
+            -module             => 'Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::DiamondBlastp',
+            -parameters         => {
+                %blastp_parameters,
+            },
+            -flow_into => {
+               -1 => [ 'diamond_blastp_himem_no_runlimit' ],  # MEMLIMIT
+            },
+            -hive_capacity => $self->o('blastpu_capacity'),
+        },
+
+        {   -logic_name         => 'diamond_blastp_himem_no_runlimit',
+            -module             => 'Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::DiamondBlastp',
+            -parameters         => {
+                %blastp_parameters,
+            },
+            -rc_name       => '2Gb_job',
+            -priority      => 20,
+            -hive_capacity => $self->o('blastpu_capacity'),
+        },
+
+    ];
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DiamondAgainstRef.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DiamondAgainstRef.pm
@@ -33,13 +33,6 @@ use warnings;
 use Bio::EnsEMBL::Hive::Version 2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf; # For WHEN and INPUT_PLUS
 
-sub default_options {
-    my ($self) = @_;
-    return {
-        %{$self->SUPER::default_options},
-    }
-}
-
 sub pipeline_analyses_diamond_against_refdb {
     my ($self) = @_;
 
@@ -56,12 +49,12 @@ sub pipeline_analyses_diamond_against_refdb {
             -parameters         => {
                 %blastp_parameters,
             },
-            -rc_name       => '500Mb_6_hour_job',
-            -flow_into => {
+            -rc_name            => '500Mb_6_hour_job',
+            -flow_into          => {
                -1 => [ 'diamond_blastp_himem' ],  # MEMLIMIT
                -2 => 'break_batch',
             },
-            -hive_capacity => $self->o('blastpu_capacity'),
+            -hive_capacity      => $self->o('blastpu_capacity'),
         },
 
         {   -logic_name         => 'diamond_blastp_himem',
@@ -69,17 +62,17 @@ sub pipeline_analyses_diamond_against_refdb {
             -parameters         => {
                 %blastp_parameters,
             },
-            -rc_name       => '2Gb_6_hour_job',
-            -flow_into => {
+            -rc_name            => '2Gb_6_hour_job',
+            -flow_into          => {
                -2 => 'break_batch',
             },
-            -priority      => 20,
-            -hive_capacity => $self->o('blastpu_capacity'),
+            -priority           => 20,
+            -hive_capacity      => $self->o('blastpu_capacity'),
         },
 
         {   -logic_name         => 'break_batch',
             -module             => 'Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::BreakBlastBatch',
-            -flow_into  => {
+            -flow_into          => {
                 2 => 'diamond_blastp_no_runlimit',
             }
         },
@@ -89,10 +82,10 @@ sub pipeline_analyses_diamond_against_refdb {
             -parameters         => {
                 %blastp_parameters,
             },
-            -flow_into => {
+            -flow_into          => {
                -1 => [ 'diamond_blastp_himem_no_runlimit' ],  # MEMLIMIT
             },
-            -hive_capacity => $self->o('blastpu_capacity'),
+            -hive_capacity      => $self->o('blastpu_capacity'),
         },
 
         {   -logic_name         => 'diamond_blastp_himem_no_runlimit',
@@ -100,9 +93,9 @@ sub pipeline_analyses_diamond_against_refdb {
             -parameters         => {
                 %blastp_parameters,
             },
-            -rc_name       => '2Gb_job',
-            -priority      => 20,
-            -hive_capacity => $self->o('blastpu_capacity'),
+            -rc_name            => '2Gb_job',
+            -priority           => 20,
+            -hive_capacity      => $self->o('blastpu_capacity'),
         },
 
     ];

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DiamondAgainstRef.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DiamondAgainstRef.pm
@@ -37,9 +37,9 @@ sub pipeline_analyses_diamond_against_refdb {
     my ($self) = @_;
 
     my %blastp_parameters = (
-        'blast_bin_dir' => $self->o('blast_bin_dir'),
-        'blast_params'  => "#expr(#all_blast_params#->[2])expr#",
-        'evalue_limit'  => "#expr(#all_blast_params#->[3])expr#",
+        'diamond_exe'   => $self->o('diamond_exe'),
+        'blast_params'  => $self->o('blast_params'),
+        'evalue_limit'  => $self->o('evalue_limit'),
         'blast_db'      => $self->o('blast_db'),
     );
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DiamondAgainstRef.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DiamondAgainstRef.pm
@@ -49,7 +49,7 @@ sub pipeline_analyses_diamond_against_refdb {
             -parameters         => {
                 %blastp_parameters,
             },
-            -rc_name            => '500Mb_6_hour_job',
+            -rc_name            => '500Mb_4c_20min_job',
             -flow_into          => {
                -1 => [ 'diamond_blastp_himem' ],  # MEMLIMIT
                -2 => 'break_batch',
@@ -62,7 +62,7 @@ sub pipeline_analyses_diamond_against_refdb {
             -parameters         => {
                 %blastp_parameters,
             },
-            -rc_name            => '2Gb_6_hour_job',
+            -rc_name            => '2Gb_4c_20min_job',
             -flow_into          => {
                -2 => 'break_batch',
             },
@@ -82,6 +82,7 @@ sub pipeline_analyses_diamond_against_refdb {
             -parameters         => {
                 %blastp_parameters,
             },
+            -rc_name            => '500Mb_4c_job',
             -flow_into          => {
                -1 => [ 'diamond_blastp_himem_no_runlimit' ],  # MEMLIMIT
             },
@@ -93,7 +94,7 @@ sub pipeline_analyses_diamond_against_refdb {
             -parameters         => {
                 %blastp_parameters,
             },
-            -rc_name            => '2Gb_job',
+            -rc_name            => '2Gb_4c_job',
             -priority           => 20,
             -hive_capacity      => $self->o('blastpu_capacity'),
         },

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/DiamondBlastp.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/DiamondBlastp.pm
@@ -54,18 +54,14 @@ sub run {
     my $blast_params          = $self->param('blast_params')  || '';  # no parameters to C++ binary means having composition stats on and -seg masking off
     my $evalue_limit          = $self->param('evalue_limit');
     my $worker_temp_directory = $self->worker_temp_directory;
-
-    my $blast_infile  = $worker_temp_directory . '/blast.in.'.$$;     # only for debugging
-    my $blast_outfile = $worker_temp_directory . '/blast.out.'.$$;    # looks like inevitable evil (tried many hairy alternatives and failed)
+    my $blast_outfile         = $worker_temp_directory . '/blast.out.' . $$; # looks like inevitable evil
 
     Bio::EnsEMBL::Compara::Utils::Preloader::load_all_sequences($self->compara_dba->get_SequenceAdaptor, undef, $self->param('query_set'));
 
     if ($self->debug) {
+        my $blast_infile  = $worker_temp_directory . '/blast.in.' . $$;  # only for debugging
         print "diamond_infile $blast_infile\n";
         my $members = $self->param('query_set')->get_all_Members;
-        foreach my $member ( @$members ) {
-            print Dumper $member unless $member->isa('Bio::EnsEMBL::Compara::SeqMember');
-        }
         $self->param('query_set')->print_sequences_to_file($blast_infile, -format => 'fasta');
     }
 
@@ -85,7 +81,7 @@ sub run {
 
         my $features = $self->parse_blast_table_into_paf($blast_outfile, $self->param('genome_db_id'), $target_genome_db_id);
 
-        unless($self->param('expected_members') == scalar(keys(%{$self->param('num_query_member')}))) {
+        unless ($self->param('expected_members') == scalar(keys(%{$self->param('num_query_member')}))) {
             # Most likely, this is happening due to MEMLIMIT, so make the job sleep if it parsed 0 sequences, to wait for MEMLIMIT to happen properly.
             sleep(5);
         }
@@ -96,4 +92,5 @@ sub run {
 
     $self->param('cross_pafs', $cross_pafs);
 }
+
 1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/DiamondBlastp.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/DiamondBlastp.pm
@@ -1,0 +1,100 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::DiamondBlastp
+
+=head1 DESCRIPTION
+
+Create fasta file containing batch_size number of sequences. Run DIAMOND and parse the output into
+PeptideAlignFeature objects. Store PeptideAlignFeature objects in the compara database
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::DiamondBlastp;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BlastAndParsePAF');
+
+sub get_queries {
+    my $self = shift @_;
+
+    my $start_member_id = $self->param_required('start_member_id');
+    my $end_member_id   = $self->param_required('end_member_id');
+
+    #Get list of members and sequences
+    my $member_ids = $self->compara_dba->get_HMMAnnotAdaptor->fetch_all_seqs_missing_annot_by_range($start_member_id, $end_member_id, 'no_null');
+    return $self->compara_dba->get_SeqMemberAdaptor->fetch_all_by_dbID_list($member_ids);
+}
+
+sub run {
+    my $self = shift @_;
+
+    #my $diamond_exe             = $self->param('diamond_exe'); 
+    # This will be in ENV.pm once installed properly in farm, currently diamond is installed locally in my $USER .bin/
+    my $diamond_exe             = 'diamond';
+    my $blast_params            = $self->param('blast_params')  || '';  # no parameters to C++ binary means having composition stats on and -seg masking off
+    my $evalue_limit            = $self->param('evalue_limit');
+    my $tophits                 = $self->param('tophits');
+
+    my $worker_temp_directory   = $self->worker_temp_directory;
+
+    my $blast_infile  = $worker_temp_directory . '/blast.in.'.$$;     # only for debugging
+    my $blast_outfile = $worker_temp_directory . '/blast.out.'.$$;    # looks like inevitable evil (tried many hairy alternatives and failed)
+
+    Bio::EnsEMBL::Compara::Utils::Preloader::load_all_sequences($self->compara_dba->get_SequenceAdaptor, undef, $self->param('query_set'));
+
+    if ($self->debug) {
+        print "diamond_infile $blast_infile\n";
+        my $members = $self->param('query_set')->get_all_Members;
+        foreach my $member ( @$members ) {
+            print Dumper $member unless $member->isa('Bio::EnsEMBL::Compara::SeqMember');
+        }
+        $self->param('query_set')->print_sequences_to_file($blast_infile, -format => 'fasta');
+    }
+
+    $self->compara_dba->dbc->disconnect_if_idle();
+
+    my $cross_pafs = [];
+    foreach my $blast_db (keys %{$self->param('all_blast_db')}) {
+        my $target_genome_db_id = $self->param('all_blast_db')->{$blast_db};
+
+        my $cmd = "$diamond_exe blastp -d $blast_db --evalue $evalue_limit --out $blast_outfile --outfmt 6 qseqid sseqid evalue score nident pident qstart qend sstart send length positive ppos qseq_gapped sseq_gapped $blast_params";
+
+        my $run_cmd = $self->write_to_command($cmd, sub {
+                my $blast_fh = shift;
+                $self->param('query_set')->print_sequences_to_file($blast_fh, -format => 'fasta');
+        } );
+        print "Time for diamond search " . $run_cmd->runtime_msec . " msec\n";
+
+        my $features = $self->parse_blast_table_into_paf($blast_outfile, $self->param('genome_db_id'), $target_genome_db_id);
+
+        unless($self->param('expected_members') == scalar(keys(%{$self->param('num_query_member')}))) {
+            # Most likely, this is happening due to MEMLIMIT, so make the job sleep if it parsed 0 sequences, to wait for MEMLIMIT to happen properly.
+            sleep(5);
+        }
+
+        push @$cross_pafs, @$features;
+        unlink $blast_outfile unless $self->debug;
+    }
+
+    $self->param('cross_pafs', $cross_pafs);
+}
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/DiamondBlastp.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/DiamondBlastp.pm
@@ -21,8 +21,9 @@ Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::DiamondBlastp
 
 =head1 DESCRIPTION
 
-Create fasta file containing batch_size number of sequences. Run DIAMOND and parse the output into
-PeptideAlignFeature objects. Store PeptideAlignFeature objects in the compara database
+Create fasta file containing batch_size number of sequences. Run DIAMOND blastp and parse
+the output into PeptideAlignFeature objects. Store PeptideAlignFeature objects in the compara
+database
 
 =cut
 
@@ -47,14 +48,12 @@ sub get_queries {
 sub run {
     my $self = shift @_;
 
-    #my $diamond_exe             = $self->param('diamond_exe'); 
+    #my $diamond_exe           = $self->param('diamond_exe'); 
     # This will be in ENV.pm once installed properly in farm, currently diamond is installed locally in my $USER .bin/
-    my $diamond_exe             = 'diamond';
-    my $blast_params            = $self->param('blast_params')  || '';  # no parameters to C++ binary means having composition stats on and -seg masking off
-    my $evalue_limit            = $self->param('evalue_limit');
-    my $tophits                 = $self->param('tophits');
-
-    my $worker_temp_directory   = $self->worker_temp_directory;
+    my $diamond_exe           = 'diamond';
+    my $blast_params          = $self->param('blast_params')  || '';  # no parameters to C++ binary means having composition stats on and -seg masking off
+    my $evalue_limit          = $self->param('evalue_limit');
+    my $worker_temp_directory = $self->worker_temp_directory;
 
     my $blast_infile  = $worker_temp_directory . '/blast.in.'.$$;     # only for debugging
     my $blast_outfile = $worker_temp_directory . '/blast.out.'.$$;    # looks like inevitable evil (tried many hairy alternatives and failed)
@@ -79,8 +78,8 @@ sub run {
         my $cmd = "$diamond_exe blastp -d $blast_db --evalue $evalue_limit --out $blast_outfile --outfmt 6 qseqid sseqid evalue score nident pident qstart qend sstart send length positive ppos qseq_gapped sseq_gapped $blast_params";
 
         my $run_cmd = $self->write_to_command($cmd, sub {
-                my $blast_fh = shift;
-                $self->param('query_set')->print_sequences_to_file($blast_fh, -format => 'fasta');
+            my $blast_fh = shift;
+            $self->param('query_set')->print_sequences_to_file($blast_fh, -format => 'fasta');
         } );
         print "Time for diamond search " . $run_cmd->runtime_msec . " msec\n";
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/DiamondBlastp.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/DiamondBlastp.pm
@@ -48,9 +48,7 @@ sub get_queries {
 sub run {
     my $self = shift @_;
 
-    #my $diamond_exe           = $self->param('diamond_exe'); 
-    # This will be in ENV.pm once installed properly in farm, currently diamond is installed locally in my $USER .bin/
-    my $diamond_exe           = 'diamond';
+    my $diamond_exe           = $self->param('diamond_exe');
     my $blast_params          = $self->param('blast_params')  || '';  # no parameters to C++ binary means having composition stats on and -seg masking off
     my $evalue_limit          = $self->param('evalue_limit');
     my $worker_temp_directory = $self->worker_temp_directory;


### PR DESCRIPTION
## Description

This pipeline is intended for the rapid release, therefore it needs to be pretty rapid. The changes here switch `BLASTp` for new program `DIAMOND` which immediately speeds the analyses up to between 2.5 and 5% faster than previously. Some slight capacity alterations, and internal `DIAMOND` parameters to clean it up nicely.

**Related JIRA tickets:**
- ENSCOMPARASW-3780

## Overview of changes
_Give details of what changes were required to solve the problem. Break into sections if applicable._

#### Change 1
- New runnable for the diamond command based on `Bio::EnsEMBL::Compara::RunnableDB::BlastAndParsePAF`

#### Change 2
- Rename of `Parts/` and analyses to `diamond` to avoid confusion

#### Change 3
- New parameters for Diamond compatibility, diamond has some quirks which means it wasn't a simple replace

## Testing
This has been tested in several test pipelines to get the best results.
[Here for one genome](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-4&port=4401&dbname=cristig_homology_annotation_diamond_1_sensitive)
[Here for 10 genomes](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-4&port=4401&dbname=cristig_homology_annotation_diamond_10_opt)
[Here is the most optimal](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-4&port=4401&dbname=cristig_homology_annotation_diamond_1_rc_test)

## Notes
The results can likely be further optimised, but they are efficient and sensitive enough for purpose and any further optimisation may not be worthwhile or cost effective at this time.