### PR TITLE
Update travis settings and remove external unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ language: generic
 
 env:
   global:
+    # yamllint disable-line rule:line-length
     - secure: bGSZASCtRCcE2VZ3u4hdvjh6CDHe+Uo3MR7B4eobSFFhZVjIN3/DKaGrQYprEeSIB/vb75rveyTheO3qe3lHwq71e18cBk2ulQA6/L0eUJYsoR3u2y7d9whu8dS97IoLzize6hItxJFP8TmRaJBtWqOixyWHNW72X/fKF1a192E=
-    - COVERALLS_PARALLEL=true
 
 addons:
   apt:
     packages:
-    - graphviz
+      - graphviz
 
 services:
   - mysql
@@ -19,8 +19,9 @@ cache:
   directories:
     - $HOME/deps
 
-# Clone all repositories and setup the directory structure
+# Clone all repositories, setup the directory structure and the environment
 before_install:
+    # yamllint disable-line rule:indentation
     - cpanm -nq local::lib
     - eval "$(perl -Mlocal::lib=${HOME}/deps)"
     - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-test.git
@@ -29,30 +30,32 @@ before_install:
     - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-variation.git
     - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-io.git
     - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-hive.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-taxonomy.git
     - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-datacheck.git
+    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-hive.git
+    - git clone --branch stable --depth 1 https://github.com/Ensembl/ensembl-taxonomy.git
     - ln -s . ensembl-compara
     - git clone --branch v1.6.x --depth 1 https://github.com/bioperl/bioperl-live
     - git clone --branch release-1-6-9 --depth 1 https://github.com/bioperl/bioperl-run
     - sed -i '/Bio::DB::HTS/d' ensembl-rest/cpanfile
-
-# Setup the Perl dependencies and configuration
-install:
+    # Setup the environment variables
+    - export ENSEMBL_CVS_ROOT_DIR=$PWD
+    - export EHIVE_ROOT_DIR=$PWD/ensembl-hive
+    - export PERL5LIB=$PERL5LIB:$PWD/bioperl-live
+    - export PERL5LIB=$PERL5LIB:$PWD/bioperl-run/lib
+    - export PERL5LIB=$PERL5LIB:$PWD/modules
+    - export PERL5LIB=$PERL5LIB:$PWD/travisci/fake_libs/
+    - export PERL5LIB=$PERL5LIB:$PWD/ensembl/modules
+    - export PERL5LIB=$PERL5LIB:$PWD/ensembl-rest/lib
+    - export PERL5LIB=$PERL5LIB:$PWD/ensembl-hive/modules
+    - export PERL5LIB=$PERL5LIB:$PWD/ensembl-test/modules
+    - export PERL5LIB=$PERL5LIB:$PWD/ensembl-funcgen/modules
+    - export PERL5LIB=$PERL5LIB:$PWD/ensembl-variation/modules
+    - export PERL5LIB=$PERL5LIB:$PWD/ensembl-taxonomy/modules
+    - export PERL5LIB=$PERL5LIB:$PWD/ensembl-io/modules
+    - export PERL5LIB=$PERL5LIB:$PWD/ensembl-datacheck/lib
     - cp -f travisci/MultiTestDB.conf.travisci  modules/t/MultiTestDB.conf
     - cp -f ensembl-rest/travisci/MultiTestDB.conf.travisci ensembl-rest/t/MultiTestDB.conf
     - cp -f ensembl/travisci/MultiTestDB.conf.travisci.mysql  ensembl/modules/t/MultiTestDB.conf
-    - cpanm --quiet --installdeps --notest --cpanfile ensembl/cpanfile .
-    # 8.43 is the last version compatible with Perl 5.14
-    - cpanm --quiet --notest Mojolicious@8.43
-    - cpanm --quiet --installdeps --notest --cpanfile ensembl-rest/cpanfile .
-    - cpanm --quiet --installdeps --notest --cpanfile ensembl-hive/cpanfile .
-    - cpanm --quiet --installdeps --notest .
-    - cpanm --quiet --notest Devel::Cover::Report::Coveralls
-    - cpanm --quiet --notest Devel::Cover::Report::Codecov
-
-# Setup the MySQL server
-before_script:
     - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
 
 
@@ -63,9 +66,19 @@ jobs:
       perl: 5.30
       name: "Housekeeping (all languages)"
       install:
-        - cp -f travisci/MultiTestDB.conf.travisci  modules/t/MultiTestDB.conf
+        - sudo apt-get -y install shellcheck
+        # --user is required on Perl VMs because it's the system pip/python
+        - pip install --user yamllint
         - cpanm --quiet --installdeps --notest --cpanfile ensembl/cpanfile .
-      script: ./travisci/all-housekeeping_harness.sh
+        - cpanm --quiet --installdeps --notest .
+      script: prove -r ./travisci/all-housekeeping/
+
+    - language: perl
+      perl: 5.30
+      name: "SQL unit tests"
+      install:
+        - cpanm --quiet --installdeps --notest --cpanfile ensembl/cpanfile .
+      script: prove -r ./travisci/sql-unittest/
 
     - language: perl
       dist: trusty   # 5.22 is the minimum on xenial
@@ -73,6 +86,11 @@ jobs:
       name: "Perl unit tests on the minimum version"
       env:
         - COVERAGE=false
+      install:
+        - cpanm --quiet --installdeps --notest --cpanfile ensembl/cpanfile .
+        - cpanm --quiet --installdeps --notest --cpanfile ensembl-hive/cpanfile .
+        - cpanm --quiet --installdeps --notest --cpanfile ensembl-rest/cpanfile .
+        - cpanm --quiet --installdeps --notest .
       script: ./travisci/perl-unittest_harness.sh
 
     - language: perl
@@ -80,9 +98,14 @@ jobs:
       name: "Perl unit tests on the latest version, with code coverage"
       env:
         - COVERAGE=true
+      install:
+        - cpanm --quiet --installdeps --notest --cpanfile ensembl/cpanfile .
+        - cpanm --quiet --installdeps --notest --cpanfile ensembl-hive/cpanfile .
+        - cpanm --quiet --installdeps --notest --cpanfile ensembl-rest/cpanfile .
+        - cpanm --quiet --installdeps --notest .
+        - cpanm --quiet --notest Devel::Cover::Report::Codecov
       script: ./travisci/perl-unittest_harness.sh
       after_success:
-        - cover --nosummary -report coveralls
         - cover --nosummary -report codecov
 
     - language: perl
@@ -90,8 +113,6 @@ jobs:
       name: "Perl linter"
       install:
         - cpanm --quiet --installdeps --notest --cpanfile ensembl/cpanfile .
-      before_script:
-        - echo
       script: ./travisci/perl-linter_harness.sh
 
     - language: python
@@ -104,8 +125,6 @@ jobs:
         - echo
       install:
         - pip install -r requirements.txt .
-      before_script:
-        - echo
       script: ./travisci/python-unittest_harness.sh
 
     - language: python
@@ -117,14 +136,11 @@ jobs:
       before_install:
         - echo
       install:
-        - pip install pytest-cov coveralls codecov
+        - pip install pytest-cov codecov
         - pip install -r requirements.txt
         - pip install -e .
-      before_script:
-        - echo
       script: ./travisci/python-unittest_harness.sh
       after_success:
-        - coveralls
         - codecov
 
     - language: python
@@ -135,9 +151,4 @@ jobs:
       install:
         - pip install pylint mypy
         - pip install -r requirements.txt .
-      before_script:
-        - echo
       script: ./travisci/python-linter_harness.sh
-
-notifications:
-  webhooks: https://coveralls.io/webhook

--- a/travisci/perl-unittest_harness.sh
+++ b/travisci/perl-unittest_harness.sh
@@ -19,29 +19,12 @@
 echo "We are running Perl '$TRAVIS_PERL_VERSION', Coverage reporting is set to '$COVERAGE'"
 
 # Setup the environment variables
-export ENSEMBL_CVS_ROOT_DIR=$PWD
-export EHIVE_ROOT_DIR=$PWD/ensembl-hive
 export TEST_AUTHOR=$USER
-export PERL5LIB=$PERL5LIB:$PWD/bioperl-live
-export PERL5LIB=$PERL5LIB:$PWD/bioperl-run/lib
-export PERL5LIB=$PERL5LIB:$PWD/modules
-export PERL5LIB=$PERL5LIB:$PWD/travisci/fake_libs/
-export PERL5LIB=$PERL5LIB:$PWD/ensembl/modules
-export PERL5LIB=$PERL5LIB:$PWD/ensembl-rest/lib
-export PERL5LIB=$PERL5LIB:$PWD/ensembl-hive/modules
-export PERL5LIB=$PERL5LIB:$PWD/ensembl-test/modules
-export PERL5LIB=$PERL5LIB:$PWD/ensembl-funcgen/modules
-export PERL5LIB=$PERL5LIB:$PWD/ensembl-variation/modules
-export PERL5LIB=$PERL5LIB:$PWD/ensembl-taxonomy/modules
-export PERL5LIB=$PERL5LIB:$PWD/ensembl-io/modules
-
 
 ENSEMBL_PERL5OPT='-MDevel::Cover=+ignore,bioperl,+ignore,ensembl,+ignore,ensembl-test,+ignore,ensembl-variation,+ignore,ensembl-funcgen'
 ENSEMBL_TESTER="$PWD/ensembl-test/scripts/runtests.pl"
 ENSEMBL_TESTER_OPTIONS=()
 COMPARA_SCRIPTS=("$PWD/modules/t")
-CORE_SCRIPTS=("$PWD/ensembl/modules/t/compara.t")
-REST_SCRIPTS=("$PWD/ensembl-rest/t/genomic_alignment.t" "$PWD/ensembl-rest/t/info.t" "$PWD/ensembl-rest/t/taxonomy.t" "$PWD/ensembl-rest/t/homology.t" "$PWD/ensembl-rest/t/gene_tree.t" "$PWD/ensembl-rest/t/cafe_tree.t" "$PWD/ensembl-rest/t/family.t")
 
 if [ "$COVERAGE" = 'true' ]; then
   EFFECTIVE_PERL5OPT="$ENSEMBL_PERL5OPT"
@@ -53,28 +36,16 @@ fi
 echo "Running ensembl-compara test suite using $PERL5LIB"
 PERL5OPT="$EFFECTIVE_PERL5OPT" perl "$ENSEMBL_TESTER" "${ENSEMBL_TESTER_OPTIONS[@]}" "${COMPARA_SCRIPTS[@]}"
 rt1=$?
-echo "Running ensembl test suite using $PERL5LIB"
-PERL5OPT="$EFFECTIVE_PERL5OPT" perl "$ENSEMBL_TESTER" "${ENSEMBL_TESTER_OPTIONS[@]}" "${CORE_SCRIPTS[@]}"
-rt2=$?
-
-#if [[ "$TRAVIS_PERL_VERSION" != "5.14" ]]; then
-  #echo "Skipping ensembl-rest test suite"
-  #rt3=0
-#else
-  echo "Running ensembl-rest test suite using $PERL5LIB"
-  PERL5OPT="$EFFECTIVE_PERL5OPT" perl "$ENSEMBL_TESTER" "${ENSEMBL_TESTER_OPTIONS[@]}" "${REST_SCRIPTS[@]}"
-  rt3=$?
-#fi
 
 # Check that all the Perl files can be compiled
 find docs modules scripts sql travisci -iname '*.t' -print0 | xargs -0 -n 1 perl -c
-rt4=$?
+rt2=$?
 find docs modules scripts sql travisci -iname '*.pl' -print0 | xargs -0 -n 1 perl -c
-rt5=$?
+rt3=$?
 find docs modules scripts sql travisci -iname '*.pm' \! -name 'LoadSynonyms.pm' \! -name 'HALAdaptor.pm' \! -name 'HALXS.pm' -print0 | xargs -0 -n 1 perl -c
-rt6=$?
+rt4=$?
 
-if [[ ($rt1 -eq 0) && ($rt2 -eq 0) && ($rt3 -eq 0) && ($rt4 -eq 0) && ($rt5 -eq 0) && ($rt6 -eq 0)]]; then
+if [[ ($rt1 -eq 0) && ($rt2 -eq 0) && ($rt3 -eq 0) && ($rt4 -eq 0)]]; then
   exit 0
 else
   exit 255


### PR DESCRIPTION
## Description

Dev and production branches are allowed to deviate in terms of schema, etc, so the external (`ensembl`, `ensembl-rest`) tests are no longer relevant (and always fail anyway)

**Related JIRA tickets:**
- ENSCOMPARASW-4050

## Overview of changes

#### Change #1
- copied `.travis.yml` and `travisci/perl-unittest_harness.sh` from `master` (since it had a similar rework recently)
- edited `.travis.yml` to remove external test job

## Testing
Will test with this PR

## Notes
This PR is tiny - one reviewer should be enough
