### PR TITLE
Feature/rm genome msas

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -12,6 +12,7 @@ requires 'Capture::Tiny';
 requires 'Set::IntervalTree';
 requires 'namespace::autoclean';
 requires 'XML::LibXML';
+requires 'Array::Utils';
 
 test_requires 'Test::Exception';
 test_requires 'Test::Most';

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/GenomicAlignTreeAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/GenomicAlignTreeAdaptor.pm
@@ -863,9 +863,9 @@ sub update_neighbourhood_data {
 
   Arg  1     : reference to Bio::EnsEMBL::Compara::GenomicAlignTree
   Arg  2     : int $flanking
-  Example    : $self->update_neighbourhood_data($node);
-  Description: Update the left and right node_ids of a genomic_align_tree
-               table in a database
+  Example    : $self->set_neighbour_nodes_for_leaf($leaf);
+  Description: Update the left and right node id attributes of the given
+               leaf node from a genomic align tree
   Returntype : none
   Exceptions : none
   Caller     : none
@@ -912,7 +912,7 @@ sub set_neighbour_nodes_for_leaf {
   my $dnafrag_strand = $genomic_align->dnafrag_strand;
 
   #forward strand
-  my $table;
+  my ($table, $left_node_id, $right_node_id);
   if ($dnafrag_strand == 1) {
 
       #find genomic_align to left of current genomic_align
@@ -936,7 +936,7 @@ sub set_neighbour_nodes_for_leaf {
 	  my ($this_node_id, $this_dnafrag_start, $this_dnafrag_end, $this_dnafrag_strand) = @{$table->[$i]};
 	  if ($this_dnafrag_start == $dnafrag_start and $this_dnafrag_end == $dnafrag_end) {
 	      ## $table->[$i] correspond to the query node
-	      $node->left_node_id($table->[$i-1]->[0]) if ($i > 0);
+	      $left_node_id = $table->[$i-1]->[0] if ($i > 0);
 	      last;
 	  }
       }
@@ -962,12 +962,13 @@ sub set_neighbour_nodes_for_leaf {
 	  my ($this_node_id, $this_dnafrag_start, $this_dnafrag_end, $this_dnafrag_strand) = @{$table->[$i]};
 	  if ($this_dnafrag_start == $dnafrag_start and $this_dnafrag_end == $dnafrag_end) {
 	      ## $table->[$i] correspond to the query node
-	      $node->left_node_id($table->[$i+1]->[0]) if ($i+1 < @$table);
+	      $left_node_id = $table->[$i+1]->[0] if ($i+1 < @$table);
 	      last;
 	  }
       }
   }
   $sth->finish;
+  $node->left_node_id($left_node_id);
 
   #Region to the right of the genomic_align
   #reset $flanking
@@ -1002,7 +1003,7 @@ sub set_neighbour_nodes_for_leaf {
 	  my ($this_node_id, $this_dnafrag_start, $this_dnafrag_end, $this_dnafrag_strand) = @{$table->[$i]};
 	  if ($this_dnafrag_start == $dnafrag_start and $this_dnafrag_end == $dnafrag_end) {
 	      ## $table->[$i] correspond to the query node
-	      $node->right_node_id($table->[$i+1]->[0]) if ($i + 1 < @$table);
+	      $right_node_id = $table->[$i+1]->[0] if ($i + 1 < @$table);
 	      last;
 	  }
       }
@@ -1024,17 +1025,16 @@ sub set_neighbour_nodes_for_leaf {
       for (my $i = 0; $i < @$table; $i++) {
 	  my ($this_node_id, $this_dnafrag_start, $this_dnafrag_end, $this_dnafrag_strand) = @{$table->[$i]};
 	  if ($this_dnafrag_start == $dnafrag_start and $this_dnafrag_end == $dnafrag_end) {
-	      $node->right_node_id($table->[$i-1]->[0]) if ($i > 0);
+	      $right_node_id = $table->[$i-1]->[0] if ($i > 0);
 	      last;
 	  }
       }
   }
   $sth->finish;
+  $node->right_node_id($right_node_id);
 
   # Store this in the DB
-  if ($node->left_node_id or $node->right_node_id) {
-    $self->update_neighbourhood_data($node);
-  }
+  $self->update_neighbourhood_data($node);
 
   return $node;
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
@@ -1,0 +1,439 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::UpdateMSA_conf
+
+=head1 SYNOPSYS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::UpdateMSA_conf -host mysql-ens-compara-prod-X -port XXXX \
+        -division $COMPARA_DIV -method_type <lowercase_method_type> -species_set_name <species_set_name>
+
+=head1 DESCRIPTION
+
+The PipeConfig file for the pipeline that copies the data from the previous
+release MSA and updates it. This update involves:
+- Mercator-Pecan: remove the updated species and recompute GERP
+- EPO: copy the ancestral core db and update the dna names, remove the updated
+  species from the EPO MSA and update the ancestral dnafrag ids, and recompute
+  its EPO Extended MSA (GERP included), incorporating the updated species
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::UpdateMSA_conf;
+
+use strict;
+use warnings;
+
+use JSON;
+
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;  # for WHEN and INPUT_PLUS
+
+use Bio::EnsEMBL::Compara::PipeConfig::Parts::EPOAncestral;
+use Bio::EnsEMBL::Compara::PipeConfig::Parts::EpoLowCoverage;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
+
+
+sub default_options {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::default_options},  # inherit the generic ones
+
+        'pipeline_name' => $self->o('species_set_name') . '_' . $self->o('method_type') . '_update_' . $self->o('rel_with_suffix'),
+        'work_dir'      => $self->o('pipeline_dir'),
+        'output_dir'    => $self->o('work_dir') . '/feature_dumps/',
+        'bed_dir'       => $self->o('work_dir') . '/bed_dir/',
+
+        'master_db'         => 'compara_master',
+        'prev_db'           => 'compara_prev',
+        'reuse_db'          => $self->o('species_set_name') . '_' . $self->o('method_type') . '_prev',
+        'prev_ancestral_db' => $self->o('species_set_name') . '_ancestral',
+        
+        # EPOAncestral parameters
+        'ancestral_sequences_name'          => 'ancestral_sequences',
+        'ancestral_sequences_display_name'  => 'Ancestral sequences',
+        # Core ancestral database, created on the same server as the pipeline database
+        'ancestral_db'             => {
+            -driver  => $self->o('pipeline_db', '-driver'),
+            -host    => $self->o('pipeline_db', '-host'),
+            -port    => $self->o('pipeline_db', '-port'),
+            -user    => $self->o('pipeline_db', '-user'),
+            -pass    => $self->o('pipeline_db', '-pass'),
+            -species => $self->o('ancestral_sequences_name'),
+            -dbname  => $self->o('dbowner') . '_' . $self->o('species_set_name') . '_ancestral_core_' . $self->o('rel_with_suffix'),
+        },
+        
+        # EpoLowCoverage parameters
+        'epo_db'            => $self->pipeline_url(),
+        'low_epo_mlss_id'   => undef,  # required but unused
+        'base_epo_mlss_id'  => undef,  # required but unused
+        'max_block_size'    => 1000000,  # max size of alignment before splitting
+        'pairwise_location' => [ qw(compara_prev lastz_batch_*) ],  # default location for pairwise alignments (can be a string or an array-ref)
+        'lastz_complete'    => 0,  # set to 1 when all relevant LastZs have complete
+
+        # GERP default parameters
+        'run_gerp'          => 1,
+        'gerp_window_sizes' => [1, 10, 100, 500],
+
+        # Default statistics
+        'skip_multiplealigner_stats'    => 0,  # skip this module if set to 1
+
+        # Resource requirements
+        'gerp_capacity' => 500,
+    };
+}
+
+
+sub pipeline_checks_pre_init {
+    my ($self) = @_;
+    
+    die "The method type has to be in lowercase" if $self->o('method_type') =~ /^(EPO|PECAN)$/;
+    die "The method type '" . $self->o('method_type') . "' is not an updatable MSA" if $self->o('method_type') !~ /^(epo|pecan)$/;
+}
+
+
+sub pipeline_create_commands {
+    my ($self) = @_;
+
+    return [
+        @{$self->SUPER::pipeline_create_commands},  # inherit creation of DB, hive tables and compara tables
+
+        $self->pipeline_create_commands_rm_mkdir(['work_dir', 'output_dir', 'bed_dir']),
+    ];
+}
+
+
+sub pipeline_wide_parameters {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::pipeline_wide_parameters},  # inherit anything from the base class
+
+        'master_db'         => $self->o('master_db'),
+        'prev_db'           => $self->o('prev_db'),
+        'reuse_db'          => $self->o('reuse_db'),
+        'ancestral_db'      => $self->o('ancestral_db'),
+        'prev_ancestral_db' => $self->o('prev_ancestral_db'),
+
+        'method_type'       => $self->o('method_type'),
+        'species_set_name'  => $self->o('species_set_name'),
+        'curr_release'      => $self->o('ensembl_release'),
+
+        'genome_dumps_dir'  => $self->o('genome_dumps_dir'),
+
+        'lastz_complete'             => $self->o('lastz_complete'),
+        'run_gerp'                   => $self->o('run_gerp'),
+        'skip_multiplealigner_stats' => $self->o('skip_multiplealigner_stats'),
+    };
+}
+
+
+sub core_pipeline_analyses {
+    my $self = shift;
+
+    return [
+        {   -logic_name => 'load_mlss_ids',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::LoadMLSSids',
+            -input_ids  => [{}],
+            -parameters => {
+                'method_type'      => $self->o('method_type'),
+                'species_set_name' => $self->o('species_set_name'),
+                'release'          => '#curr_release#',
+                'add_prev_mlss'    => 1,
+                'add_sister_mlsss' => 1,
+                'branch_code'      => 2,
+            },
+            -rc_name    => '500Mb_job',
+            -flow_into  => {
+                '2->A'  => WHEN(
+                    '#method_type# eq "epo"' => { 'populate_new_database' => {
+                        'mlss_id_list' => [ '#mlss_id#', '#prev_mlss_id#', '#ext_mlss_id#', '#ce_mlss_id#', '#cs_mlss_id#' ],
+                    }},
+                    ELSE                        { 'populate_new_database' => {
+                        'mlss_id_list' => [ '#mlss_id#', '#prev_mlss_id#', '#ce_mlss_id#', '#cs_mlss_id#' ],
+                    }},
+                ),
+                'A->2'  => [ 'msa_update_factory' ],
+            },
+        },
+        {   -logic_name => 'populate_new_database',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomicAlignBlock::PopulateNewDatabase',
+            -parameters => {
+                'program'           => $self->o('populate_new_database_exe'),
+                'reg_conf'          => $self->o('reg_conf'),
+                'old_compara_db'    => '#prev_db#',
+                'filter_by_mlss'    => 1,
+                'skip_gerp'         => 1,
+            },
+            -rc_name    => '500Mb_job',
+        },
+        # Update the MSA-related information in this and the ancestral core databases
+        {   -logic_name => 'msa_update_factory',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => {
+                '1->A'  => WHEN(
+                    '#method_type# eq "epo"'    => {
+                        'set_gerp_mlss_tag' => INPUT_PLUS(),
+                        'set_internal_ids'  => INPUT_PLUS(),
+                        'mlss_factory'      => { 'inputlist' => [['#mlss_id#'], ['#ext_mlss_id#']] },
+                        'drop_ancestral_db' => { 'mlss_id' => '#mlss_id#', 'prev_mlss_id' => '#prev_mlss_id#' },
+                    },
+                    ELSE                           {
+                        'set_gerp_mlss_tag' => { 'ext_mlss_id' => '#mlss_id#', 'ce_mlss_id' => '#ce_mlss_id#', 'cs_mlss_id' => '#cs_mlss_id#' },
+                        'mlss_factory'      => { 'inputlist' => [['#mlss_id#']] },
+                    }
+                ),
+                'A->1'  => [ 'transfer_msa' ],
+            },
+        },
+        {   -logic_name => 'set_internal_ids',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
+            -parameters => {
+                'sql' => [
+                    'ALTER TABLE genomic_align AUTO_INCREMENT=#expr((#ext_mlss_id# * 10**10) + 1)expr#',
+                    'ALTER TABLE genomic_align_block AUTO_INCREMENT=#expr((#ext_mlss_id# * 10**10) + 1)expr#',
+                    'ALTER TABLE genomic_align_tree AUTO_INCREMENT=#expr((#ext_mlss_id# * 10**10) + 1)expr#'
+                ],
+            },
+        },
+        {   -logic_name => 'mlss_factory',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+            -parameters => {
+                'column_names'  => [ 'mlss_id' ],
+            },
+            -flow_into  => {
+                2 => [ 'make_species_tree' ],
+            },
+        },
+        {   -logic_name => 'make_species_tree',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::MakeSpeciesTree',
+            -parameters => {
+                'species_tree_input_file' => $self->o('binary_species_tree'),
+            },
+            -rc_name    => '500Mb_job',
+        },
+        # Copy the 4 tables with data in the ancestral core database and update the ancestor names with the
+        # new MLSS id
+        {   -logic_name => 'table_factory',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+            -parameters => {
+                'inputlist'     => [ 'coord_system', 'dna', 'meta', 'seq_region' ],
+                'column_names'  => [ 'table' ],
+            },
+            -flow_into  => {
+                '2->A' => [ 'copy_ancestral_table' ],
+                'A->1' => [ 'update_ancestor_names' ],
+            },
+        },
+        {   -logic_name => 'copy_ancestral_table',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::MySQLTransfer',
+            -parameters => {
+                'src_db_conn'   => $self->o('prev_ancestral_db'),
+                'dest_db_conn'  => $self->o('ancestral_db'),
+            },
+        },
+        {   -logic_name => 'update_ancestor_names',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
+            -parameters => {
+                'db_conn' => $self->o('ancestral_db'),
+                'sql'     => [
+                    'UPDATE seq_region SET name = REPLACE(name, "_#prev_mlss_id#_", "_#mlss_id#_")',
+                ],
+            },
+        },
+        # Transfer MLSS, GA* and dnafrag ids from the previous MLSS id to the current one, update the MSA and
+        # ancestral core database, and finally remove the previous MSA information
+        {   -logic_name => 'transfer_msa',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::UpdateMSA::TransferAlignment',
+            -parameters => {
+                'method_type' => $self->o('method_type'),
+            },
+            -flow_into  => [ 'affected_gabs_factory' ],
+        },
+        {   -logic_name => 'affected_gabs_factory',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::UpdateMSA::UpdateGABFactory',
+            -flow_into  => {
+                '2->A' => [ 'update_gab' ],
+                'A->1' => WHEN(
+                    '#method_type# eq "epo"' => [ 'sync_ancestral_database' ],
+                    ELSE                        [ 'remove_prev_mlss' ],
+                ),
+            },
+        },
+        {   -logic_name     => 'update_gab',
+            -module         => 'Bio::EnsEMBL::Compara::RunnableDB::UpdateMSA::UpdateGAB',
+            -rc_name        => '1Gb_job',
+            -batch_size     => 50,
+            -hive_capacity  => 250,
+            -flow_into      => {
+                2   => '?accu_name=ancestor_names&accu_address=[]&accu_input_variable=name',
+            }
+        },
+        {   -logic_name => 'sync_ancestral_database',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::UpdateMSA::SyncAncestralDB',
+            -parameters => {
+                'ancestral_db' => $self->o('ancestral_db'),
+            },
+            -flow_into  => [ 'remove_prev_mlss' ],
+        },
+        {   -logic_name => 'remove_prev_mlss',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
+            -parameters => {
+                'wrap_in_transaction' => 1,
+                'sql'                 => [
+                    'SET FOREIGN_KEY_CHECKS=0',
+                    'DELETE stn, stnt FROM species_tree_node stn LEFT JOIN species_tree_node_tag stnt USING (node_id) JOIN species_tree_root str USING (root_id) WHERE method_link_species_set_id = #prev_mlss_id#',
+                    'DELETE FROM species_tree_root WHERE method_link_species_set_id = #prev_mlss_id#',
+                    'DELETE FROM method_link_species_set_tag WHERE method_link_species_set_id = #prev_mlss_id#',
+                    'DELETE FROM method_link_species_set WHERE method_link_species_set_id = #prev_mlss_id#',
+                    'SET FOREIGN_KEY_CHECKS=1',
+                ],
+            },
+            -flow_into  => {
+                '1->A'  => WHEN( '#run_gerp# && #method_type# eq "pecan"' => [ 'set_gerp_neutral_rate' ] ),
+                'A->1'  => [ 'create_neighbour_nodes_jobs_alignment' ],
+                '1'     => WHEN( '#method_type# eq "epo"' => [ 'epo_extended_rib' ] ),
+            },
+        },
+        # EPO Extended pipeline
+        {   -logic_name => 'epo_extended_rib',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => WHEN( '#lastz_complete#' => [ 'create_default_pairwise_mlss' ] ),
+        },
+        {   -logic_name => 'create_low_coverage_genome_jobs',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+            -parameters => {
+                'inputquery'    => 'SELECT genomic_align_block_id, #ext_mlss_id# FROM genomic_align ga LEFT JOIN dnafrag USING (dnafrag_id) WHERE method_link_species_set_id = #mlss_id# AND coord_system_name != "ancestralsegment" GROUP BY genomic_align_block_id',
+                'column_names'  => [ 'genomic_align_block_id', 'mlss_id' ],
+            },
+            -rc_name => '4Gb_job',
+            -flow_into => {
+                '2->A' => [ 'low_coverage_genome_alignment' ],
+                'A->1' => [ 'set_internal_ids_epo_extended' ],
+            },
+        },
+        {   -logic_name => 'set_internal_ids_epo_extended',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::PairAligner::SetInternalIdsCollection',
+            -parameters => {
+                'method_link_species_set_id' => '#ext_mlss_id#',
+            },
+            -flow_into  => {
+                1   => { 'create_neighbour_nodes_jobs_alignment' => { 'mlss_id' => '#ext_mlss_id#', 'method_type' => 'epo_extended' } },
+            },
+        },
+        # Create/update the neighbour nodes for both EPO and EPO Extended MSAs
+        {   -logic_name => 'create_neighbour_nodes_jobs_alignment',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+            -parameters => {
+                'inputquery'    => 'SELECT gat2.root_id, #mlss_id# FROM genomic_align_tree gat1 LEFT JOIN genomic_align ga USING (node_id) JOIN genomic_align_tree gat2 USING (root_id) WHERE gat2.parent_id IS NULL AND ga.method_link_species_set_id = #mlss_id# GROUP BY gat2.root_id',
+                'column_names'  => [ 'root_id', 'mlss_id' ],
+            },
+            -rc_name    => '2Gb_job',
+            -flow_into  => {
+                '2->A' => [ 'set_neighbour_nodes' ],
+                'A->1' => { 'update_max_alignment_length' => { 'method_link_species_set_id' => '#mlss_id#', 'method_type' => '#method_type#' } },
+            },
+        },  
+        {   -logic_name    => 'set_neighbour_nodes',
+            -module        => 'Bio::EnsEMBL::Compara::RunnableDB::EpoLowCoverage::SetNeighbourNodes',
+            -rc_name       => '2Gb_job',
+            -batch_size    => 10, 
+            -hive_capacity => 20, 
+        },
+        # Flow Mercator-Pecan GABs to compute their GERPs
+        {   -logic_name => 'flow_gabs',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+            -parameters => {
+                'inputquery'    => 'SELECT genomic_align_block_id, #mlss_id# FROM genomic_align_block WHERE method_link_species_set_id = #mlss_id#',
+                'column_names'  => [ 'genomic_align_block_id', 'mlss_id' ],
+            },
+            -flow_into  => {
+                2   => [ 'gerp' ],
+            },
+        },
+        # Update max alignment MLSS tag
+        {   -logic_name => 'update_max_alignment_length',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomicAlignBlock::UpdateMaxAlignmentLength',
+            -rc_name    => '2Gb_job',
+            -flow_into  => [ 'healthcheck_factory' ],
+        },
+
+        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::EPOAncestral::pipeline_analyses_epo_ancestral($self) },
+        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::EpoLowCoverage::pipeline_analyses_epo2x_alignment($self) },
+        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::EpoLowCoverage::pipeline_analyses_healthcheck($self) },
+    ];
+}
+
+
+sub tweak_analyses {
+    my $self = shift;
+    my $analyses_by_name = shift;
+    # Set MLSS tag only for EPO MSAs and disconnect set_mlss_tag
+    # Change the parameters to work with "local" parameters instead of pipeline-wide ones
+    $analyses_by_name->{'set_gerp_mlss_tag'}->{'-parameters'} = { 'sql' => [
+        'INSERT INTO method_link_species_set_tag (method_link_species_set_id, tag, value) VALUES (#cs_mlss_id#, "msa_mlss_id", #ext_mlss_id#)',
+        'INSERT INTO method_link_species_set_tag (method_link_species_set_id, tag, value) VALUES (#ce_mlss_id#, "msa_mlss_id", #ext_mlss_id#)',
+    ]};
+    $analyses_by_name->{'set_gerp_mlss_tag'}->{'-flow_into'} = WHEN( '#method_type# eq "epo"' => [ 'set_mlss_tag' ] );
+    $analyses_by_name->{'set_mlss_tag'}->{'-parameters'} = { 'sql'   => [
+        'INSERT INTO method_link_species_set_tag (method_link_species_set_id, tag, value) VALUES (#ext_mlss_id#, "base_mlss_id", #mlss_id#)',
+    ]};
+    delete $analyses_by_name->{'set_mlss_tag'}->{'-flow_into'};
+    # Flow to table_factory to copy the previous ancestral core database
+    $analyses_by_name->{'find_ancestral_seq_gdb'}->{'-flow_into'}->{1} = [ 'table_factory' ];
+    # Link GERP analysis capacities with parameter
+    $analyses_by_name->{'gerp'}->{'-analysis_capacity'} = $self->o('gerp_capacity');
+    $analyses_by_name->{'gerp_himem'}->{'-analysis_capacity'} = $self->o('gerp_capacity');
+    # Update EPO Extended analyses to deal with "local" parameters and change the flow between analyses to
+    # integrate Mercator-Pecan compatibility
+    $analyses_by_name->{'create_default_pairwise_mlss'}->{'-parameters'} = {
+        'new_method_link_species_set_id'  => '#ext_mlss_id#',
+        'base_method_link_species_set_id' => '#mlss_id#',
+        'pairwise_location'               => $self->o('pairwise_location'),
+        'base_location'                   => $self->o('epo_db'),
+        'prev_epo_db'                     => '#reuse_db#',
+    };
+    $analyses_by_name->{'create_default_pairwise_mlss'}->{'-flow_into'}->{1} = WHEN(
+        '#run_gerp#' => [ 'set_gerp_neutral_rate' ],
+        ELSE            [ 'create_low_coverage_genome_jobs' ]
+    );
+    $analyses_by_name->{'set_gerp_neutral_rate'}->{'-flow_into'}->{1} = WHEN(
+        '#method_type# eq "epo"' => [ 'create_low_coverage_genome_jobs' ],
+        ELSE                        [ 'flow_gabs' ]
+    );
+    # Set MLSS id to EPO Extended to ensure correct link is flown to GERP analyses
+    $analyses_by_name->{'low_coverage_genome_alignment'}->{'-parameters'}->{'mlss_id'} = '#ext_mlss_id#';
+    $analyses_by_name->{'low_coverage_genome_alignment_himem'}->{'-parameters'}->{'mlss_id'} = '#ext_mlss_id#';
+    $analyses_by_name->{'low_coverage_genome_alignment_hugemem'}->{'-parameters'}->{'mlss_id'} = '#ext_mlss_id#';
+    # Run HCs on GERPs only for Mercator-Pecan and EPO Extended MLSS ids
+    $analyses_by_name->{'healthcheck_factory'}->{'-flow_into'} = {
+        '1->A' => WHEN (
+            '#run_gerp# && #method_type# ne "epo"' => { 'conservation_score_healthcheck' => [
+                { 'test' => 'conservation_jobs', 'logic_name' => 'gerp', 'method_link_type' => '#method_type#' },
+                { 'test' => 'conservation_scores', 'method_link_species_set_id' => '#cs_mlss_id#' },
+            ]}
+        ),
+        'A->1' => WHEN(
+            'not #skip_multiplealigner_stats#' => { 'multiplealigner_stats_factory' => { 'mlss_id' => '#method_link_species_set_id#' } },
+            ELSE                                  [ 'end_pipeline' ]
+        ),
+    };
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
@@ -40,8 +40,6 @@ package Bio::EnsEMBL::Compara::PipeConfig::UpdateMSA_conf;
 use strict;
 use warnings;
 
-use JSON;
-
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;  # for WHEN and INPUT_PLUS
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::EPOAncestral;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
@@ -156,13 +156,13 @@ sub core_pipeline_analyses {
             -rc_name    => '500Mb_job',
             -flow_into  => {
                 '2->A'  => WHEN(
-                    '#method_type# eq "epo" && #run_gerp#' => { 'populate_new_database' => {
+                    '#method_type# eq "epo" && #run_gerp#'  => { 'populate_new_database' => {
                         'mlss_id_list' => [ '#mlss_id#', '#prev_mlss_id#', '#ext_mlss_id#', '#ce_mlss_id#', '#cs_mlss_id#' ],
                     }},
                     '#method_type# eq "epo" && !#run_gerp#' => { 'populate_new_database' => {
                         'mlss_id_list' => [ '#mlss_id#', '#prev_mlss_id#', '#ext_mlss_id#' ],
                     }},
-                    ELSE                        { 'populate_new_database' => {
+                    ELSE                                       { 'populate_new_database' => {
                         'mlss_id_list' => [ '#mlss_id#', '#prev_mlss_id#', '#ce_mlss_id#', '#cs_mlss_id#' ],
                     }},
                 ),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
@@ -64,7 +64,6 @@ sub default_options {
         'prev_db'           => 'compara_prev',
         'reuse_db'          => $self->o('species_set_name') . '_' . $self->o('method_type') . '_prev',
         'prev_ancestral_db' => $self->o('species_set_name') . '_ancestral',
-        
         # EPOAncestral parameters
         'ancestral_sequences_name'          => 'ancestral_sequences',
         'ancestral_sequences_display_name'  => 'Ancestral sequences',
@@ -78,7 +77,6 @@ sub default_options {
             -species => $self->o('ancestral_sequences_name'),
             -dbname  => $self->o('dbowner') . '_' . $self->o('species_set_name') . '_ancestral_core_' . $self->o('rel_with_suffix'),
         },
-        
         # EpoLowCoverage parameters
         'epo_db'            => $self->pipeline_url(),
         'low_epo_mlss_id'   => undef,  # required but unused
@@ -102,7 +100,6 @@ sub default_options {
 
 sub pipeline_checks_pre_init {
     my ($self) = @_;
-    
     die "The method type has to be in lowercase" if $self->o('method_type') =~ /^(EPO|PECAN)$/;
     die "The method type '" . $self->o('method_type') . "' is not an updatable MSA" if $self->o('method_type') !~ /^(epo|pecan)$/;
 }
@@ -351,12 +348,12 @@ sub core_pipeline_analyses {
                 '2->A' => [ 'set_neighbour_nodes' ],
                 'A->1' => { 'update_max_alignment_length' => { 'method_link_species_set_id' => '#mlss_id#', 'method_type' => '#method_type#' } },
             },
-        },  
+        },
         {   -logic_name    => 'set_neighbour_nodes',
             -module        => 'Bio::EnsEMBL::Compara::RunnableDB::EpoLowCoverage::SetNeighbourNodes',
             -rc_name       => '2Gb_job',
-            -batch_size    => 10, 
-            -hive_capacity => 20, 
+            -batch_size    => 10,
+            -hive_capacity => 20,
         },
         # Flow Mercator-Pecan GABs to compute their GERPs
         {   -logic_name => 'flow_gabs',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
@@ -294,12 +294,10 @@ sub core_pipeline_analyses {
             -parameters => {
                 'wrap_in_transaction' => 1,
                 'sql'                 => [
-                    'SET FOREIGN_KEY_CHECKS=0',
-                    'DELETE stn, stnt FROM species_tree_node stn LEFT JOIN species_tree_node_tag stnt USING (node_id) JOIN species_tree_root str USING (root_id) WHERE method_link_species_set_id = #prev_mlss_id#',
+                    'DELETE stn, stnt FROM species_tree_node stn LEFT JOIN species_tree_node_tag stnt USING (node_id) JOIN species_tree_root str USING (root_id) WHERE method_link_species_set_id = #prev_mlss_id# ORDER BY stn.node_id DESC',
                     'DELETE FROM species_tree_root WHERE method_link_species_set_id = #prev_mlss_id#',
                     'DELETE FROM method_link_species_set_tag WHERE method_link_species_set_id = #prev_mlss_id#',
                     'DELETE FROM method_link_species_set WHERE method_link_species_set_id = #prev_mlss_id#',
-                    'SET FOREIGN_KEY_CHECKS=1',
                 ],
             },
             -flow_into  => {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoLowCoverage/LowCoverageGenomeAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoLowCoverage/LowCoverageGenomeAlignment.pm
@@ -783,7 +783,7 @@ sub get_species_tree {
       $self->compara_dba->get_SpeciesTreeAdaptor->fetch_by_method_link_species_set_id_label($self->param_required('mlss_id'), 'default')->root;
 
   #if the tree leaves are species names, need to convert these into genome_db_ids
-  my $genome_dbs = $self->compara_dba->get_GenomeDBAdaptor->fetch_all();
+  my $genome_dbs = $self->compara_dba->get_GenomeDBAdaptor->fetch_all_current();
 
   my %leaf_check;
   foreach my $genome_db (@$genome_dbs) {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/SyncAncestralDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/SyncAncestralDB.pm
@@ -65,7 +65,7 @@ sub run {
     # Speed up deleting data by disabling the tables keys
     $dbc->do("ALTER TABLE `dna` DISABLE KEYS");
     $dbc->do("ALTER TABLE `seq_region` DISABLE KEYS");
-    # Deelte the sequence regions that have been removed from the MSA as well
+    # Delete the sequence regions that have been removed from the MSA as well
     my $nrows = $dbc->do("DELETE seq_region, dna FROM seq_region JOIN dna USING (seq_region_id)
         WHERE name IN ('" . join("','", @$ancestor_names) . "')");
     print "Removed $nrows row(s) from seq_region and dna tables\n" if $self->debug;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/SyncAncestralDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/SyncAncestralDB.pm
@@ -69,7 +69,7 @@ sub run {
     my $nrows = $dbc->do("DELETE seq_region, dna FROM seq_region JOIN dna USING (seq_region_id)
         WHERE name IN ('" . join("','", @$ancestor_names) . "')");
     print "Removed $nrows row(s) from seq_region and dna tables\n" if $self->debug;
-    # Enable the tables keys back
+    # Re-enable the tables keys
     $dbc->do("ALTER TABLE `seq_region` ENABLE KEYS");
     $dbc->do("ALTER TABLE `dna` ENABLE KEYS");
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/SyncAncestralDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/SyncAncestralDB.pm
@@ -1,0 +1,78 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::UpdateMSA::SyncAncestralDB
+
+=head1 DESCRIPTION
+
+Removes all entries in seq_region and dna tables that match ancestor_names in
+the given ancestral database.
+
+=over
+
+=item ancestral_db
+
+Mandatory. Ancestral database connection hash.
+
+=item ancestor_names
+
+Mandatory. List of ancestor names to be removed (should match the name field in
+seq_region table).
+
+=back
+
+=head1 EXAMPLES
+
+    standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::UpdateMSA::SyncAncestralDB \
+        -ancestral_db "{'-dbname' => 'jalvarez_mammals_ancestral_core_102', '-driver' => 'mysql', '-host' => 'mysql-ens-compara-prod-9', '-pass' => '$ENSADMIN_PSW', '-port' => 4647, '-species' => 'ancestral_sequences', '-user' => 'ensadmin'}" \
+        -ancestor_names "['Ancestor_1904_1','Ancestor_1904_20']"
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::UpdateMSA::SyncAncestralDB;
+
+use warnings;
+use strict;
+
+use Bio::EnsEMBL::Registry;
+use Bio::EnsEMBL::Hive::Utils;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub run {
+    my $self = shift;
+    my $ancestral_db = $self->param_required('ancestral_db');
+    my $ancestor_names = $self->param_required('ancestor_names');
+
+    my $dbc = Bio::EnsEMBL::Hive::Utils::go_figure_dbc($ancestral_db);
+    # Speed up deleting data by disabling the tables keys
+    $dbc->do("ALTER TABLE `dna` DISABLE KEYS");
+    $dbc->do("ALTER TABLE `seq_region` DISABLE KEYS");
+    # Deelte the sequence regions that have been removed from the MSA as well
+    my $nrows = $dbc->do("DELETE seq_region, dna FROM seq_region JOIN dna USING (seq_region_id)
+        WHERE name IN ('" . join("','", @$ancestor_names) . "')");
+    print "Removed $nrows row(s) from seq_region and dna tables\n" if $self->debug;
+    # Enable the tables keys back
+    $dbc->do("ALTER TABLE `seq_region` ENABLE KEYS");
+    $dbc->do("ALTER TABLE `dna` ENABLE KEYS");
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/TransferAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/TransferAlignment.pm
@@ -99,7 +99,7 @@ sub run {
                 df.name = REPLACE(df.name, '_${prev_mlss_id}_', '_${curr_mlss_id}_')
                 WHERE df.name LIKE 'Ancestor_${prev_mlss_id}_%'");
         }
-        # The work is done, enable foreign key constraints again
+        # The work is done, re-enable foreign key constraints
         $dba->dbc->do("SET FOREIGN_KEY_CHECKS=1");
     });
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/TransferAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/TransferAlignment.pm
@@ -56,7 +56,6 @@ use warnings;
 use strict;
 
 use Bio::EnsEMBL::Registry;
-use Bio::EnsEMBL::Hive::Utils;
 
 use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/TransferAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/TransferAlignment.pm
@@ -1,0 +1,108 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::TransferAlignment
+
+=head1 DESCRIPTION
+
+Transfers the genomic align, genomic align block and genomic align tree entries
+from the previous alignment MLSS to the current one. If the MLSS ids correspond
+to an EPO MSA, the ancestral dnafrags are also transferred, updating both their
+dnafrag id and name.
+
+=over
+
+=item method_type
+
+Mandatory. Method type of the given MLSS ids.
+
+=item mlss_id
+
+Mandatory. Current release alignment's MLSS id.
+
+=item prev_mlss_id
+
+Mandatory. Previous release alignment's MLSS id.
+
+=back
+
+=head1 EXAMPLES
+
+    standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::TransferAlignment \
+        -compara_db $(mysql-ens-compara-prod-9-ensadmin details url jalvarez_amniotes_pecan_update_101) \
+        -method_type pecan -mlss_id 1897 -prev_mlss_id 1831
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::UpdateMSA::TransferAlignment;
+
+use warnings;
+use strict;
+
+use Bio::EnsEMBL::Registry;
+use Bio::EnsEMBL::Hive::Utils;
+
+use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub run {
+    my $self = shift;
+    my $method_type = $self->param_required('method_type');
+    my $prev_mlss_id = $self->param_required('prev_mlss_id');
+    my $curr_mlss_id = $self->param_required('mlss_id');
+    my $dba = $self->compara_dba;
+    # Calculate the id diff to sum to every id column based on the difference between both MLSS ids
+    my $id_diff = ($curr_mlss_id - $prev_mlss_id) * 10**10;
+    # Get the id range to pick the right nodes in genomic_align_tree table
+    my $min_id = $prev_mlss_id * 10**10;
+    my $max_id = $min_id + 10**10;
+    # Do all the updates in a single transaction to make sure the database is consistent if something fails
+    $dba->dbc->sql_helper->transaction(-CALLBACK => sub {
+        # Disable foreign key constraints
+        $dba->dbc->do("SET FOREIGN_KEY_CHECKS=0");
+        # Update main id columns in genomic_align table
+        $dba->dbc->do("UPDATE genomic_align SET genomic_align_id = genomic_align_id + $id_diff,
+            genomic_align_block_id = genomic_align_block_id + $id_diff,
+            method_link_species_set_id = $curr_mlss_id, node_id = node_id + $id_diff
+            WHERE method_link_species_set_id = $prev_mlss_id");
+        # Update main id columns in genomic_align_block table
+        $dba->dbc->do("UPDATE genomic_align_block SET genomic_align_block_id = genomic_align_block_id + $id_diff,
+            method_link_species_set_id = $curr_mlss_id, group_id = group_id + $id_diff
+            WHERE method_link_species_set_id = $prev_mlss_id");
+        # Update all id columns in genomic_align_tree table
+        $dba->dbc->do("UPDATE genomic_align_tree SET node_id = node_id + $id_diff,
+            parent_id = parent_id + $id_diff, root_id = root_id + $id_diff,
+            left_node_id = left_node_id + $id_diff, right_node_id = right_node_id + $id_diff
+            WHERE node_id BETWEEN $min_id AND $max_id");
+        # If it is an EPO MSA, transfer the ancestral dnafrags to the new MLSS id
+        if ( $method_type =~ /^EPO$/i ) {
+            $dba->dbc->do("UPDATE dnafrag df JOIN genomic_align ga USING (dnafrag_id)
+                SET df.dnafrag_id = df.dnafrag_id + $id_diff, ga.dnafrag_id = ga.dnafrag_id + $id_diff,
+                df.name = REPLACE(df.name, '_${prev_mlss_id}_', '_${curr_mlss_id}_')
+                WHERE df.name LIKE 'Ancestor_${prev_mlss_id}_%'");
+        }
+        # The work is done, enable foreign key constraints again
+        $dba->dbc->do("SET FOREIGN_KEY_CHECKS=1");
+    });
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/UpdateGAB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/UpdateGAB.pm
@@ -1,0 +1,279 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::UpdateMSA::UpdateGAB
+
+=head1 DESCRIPTION
+
+Updates the genomic align block (GAB) and its genomic align tree (GAT) (EPO
+only), removing the given genomic aligns (GAs), and their corresponding
+ancestral GAs, dnafrags and GAT nodes to keep the tree binary (EPO only). Flows
+each one of the ancestor dnafrag names that have been removed to branch 2.
+
+If the GAB is left with less than 2 GAs, it is removed altogether with the
+ancestral GAB, GAs and dnafrags, and the whole GAT (EPO only). Otherwise, the
+CIGAR lines of the remaining GAs (and ancestral GAs) are updated, and so it is
+the GAB (and ancestral GAB) alignment length.
+
+=over
+
+=item gab_id
+
+Mandatory. Genomic align block ID to be updated.
+
+=item ga_id_list
+
+Mandatory. List of genomic align IDs to be removed from the given genomic align
+block.
+
+=back
+
+=head1 EXAMPLES
+
+    standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::UpdateMSA::UpdateGAB \
+        -compara_db $(mysql-ens-compara-prod-9-ensadmin details url jalvarez_mammals_epo_update_102) \
+        -gab_id 19040000000160 -ga_id_list "[19040000000645,19040000000646]"
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::UpdateMSA::UpdateGAB;
+
+use warnings;
+use strict;
+
+use Bio::EnsEMBL::Registry;
+use Bio::EnsEMBL::Hive::Utils;
+
+use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
+use Bio::EnsEMBL::Compara::Utils::Cigars;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub run {
+    my $self = shift;
+    my $gab_id = $self->param_required('gab_id');
+    my $ga_ids_to_rm = $self->param_required('ga_id_list');
+    # Get all the genomic aligns (GAs) for the given genomic align block (GAB) and skip the ones we already
+    # know are going to be removed
+    my $gab = $self->compara_dba->get_GenomicAlignBlockAdaptor->fetch_by_dbID($gab_id);
+    my %genomic_aligns = map { $_->dbID => $_ } @{ $gab->genomic_align_array };
+    # Check the number of remaining GAs in this GAB
+    if ( (scalar keys(%genomic_aligns) - scalar @$ga_ids_to_rm) < 2 ) {
+        # A GAB must have at least 2 GAs: remove this GAB and all its related information
+        print "GAB $gab_id needs to be removed\n" if $self->debug;
+        $self->_remove_gab($gab, [ keys %genomic_aligns ]);
+    } else {
+        # Update the remaining GAs, deleting every gap-only column that may be left, and the genomic align
+        # tree (GAT)
+        delete @genomic_aligns{@$ga_ids_to_rm};
+        print "GAB $gab_id needs to be updated\n" if $self->debug;
+        $self->_update_gab($gab, $ga_ids_to_rm, [ values %genomic_aligns ]);
+    }
+}
+
+
+sub write_output {
+    my $self = shift;
+    my $gas_to_update = $self->param('gas_to_update');
+    my $new_aln_length = $self->param('new_aln_length');
+    my $gabs_to_update = $self->param('gabs_to_update');
+    my $node_ids_to_update = $self->param('node_ids_to_update');
+    my $ga_ids_to_rm = $self->param('ga_ids_to_rm');
+    my $gab_ids_to_rm = $self->param('gab_ids_to_rm');
+    my $node_ids_to_rm = $self->param('node_ids_to_rm');
+    my $dnafrag_ids_to_rm = $self->param('dnafrag_ids_to_rm');
+    my $gat_root_id = $self->param('gat_root_id');
+
+    my $dba = $self->compara_dba;
+    my @ancestor_names;
+    # Update the genomic_align* tables in a single transaction to make sure the database is consistent if
+    # something fails
+    $dba->dbc->sql_helper->transaction(-CALLBACK => sub {
+        if ( defined $gas_to_update ) {
+            # Update the CIGAR lines
+            my $sth = $dba->dbc->prepare("UPDATE genomic_align SET cigar_line = ? WHERE genomic_align_id = ?");
+            foreach my $ga_id ( keys %$gas_to_update ) {
+                $sth->execute($gas_to_update->{$ga_id}, $ga_id);
+            }
+        }
+        if ( defined $gabs_to_update ) {
+            # Update the length of both the main GAB and the ancestral GAB (if any)
+            $dba->dbc->do("UPDATE genomic_align_block SET length = $new_aln_length WHERE genomic_align_block_id IN (" .
+                join(',', map {$_->dbID} @$gabs_to_update) . ")");
+        }
+        if ( defined $node_ids_to_update ) {
+            # Move nodes to their new position inside the GAT
+            my $sth = $dba->dbc->prepare("UPDATE genomic_align_tree SET parent_id = ?, distance_to_parent = ? WHERE node_id = ?");
+            foreach my $node_id ( keys %$node_ids_to_update ) {
+                my $values = $node_ids_to_update->{$node_id};
+                if ( ! defined $values->{parent_id} ) {
+                    # This node is going to be the new root: update the root_id of the entire GAT
+                    $dba->dbc->do("UPDATE genomic_align_tree SET root_id = $node_id WHERE root_id = " . $values->{prev_root_id});
+                }
+                $sth->execute($values->{parent_id}, $values->{distance}, $node_id);
+            }
+        }
+        # Disable foreign key constraints
+        $dba->dbc->do("SET FOREIGN_KEY_CHECKS = 0");
+        # Delete all marked GAs, GABs, GAT nodes and ancestral dnafrag ids
+        my $nrows = $dba->dbc->do("DELETE FROM genomic_align WHERE genomic_align_id IN (" . join(',', @$ga_ids_to_rm) . ")");
+        print "Removed $nrows row(s) from genomic_align\n" if $self->debug;
+        if ( defined $gab_ids_to_rm && @$gab_ids_to_rm ) {
+            $nrows = $dba->dbc->do("DELETE FROM genomic_align_block WHERE genomic_align_block_id IN (" . join(',', @$gab_ids_to_rm) . ")");
+            print "Removed $nrows row(s) from genomic_align_block\n" if $self->debug;
+        }
+        if ( defined $node_ids_to_rm && @$node_ids_to_rm ) {
+            $nrows = $dba->dbc->do("DELETE FROM genomic_align_tree WHERE node_id IN (" . join(',', @$node_ids_to_rm) . ")");
+            print "Removed $nrows row(s) from genomic_align_tree\n" if $self->debug;
+        }
+        if ( defined $dnafrag_ids_to_rm && @$dnafrag_ids_to_rm ) {
+            # Get the names of the ancestral dnafrags to be removed to do the same in the ancestral database
+            my $dnafrag_ids = join(',', @$dnafrag_ids_to_rm);
+            my $sth = $dba->dbc->prepare("SELECT name FROM dnafrag WHERE dnafrag_id IN ($dnafrag_ids)");
+            $sth->execute();
+            while ( my $dnafrag_name = $sth->fetchrow ) {
+                push @ancestor_names, $dnafrag_name;
+            }
+            $nrows = $dba->dbc->do("DELETE FROM dnafrag WHERE dnafrag_id IN ($dnafrag_ids)");
+            print "Removed $nrows ancestral row(s) from dnafrag\n" if $self->debug;
+        }
+        # The work is done, enable foreign key constraints again
+        $dba->dbc->do("SET FOREIGN_KEY_CHECKS = 1");
+    });
+
+    # Update the left and right indexes of this GAT
+    if ( defined $gat_root_id ) {
+        my $gat_adaptor = $self->compara_dba->get_GenomicAlignTreeAdaptor;
+        my $root = $gat_adaptor->fetch_tree_by_root_id($gat_root_id);
+        $root->build_leftright_indexing();
+        $gat_adaptor->update_subtree($root);
+    }
+    
+    # Flow the ancestor dnafrag names to syncronise the ancestral database with the dnafrag table
+    $self->dataflow_output_id({ name => $_ }, 2) for @ancestor_names;
+}
+
+
+sub _remove_gab {
+    my ($self, $gab, $ga_ids_to_rm) = @_;
+
+    my $dba = $self->compara_dba;
+    my $gat_adaptor = $dba->get_GenomicAlignTreeAdaptor();
+
+    my (%gab_ids_to_rm, @node_ids_to_rm, @dnafrag_ids_to_rm);
+    $gab_ids_to_rm{$gab->dbID} = 1;
+    if ( my $gat = $gat_adaptor->fetch_by_GenomicAlignBlock($gab) ) {
+        # Mark all the nodes in the GAT as to be removed (including the ancestral GAB and its GAs)
+        foreach my $node ( @{ $gat->root->get_all_nodes() } ) {
+            push @node_ids_to_rm, $node->dbID;
+            if (! $node->is_leaf ) {
+                my $ga = $node->get_all_genomic_aligns_for_node->[0];
+                $gab_ids_to_rm{$ga->genomic_align_block_id} = 1;
+                push @$ga_ids_to_rm, $ga->dbID;
+                push @dnafrag_ids_to_rm, $ga->dnafrag_id;
+            }
+        }
+    }
+
+    $self->param('ga_ids_to_rm', $ga_ids_to_rm);
+    $self->param('gab_ids_to_rm', [ keys %gab_ids_to_rm ]);
+    $self->param('node_ids_to_rm', \@node_ids_to_rm);
+    $self->param('dnafrag_ids_to_rm', \@dnafrag_ids_to_rm);
+}
+
+
+sub _update_gab {
+    my ($self, $gab, $ga_ids_to_rm, $genomic_aligns) = @_;
+    my %ga_ids_to_rm = map { $_ => 1 } @$ga_ids_to_rm;
+    my @gabs_to_update = ( $gab );
+
+    my $dba = $self->compara_dba;
+    my $ga_adaptor = $dba->get_GenomicAlignAdaptor();
+    my $gat_adaptor = $dba->get_GenomicAlignTreeAdaptor();
+
+    my (%node_ids_to_rm, %node_ids_to_update, $gat_root, @dnafrag_ids_to_rm);
+    if ( my $gat = $gat_adaptor->fetch_by_GenomicAlignBlock($gab) ) {
+        $gat_root = $gat->root;
+        # Get all the GAT inner nodes that are going to loose at least one child
+        my %children_to_rm;
+        foreach my $ga_id ( keys %ga_ids_to_rm ) {
+            my $leaf_id = $ga_adaptor->fetch_by_dbID($ga_id)->node_id;
+            $node_ids_to_rm{$leaf_id} = 1;
+            my $inner_node = $gat_adaptor->fetch_by_dbID($leaf_id)->parent;
+            push @{ $children_to_rm{$inner_node->dbID} }, $leaf_id;
+            # If only one child is removed, the other child will replace this node in the GAT
+            if ( (scalar $children_to_rm{$inner_node->dbID} == 2) && defined $inner_node->parent ) {
+                push @{ $children_to_rm{$inner_node->parent->dbID} }, $inner_node->dbID;
+            }
+        }
+        # Each inner node in a GAT must have two children: if at least one is removed, the inner node has to
+        # be removed as well
+        $node_ids_to_rm{$_} = 1 for keys %children_to_rm;
+        # Get the list of ancestral GAs, dnafrags and nodes to remove, plus the nodes to relocate in the GAT
+        foreach my $node ( @{ $gat_root->get_all_nodes() } ) {
+            my $node_ga = $node->get_all_genomic_aligns_for_node->[0];
+            if ( exists $node_ids_to_rm{$node->dbID} ) {
+                $ga_ids_to_rm{$node_ga->dbID} = 1;
+                push @dnafrag_ids_to_rm, $node_ga->dnafrag_id unless $node->is_leaf();
+            } else {
+                if ( $node->has_parent() && exists $node_ids_to_rm{$node->parent->dbID} ) {
+                    # Find the final parent node, as it can be a (great-)*grandparent
+                    my $new_parent = $node->parent->parent;
+                    while ( defined $new_parent && exists $node_ids_to_rm{$new_parent->dbID} ) {
+                        $new_parent = $new_parent->parent;
+                    }
+                    # If $parent is undefined we have reached the GAT root, so this node will be the new root
+                    $gat_root = $node unless defined $new_parent;
+                    $node_ids_to_update{$node->dbID} = {
+                        parent_id    => defined $new_parent ? $new_parent->dbID : undef,
+                        prev_root_id => $node->root->dbID,  # only used to update root_id
+                        distance     => defined $new_parent ? $node->distance_to_node($new_parent) : $node->distance_to_root(),
+                    };
+                }
+                # Also include the ancestral GAs that will remain to update their CIGAR lines
+                push @$genomic_aligns, $node_ga unless $node->is_leaf();
+            }
+        }
+        # The ancestral GAB will need to be updated as well
+        push @gabs_to_update, $genomic_aligns->[-1]->genomic_align_block;
+    }
+    # Get the new CIGAR lines, discarding any gap-only column produced by the removal of the marked GAs
+    my @prev_cigars = map { $_->cigar_line } @$genomic_aligns;
+    my @updated_cigars = Bio::EnsEMBL::Compara::Utils::Cigars::minimize_cigars(@prev_cigars);
+    my %gas_to_update;
+    while ( my ($index, $cigar) = each @updated_cigars ) {
+        next if $cigar eq $prev_cigars[$index];
+        $gas_to_update{$genomic_aligns->[$index]->dbID} = $cigar;
+    }
+    # Get the new alignment length
+    my $new_aln_length = Bio::EnsEMBL::Compara::Utils::Cigars::alignment_length_from_cigar($updated_cigars[0]);
+
+    $self->param('gas_to_update', \%gas_to_update);
+    $self->param('new_aln_length', $new_aln_length);
+    $self->param('gabs_to_update', \@gabs_to_update);
+    $self->param('node_ids_to_update', \%node_ids_to_update);
+    $self->param('ga_ids_to_rm', [ keys %ga_ids_to_rm ]);
+    $self->param('node_ids_to_rm', [ keys %node_ids_to_rm ]);
+    $self->param('dnafrag_ids_to_rm', \@dnafrag_ids_to_rm);
+    $self->param('gat_root_id', $gat_root->dbID) if defined $gat_root;
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/UpdateGAB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/UpdateGAB.pm
@@ -165,7 +165,7 @@ sub write_output {
         $root->build_leftright_indexing();
         $gat_adaptor->update_subtree($root);
     }
-    
+
     # Flow the ancestor dnafrag names to syncronise the ancestral database with the dnafrag table
     $self->dataflow_output_id({ name => $_ }, 2) for @ancestor_names;
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/UpdateGAB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/UpdateGAB.pm
@@ -77,13 +77,13 @@ sub run {
     if ( (scalar keys(%genomic_aligns) - scalar @$ga_ids_to_rm) < 2 ) {
         # A GAB must have at least 2 GAs: remove this GAB and all its related information
         print "GAB $gab_id needs to be removed\n" if $self->debug;
-        $self->_remove_gab($gab, [ keys %genomic_aligns ]);
+        $self->_register_gab_for_rm($gab, [ keys %genomic_aligns ]);
     } else {
         # Update the remaining GAs, deleting every gap-only column that may be left, and the genomic align
         # tree (GAT)
         delete @genomic_aligns{@$ga_ids_to_rm};
         print "GAB $gab_id needs to be updated\n" if $self->debug;
-        $self->_update_gab($gab, $ga_ids_to_rm, [ values %genomic_aligns ]);
+        $self->_register_gab_for_update($gab, $ga_ids_to_rm, [ values %genomic_aligns ]);
     }
 }
 
@@ -170,7 +170,7 @@ sub write_output {
 }
 
 
-sub _remove_gab {
+sub _register_gab_for_rm {
     my ($self, $gab, $ga_ids_to_rm) = @_;
 
     my $dba = $self->compara_dba;
@@ -200,7 +200,7 @@ sub _remove_gab {
 }
 
 
-sub _update_gab {
+sub _register_gab_for_update {
     my ($self, $gab, $ga_ids_to_rm, $genomic_aligns) = @_;
     my %ga_ids_to_rm = map { $_ => 1 } @$ga_ids_to_rm;
     my @gabs_to_update = ( $gab );

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/UpdateGAB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/UpdateGAB.pm
@@ -58,7 +58,6 @@ use warnings;
 use strict;
 
 use Bio::EnsEMBL::Registry;
-use Bio::EnsEMBL::Hive::Utils;
 
 use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
 use Bio::EnsEMBL::Compara::Utils::Cigars;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/UpdateGAB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/UpdateGAB.pm
@@ -154,7 +154,7 @@ sub write_output {
             $nrows = $dba->dbc->do("DELETE FROM dnafrag WHERE dnafrag_id IN ($dnafrag_ids)");
             print "Removed $nrows ancestral row(s) from dnafrag\n" if $self->debug;
         }
-        # The work is done, enable foreign key constraints again
+        # The work is done, re-enable foreign key constraints
         $dba->dbc->do("SET FOREIGN_KEY_CHECKS = 1");
     });
 
@@ -211,7 +211,7 @@ sub _update_gab {
     my (%node_ids_to_rm, %node_ids_to_update, $gat_root, @dnafrag_ids_to_rm);
     if ( my $gat = $gat_adaptor->fetch_by_GenomicAlignBlock($gab) ) {
         $gat_root = $gat->root;
-        # Get all the GAT inner nodes that are going to loose at least one child
+        # Get all the GAT inner nodes that are going to lose at least one child
         my %children_to_rm;
         foreach my $ga_id ( keys %ga_ids_to_rm ) {
             my $leaf_id = $ga_adaptor->fetch_by_dbID($ga_id)->node_id;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/UpdateGABFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/UpdateGABFactory.pm
@@ -52,7 +52,6 @@ use strict;
 use Array::Utils qw(array_minus);
 
 use Bio::EnsEMBL::Registry;
-use Bio::EnsEMBL::Hive::Utils;
 
 use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/UpdateGABFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/UpdateGABFactory.pm
@@ -1,0 +1,102 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::UpdateMSA::UpdateMSA::UpdateGABFactory
+
+=head1 DESCRIPTION
+
+Flows 1 job per genomic align block id (and corresponding genomic align ids)
+that are affected by the species removed in the given MSA MLSS.
+
+=over
+
+=item mlss_id
+
+Mandatory. Current release MSA's MLSS id.
+
+=item prev_mlss_id
+
+Mandatory. Previous release MSA's MLSS id.
+
+=back
+
+=head1 EXAMPLES
+
+    standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::UpdateMSA::UpdateGABFactory \
+        -compara_db $(mysql-ens-compara-prod-9-ensadmin details url jalvarez_amniotes_pecan_update_101) \
+        -mlss_id 1897 -prev_mlss_id 1831
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::UpdateMSA::UpdateGABFactory;
+
+use warnings;
+use strict;
+
+use Array::Utils qw(array_minus);
+
+use Bio::EnsEMBL::Registry;
+use Bio::EnsEMBL::Hive::Utils;
+
+use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub fetch_input {
+    my $self = shift;
+    my $prev_mlss_id = $self->param_required('prev_mlss_id');
+    my $curr_mlss_id = $self->param_required('mlss_id');
+    my $dba = $self->compara_dba;
+    # Get the list of retired genomes that have to be removed from the MSA
+    my $mlss_adaptor = $dba->get_MethodLinkSpeciesSetAdaptor();
+    my $prev_mlss = $mlss_adaptor->fetch_by_dbID($prev_mlss_id);
+    my $curr_mlss = $mlss_adaptor->fetch_by_dbID($curr_mlss_id);
+    # Set algebra: prev_genome_db_ids - curr_genome_db_ids
+    my @gdbs_to_rm = map { $_->dbID }
+        array_minus(@{ $prev_mlss->species_set->genome_dbs }, @{ $curr_mlss->species_set->genome_dbs });
+    die "No genomes to remove in the MSA. Are you sure you need to update it?" if !@gdbs_to_rm;
+    print "Genome dbs to remove: " . join(', ', @gdbs_to_rm) . "\n" if $self->debug;
+    # Get the ids of every genomic align and genomic align block affected
+    my $sth = $dba->dbc->prepare("SELECT genomic_align_id, genomic_align_block_id FROM genomic_align ga
+        JOIN dnafrag df USING (dnafrag_id) WHERE method_link_species_set_id = $curr_mlss_id
+        AND genome_db_id IN (" . join(',', @gdbs_to_rm) . ")");
+    $sth->execute();
+    my %affected_gabs;
+    while ( my ($ga_id, $gab_id) = $sth->fetchrow ) {
+        push @{ $affected_gabs{$gab_id} }, $ga_id;
+    }
+    $self->param('affected_gabs', \%affected_gabs);
+}
+
+
+sub write_output {
+    my $self = shift;
+    my $affected_gabs = $self->param('affected_gabs');
+
+    foreach my $gab_id ( keys %$affected_gabs ) {
+        $self->dataflow_output_id({
+            'gab_id'     => $gab_id,
+            'ga_id_list' => $affected_gabs->{$gab_id},
+        }, 2);
+    }
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/UpdateGABFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/UpdateMSA/UpdateGABFactory.pm
@@ -17,7 +17,7 @@ limitations under the License.
 
 =head1 NAME
 
-Bio::EnsEMBL::Compara::RunnableDB::UpdateMSA::UpdateMSA::UpdateGABFactory
+Bio::EnsEMBL::Compara::RunnableDB::UpdateMSA::UpdateGABFactory
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
## Description

With the new frozen release cycle we want to be able to remove non-reference species that are updated from EPO/Mercator-Pecan, and moved them to EPO Extended (in the former case), to avoid recalculating EPO/Mercator-Pecan MSAs again. This pipeline will take care of this automatically for a given method link and species set name.

**Related JIRA tickets:**
- ENSCOMPARASW-3065

## Overview of changes
#### Change 1
- This pipeline copies the MSA information from the previous release, updating the ancestral database if required, and updates the MLSS tags as well as the ancestral `dnafrag`s and all the ids that have the MLSS integrated in them. Afterwards, it will check the `GAB`s affected by the removed genome(s) and update them, updating also the `GA`s, `GAT`s (EPO only). The `GAB`s are treated in parallel and all the updates for each one are performed in a single transaction, to ensure consistency.

#### Change 2
- The EPO Extended pipeline has been integrated as @carlacummins said it wouldn't make a difference in terms of time cost to update the MSA adding the new genome(s) or to recompute it again from scratch, so I have decided to go for the latter option.

## Testing
I have run two "fake" production runs (from e101 to e102), one for [Mercator-Pecan](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-9&port=4647&dbname=jalvarez_amniotes_pecan_update_102) and another for [mammals EPO](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-9&port=4647&dbname=jalvarez_mammals_epo_update_102).

## Notes
- Since we are tight on time, I won't add unit tests for the new runnables in this PR. I will submit a new PR in the near future with those.
- The new dependency was already present in the farm, so that is why I used it.
- The latest commit (https://github.com/Ensembl/ensembl-compara/pull/236/commits/ac357e94670fc29ccc23fb255d9e89c4664c39ce) can be seen in [fish EPO](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-9&port=4647&dbname=jalvarez_fish_epo_update_102).