### PR TITLE
Read non-reference sequences from Fasta files

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
@@ -856,26 +856,23 @@ sub _get_genome_dump_path {
 
 sub get_faidx_helper {
     my $self = shift;
-    my $mask = shift;
-    my $non_reference = shift;
 
     # Ancestral sequences are not dumped
     return undef if $self->name eq 'ancestral_sequences';
 
-    my $faidx_key = '_faidx_helper_' . ($mask // '') . ($non_reference ? ' _non_ref' : '');
-    unless (exists $self->{$faidx_key}) {
-        $self->{$faidx_key} = undef;
-        if ($self->adaptor and (my $dump_dir_location = $self->adaptor->dump_dir_location)) {
-            my $path = $self->_get_genome_dump_path($dump_dir_location, $mask, $non_reference);
+    if ($self->adaptor and (my $dump_dir_location = $self->adaptor->dump_dir_location)) {
+        my $path = $self->_get_genome_dump_path($dump_dir_location, @_);
+        $self->{'_faidx_helper'} //= {};
+        unless (exists $self->{'_faidx_helper'}->{$path}) {
             if (-e $path) {
                 require Bio::DB::HTS::Faidx;
-                $self->{$faidx_key} = Bio::DB::HTS::Faidx->new($path);
+                $self->{'_faidx_helper'}->{$path} = Bio::DB::HTS::Faidx->new($path);
             } else {
                 die "Could not find $path";
             }
         }
+        return $self->{'_faidx_helper'}->{$path};
     }
-    return $self->{$faidx_key};
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
@@ -818,7 +818,14 @@ sub _get_genome_dump_path {
     require Bio::EnsEMBL::Hive::Utils;
     my $subdir = $self->dbID ? Bio::EnsEMBL::Hive::Utils::dir_revhash($self->dbID) : '';
 
-    my $filename = $self->name . '.' . $self->assembly . ($self->genome_component ? '.comp' . $self->genome_component : '') . ($mask ? '.' . $mask : '') . '.fa';
+    my @name_components = (
+        $self->name,
+        $self->assembly,
+    );
+    push @name_components, 'comp'.$self->genome_component if $self->genome_component;
+    push @name_components, $mask if $mask;
+
+    my $filename = join('.', @name_components) . '.fa';
     return "$dir/$subdir/$filename";
 }
 

--- a/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
@@ -830,7 +830,7 @@ sub _get_genome_dump_path {
         $self->name,
         $self->assembly,
     );
-    push @name_components, 'comp'.$self->genome_component if $self->genome_component;
+    push @name_components, 'comp' . $self->genome_component if $self->genome_component;
     push @name_components, 'non_ref' if $non_reference;
     push @name_components, $mask if $mask;
 

--- a/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
@@ -801,7 +801,7 @@ sub _get_unique_key {
                 $genome_db->_get_genome_dump_path($base_dir, 'hard');
                 $genome_db->_get_genome_dump_path($base_dir, 'soft', 'non_ref');
   Description : Returns the expected path for the Fasta dump of this genome, given the
-                requested dump options. This method allows pipelines to refer to and us
+                requested dump options. This method allows pipelines to refer to and use
                 files that are centrally created.
                 To behave nicely at scale, the files are expected to be spread according
                 to the dbID of the GenomeDB, using eHive's dir_revhash, e.g.

--- a/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
@@ -847,7 +847,7 @@ sub _get_genome_dump_path {
                 $genome_db->get_faidx_helper('soft', 'non_ref');
   Description : Return the instance of Bio::DB::HTS::Faidx for this type of Fasta file, if
                 a directory has been registered (see L<GenomeDBADaptor::dump_dir_location>).
-                A description of the options ($mask etc) can be found in L<_get_genome_dump_path>
+                A description of the options ($mask, etc) can be found in L<_get_genome_dump_path>
   Returntype  : Bio::DB::HTS::Faidx instance
   Exceptions  : Will die if dump_dir_location is set but the file is not found
   Caller      : general

--- a/modules/Bio/EnsEMBL/Compara/Locus.pm
+++ b/modules/Bio/EnsEMBL/Compara/Locus.pm
@@ -449,8 +449,10 @@ sub get_sequence {
     my $faidx_helper;
     if ($self->dnafrag->is_reference) {
         $faidx_helper = $self->genome_db->get_faidx_helper($mask);
-    } else {
+    } elsif ($self->dnafrag->coord_system_name ne 'lrg') {
         $faidx_helper = $self->genome_db->get_faidx_helper($mask, 'non_ref');
+    } else {
+        # LRGs are not dumped in a Fasta file
     }
 
     if ($faidx_helper) {

--- a/modules/Bio/EnsEMBL/Compara/Locus.pm
+++ b/modules/Bio/EnsEMBL/Compara/Locus.pm
@@ -444,14 +444,24 @@ sub get_sequence {
     my $mask = shift;
 
     my $seq;
-    # Only reference dnafrags are dumped
-    if ($self->dnafrag->is_reference && (my $faidx_helper = $self->genome_db->get_faidx_helper($mask))) {
+
+    # Find a Fasta file
+    my $faidx_helper;
+    if ($self->dnafrag->is_reference) {
+        $faidx_helper = $self->genome_db->get_faidx_helper($mask);
+    } else {
+        $faidx_helper = $self->genome_db->get_faidx_helper($mask, 'non_ref');
+    }
+
+    if ($faidx_helper) {
         # Sequence names in the Fasta file are expected to be dnafrag_ids;
         # Coordinates are 0-based
         $seq = $faidx_helper->get_sequence2_no_length($self->dnafrag_id, $self->dnafrag_start-1, $self->dnafrag_end-1);
         die "sequence length doesn't match !" if CORE::length($seq) != ($self->dnafrag_end-$self->dnafrag_start+1);
         reverse_comp(\$seq) if $self->dnafrag_strand < 0;
+
     } else {
+        # If there is no file, query the database via the Core API
         $self->genome_db->db_adaptor->dbc->prevent_disconnect( sub {
             if ($mask) {
                 if ($mask =~ /^soft/i) {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpGenomes_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpGenomes_conf.pm
@@ -125,7 +125,10 @@ sub pipeline_analyses {
                     'all_current'       => $self->o('all_current'),
                 }],
             -flow_into  => {
-                2 => [ 'genome_dump_unmasked', 'genome_dump_masked', ],
+                2 => [
+                    'genome_dump_unmasked', 'genome_dump_masked',
+                    'genome_dump_unmasked_non_ref', 'genome_dump_masked_non_ref',
+                ],
             },
         },
 
@@ -155,6 +158,30 @@ sub pipeline_analyses {
         {   -logic_name => 'genome_dump_masked',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::DumpGenomes::DumpMaskedGenomeSequence',
             -parameters => {
+                'force_redump'  => $self->o('force_redump'),
+            },
+            -flow_into  => {
+                2 => [ 'build_faidx_index' ],
+            },
+            -rc_name    => '4Gb_job',
+            -hive_capacity  => $self->o('dump_capacity'),
+        },
+
+        {   -logic_name => 'genome_dump_unmasked_non_ref',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::DumpGenomes::DumpUnmaskedGenomeSequence',
+            -parameters => {
+                'is_reference'  => 0,
+                'force_redump'  => $self->o('force_redump'),
+            },
+            -flow_into  => [ 'build_faidx_index' ],
+            -rc_name    => '4Gb_job',
+            -hive_capacity  => $self->o('dump_capacity'),
+        },
+
+        {   -logic_name => 'genome_dump_masked_non_ref',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::DumpGenomes::DumpMaskedGenomeSequence',
+            -parameters => {
+                'is_reference'  => 0,
                 'force_redump'  => $self->o('force_redump'),
             },
             -flow_into  => {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpGenomes_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpGenomes_conf.pm
@@ -142,7 +142,7 @@ sub pipeline_analyses {
         # have been made by replacing a-z with A-Z.
 
         {   -logic_name => 'genome_dump_unmasked',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::DumpUnmaskedGenomeSequence',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::DumpGenomes::DumpUnmaskedGenomeSequence',
             -parameters => {
                 'force_redump'  => $self->o('force_redump'),
             },
@@ -153,7 +153,7 @@ sub pipeline_analyses {
         },
 
         {   -logic_name => 'genome_dump_masked',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::DumpMaskedGenomeSequence',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::DumpGenomes::DumpMaskedGenomeSequence',
             -parameters => {
                 'force_redump'  => $self->o('force_redump'),
             },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpGenomes_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpGenomes_conf.pm
@@ -133,6 +133,14 @@ sub pipeline_analyses {
         # so dataflows on branch #2, whereas DumpUnmaskedGenomeSequence creates a single
         # file and is allowed to amend the dataflow on branch #1
 
+        # NOTE: The unmasked genome is dumped separately in order to get it
+        # done quicker (and start the exonerate indexing quicker). This is
+        # because fetching the masked DNA sequences is significantly slower
+        # than the unmasked DNA sequences.
+        # Otherwise, just like the hard-masked file is made from the
+        # soft-masked file by replacing a-z with N, the unmasked file could
+        # have been made by replacing a-z with A-Z.
+
         {   -logic_name => 'genome_dump_unmasked',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::DumpUnmaskedGenomeSequence',
             -parameters => {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpGenomes_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpGenomes_conf.pm
@@ -129,6 +129,10 @@ sub pipeline_analyses {
             },
         },
 
+        # NOTE: DumpUnmaskedGenomeSequence creates two files (soft- and hard-masked),
+        # so dataflows on branch #2, whereas DumpUnmaskedGenomeSequence creates a single
+        # file and is allowed to amend the dataflow on branch #1
+
         {   -logic_name => 'genome_dump_unmasked',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::DumpUnmaskedGenomeSequence',
             -parameters => {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpGenomes_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpGenomes_conf.pm
@@ -132,7 +132,7 @@ sub pipeline_analyses {
             },
         },
 
-        # NOTE: DumpUnmaskedGenomeSequence creates two files (soft- and hard-masked),
+        # NOTE: DumpMaskedGenomeSequence creates two files (soft- and hard-masked),
         # so dataflows on branch #2, whereas DumpUnmaskedGenomeSequence creates a single
         # file and is allowed to amend the dataflow on branch #1
 

--- a/modules/Bio/EnsEMBL/Compara/Production/EPOanchors/DumpGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/Production/EPOanchors/DumpGenomeSequence.pm
@@ -124,15 +124,15 @@ sub fetch_input {
     $genome_db->db_adaptor->dbc->prevent_disconnect( sub {
             foreach my $ref_dnafrag( @$dnafrags ) {
                 $dnafrag_names_2_dbID->{$ref_dnafrag->name} = $ref_dnafrag->dbID;
+                my $slice = $ref_dnafrag->slice;
                 if ($mask) {
                     if ($mask =~ /soft/i) {
-                        $serializer->print_Seq($ref_dnafrag->slice->get_repeatmasked_seq(undef, 1));
+                        $slice = $slice->get_repeatmasked_seq(undef, 1);
                     } elsif ($mask =~ /hard/i) {
-                        $serializer->print_Seq($ref_dnafrag->slice->get_repeatmasked_seq());
+                        $slice = $slice->get_repeatmasked_seq();
                     }
-                } else {
-                    $serializer->print_Seq($ref_dnafrag->slice);
                 }
+                $serializer->print_Seq($slice);
             }
         });
 	close($filehandle);

--- a/modules/Bio/EnsEMBL/Compara/Production/EPOanchors/DumpGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/Production/EPOanchors/DumpGenomeSequence.pm
@@ -55,6 +55,7 @@ use File::Path qw(make_path);
 
 use Bio::EnsEMBL::PaddedSlice;
 use Bio::EnsEMBL::Utils::IO::FASTASerializer;
+use Bio::EnsEMBL::Compara::Utils::Preloader;
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
@@ -109,6 +110,7 @@ sub fetch_input {
     $serializer->line_width($self->param('seq_width'));
 
     my $dnafrags = $self->compara_dba->get_DnaFragAdaptor->fetch_all_by_GenomeDB($genome_db, -IS_REFERENCE => $self->param('is_reference'));
+    Bio::EnsEMBL::Compara::Utils::Preloader::load_all_AltRegions($self->compara_dba->get_DnaFragAltRegionAdaptor, $dnafrags) unless $self->param('is_reference');
     $self->compara_dba->dbc->disconnect_if_idle();
 
     # Cellular-component filtering

--- a/modules/Bio/EnsEMBL/Compara/Production/EPOanchors/DumpGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/Production/EPOanchors/DumpGenomeSequence.pm
@@ -121,6 +121,9 @@ sub fetch_input {
         $dnafrags = [grep {!$excl{$_->cellular_component}} @$dnafrags];
     }
 
+    # LRGs are systematically excluded
+    $dnafrags = [grep {$_->coord_system_name ne 'lrg'} @$dnafrags];
+
     my $mask = $self->param('repeat_masked');
 
     $genome_db->db_adaptor->dbc->prevent_disconnect( sub {

--- a/modules/Bio/EnsEMBL/Compara/Production/EPOanchors/DumpGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/Production/EPOanchors/DumpGenomeSequence.pm
@@ -111,7 +111,7 @@ sub fetch_input {
 
     my $dnafrags = $self->compara_dba->get_DnaFragAdaptor->fetch_all_by_GenomeDB($genome_db, -IS_REFERENCE => $self->param('is_reference'));
     Bio::EnsEMBL::Compara::Utils::Preloader::load_all_AltRegions($self->compara_dba->get_DnaFragAltRegionAdaptor, $dnafrags) unless $self->param('is_reference');
-    $self->compara_dba->dbc->disconnect_if_idle();
+    $self->disconnect_from_databases();
 
     # Cellular-component filtering
     if (@{$self->param('cellular_components_only')}) {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/BaseDumpGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/BaseDumpGenomeSequence.pm
@@ -43,6 +43,8 @@ sub param_defaults {
     return {
         %{ $self->SUPER::param_defaults },
 
+        'is_reference'  => 1,       # Set this to 0 to only dump the non-reference dnafrags. This Runnable does not support dumping all dnafrags at once
+
         # Parameters of Bio::EnsEMBL::Utils::IO::FASTASerializer
         # They have a default value in the serializer itself, but can be redefined here
         'seq_width'     => 60,      # Characters per line in the FASTA file. Defaults to 60
@@ -63,8 +65,8 @@ sub fetch_input {
     $self->param_required('genome_dumps_dir');
 
     # The expected file size: DNA + line-returns + dnafrag name + ">" + line-return
-    my $sql = 'SELECT SUM(length + CEIL(length/?) + FLOOR(LOG10(dnafrag_id)) + 3) FROM dnafrag WHERE genome_db_id = ? AND is_reference = 1';
-    my ($ref_size) = $self->compara_dba->dbc->db_handle->selectrow_array($sql, undef, $self->param('seq_width'), $genome_db->dbID);
+    my $sql = 'SELECT SUM(length + CEIL(length/?) + FLOOR(LOG10(dnafrag_id)) + 3) FROM dnafrag WHERE genome_db_id = ? AND is_reference = ?';
+    my ($ref_size) = $self->compara_dba->dbc->db_handle->selectrow_array($sql, undef, $self->param('seq_width'), $genome_db->dbID, $self->param_required('is_reference'));
     $self->param('ref_size', $ref_size);
 
     my $paths = $self->set_dump_paths();

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/BaseDumpGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/BaseDumpGenomeSequence.pm
@@ -38,6 +38,19 @@ use File::Basename;
 use base ('Bio::EnsEMBL::Compara::Production::EPOanchors::DumpGenomeSequence');
 
 
+sub param_defaults {
+    my $self = shift;
+    return {
+        %{ $self->SUPER::param_defaults },
+
+        # Parameters of Bio::EnsEMBL::Utils::IO::FASTASerializer
+        # They have a default value in the serializer itself, but can be redefined here
+        'seq_width'     => 60,      # Characters per line in the FASTA file. Defaults to 60
+        'chunk_factor'  => undef,   # Number of lines to be buffered by the serializer. Defaults to 1,000
+    }
+}
+
+
 sub fetch_input {
     my $self = shift;
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/BaseDumpGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/BaseDumpGenomeSequence.pm
@@ -1,0 +1,91 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::DumpGenomes::BaseDumpGenomeSequence
+
+=head1 DESCRIPTION
+
+Pseudo Runnable with the functionality that is needed and shared by
+DumpMaskedGenomeSequence and DumpUnmaskedGenomeSequence.
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::DumpGenomes::BaseDumpGenomeSequence;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::Production::EPOanchors::DumpGenomeSequence');
+
+
+sub fetch_input {
+    my $self = shift;
+
+    # Fetch the GenomeDB
+    my $genome_db = $self->compara_dba->get_GenomeDBAdaptor->fetch_by_dbID( $self->param_required('genome_db_id') )
+                     || die "Cannot find a GenomeDB with dbID=".$self->param('genome_db_id');
+    $self->param('genome_db', $genome_db);
+
+    # Where the files should be
+    $self->param_required('genome_dumps_dir');
+
+    # The expected file size: DNA + line-returns + dnafrag name + ">" + line-return
+    my $sql = 'SELECT SUM(length + CEIL(length/?) + FLOOR(LOG10(dnafrag_id)) + 3) FROM dnafrag WHERE genome_db_id = ? AND is_reference = 1';
+    my ($ref_size) = $self->compara_dba->dbc->db_handle->selectrow_array($sql, undef, $self->param('seq_width'), $genome_db->dbID);
+
+    my $paths = $self->set_dump_paths();
+
+    # If all the files are there, we're good to go
+    my $dump_needed = 0;
+    foreach my $path (@$paths) {
+        unless (-e $path) {
+            $self->warning("$path doesn't exist");
+            $dump_needed = 1;
+            last;
+        }
+        if ($ref_size != -s $path) {
+            $self->warning("$path is " . (-s $path) . " bytes instead of $ref_size" );
+            $dump_needed = 1;
+            last;
+        }
+    }
+    if (!$dump_needed) {
+        if (grep {$_ eq $genome_db->name} @{$self->param_required('force_redump')}) {
+            $self->warning('Dumps of ' . $genome_db->name . ' look fine, but redump requested');
+        } else {
+            $self->write_output();
+            $self->input_job->autoflow(0);
+            $self->complete_early('All dumps already there');
+        }
+    }
+
+    my $tmp_dump_file = $self->worker_temp_directory . '/' . $self->param_required('genome_db_id') . '.fa';
+
+    $self->param('cellular_components_exclude', []);                # Dump everything
+    $self->param('cellular_components_only',    []);                # I said everything
+    $self->param('genome_dump_file',            $tmp_dump_file);    # Somewhere under /tmp
+
+    $self->SUPER::fetch_input();
+}
+
+
+1;
+

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/BaseDumpGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/BaseDumpGenomeSequence.pm
@@ -65,6 +65,7 @@ sub fetch_input {
     # The expected file size: DNA + line-returns + dnafrag name + ">" + line-return
     my $sql = 'SELECT SUM(length + CEIL(length/?) + FLOOR(LOG10(dnafrag_id)) + 3) FROM dnafrag WHERE genome_db_id = ? AND is_reference = 1';
     my ($ref_size) = $self->compara_dba->dbc->db_handle->selectrow_array($sql, undef, $self->param('seq_width'), $genome_db->dbID);
+    $self->param('ref_size', $ref_size);
 
     my $paths = $self->set_dump_paths();
 
@@ -105,8 +106,10 @@ sub fetch_input {
 sub _install_dump {
     my ($self, $tmp_dump_file, $target_file) = @_;
 
-    my $ref_size = -s $tmp_dump_file;
-    die "$tmp_dump_file is empty" unless $ref_size;
+    my $ref_size = $self->param('ref_size');
+    if ($ref_size != -s $tmp_dump_file) {
+        die "$tmp_dump_file is " . (-s $tmp_dump_file) . " bytes instead of $ref_size";
+    }
 
     # Assuming all three files are in the same directory
     my $cmd = ['mkdir', '-p', dirname($target_file)];

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/BaseDumpGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/BaseDumpGenomeSequence.pm
@@ -68,7 +68,7 @@ sub fetch_input {
     # with:
     # - the number of line returns needed to wrap a sequence is: CEIL(length/line_width)
     # - the size of the base 10 representation of an integer is: FLOOR(LOG10(number))+1
-    my $sql = 'SELECT SUM(length + CEIL(length/?) + FLOOR(LOG10(dnafrag_id)) + 3) FROM dnafrag WHERE genome_db_id = ? AND is_reference = ?';
+    my $sql = 'SELECT SUM(length + CEIL(length/?) + FLOOR(LOG10(dnafrag_id)) + 3) FROM dnafrag WHERE genome_db_id = ? AND is_reference = ? AND coord_system_name != "lrg"';
     my ($ref_size) = $self->compara_dba->dbc->db_handle->selectrow_array($sql, undef, $self->param('seq_width'), $genome_db->dbID, $self->param_required('is_reference'));
     $self->param('ref_size', $ref_size);
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/BaseDumpGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/BaseDumpGenomeSequence.pm
@@ -64,7 +64,10 @@ sub fetch_input {
     # Where the files should be
     $self->param_required('genome_dumps_dir');
 
-    # The expected file size: DNA + line-returns + dnafrag name + ">" + line-return
+    # The expected file size is: DNA + its line-returns + ">" + dnafrag_id + line-return
+    # with:
+    # - the number of line returns needed to wrap a sequence is: CEIL(length/line_width)
+    # - the size of the base 10 representation of an integer is: FLOOR(LOG10(number))+1
     my $sql = 'SELECT SUM(length + CEIL(length/?) + FLOOR(LOG10(dnafrag_id)) + 3) FROM dnafrag WHERE genome_db_id = ? AND is_reference = ?';
     my ($ref_size) = $self->compara_dba->dbc->db_handle->selectrow_array($sql, undef, $self->param('seq_width'), $genome_db->dbID, $self->param_required('is_reference'));
     $self->param('ref_size', $ref_size);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/BaseDumpGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/BaseDumpGenomeSequence.pm
@@ -66,7 +66,7 @@ sub fetch_input {
 
     # The expected file size is: DNA + its line-returns + ">" + dnafrag_id + line-return
     # with:
-    # - the number of line returns needed to wrap a sequence is: CEIL(length/line_width)
+    # - the number of line-returns needed to wrap a sequence is: CEIL(length/line_width)
     # - the size of the base 10 representation of an integer is: FLOOR(LOG10(number))+1
     my $sql = 'SELECT SUM(length + CEIL(length/?) + FLOOR(LOG10(dnafrag_id)) + 3) FROM dnafrag WHERE genome_db_id = ? AND is_reference = ? AND coord_system_name != "lrg"';
     my ($ref_size) = $self->compara_dba->dbc->db_handle->selectrow_array($sql, undef, $self->param('seq_width'), $genome_db->dbID, $self->param_required('is_reference'));
@@ -141,4 +141,3 @@ sub _install_dump {
 
 
 1;
-

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpMaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpMaskedGenomeSequence.pm
@@ -59,8 +59,8 @@ sub set_dump_paths {
     my $genome_db = $self->param('genome_db');
 
     # Where the files should be
-    $self->param('soft_masked_file', $genome_db->_get_genome_dump_path($self->param('genome_dumps_dir'), 'soft'));
-    $self->param('hard_masked_file', $genome_db->_get_genome_dump_path($self->param('genome_dumps_dir'), 'hard'));
+    $self->param('soft_masked_file', $genome_db->_get_genome_dump_path($self->param('genome_dumps_dir'), 'soft', not $self->param('is_reference')));
+    $self->param('hard_masked_file', $genome_db->_get_genome_dump_path($self->param('genome_dumps_dir'), 'hard', not $self->param('is_reference')));
 
     return [$self->param('soft_masked_file'), $self->param('hard_masked_file')];
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpMaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpMaskedGenomeSequence.pm
@@ -50,19 +50,6 @@ use warnings;
 use base ('Bio::EnsEMBL::Compara::RunnableDB::DumpGenomes::BaseDumpGenomeSequence');
 
 
-sub param_defaults {
-    my $self = shift;
-    return {
-        %{ $self->SUPER::param_defaults },
-
-        # Parameters of Bio::EnsEMBL::Utils::IO::FASTASerializer
-        # They have a default value in the serializer itself, but can be redefined here
-        'seq_width'     => 60,      # Characters per line in the FASTA file. Defaults to 60
-        'chunk_factor'  => undef,   # Number of lines to be buffered by the serializer. Defaults to 1,000
-    }
-}
-
-
 sub set_dump_paths {
     my $self = shift;
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpMaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpMaskedGenomeSequence.pm
@@ -53,13 +53,14 @@ use base ('Bio::EnsEMBL::Compara::RunnableDB::DumpGenomes::BaseDumpGenomeSequenc
 sub set_dump_paths {
     my $self = shift;
 
+    # The Runnable dumps the soft-masked genome and then converts it to hard-masked
+    $self->param('repeat_masked', 'soft');
+
     my $genome_db = $self->param('genome_db');
 
     # Where the files should be
     $self->param('soft_masked_file', $genome_db->_get_genome_dump_path($self->param('genome_dumps_dir'), 'soft'));
     $self->param('hard_masked_file', $genome_db->_get_genome_dump_path($self->param('genome_dumps_dir'), 'hard'));
-
-    $self->param('repeat_masked',               'soft');            # and soft-masked.
 
     return [$self->param('soft_masked_file'), $self->param('hard_masked_file')];
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpMaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpMaskedGenomeSequence.pm
@@ -19,11 +19,11 @@ limitations under the License.
 
 =head1 NAME
 
-Bio::EnsEMBL::Compara::RunnableDB::DumpUnmaskedGenomeSequence
+Bio::EnsEMBL::Compara::RunnableDB::DumpGenomes::DumpMaskedGenomeSequence
 
 =head1 DESCRIPTION
 
-Module to dump the unmasked genome sequences.
+Module to dump the soft- and hard-masked genome sequences.
 The files are moved to a shared directory.
 
 Input parameters
@@ -42,7 +42,7 @@ Base directory in which to dump the genomes
 
 =cut
 
-package Bio::EnsEMBL::Compara::RunnableDB::DumpUnmaskedGenomeSequence;
+package Bio::EnsEMBL::Compara::RunnableDB::DumpGenomes::DumpMaskedGenomeSequence;
 
 use strict;
 use warnings;
@@ -75,7 +75,8 @@ sub fetch_input {
 
     # Where the files should be
     $self->param_required('genome_dumps_dir');
-    $self->param('unmasked_file',    $genome_db->_get_genome_dump_path($self->param('genome_dumps_dir')));
+    $self->param('soft_masked_file', $genome_db->_get_genome_dump_path($self->param('genome_dumps_dir'), 'soft'));
+    $self->param('hard_masked_file', $genome_db->_get_genome_dump_path($self->param('genome_dumps_dir'), 'hard'));
 
     # The expected file size: DNA + line-returns + dnafrag name + ">" + line-return
     my $sql = 'SELECT SUM(length + CEIL(length/?) + FLOOR(LOG10(dnafrag_id)) + 3) FROM dnafrag WHERE genome_db_id = ? AND is_reference = 1';
@@ -83,7 +84,7 @@ sub fetch_input {
 
     # If all the files are there, we're good to go
     my $err = 0;
-    foreach my $file_param (qw(unmasked_file)) {
+    foreach my $file_param (qw(soft_masked_file hard_masked_file)) {
         unless (-e $self->param($file_param)) {
             $self->warning($self->param($file_param) . " doesn't exist");
             $err = 1;
@@ -97,11 +98,11 @@ sub fetch_input {
     }
     if (!$err) {
         if (grep {$_ eq $genome_db->name} @{$self->param_required('force_redump')}) {
-            $self->warning('Dump of ' . $genome_db->name . ' look fine, but redump requested');
+            $self->warning('Dumps of ' . $genome_db->name . ' look fine, but redump requested');
         } else {
             $self->write_output();
             $self->input_job->autoflow(0);
-            $self->complete_early('Dump already there');
+            $self->complete_early('All dumps already there');
         }
     }
 
@@ -110,7 +111,7 @@ sub fetch_input {
     $self->param('cellular_components_exclude', []);                # Dump everything
     $self->param('cellular_components_only',    []);                # I said everything
     $self->param('genome_dump_file',            $tmp_dump_file);    # Somewhere under /tmp
-    $self->param('repeat_masked',               undef);             # and not masked.
+    $self->param('repeat_masked',               'soft');            # and soft-masked.
 
     $self->SUPER::fetch_input();
 }
@@ -121,19 +122,25 @@ sub run {
 
     # Get the filenames
     my $tmp_dump_file    = $self->param('genome_dump_file');
-    my $unmasked_file    = $self->param('unmasked_file');
+    my $soft_masked_file = $self->param('soft_masked_file');
+    my $hard_masked_file = $self->param('hard_masked_file');
 
     my $ref_size = -s $tmp_dump_file;
     die "$tmp_dump_file is empty" unless $ref_size;
 
-    # Make the directory
-    my $cmd = ['mkdir', '-p', dirname($unmasked_file)];
+    # Assuming all three files are in the same directory
+    my $cmd = ['mkdir', '-p', dirname($soft_masked_file)];
     $self->run_command($cmd, { die_on_failure => 1 });
 
     # Copy the file (making sure the file permissions are correct regarless of the user's umask)
-    $cmd = ['install', '--preserve-timestamps', '--mode=664', $tmp_dump_file, $unmasked_file];
+    $cmd = ['install', '--preserve-timestamps', '--mode=664', $tmp_dump_file, $soft_masked_file];
     $self->run_command($cmd, { die_on_failure => 1 });
-    die "$unmasked_file size mismatch" if $ref_size != -s $unmasked_file;
+    die "$soft_masked_file size mismatch" if $ref_size != -s $soft_masked_file;
+
+    # Convert to hard-masked
+    $cmd = qq{bash -c "tr a-z N < '$tmp_dump_file' > '$hard_masked_file'"};
+    $self->run_command($cmd, { die_on_failure => 1 });
+    die "$hard_masked_file size mismatch" if $ref_size != -s $hard_masked_file;
 
     unlink $tmp_dump_file;
 }
@@ -141,7 +148,8 @@ sub run {
 
 sub write_output {
     my ($self) = @_;
-    $self->dataflow_output_id( {'genome_dump_file' => $self->param('unmasked_file')} );
+    $self->dataflow_output_id( {'mask' => 'soft', 'genome_dump_file' => $self->param('soft_masked_file')}, 2 );
+    $self->dataflow_output_id( {'mask' => 'hard', 'genome_dump_file' => $self->param('hard_masked_file')}, 2 );
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpMaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpMaskedGenomeSequence.pm
@@ -49,7 +49,7 @@ use warnings;
 
 use File::Basename;
 
-use base ('Bio::EnsEMBL::Compara::Production::EPOanchors::DumpGenomeSequence');
+use base ('Bio::EnsEMBL::Compara::RunnableDB::DumpGenomes::BaseDumpGenomeSequence');
 
 
 sub param_defaults {
@@ -65,55 +65,18 @@ sub param_defaults {
 }
 
 
-sub fetch_input {
+sub set_dump_paths {
     my $self = shift;
 
-    # Fetch the GenomeDB
-    my $genome_db = $self->compara_dba->get_GenomeDBAdaptor->fetch_by_dbID( $self->param_required('genome_db_id') )
-                     || die "Cannot find a GenomeDB with dbID=".$self->param('genome_db_id');
-    $self->param('genome_db', $genome_db);
+    my $genome_db = $self->param('genome_db');
 
     # Where the files should be
-    $self->param_required('genome_dumps_dir');
     $self->param('soft_masked_file', $genome_db->_get_genome_dump_path($self->param('genome_dumps_dir'), 'soft'));
     $self->param('hard_masked_file', $genome_db->_get_genome_dump_path($self->param('genome_dumps_dir'), 'hard'));
 
-    # The expected file size: DNA + line-returns + dnafrag name + ">" + line-return
-    my $sql = 'SELECT SUM(length + CEIL(length/?) + FLOOR(LOG10(dnafrag_id)) + 3) FROM dnafrag WHERE genome_db_id = ? AND is_reference = 1';
-    my ($ref_size) = $self->compara_dba->dbc->db_handle->selectrow_array($sql, undef, $self->param('seq_width'), $genome_db->dbID);
-
-    # If all the files are there, we're good to go
-    my $err = 0;
-    foreach my $file_param (qw(soft_masked_file hard_masked_file)) {
-        unless (-e $self->param($file_param)) {
-            $self->warning($self->param($file_param) . " doesn't exist");
-            $err = 1;
-            last;
-        }
-        if ($ref_size != -s $self->param($file_param)) {
-            $self->warning($self->param($file_param) . " is " . (-s $self->param($file_param)) . " bytes instead of $ref_size" );
-            $err = 1;
-            last;
-        }
-    }
-    if (!$err) {
-        if (grep {$_ eq $genome_db->name} @{$self->param_required('force_redump')}) {
-            $self->warning('Dumps of ' . $genome_db->name . ' look fine, but redump requested');
-        } else {
-            $self->write_output();
-            $self->input_job->autoflow(0);
-            $self->complete_early('All dumps already there');
-        }
-    }
-
-    my $tmp_dump_file = $self->worker_temp_directory . '/' . $self->param_required('genome_db_id') . '.fa';
-
-    $self->param('cellular_components_exclude', []);                # Dump everything
-    $self->param('cellular_components_only',    []);                # I said everything
-    $self->param('genome_dump_file',            $tmp_dump_file);    # Somewhere under /tmp
     $self->param('repeat_masked',               'soft');            # and soft-masked.
 
-    $self->SUPER::fetch_input();
+    return [$self->param('soft_masked_file'), $self->param('hard_masked_file')];
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpMaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpMaskedGenomeSequence.pm
@@ -36,7 +36,7 @@ dbID of the GenomeDB to dump
 
 =item genome_dumps_dir
 
-Base directory in which to dump the genomes
+Base directory in which to dump the genome
 
 =back
 
@@ -92,4 +92,3 @@ sub write_output {
 }
 
 1;
-

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpUnmaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpUnmaskedGenomeSequence.pm
@@ -50,19 +50,6 @@ use warnings;
 use base ('Bio::EnsEMBL::Compara::RunnableDB::DumpGenomes::BaseDumpGenomeSequence');
 
 
-sub param_defaults {
-    my $self = shift;
-    return {
-        %{ $self->SUPER::param_defaults },
-
-        # Parameters of Bio::EnsEMBL::Utils::IO::FASTASerializer
-        # They have a default value in the serializer itself, but can be redefined here
-        'seq_width'     => 60,      # Characters per line in the FASTA file. Defaults to 60
-        'chunk_factor'  => undef,   # Number of lines to be buffered by the serializer. Defaults to 1,000
-    }
-}
-
-
 sub set_dump_paths {
     my $self = shift;
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpUnmaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpUnmaskedGenomeSequence.pm
@@ -19,11 +19,11 @@ limitations under the License.
 
 =head1 NAME
 
-Bio::EnsEMBL::Compara::RunnableDB::DumpMaskedGenomeSequence
+Bio::EnsEMBL::Compara::RunnableDB::DumpGenomes::DumpUnmaskedGenomeSequence
 
 =head1 DESCRIPTION
 
-Module to dump the soft- and hard-masked genome sequences.
+Module to dump the unmasked genome sequences.
 The files are moved to a shared directory.
 
 Input parameters
@@ -42,7 +42,7 @@ Base directory in which to dump the genomes
 
 =cut
 
-package Bio::EnsEMBL::Compara::RunnableDB::DumpMaskedGenomeSequence;
+package Bio::EnsEMBL::Compara::RunnableDB::DumpGenomes::DumpUnmaskedGenomeSequence;
 
 use strict;
 use warnings;
@@ -75,8 +75,7 @@ sub fetch_input {
 
     # Where the files should be
     $self->param_required('genome_dumps_dir');
-    $self->param('soft_masked_file', $genome_db->_get_genome_dump_path($self->param('genome_dumps_dir'), 'soft'));
-    $self->param('hard_masked_file', $genome_db->_get_genome_dump_path($self->param('genome_dumps_dir'), 'hard'));
+    $self->param('unmasked_file',    $genome_db->_get_genome_dump_path($self->param('genome_dumps_dir')));
 
     # The expected file size: DNA + line-returns + dnafrag name + ">" + line-return
     my $sql = 'SELECT SUM(length + CEIL(length/?) + FLOOR(LOG10(dnafrag_id)) + 3) FROM dnafrag WHERE genome_db_id = ? AND is_reference = 1';
@@ -84,7 +83,7 @@ sub fetch_input {
 
     # If all the files are there, we're good to go
     my $err = 0;
-    foreach my $file_param (qw(soft_masked_file hard_masked_file)) {
+    foreach my $file_param (qw(unmasked_file)) {
         unless (-e $self->param($file_param)) {
             $self->warning($self->param($file_param) . " doesn't exist");
             $err = 1;
@@ -98,11 +97,11 @@ sub fetch_input {
     }
     if (!$err) {
         if (grep {$_ eq $genome_db->name} @{$self->param_required('force_redump')}) {
-            $self->warning('Dumps of ' . $genome_db->name . ' look fine, but redump requested');
+            $self->warning('Dump of ' . $genome_db->name . ' look fine, but redump requested');
         } else {
             $self->write_output();
             $self->input_job->autoflow(0);
-            $self->complete_early('All dumps already there');
+            $self->complete_early('Dump already there');
         }
     }
 
@@ -111,7 +110,7 @@ sub fetch_input {
     $self->param('cellular_components_exclude', []);                # Dump everything
     $self->param('cellular_components_only',    []);                # I said everything
     $self->param('genome_dump_file',            $tmp_dump_file);    # Somewhere under /tmp
-    $self->param('repeat_masked',               'soft');            # and soft-masked.
+    $self->param('repeat_masked',               undef);             # and not masked.
 
     $self->SUPER::fetch_input();
 }
@@ -122,25 +121,19 @@ sub run {
 
     # Get the filenames
     my $tmp_dump_file    = $self->param('genome_dump_file');
-    my $soft_masked_file = $self->param('soft_masked_file');
-    my $hard_masked_file = $self->param('hard_masked_file');
+    my $unmasked_file    = $self->param('unmasked_file');
 
     my $ref_size = -s $tmp_dump_file;
     die "$tmp_dump_file is empty" unless $ref_size;
 
-    # Assuming all three files are in the same directory
-    my $cmd = ['mkdir', '-p', dirname($soft_masked_file)];
+    # Make the directory
+    my $cmd = ['mkdir', '-p', dirname($unmasked_file)];
     $self->run_command($cmd, { die_on_failure => 1 });
 
     # Copy the file (making sure the file permissions are correct regarless of the user's umask)
-    $cmd = ['install', '--preserve-timestamps', '--mode=664', $tmp_dump_file, $soft_masked_file];
+    $cmd = ['install', '--preserve-timestamps', '--mode=664', $tmp_dump_file, $unmasked_file];
     $self->run_command($cmd, { die_on_failure => 1 });
-    die "$soft_masked_file size mismatch" if $ref_size != -s $soft_masked_file;
-
-    # Convert to hard-masked
-    $cmd = qq{bash -c "tr a-z N < '$tmp_dump_file' > '$hard_masked_file'"};
-    $self->run_command($cmd, { die_on_failure => 1 });
-    die "$hard_masked_file size mismatch" if $ref_size != -s $hard_masked_file;
+    die "$unmasked_file size mismatch" if $ref_size != -s $unmasked_file;
 
     unlink $tmp_dump_file;
 }
@@ -148,8 +141,7 @@ sub run {
 
 sub write_output {
     my ($self) = @_;
-    $self->dataflow_output_id( {'mask' => 'soft', 'genome_dump_file' => $self->param('soft_masked_file')}, 2 );
-    $self->dataflow_output_id( {'mask' => 'hard', 'genome_dump_file' => $self->param('hard_masked_file')}, 2 );
+    $self->dataflow_output_id( {'genome_dump_file' => $self->param('unmasked_file')} );
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpUnmaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpUnmaskedGenomeSequence.pm
@@ -47,8 +47,6 @@ package Bio::EnsEMBL::Compara::RunnableDB::DumpGenomes::DumpUnmaskedGenomeSequen
 use strict;
 use warnings;
 
-use File::Basename;
-
 use base ('Bio::EnsEMBL::Compara::RunnableDB::DumpGenomes::BaseDumpGenomeSequence');
 
 
@@ -84,17 +82,7 @@ sub run {
     my $tmp_dump_file    = $self->param('genome_dump_file');
     my $unmasked_file    = $self->param('unmasked_file');
 
-    my $ref_size = -s $tmp_dump_file;
-    die "$tmp_dump_file is empty" unless $ref_size;
-
-    # Make the directory
-    my $cmd = ['mkdir', '-p', dirname($unmasked_file)];
-    $self->run_command($cmd, { die_on_failure => 1 });
-
-    # Copy the file (making sure the file permissions are correct regarless of the user's umask)
-    $cmd = ['install', '--preserve-timestamps', '--mode=664', $tmp_dump_file, $unmasked_file];
-    $self->run_command($cmd, { die_on_failure => 1 });
-    die "$unmasked_file size mismatch" if $ref_size != -s $unmasked_file;
+    $self->_install_dump($tmp_dump_file, $unmasked_file);
 
     unlink $tmp_dump_file;
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpUnmaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpUnmaskedGenomeSequence.pm
@@ -36,7 +36,7 @@ dbID of the GenomeDB to dump
 
 =item genome_dumps_dir
 
-Base directory in which to dump the genomes
+Base directory in which to dump the genome
 
 =back
 
@@ -81,4 +81,3 @@ sub write_output {
 }
 
 1;
-

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpUnmaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpGenomes/DumpUnmaskedGenomeSequence.pm
@@ -56,7 +56,7 @@ sub set_dump_paths {
     my $genome_db = $self->param('genome_db');
 
     # Where the files should be
-    $self->param('unmasked_file',    $genome_db->_get_genome_dump_path($self->param('genome_dumps_dir')));
+    $self->param('unmasked_file', $genome_db->_get_genome_dump_path($self->param('genome_dumps_dir'), undef,  not $self->param('is_reference')));
 
     return [$self->param('unmasked_file')];
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMaskedGenomeSequence.pm
@@ -55,7 +55,6 @@ use strict;
 use warnings;
 
 use File::Basename;
-use File::Path qw(make_path);
 
 use base ('Bio::EnsEMBL::Compara::Production::EPOanchors::DumpGenomeSequence');
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMaskedGenomeSequence.pm
@@ -128,7 +128,6 @@ sub run {
     my $self = shift;
 
     # Get the filenames
-    my $genome_db        = $self->param('genome_db');
     my $tmp_dump_file    = $self->param('genome_dump_file');
     my $soft_masked_file = $self->param('soft_masked_file');
     my $hard_masked_file = $self->param('hard_masked_file');

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMaskedGenomeSequence.pm
@@ -40,13 +40,6 @@ Base directory in which to dump the genomes
 
 =back
 
-=head1 CONTACT
-
-This modules is part of the EnsEMBL project (http://www.ensembl.org)
-
-Questions can be posted to the ensembl-dev mailing list:
-http://lists.ensembl.org/mailman/listinfo/dev
-
 =cut
 
 package Bio::EnsEMBL::Compara::RunnableDB::DumpMaskedGenomeSequence;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpUnmaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpUnmaskedGenomeSequence.pm
@@ -55,7 +55,6 @@ use strict;
 use warnings;
 
 use File::Basename;
-use File::Path qw(make_path);
 
 use base ('Bio::EnsEMBL::Compara::Production::EPOanchors::DumpGenomeSequence');
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpUnmaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpUnmaskedGenomeSequence.pm
@@ -127,7 +127,6 @@ sub run {
     my $self = shift;
 
     # Get the filenames
-    my $genome_db        = $self->param('genome_db');
     my $tmp_dump_file    = $self->param('genome_dump_file');
     my $unmasked_file    = $self->param('unmasked_file');
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpUnmaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpUnmaskedGenomeSequence.pm
@@ -40,13 +40,6 @@ Base directory in which to dump the genomes
 
 =back
 
-=head1 CONTACT
-
-This modules is part of the EnsEMBL project (http://www.ensembl.org)
-
-Questions can be posted to the ensembl-dev mailing list:
-http://lists.ensembl.org/mailman/listinfo/dev
-
 =cut
 
 package Bio::EnsEMBL::Compara::RunnableDB::DumpUnmaskedGenomeSequence;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpUnmaskedGenomeSequence.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpUnmaskedGenomeSequence.pm
@@ -82,6 +82,7 @@ sub fetch_input {
     $self->param('genome_db', $genome_db);
 
     # Where the files should be
+    $self->param_required('genome_dumps_dir');
     $self->param('unmasked_file',    $genome_db->_get_genome_dump_path($self->param('genome_dumps_dir')));
 
     # The expected file size: DNA + line-returns + dnafrag name + ">" + line-return

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/ParsePairAlignerConf.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/ParsePairAlignerConf.pm
@@ -468,13 +468,15 @@ sub set_pair_aligner_options {
 		 # ensure that the smallest taxonomic group settings are applied
 		 # when dealing with nested sets
 		next if ( defined $these_settings && scalar(@clade_gdbs) >= $this_clade_size );
-		$this_clade_size = scalar @clade_gdbs;
 
 		# if both ref and non-ref are present, use these settings
 		my $found_ref     = grep { $_->dbID == $ref_genome_db->dbID } @clade_gdbs;
 		my $found_non_ref = grep { $_->dbID == $non_ref_genome_db->dbID } @clade_gdbs;
 		
-		$these_settings = $taxon_settings{$tax_id} if ( $found_ref && $found_non_ref );
+		if ( $found_ref && $found_non_ref ) {
+			$these_settings = $taxon_settings{$tax_id};
+			$this_clade_size = scalar @clade_gdbs;
+		}
 	}
 
 	$these_settings = $default_settings unless ( defined $these_settings );

--- a/modules/Bio/EnsEMBL/Compara/Utils/Preloader.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Preloader.pm
@@ -207,6 +207,8 @@ sub _load_and_attach_all {
 sub load_all_sequences {
     my ($sequence_adaptor, $seq_type, @args) = @_;
 
+    assert_ref($sequence_adaptor, 'Bio::EnsEMBL::Compara::DBSQL::SequenceAdaptor', 'sequence_adaptor');
+
     my $internal_sequence_key = $seq_type ? "_sequence_$seq_type" : '_sequence';
     my $internal_key_for_adaptor = $seq_type ? 'dbID' : '_sequence_id';
 
@@ -249,6 +251,8 @@ sub load_all_sequences {
 
 sub expand_Homologies {
     my $aligned_member_adaptor = shift;
+
+    assert_ref($aligned_member_adaptor, 'Bio::EnsEMBL::Compara::DBSQL::AlignedMemberAdaptor', 'aligned_member_adaptor');
 
     my %homologies;
     foreach my $a (@_) {

--- a/modules/Bio/EnsEMBL/Compara/Utils/Preloader.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Preloader.pm
@@ -278,8 +278,6 @@ sub expand_Homologies {
   Description : Method to load the alt-regions of many DnaFrags in a minimum number of queries
   Returntype  : Arrayref of Bio::EnsEMBL::Compara::Locus: the objects (alt-regions) loaded from the database
   Exceptions  : none
-  Caller      : general
-  Status      : Stable
 
 =cut
 

--- a/modules/Bio/EnsEMBL/Compara/Utils/Preloader.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Preloader.pm
@@ -274,7 +274,7 @@ sub expand_Homologies {
   Arg[1]      : Bio::EnsEMBL::Compara::DBSQL::DnaFragAltRegionAdaptor $dnafrag_alt_region_adaptor.
                 The adaptor that is used to retrieve the objects.
   Arg[2..n]   : Objects or arrays
-  Example     : load_all_AltRegions($dnafrag_alt_region_adaptor, $dnafrags);
+  Example     : my $alt_regions = load_all_AltRegions($dnafrag_alt_region_adaptor, $dnafrags);
   Description : Method to load the alt-regions of many DnaFrags in a minimum number of queries
   Returntype  : Arrayref of Bio::EnsEMBL::Compara::Locus objects (alt-regions) loaded from the database
   Exceptions  : none

--- a/modules/Bio/EnsEMBL/Compara/Utils/Preloader.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Preloader.pm
@@ -271,7 +271,8 @@ sub expand_Homologies {
 
 =head2 load_all_AltRegions
 
-  Arg[1]      : Bio::EnsEMBL::Compara::DBSQL::DnaFragAltRegionAdaptor $dnafrag_alt_region_adaptor. The adaptor that is used to retrieve the objects.
+  Arg[1]      : Bio::EnsEMBL::Compara::DBSQL::DnaFragAltRegionAdaptor $dnafrag_alt_region_adaptor.
+                The adaptor that is used to retrieve the objects.
   Arg[2..n]   : Objects or arrays
   Example     : load_all_AltRegions($dnafrag_alt_region_adaptor, $dnafrags);
   Description : Method to load the alt-regions of many DnaFrags in a minimum number of queries
@@ -289,7 +290,7 @@ sub load_all_AltRegions {
 
     my %dnafrags;
     foreach my $a (@_) {
-        foreach my $d (@{wrap_array($a)}) {
+        foreach my $d ( @{ wrap_array($a) } ) {
             next if !check_ref($d, 'Bio::EnsEMBL::Compara::DnaFrag') ;      # It has to be a DnaFrag
             next if exists $d->{'_alt_region'};                             # ... that doesn't have its alt-region yet
             $dnafrags{$d->dbID} = $d;

--- a/modules/Bio/EnsEMBL/Compara/Utils/Preloader.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Preloader.pm
@@ -276,7 +276,7 @@ sub expand_Homologies {
   Arg[2..n]   : Objects or arrays
   Example     : load_all_AltRegions($dnafrag_alt_region_adaptor, $dnafrags);
   Description : Method to load the alt-regions of many DnaFrags in a minimum number of queries
-  Returntype  : Arrayref of Bio::EnsEMBL::Compara::Locus: the objects (alt-regions) loaded from the database
+  Returntype  : Arrayref of Bio::EnsEMBL::Compara::Locus objects (alt-regions) loaded from the database
   Exceptions  : none
 
 =cut

--- a/modules/t/dnaFragAltRegionAdaptor.t
+++ b/modules/t/dnaFragAltRegionAdaptor.t
@@ -22,6 +22,7 @@ use Test::More;
 use Test::Exception;
 
 use Bio::EnsEMBL::Compara::Locus;
+use Bio::EnsEMBL::Compara::Utils::Preloader;
 use Bio::EnsEMBL::Test::MultiTestDB;
 use Bio::EnsEMBL::Test::TestUtils;
 
@@ -141,5 +142,30 @@ subtest 'Test Bio::EnsEMBL::Compara::DnaFrag get_alt_region', sub {
     is($alt_region->dnafrag_end, 1500000, 'Checking dnafrag_end');
 
 };
+
+subtest 'Test Bio::EnsEMBL::Compara::Utils::Preloader load_all_AltRegions', sub {
+
+    my $dnafrag_adaptor = $dnafrag_altregion_adaptor->db->get_DnaFragAdaptor;
+    my $dnafrags = $dnafrag_adaptor->fetch_all_by_dbID_list([$dnafrag_id, 13708879]);
+    is(scalar(@$dnafrags), 2, "Fetched two dnafrags");
+
+    Bio::EnsEMBL::Compara::Utils::Preloader::load_all_AltRegions($dnafrag_altregion_adaptor, $dnafrags);
+    my ($df1, $df2) = @$dnafrags;
+    if ($df1->dbID != $dnafrag_id) {
+        ($df2, $df1) = @$dnafrags;
+    }
+
+    ok(exists $df1->{_alt_region}, "1st dnafrag has an entry for _alt_region");
+    is($df1->{_alt_region}, undef, "And the value is undef");
+    ok(exists $df2->{_alt_region}, "2nd dnafrag has an entry for _alt_region");
+    ok($df2->{_alt_region}, "And the value defined");
+    my $alt_region = $df2->{_alt_region};
+    isa_ok($alt_region, 'Bio::EnsEMBL::Compara::Locus', 'alt_region');
+    is($alt_region->dnafrag_id, 13708879, 'Checking dbID');
+    is($alt_region->dnafrag_start, 1000000, 'Checking dnafrag_start');
+    is($alt_region->dnafrag_end, 1500000, 'Checking dnafrag_end');
+
+};
+
 
 done_testing();

--- a/modules/t/genomeDB.t
+++ b/modules/t/genomeDB.t
@@ -103,4 +103,16 @@ subtest "Test Bio::EnsEMBL::Compara::GenomeDB new_fast method", sub {
     done_testing();
 };
 
+subtest "Test Bio::EnsEMBL::Compara::GenomeDB _get_genome_dump_path method", sub {
+    my $genome_db = Bio::EnsEMBL::Compara::GenomeDB->new(-name => $name, -assembly => $assembly);
+    is($genome_db->_get_genome_dump_path('XX'), 'XX//homo_sapiens.GRCh37.fa');
+    $genome_db->dbID(123);
+    is($genome_db->_get_genome_dump_path('XX'), 'XX/3/2/homo_sapiens.GRCh37.fa');
+    is($genome_db->_get_genome_dump_path('XX', 'soft'), 'XX/3/2/homo_sapiens.GRCh37.soft.fa');
+    is($genome_db->_get_genome_dump_path('XX', undef, 'non_ref'), 'XX/3/2/homo_sapiens.GRCh37.non_ref.fa');
+    is($genome_db->_get_genome_dump_path('XX', 'hard', 'non_ref'), 'XX/3/2/homo_sapiens.GRCh37.non_ref.hard.fa');
+    $genome_db->genome_component('C');
+    is($genome_db->_get_genome_dump_path('XX', 'hard', 'non_ref'), 'XX/3/2/homo_sapiens.GRCh37.compC.non_ref.hard.fa');
+};
+
 done_testing();


### PR DESCRIPTION
## Description

In this PR I am addressing ENSCOMPARASW-3503, which is about being able to read from the genome dumps (Fasta files) for the non-reference dnafrags too. The only pipeline expected to benefit from that is LastZ.

## Overview of changes

1. Refactoring of the two Runnables that dump the genomes (masked and non-masked) as they share a lot of code.
2. Extended the function of GenomeDB that returns the path to the shared Fasta file. The "main" Fasta must still contain only the reference dnafrags because of the EPO pipeline, so I put the non-reference dnafrags in a file named `non_ref`. It's also cleaner w.r.t the DumpGenomes pipeline as a new run will not touch any existing file, just add a bunch of `non_ref` files.
3. Introduced an option in the Runnable to allow dumping non-reference dnafrags. These sequences are the alt-regions (cf #239) padded with Ns to save time, since we don't care about the sequence outside of the alt-region
4. Updated the DumpGenomes pipeline to dump the non-reference sequences too
5. Extended the `Locus::get_sequence` to work on non-reference sequences too
6. Excluded the LRGs from everything
7. Added a method in `Utils::Preloader` to load all alt-regions (and a couple of missing `assert_ref` in other functions), which simplifies RunnableDB/PairAligner/ChunkAndGroupDna.pm
8. Fixed a long-standing bug whereby ParsePairAlignerConf was not always selecting the matching taxon_id (if it first encountered a non-matching one). This would cause for instance two primates to be aligned with the default settings. It may explain why we had so much difficulties with certain species, even after switching their clade to the "primates" settings: maybe the settings were still not being used !

## Testing

1. Unit-tests are partial (only `Utils::Preloader` and `GenomeDB::_get_genome_dump_path`) because the rest (pipelines) is currently not covered by any tests.
2. Test run of the DumpGenomes pipeline
3. Tested the LastZ pipeline on e103 batch 5. I added a `die` in `Locus::get_sequence` to prevent it from getting the sequence from the Core database, and it was never reached. I checked that I got the same alignments as in batch5b (uni-directional run on the e100 code-base)

## Notes

* The non-ref files are pretty big (50+ GB) and it's easy to run out of space on `/scratch`. It would then be better to run the DumpGenomes pipeline off a temp area on /hps
* The exclusion of LRGs in many files is a bit annoying. Since we don't do anything with LRGs any more, what about not loading them at all ? The most future-proof would in fact be to 1) allow the LRG members to be stored without dnafrag_ids, 2) stop loading the LRG dnafrags, 3) remove all the exclusion rules
