### PR TITLE
Overkill to be extra sure that trees to be deleted are deleted

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/DeleteOneTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/DeleteOneTree.pm
@@ -47,8 +47,8 @@ sub write_output {
         $tree->preload;
         $gene_tree_adaptor->delete_tree($tree);
         $tree->release_tree;
-    }, 1, 2 );
-    $self->_check_clean_eradication(); # Make sure that the tree has been removed after waiting 2 seconds and retrying once - a messy reindex is a pointlss reindex
+    }, 1, 2 );  # Retry once and wait 2 seconds between retries
+    $self->_check_clean_eradication();  # Make sure that the tree has been removed - a messy reindex is a pointless reindex
 }
 
 sub _check_clean_eradication {
@@ -61,4 +61,3 @@ sub _check_clean_eradication {
 }
 
 1;
-

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/DeleteOneTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/DeleteOneTree.pm
@@ -47,7 +47,17 @@ sub write_output {
         $tree->preload;
         $gene_tree_adaptor->delete_tree($tree);
         $tree->release_tree;
-    } );
+    }, 1, 2 );
+    $self->_check_clean_eradication(); # Make sure that the tree has been removed after waiting 2 seconds and retrying once - a messy reindex is a pointlss reindex
+}
+
+sub _check_clean_eradication {
+    my $self = shift @_;
+
+    my $gene_tree_adaptor = $self->compara_dba->get_GeneTreeAdaptor;
+    if (my $tree = $gene_tree_adaptor->fetch_by_dbID($self->param_required('gene_tree_id'))) {
+        die 'Tree with root_id=' . $self->param('gene_tree_id') . ' removal has failed.';
+    }
 }
 
 1;


### PR DESCRIPTION
## Description

Reindex of ncRNA trees for default vertebrates from release 100 to 101 was messy. I followed the problem sequences/trees through the reindex pipeline and all those that should flowed through correctly. The majority of the issues were actually caused by incorrect data in the release 100 trees being copied across. The only detectable issues caused by a bug in the reindex pipeline was the removal of the trees in which members had been lost between releases. These were dataflowed correctly, and picked up in the correct analyses later on, with `DONE` jobs apparently smooth. Somewhere along the line, I suspect that the transaction did not execute as smoothly as suggested and errors were missed. There does not seem to be edge case issues as assumed after all.

**Related JIRA tickets:**
- ENSCOMPARASW-3603

## Overview of changes
I have put in a check (overkill) following a retry with pause in the `delete_tree` transaction in `DeleteOneTree.pm` to ensure that the tree is removed. If the tree is not removed, the job will fail, preventing painful debugging later on.

## Testing
The runnables were checked in standalone mode with the known incorrect data to ensure the correct dataflows, and execution manually.

## Notes
I have no idea what caused the issues in the e100 ncRNA pipeline and why these were not picked up on in the original datachecking/healthchecking to pass on to the reindexed version. Perhaps worth running DCs on the previous pipelines before reindexing in the future.
