### PR TITLE
Expanded the tests to check that the indexes are the same too

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/Utils/Test.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Test.pm
@@ -358,14 +358,24 @@ sub get_schema_from_database {
     my @table_names = keys %{ $sth->fetchall_hashref('TABLE_NAME') };
     my %schema;
     foreach my $t (@table_names) {
+
+        # Fetch the list of columns
         $sth = $dbh->column_info(undef, undef, $t, '%');
         $schema{$t}->{'COLUMNS'} = $sth->fetchall_hashref('COLUMN_NAME');
+
+        # Fetch the primary key
         my @pk_columns = $dbh->primary_key_info(undef, undef, $t);
         $schema{$t}->{'PRIMARY_KEY'} = \@pk_columns;
+
+        # Fetch the indexes
+        # Note that unlike the two others, this call requires the database name
         $sth = $dbh->statistics_info(undef, $db_name, $t, undef, 'quick');
         $schema{$t}->{'INDEXES'} = $sth->fetchall_hashref(['INDEX_NAME', 'ORDINAL_POSITION']);
         foreach my $h (values %{$schema{$t}->{'INDEXES'}}) {
+            # To make this identical across databases:
+            # 1. Remove the database name
             delete $_->{TABLE_SCHEM} for values %$h;
+            # 2. Remove stats about the number of entries
             delete $_->{CARDINALITY} for values %$h;
         }
     }

--- a/modules/t/test-genome-DBs/homology/compara/table.sql
+++ b/modules/t/test-genome-DBs/homology/compara/table.sql
@@ -147,7 +147,6 @@ CREATE TABLE `gene_member` (
   PRIMARY KEY (`gene_member_id`),
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
@@ -264,7 +263,9 @@ CREATE TABLE `gene_tree_root_attr` (
   `taxonomic_coverage` float DEFAULT NULL,
   `ratio_species_genes` float DEFAULT NULL,
   `model_name` varchar(40) DEFAULT NULL,
-  PRIMARY KEY (`root_id`)
+  PRIMARY KEY (`root_id`),
+  KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
+  KEY `lca_node_id` (`lca_node_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_root_tag` (

--- a/modules/t/test-genome-DBs/multi/compara/table.sql
+++ b/modules/t/test-genome-DBs/multi/compara/table.sql
@@ -147,7 +147,6 @@ CREATE TABLE `gene_member` (
   PRIMARY KEY (`gene_member_id`),
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
@@ -264,7 +263,9 @@ CREATE TABLE `gene_tree_root_attr` (
   `taxonomic_coverage` float DEFAULT NULL,
   `ratio_species_genes` float DEFAULT NULL,
   `model_name` varchar(40) DEFAULT NULL,
-  PRIMARY KEY (`root_id`)
+  PRIMARY KEY (`root_id`),
+  KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
+  KEY `lca_node_id` (`lca_node_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_root_tag` (

--- a/modules/t/test-genome-DBs/mysqlimport_test/compara/table.sql
+++ b/modules/t/test-genome-DBs/mysqlimport_test/compara/table.sql
@@ -148,7 +148,6 @@ CREATE TABLE `gene_member` (
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `source_name` (`source_name`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `canonical_member_id` (`canonical_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
@@ -176,9 +175,9 @@ CREATE TABLE `gene_member_qc` (
   `n_orth` int(11) DEFAULT NULL,
   `avg_cov` float DEFAULT NULL,
   `status` varchar(50) NOT NULL,
-  KEY `seq_member_id` (`seq_member_id`),
   KEY `genome_db_id` (`genome_db_id`),
-  KEY `gene_member_stable_id` (`gene_member_stable_id`)
+  KEY `gene_member_stable_id` (`gene_member_stable_id`),
+  KEY `seq_member_id` (`seq_member_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_node` (
@@ -235,7 +234,6 @@ CREATE TABLE `gene_tree_root` (
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `gene_align_id` (`gene_align_id`),
-  KEY `species_tree_root_id` (`species_tree_root_id`),
   KEY `ref_root_id` (`ref_root_id`),
   KEY `tree_type` (`tree_type`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;

--- a/modules/t/test-genome-DBs/orth_qm_goc/compara/table.sql
+++ b/modules/t/test-genome-DBs/orth_qm_goc/compara/table.sql
@@ -147,7 +147,6 @@ CREATE TABLE `gene_member` (
   PRIMARY KEY (`gene_member_id`),
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
@@ -264,7 +263,9 @@ CREATE TABLE `gene_tree_root_attr` (
   `taxonomic_coverage` float DEFAULT NULL,
   `ratio_species_genes` float DEFAULT NULL,
   `model_name` varchar(40) DEFAULT NULL,
-  PRIMARY KEY (`root_id`)
+  PRIMARY KEY (`root_id`),
+  KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
+  KEY `lca_node_id` (`lca_node_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_root_tag` (

--- a/modules/t/test-genome-DBs/orth_qm_wga/cc21_pair_species/table.sql
+++ b/modules/t/test-genome-DBs/orth_qm_wga/cc21_pair_species/table.sql
@@ -147,7 +147,6 @@ CREATE TABLE `gene_member` (
   PRIMARY KEY (`gene_member_id`),
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
@@ -264,7 +263,9 @@ CREATE TABLE `gene_tree_root_attr` (
   `taxonomic_coverage` float DEFAULT NULL,
   `ratio_species_genes` float DEFAULT NULL,
   `model_name` varchar(40) DEFAULT NULL,
-  PRIMARY KEY (`root_id`)
+  PRIMARY KEY (`root_id`),
+  KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
+  KEY `lca_node_id` (`lca_node_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_root_tag` (

--- a/modules/t/test-genome-DBs/orth_qm_wga/cc21_prepare_orth/table.sql
+++ b/modules/t/test-genome-DBs/orth_qm_wga/cc21_prepare_orth/table.sql
@@ -147,7 +147,6 @@ CREATE TABLE `gene_member` (
   PRIMARY KEY (`gene_member_id`),
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
@@ -264,7 +263,9 @@ CREATE TABLE `gene_tree_root_attr` (
   `taxonomic_coverage` float DEFAULT NULL,
   `ratio_species_genes` float DEFAULT NULL,
   `model_name` varchar(40) DEFAULT NULL,
-  PRIMARY KEY (`root_id`)
+  PRIMARY KEY (`root_id`),
+  KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
+  KEY `lca_node_id` (`lca_node_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_root_tag` (

--- a/modules/t/test-genome-DBs/orth_qm_wga/cc21_prev_orth_test/table.sql
+++ b/modules/t/test-genome-DBs/orth_qm_wga/cc21_prev_orth_test/table.sql
@@ -147,7 +147,6 @@ CREATE TABLE `gene_member` (
   PRIMARY KEY (`gene_member_id`),
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
@@ -264,7 +263,9 @@ CREATE TABLE `gene_tree_root_attr` (
   `taxonomic_coverage` float DEFAULT NULL,
   `ratio_species_genes` float DEFAULT NULL,
   `model_name` varchar(40) DEFAULT NULL,
-  PRIMARY KEY (`root_id`)
+  PRIMARY KEY (`root_id`),
+  KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
+  KEY `lca_node_id` (`lca_node_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_root_tag` (

--- a/modules/t/test-genome-DBs/orth_qm_wga/cc21_select_mlss/table.sql
+++ b/modules/t/test-genome-DBs/orth_qm_wga/cc21_select_mlss/table.sql
@@ -147,7 +147,6 @@ CREATE TABLE `gene_member` (
   PRIMARY KEY (`gene_member_id`),
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
@@ -264,7 +263,9 @@ CREATE TABLE `gene_tree_root_attr` (
   `taxonomic_coverage` float DEFAULT NULL,
   `ratio_species_genes` float DEFAULT NULL,
   `model_name` varchar(40) DEFAULT NULL,
-  PRIMARY KEY (`root_id`)
+  PRIMARY KEY (`root_id`),
+  KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
+  KEY `lca_node_id` (`lca_node_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_root_tag` (

--- a/modules/t/test-genome-DBs/parse_pair_aligner_conf/compara/table.sql
+++ b/modules/t/test-genome-DBs/parse_pair_aligner_conf/compara/table.sql
@@ -147,7 +147,6 @@ CREATE TABLE `gene_member` (
   PRIMARY KEY (`gene_member_id`),
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
@@ -264,7 +263,9 @@ CREATE TABLE `gene_tree_root_attr` (
   `taxonomic_coverage` float DEFAULT NULL,
   `ratio_species_genes` float DEFAULT NULL,
   `model_name` varchar(40) DEFAULT NULL,
-  PRIMARY KEY (`root_id`)
+  PRIMARY KEY (`root_id`),
+  KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
+  KEY `lca_node_id` (`lca_node_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_root_tag` (

--- a/modules/t/test-genome-DBs/test_master/compara/table.sql
+++ b/modules/t/test-genome-DBs/test_master/compara/table.sql
@@ -147,7 +147,6 @@ CREATE TABLE `gene_member` (
   PRIMARY KEY (`gene_member_id`),
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
@@ -264,7 +263,9 @@ CREATE TABLE `gene_tree_root_attr` (
   `taxonomic_coverage` float DEFAULT NULL,
   `ratio_species_genes` float DEFAULT NULL,
   `model_name` varchar(40) DEFAULT NULL,
-  PRIMARY KEY (`root_id`)
+  PRIMARY KEY (`root_id`),
+  KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
+  KEY `lca_node_id` (`lca_node_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_root_tag` (

--- a/modules/t/test-genome-DBs/update_homologies_test/compara/table.sql
+++ b/modules/t/test-genome-DBs/update_homologies_test/compara/table.sql
@@ -175,9 +175,9 @@ CREATE TABLE `gene_member_qc` (
   `n_orth` int(11) DEFAULT NULL,
   `avg_cov` float DEFAULT NULL,
   `status` varchar(50) NOT NULL,
-  KEY `seq_member_id` (`seq_member_id`),
   KEY `genome_db_id` (`genome_db_id`),
-  KEY `gene_member_stable_id` (`gene_member_stable_id`)
+  KEY `gene_member_stable_id` (`gene_member_stable_id`),
+  KEY `seq_member_id` (`seq_member_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_node` (
@@ -234,7 +234,6 @@ CREATE TABLE `gene_tree_root` (
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `gene_align_id` (`gene_align_id`),
-  KEY `species_tree_root_id` (`species_tree_root_id`),
   KEY `ref_root_id` (`ref_root_id`),
   KEY `tree_type` (`tree_type`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;

--- a/travisci/sql-unittest/latest_schema_patch.t
+++ b/travisci/sql-unittest/latest_schema_patch.t
@@ -34,7 +34,7 @@ my $multitestdb = Bio::EnsEMBL::Compara::Utils::Test::create_multitestdb();
 my $current_db_name = $multitestdb->create_db_name('current_schema');
 my $current_statements = Bio::EnsEMBL::Compara::Utils::Test::read_sqls("${compara_dir}/sql/table.sql");
 my $current_db = Bio::EnsEMBL::Compara::Utils::Test::load_statements($multitestdb, $current_db_name, $current_statements, 'Can load the current Compara schema');
-my $current_schema = Bio::EnsEMBL::Compara::Utils::Test::get_schema_from_database($current_db);
+my $current_schema = Bio::EnsEMBL::Compara::Utils::Test::get_schema_from_database($current_db, $current_db_name);
 Bio::EnsEMBL::Compara::Utils::Test::drop_database($multitestdb, $current_db_name);
 
 my $curr_release = software_version();
@@ -67,7 +67,7 @@ my @schema_patcher_command = (
     '--nointeractive',
 );
 Bio::EnsEMBL::Compara::Utils::Test::test_command(\@schema_patcher_command, 'Can patch the database');
-my $previous_schema = Bio::EnsEMBL::Compara::Utils::Test::get_schema_from_database($previous_db);
+my $previous_schema = Bio::EnsEMBL::Compara::Utils::Test::get_schema_from_database($previous_db, $previous_db_name);
 Bio::EnsEMBL::Compara::Utils::Test::drop_database($multitestdb, $previous_db_name);
 
 is_deeply($current_schema, $previous_schema, 'The patched schema is identical to the current one');


### PR DESCRIPTION
## Description

Follow-up of #227 / ENSCOMPARASW-3568. I have found that some test databases don't have the right set of indexes.

## Overview of changes

I have expanded `Utils::Test::get_schema_from_database` to also fetch the indexes, and updated the test databases so that they pass the check.

The trick is that the Compara test databases often have different indexes, depending on whether the real database they were created from has foreign keys or not, because MySQL automatically adds indexes in order to check the foreign key constraints.

I have made `travisci/sql-unittest/test_dbs_up_to_date.t` load the schema from two databases (with and without foreign keys) and consider all the extra indexes as optional.

## Testing

I have fixed all the test databases so that the test passes .