### PR TITLE
Bugfixes re. cigar lines, alignment length, etc

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/GenomicAlignAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/GenomicAlignAdaptor.pm
@@ -159,6 +159,10 @@ sub store {
     if(!defined($ga->method_link_species_set) or !defined($ga->method_link_species_set->dbID)) {
       throw( "method_link_species_set in GenomicAlign is not in DB" );
     }
+    my $cigar_line = $ga->cigar_line;
+    if(!$cigar_line) {
+      throw( "cigar_line is not set" );
+    }
 
     $genomic_align_sth->execute(
             ($ga->dbID or undef),
@@ -168,7 +172,7 @@ sub store {
             $ga->dnafrag_start,
             $ga->dnafrag_end,
             $ga->dnafrag_strand,
-            ($ga->cigar_line or "NULL"),    # FIXME: please check that this "NULL" string in a mediumtext field is what you really want
+            $cigar_line,
             $ga->visible,
 	    ($ga->node_id or undef)
         );

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/GenomicAlignAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/GenomicAlignAdaptor.pm
@@ -160,7 +160,7 @@ sub store {
       throw( "method_link_species_set in GenomicAlign is not in DB" );
     }
     my $cigar_line = $ga->cigar_line;
-    if(!$cigar_line) {
+    if (!$cigar_line) {
       throw( "cigar_line is not set" );
     }
 

--- a/modules/Bio/EnsEMBL/Compara/GenomicAlignTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomicAlignTree.pm
@@ -672,6 +672,7 @@ sub restrict_between_alignment_positions {
         $genomic_align_tree->reference_genomic_align_node($this_node);
       }
       if (!$skip_empty_GenomicAligns or
+          !$this_node->is_leaf or
           $restricted_genomic_align->dnafrag_start <= $restricted_genomic_align->dnafrag_end
           ) {
         ## Always skip composite segments outside of the range of restriction
@@ -691,12 +692,14 @@ sub restrict_between_alignment_positions {
         $genomic_align_group->add_GenomicAlign($this_genomic_align);
       }
     } else {
-	#Only remove leaves. Use minimise_tree to tidy up the internal nodes
-	if ($this_node->is_leaf) {
+	    # Only leaves can reach this point.
+	    # The parent loses a child, and will eventually be removed from the tree
+	    # (by a later passage through this disavow_parent, or by minimize_tree below)
 	    $this_node->disavow_parent();
 	    my $reference_genomic_align = $genomic_align_tree->reference_genomic_align;
 	    if ($reference_genomic_align) {
 		my $reference_genomic_align_node = $genomic_align_tree->reference_genomic_align_node;
+		# Use minimise_tree to tidy up the internal nodes
 		$genomic_align_tree = $genomic_align_tree->minimize_tree();
 		## Make sure links are not broken after tree minimization
 		$genomic_align_tree->reference_genomic_align($reference_genomic_align);
@@ -707,7 +710,6 @@ sub restrict_between_alignment_positions {
 		#$genomic_align_tree->reference_genomic_align->genomic_align_block($genomic_align_tree);
 		$genomic_align_tree->reference_genomic_align_node($reference_genomic_align_node);
 	    }
-	}
     }
   }
   $genomic_align_tree = $genomic_align_tree->minimize_tree();

--- a/modules/Bio/EnsEMBL/Compara/GenomicAlignTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomicAlignTree.pm
@@ -687,9 +687,9 @@ sub restrict_between_alignment_positions {
               # -> We actually still need to remove the node if it belongs
               #    to ancestral_sequences but is now a leaf, because leaves
               #    must belong to extant species
-              # (this is possible because the "reverse" in the foreach loop
-              # above means that children are processed before their parent
-              # and they can be removed below)
+              # (internal nodes can become leaves if all their children are
+              # removed, which can happen if they are gap-only, cf the
+              # disavow_parent all down below)
               if ($this_node->is_leaf and !$was_leaf{$this_node}) {
                   $record_restricted_ga = 0;
               }

--- a/modules/Bio/EnsEMBL/Compara/GenomicAlignTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomicAlignTree.pm
@@ -635,6 +635,11 @@ sub get_all_sorted_genomic_align_nodes {
                object if any. If you want to restrict an object with no coordinates
                a simple substr() will do!
 
+               NB: skip_empty_GenomicAligns only removes terminal sub-trees that
+               become gap-only after restriction. Purely internal nodes that become
+               gap-only are kept to hold the tree together, as this method can only
+               return 1 GenomicAlignTree.
+
   Returntype : Bio::EnsEMBL::Compara::GenomicAlignBlock object
   Exceptions : none
   Caller     : general

--- a/modules/Bio/EnsEMBL/Compara/GenomicAlignTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomicAlignTree.pm
@@ -663,7 +663,7 @@ sub restrict_between_alignment_positions {
   my $all_nodes = $genomic_align_tree->get_all_nodes;
   my %was_leaf = map {$_ => $_->is_leaf} @$all_nodes;
 
-  # Depth-first, children-first, traversal of the tree
+  # Postorder traversal of the tree
   #Get all the nodes and restrict but only remove leaves if necessary. Call minimize_tree at the end to 
   #remove the internal nodes
   foreach my $this_node (reverse @$all_nodes) {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Legacy/EPO_pt3_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Legacy/EPO_pt3_conf.pm
@@ -128,6 +128,7 @@ sub pipeline_wide_parameters {
 		'enredo_mapping_file' => $self->o('enredo_mapping_file'),
 		'master_db' => $self->o('master_db'),
 		'compara_mapped_anchor_db' => $self->o('compara_mapped_anchor_db'),
+		'work_dir' => $self->o('work_dir'),
 		'mlss_id' => $self->o('mlss_id'),
 		'enredo_output_file' => $self->o('enredo_output_file'),
                 'run_gerp' => $self->o('run_gerp'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MercatorPecan_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MercatorPecan_conf.pm
@@ -107,6 +107,7 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         %{$self->SUPER::pipeline_wide_parameters},          # here we inherit anything from the base class
 
         'genome_dumps_dir' => $self->o('genome_dumps_dir'),
+        'work_dir' => $self->o('work_dir'),
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MercatorPecan_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MercatorPecan_conf.pm
@@ -107,7 +107,7 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         %{$self->SUPER::pipeline_wide_parameters},          # here we inherit anything from the base class
 
         'genome_dumps_dir' => $self->o('genome_dumps_dir'),
-        'work_dir' => $self->o('work_dir'),
+        'work_dir'         => $self->o('work_dir'),
     };
 }
 
@@ -651,4 +651,3 @@ sub pipeline_analyses {
 }
 
 1;
-

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
@@ -48,7 +48,6 @@ use Bio::EnsEMBL::Compara::GenomicAlignGroup;
 use Bio::EnsEMBL::Compara::Production::Analysis::ExtendedGenomeAlignment;
 use Bio::EnsEMBL::Compara::Utils::Cigars;
 use Bio::EnsEMBL::Compara::Utils::Preloader;
-use Bio::EnsEMBL::Compara::Utils::Cigars;
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
@@ -235,11 +235,11 @@ sub _assert_tree {
     my ($self, $gat) = @_;
 
     if ($gat->get_child_count == 3) {
-        # The only ternary nodes allowed are "root" nodes of unroot trees
+        # The only ternary nodes allowed are "root" nodes of unrooted trees
         # of 3 sequences
         foreach my $child (@{$gat->children}) {
             unless ($child->is_leaf) {
-                $self->_backup_data_and_throw($gat, sprintf("Node %s is the child of a ternay node, but node a leaf of the tree", $child->name));
+                $self->_backup_data_and_throw($gat, sprintf("Node %s is the child of a ternay node, but not a leaf of the tree", $child->name));
             }
         }
     } else {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
@@ -277,14 +277,14 @@ sub _assert_cigar_lines_in_block {
             my $cigar_length = Bio::EnsEMBL::Compara::Utils::Cigars::sequence_length_from_cigar($genomic_align->cigar_line);
             my $region_length = $genomic_align->dnafrag_end - $genomic_align->dnafrag_start + 1;
             if ($cigar_length != $region_length) {
-                $self->_backup_data_and_throw($gat, "cigar_line's sequence length ($cigar_length) doesn't match the region length ($region_length)" );
+                $self->_backup_data_and_throw($gat, "cigar_line's sequence length ($cigar_length) doesn't match the region length ($region_length)");
             }
             my $aln_length = Bio::EnsEMBL::Compara::Utils::Cigars::alignment_length_from_cigar($genomic_align->cigar_line);
             $lengths{$aln_length}++;
         }
     }
     if (scalar(keys %lengths) > 1) {
-        $self->_backup_data_and_throw($gat, "Multiple alignment lengths: ". stringify(\%lengths));
+        $self->_backup_data_and_throw($gat, "Multiple alignment lengths: " . stringify(\%lengths));
     }
 }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
@@ -39,6 +39,8 @@ package Bio::EnsEMBL::Compara::RunnableDB::EpoExtended::ExtendedGenomeAlignment;
 use strict;
 use warnings;
 
+use File::Basename;
+
 use Bio::EnsEMBL::Utils::Exception qw(throw);
 
 use Bio::EnsEMBL::Compara::DnaFragRegion;
@@ -48,6 +50,7 @@ use Bio::EnsEMBL::Compara::GenomicAlignGroup;
 use Bio::EnsEMBL::Compara::Production::Analysis::ExtendedGenomeAlignment;
 use Bio::EnsEMBL::Compara::Utils::Cigars;
 use Bio::EnsEMBL::Compara::Utils::Preloader;
+use Bio::EnsEMBL::Hive::Utils ('stringify');
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
@@ -210,6 +213,8 @@ sub _write_output {
 	  }
 	  $gata->store_group($split_trees);
 	  foreach my $tree (@$split_trees) {
+	      $self->_assert_cigar_lines_in_block($tree->modern_genomic_align_block_id);
+	      $self->_assert_tree($tree);
 	      $self->_write_gerp_dataflow($tree->modern_genomic_align_block_id);
 	  }
       } else {
@@ -218,11 +223,118 @@ sub _write_output {
 	  #the left and right indexes.
 	  #	      $gata->store($genomic_align_tree, "skip_left_right_indexes");
 	  $gata->store($genomic_align_tree, $skip_left_right_index);
+	  $self->_assert_cigar_lines_in_block($genomic_align_tree->modern_genomic_align_block_id);
+	  $self->_assert_tree($genomic_align_tree);
 	  $self->_write_gerp_dataflow($genomic_align_tree->modern_genomic_align_block_id);
       }
   
   return 1;
 }
+
+sub _assert_tree {
+    my ($self, $gat) = @_;
+
+    if ($gat->get_child_count == 3) {
+        # The only ternary nodes allowed are "root" nodes of unroot trees
+        # of 3 sequences
+        foreach my $child (@{$gat->children}) {
+            unless ($child->is_leaf) {
+                $self->_backup_data_and_throw($gat, sprintf("Node %s is the child of a ternay node, but node a leaf of the tree", $child->name));
+            }
+        }
+    } else {
+        # The tree must be binary
+        foreach my $node (@{$gat->get_all_nodes}) {
+            if ($node->get_child_count == 1) {
+                $self->_backup_data_and_throw($gat, sprintf("Node %s is unary. The tree has not been minimised", $node->name));
+            } elsif ($node->get_child_count >= 3) {
+                $self->_backup_data_and_throw($gat, sprintf("Node %s is not binary (%d children)", $node->name, $node->get_child_count));
+            }
+        }
+    }
+
+    # Only the leaves have aligned sequences, all from extant species
+    foreach my $node (@{$gat->get_all_nodes}) {
+        if ($node->is_leaf) {
+            if ($node->genomic_align_group->genome_db->name eq 'ancestral_sequences') {
+                $self->_backup_data_and_throw($gat, sprintf("Node %s is a leaf, but attached to ancestral_sequences", $node->name));
+            }
+        } else {
+            if ($node->genomic_align_group) {
+                $self->_backup_data_and_throw($gat, sprintf("Node %s is internal, but has some genomic_aligns", $node->name));
+            }
+        }
+    }
+}
+
+sub _assert_cigar_lines_in_block {
+    my ($self, $gab_id) = @_;
+    my $gat = $self->compara_dba->get_GenomicAlignTreeAdaptor->fetch_by_genomic_align_block_id($gab_id);
+
+    my %lengths;
+    foreach my $genomic_align_node (@{$gat->get_all_leaves}) {
+        foreach my $genomic_align (@{$genomic_align_node->genomic_align_group->get_all_GenomicAligns}) {
+            my $cigar_length = Bio::EnsEMBL::Compara::Utils::Cigars::sequence_length_from_cigar($genomic_align->cigar_line);
+            my $region_length = $genomic_align->dnafrag_end - $genomic_align->dnafrag_start + 1;
+            if ($cigar_length != $region_length) {
+                $self->_backup_data_and_throw($gat, "cigar_line's sequence length ($cigar_length) doesn't match the region length ($region_length)" );
+            }
+            my $aln_length = Bio::EnsEMBL::Compara::Utils::Cigars::alignment_length_from_cigar($genomic_align->cigar_line);
+            $lengths{$aln_length}++;
+        }
+    }
+    if (scalar(keys %lengths) > 1) {
+        $self->_backup_data_and_throw($gat, "Multiple alignment lengths: ". stringify(\%lengths));
+    }
+}
+
+sub _backup_data_and_throw {
+    my ($self, $gat, $err) = @_;
+    my $target_dir = $self->param_required('work_dir') . '/' . $self->param('genomic_align_block_id') . '.' . basename($self->worker_temp_directory);
+    system('cp', '-a', $self->worker_temp_directory, $target_dir);
+    $self->_print_report($gat, "$target_dir/report.txt");
+    $self->_print_regions("$target_dir/regions.txt");
+    $self->_spurt("$target_dir/tree.nh", $gat->newick_format);
+    throw("Error: $err\nData copied to $target_dir");
+}
+
+sub _print_regions {
+    my ($self, $filename) = @_;
+    open(my $fh, '>', $filename);
+    foreach my $region (@{$self->param('genomic_aligns')}) {
+        print $fh join("\t",
+            $region->genome_db->name,
+            $region->genome_db->dbID,
+            $region->dnafrag->name,
+            $region->dnafrag_id,
+            $region->dnafrag->length,
+            $region->dnafrag_start,
+            $region->dnafrag_end,
+            $region->dnafrag_strand,
+        ), "\n";
+    }
+    close($fh);
+}
+
+sub _print_report {
+    my ($self, $gat, $filename) = @_;
+    open(my $fh, '>', $filename);
+    foreach my $node (@{$gat->get_all_leaves}) {
+        my $ga = $node->genomic_align_group->get_all_GenomicAligns->[0];
+        print $fh join("\t",
+            $node->name,
+            $ga->dnafrag_id,
+            $ga->dnafrag_start,
+            $ga->dnafrag_end,
+            $ga->dnafrag_end - $ga->dnafrag_start + 1,
+            length($ga->original_sequence),
+            length($ga->aligned_sequence),
+            stringify(Bio::EnsEMBL::Compara::Utils::Cigars::get_cigar_breakout($ga->cigar_line)),
+        ), "\n";
+    }
+    close($fh);
+}
+
 
 sub _write_gerp_dataflow {
     my ($self, $gab_id) = @_;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
@@ -87,6 +87,9 @@ sub fetch_input {
   #load from genomic_align_block ie using in 2X mode
   $self->_load_GenomicAligns($self->param('genomic_align_block_id'));
 
+    # Make sure we start in a clean space, free of any files from a previous job attempt
+    $self->cleanup_worker_temp_directory;
+
   if ($self->param('genomic_aligns')) {
       #load 2X genomes
       $self->_load_2XGenomes($self->param('genomic_align_block_id'));
@@ -218,11 +221,6 @@ sub _write_output {
 	  $gata->store($genomic_align_tree, $skip_left_right_index);
 	  $self->_write_gerp_dataflow($genomic_align_tree->modern_genomic_align_block_id);
       }
-
-      #DO NOT COMMENT THIS OUT!!! (at least not permenantly). Needed
-      #to clean up after each job otherwise you get files left over from
-      #the previous job.
-      $self->cleanup_worker_temp_directory;
   
   return 1;
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
@@ -239,7 +239,7 @@ sub _assert_tree {
         # of 3 sequences
         foreach my $child (@{$gat->children}) {
             unless ($child->is_leaf) {
-                $self->_backup_data_and_throw($gat, sprintf("Node %s is the child of a ternay node, but not a leaf of the tree", $child->name));
+                $self->_backup_data_and_throw($gat, sprintf("Node %s is the child of a ternary node, but not a leaf of the tree", $child->name));
             }
         }
     } else {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/MercatorPecan/Pecan.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/MercatorPecan/Pecan.pm
@@ -123,6 +123,9 @@ sub fetch_input {
   # Initialize the array
   $self->param('fasta_files', []);
   
+  # Really all this does is cleaning up a previous attempt of the same synteny_region_id
+  # It is not necessary to set up tmp_work_dir any more
+  $self->cleanup_worker_temp_directory;
   # grab synteny_region_id and create tmp_work_dir
   my $synteny_region_id = $self->param_required('synteny_region_id');
   my $tmp_work_dir = $self->worker_temp_directory . "/synteny_region_$synteny_region_id";
@@ -572,7 +575,6 @@ sub _write_gerp_dataflow {
     my $output_id = { genomic_align_block_id => $gab->dbID };
 
     $self->dataflow_output_id($output_id,1);
-    $self->cleanup_worker_temp_directory; # this is important to avoid clashes between jobs run by the same worker
 }
 
 ##########################################

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/MercatorPecan/Pecan.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/MercatorPecan/Pecan.pm
@@ -300,13 +300,13 @@ sub _assert_cigar_lines_in_block {
         my $cigar_length = Bio::EnsEMBL::Compara::Utils::Cigars::sequence_length_from_cigar($genomic_align->cigar_line);
         my $region_length = $genomic_align->dnafrag_end - $genomic_align->dnafrag_start + 1;
         if ($cigar_length != $region_length) {
-            $self->_backup_data_and_throw($gab, "cigar_line's sequence length ($cigar_length) doesn't match the region length ($region_length)" );
+            $self->_backup_data_and_throw($gab, "cigar_line's sequence length ($cigar_length) doesn't match the region length ($region_length)");
         }
         my $aln_length = Bio::EnsEMBL::Compara::Utils::Cigars::alignment_length_from_cigar($genomic_align->cigar_line);
         $lengths{$aln_length}++;
     }
     if (scalar(keys %lengths) > 1) {
-        $self->_backup_data_and_throw($gab, "Multiple alignment lengths: ". stringify(\%lengths));
+        $self->_backup_data_and_throw($gab, "Multiple alignment lengths: " . stringify(\%lengths));
     }
 }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/MercatorPecan/Pecan.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/MercatorPecan/Pecan.pm
@@ -123,8 +123,10 @@ sub fetch_input {
   # Initialize the array
   $self->param('fasta_files', []);
   
-  # Really all this does is cleaning up a previous attempt of the same synteny_region_id
-  # It is not necessary to set up tmp_work_dir any more
+  # This is only useful if the worker has previously attempted the same
+  # synteny_region_id because each synteny_region_id gets its own directory to
+  # work in. But it guarantees that the worker_temp_directory is anyway clean
+  # enough to directly host the data of the synteny_region_id if needed.
   $self->cleanup_worker_temp_directory;
   # grab synteny_region_id and create tmp_work_dir
   my $synteny_region_id = $self->param_required('synteny_region_id');

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
@@ -499,6 +499,13 @@ sub parse_results {
 
     my $alignment_file = $self->worker_temp_directory . "/output.$$.mfa";
 
+    unless ($self->param('tree_string') && -s $alignment_file) {
+        # MEMLIMIT in progress ?
+        sleep(30);
+        throw("Empty tree string") unless $self->param('tree_string');
+        throw("Empty alignment file $alignment_file");
+    }
+
     my $this_genomic_align_block = new Bio::EnsEMBL::Compara::GenomicAlignBlock;
     
     my $tree = Bio::EnsEMBL::Compara::Graph::NewickParser::parse_newick_into_tree( $self->param('tree_string') );

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
@@ -381,7 +381,26 @@ sub _backup_data_and_throw {
     my $target_dir = $self->param_required('work_dir') . '/' . $self->param('synteny_region_id') . '.' . basename($self->worker_temp_directory);
     system('cp', '-a', $self->worker_temp_directory, $target_dir);
     $self->_print_report($gat, "$target_dir/report.txt");
+    $self->_print_regions("$target_dir/regions.txt");
     throw("Error: $err\nData copied to $target_dir");
+}
+
+sub _print_regions {
+    my ($self, $filename) = @_;
+    open(my $fh, '>', $filename);
+    foreach my $region (@{$self->param('dnafrag_regions')}) {
+        print $fh join("\t",
+            $region->genome_db->name,
+            $region->genome_db->dbID,
+            $region->dnafrag->name,
+            $region->dnafrag_id,
+            $region->dnafrag->length,
+            $region->dnafrag_start,
+            $region->dnafrag_end,
+            $region->dnafrag_strand,
+        ), "\n";
+    }
+    close($fh);
 }
 
 sub _print_report {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
@@ -365,6 +365,9 @@ sub _assert_tree {
                 $self->_backup_data_and_throw($gat, sprintf("Node %s is a leaf, but attached to ancestral_sequences", $node->name));
             }
         } else {
+            if ($node->genomic_align_group->genome_db->name ne 'ancestral_sequences') {
+                $self->_backup_data_and_throw($gat, sprintf("Node %s is internal, but not attached to ancestral_sequences", $node->name));
+            }
             if ($node->get_child_count != 2) {
                 $self->_backup_data_and_throw($gat, sprintf("Node %s is not binary", $node->name));
             }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
@@ -127,6 +127,10 @@ sub fetch_input {
       $self->param('tree_string', $self->get_tree_string);
       print "tree_string ", $self->param('tree_string'), "\n";
     }
+
+    # Make sure we start in a clean space, free of any files from a previous job attempt
+    $self->cleanup_worker_temp_directory;
+
     ## Dumps fasta files for the DnaFragRegions. Fasta files order must match the entries in the
     ## newick tree. The order of the files will match the order of sequences in the tree_string.
 
@@ -351,10 +355,6 @@ sub _write_output {
 	   $self->_write_gerp_dataflow($genomic_align_tree->modern_genomic_align_block_id);
        }
    }
-	#DO NOT COMMENT THIS OUT!!! (at least not permenantly). Needed
-	#to clean up after each job otherwise you get files left over from
-	#the previous job.
-    $self->cleanup_worker_temp_directory;
 }
 
 sub _assert_binary_tree {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
@@ -192,6 +192,7 @@ sub detect_pecan_ortheus_errors {
               $err_msgs{$line} = 1;
           }
       }
+      $err_msgs{$traceback} = 1 if $trace_open;
 
       #Write to job_message table but without returing an error
       foreach my $err_msg (keys %err_msgs) {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
@@ -207,6 +207,11 @@ sub detect_pecan_ortheus_errors {
               # Let's discard this job.
               $self->input_job->autoflow(0);
               $self->complete_early( "Pecan failed to align the sequences. Skipping." );
+          } elsif ($err_msg =~ /Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: \d+/) {
+              # Not sure why this happens
+              # Let's discard this job.
+              $self->input_job->autoflow(0);
+              $self->complete_early( "Pecan failed to align the sequences. Skipping." );
           } elsif ($err_msg =~ /No path through alignment possible, so I have no choice but to exit, sorry/) {
               # Not sure why this happens
               # Let's discard this job.

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
@@ -344,24 +344,30 @@ sub _write_output {
 	   $gata->store_group($split_trees);
 	   foreach my $tree (@$split_trees) {
 	       $self->_assert_cigar_lines_in_block($tree->modern_genomic_align_block_id);
-	       $self->_assert_binary_tree($tree);
+	       $self->_assert_tree($tree);
 	       $self->_write_gerp_dataflow($tree->modern_genomic_align_block_id);
 	       
 	   }
        } else {
 	   $gata->store($genomic_align_tree, $skip_left_right_index);
 	   $self->_assert_cigar_lines_in_block($genomic_align_tree->modern_genomic_align_block_id);
-	   $self->_assert_binary_tree($genomic_align_tree);
+	   $self->_assert_tree($genomic_align_tree);
 	   $self->_write_gerp_dataflow($genomic_align_tree->modern_genomic_align_block_id);
        }
    }
 }
 
-sub _assert_binary_tree {
+sub _assert_tree {
     my ($self, $gat) = @_;
     foreach my $node (@{$gat->get_all_nodes}) {
-        if (!$node->is_leaf && ($node->get_child_count != 2)) {
-            $self->_backup_data_and_throw($gat, sprintf("Node %s is not binary", $node->name));
+        if ($node->is_leaf) {
+            if ($node->genomic_align_group->genome_db->name eq 'ancestral_sequences') {
+                $self->_backup_data_and_throw($gat, sprintf("Node %s is a leaf, but attached to ancestral_sequences", $node->name));
+            }
+        } else {
+            if ($node->get_child_count != 2) {
+                $self->_backup_data_and_throw($gat, sprintf("Node %s is not binary", $node->name));
+            }
         }
     }
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
@@ -681,7 +681,7 @@ sub get_DnaFragRegions {
 
   my $regions = $sr->get_all_DnaFragRegions();
   Bio::EnsEMBL::Compara::Utils::Preloader::load_all_DnaFrags($self->compara_dba->get_DnaFragAdaptor, $regions);
-  return [@$regions];
+  return [sort {$a->dnafrag_id <=> $b->dnafrag_id || $a->dnafrag_start <=> $b->dnafrag_start} @$regions];
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
@@ -494,6 +494,13 @@ sub parse_results {
 
                 print "store gag2 $this_node\n" if $self->debug;
 
+		    my $region_length = $dfr->dnafrag_end - $dfr->dnafrag_start + 1;
+		    my $original_sequence = $seq;
+		    $original_sequence =~ s/-//g;
+		    if (length($original_sequence) != $region_length) {
+			throw("Length mismatch: $region_length from the coordinates, ".length($original_sequence)." from the aligned string");
+		    }
+
             } else {
                 throw("Error while parsing '$header' header in '$alignment_file'. It must start by \">SeqID#####\" where ##### is the internal integer id\n");
             }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
@@ -342,7 +342,7 @@ sub _write_output {
   		   $end = $genomic_align_tree->length;
   	       }
   	       my $new_gat = $genomic_align_tree->restrict_between_alignment_positions($start, $end, "skip_empty_GenomicAligns");
-	       # Some ancestral genomic_aligns may have become full-gaps,
+	       # Some ancestral genomic_aligns may have become all gaps,
 	       # break the trees around those
 	       my $subtrees = $self->split_if_empty_ancestral_seq($new_gat);
 	       push @$split_trees, @$subtrees;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
@@ -500,7 +500,6 @@ sub parse_results {
 
     print join(" -- ", map {$_."+".$_->node_id."+".$_->name} (@{$tree->get_all_nodes()})), "\n";
     my $trees = $self->split_if_empty_ancestral_seq($tree);
-    $self->remove_empty_cols($_) for @$trees;
     $self->param('output', $trees);
 }
 
@@ -527,6 +526,10 @@ sub split_if_empty_ancestral_seq {
                    grep {scalar(@{$_->get_all_leaves}) >= 2}
                    grep {!$_->has_parent}
                    @non_empty_nodes;
+
+    # Remove the columns that have become gap-only
+    $self->remove_empty_cols($_) for @subtrees;
+
     return \@subtrees;
 }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Ortheus.pm
@@ -391,14 +391,14 @@ sub _assert_cigar_lines_in_block {
             my $cigar_length = Bio::EnsEMBL::Compara::Utils::Cigars::sequence_length_from_cigar($genomic_align->cigar_line);
             my $region_length = $genomic_align->dnafrag_end - $genomic_align->dnafrag_start + 1;
             if ($cigar_length != $region_length) {
-                $self->_backup_data_and_throw($gat, "cigar_line's sequence length ($cigar_length) doesn't match the region length ($region_length)" );
+                $self->_backup_data_and_throw($gat, "cigar_line's sequence length ($cigar_length) doesn't match the region length ($region_length)");
             }
             my $aln_length = Bio::EnsEMBL::Compara::Utils::Cigars::alignment_length_from_cigar($genomic_align->cigar_line);
             $lengths{$aln_length}++;
         }
     }
     if (scalar(keys %lengths) > 1) {
-        $self->_backup_data_and_throw($gat, "Multiple alignment lengths: ". stringify(\%lengths));
+        $self->_backup_data_and_throw($gat, "Multiple alignment lengths: " . stringify(\%lengths));
     }
 }
 
@@ -605,7 +605,7 @@ sub parse_results {
 		    my $original_sequence = $seq;
 		    $original_sequence =~ s/-//g;
 		    if (length($original_sequence) != $region_length) {
-			throw("Length mismatch: $region_length from the coordinates, ".length($original_sequence)." from the aligned string");
+			throw("Length mismatch: $region_length from the coordinates, " . length($original_sequence) . " from the aligned string\n");
 		    }
 
             } else {

--- a/modules/Bio/EnsEMBL/Compara/Utils/Cigars.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Cigars.pm
@@ -102,7 +102,7 @@ sub assert_valid_cigar {
         my @cigar_numbers = split(/[A-Z]/, $cigar_line);
         foreach my $cigar_num ( @cigar_numbers ) {
             next if ( $cigar_num eq '' || ($cigar_num =~ /^[1-9][0-9]*$/) );
-            throw("Invalid cigar_line '$cigar_line'\n");
+            throw("Invalid cigar_num '$cigar_num'\n");
         }
     } else {
         if ($cigar_line !~ /^(([1-9][0-9]*)?[A-Z])*$/) {

--- a/modules/Bio/EnsEMBL/Compara/Utils/Cigars.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Cigars.pm
@@ -273,6 +273,28 @@ sub alignment_length_from_cigar {
 }
 
 
+=head2 sequence_length_from_cigar
+
+  Arg [1]    : String $cigar_line
+  Example    : my $sequence_length = sequence_length_from_cigar($cigar_line)
+  Description: Returns how long the sequence string would be (without expanding it in memory)
+  Returntype : int
+
+=cut
+
+sub sequence_length_from_cigar {
+    my $cigar = shift;
+
+    assert_valid_cigar($cigar);
+
+    my $length = 0;
+     while ($cigar =~ /(\d*)([A-Z])/g) {
+        $length += ($1 || 1) if ($2 eq 'M') || ($2 eq 'I');
+    }
+    return $length;
+}
+
+
 =head2 consensus_cigar_line
 
   Arg [1..n] : String $cigar_line

--- a/modules/Bio/EnsEMBL/Compara/Utils/Cigars.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Cigars.pm
@@ -101,7 +101,7 @@ sub assert_valid_cigar {
     if ( length($cigar_line) > 50000 ) {
         my @cigar_numbers = split(/[A-Z]/, $cigar_line);
         foreach my $cigar_num ( @cigar_numbers ) {
-            next if ( $cigar_num eq '' || ($cigar_num =~ /^[0-9]+$/ && $cigar_num > 0) );
+            next if ( $cigar_num eq '' || ($cigar_num =~ /^[1-9][0-9]*$/) );
             throw("Invalid cigar_line '$cigar_line'\n");
         }
     } else {

--- a/modules/Bio/EnsEMBL/Compara/Utils/Cigars.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Cigars.pm
@@ -267,7 +267,7 @@ sub alignment_length_from_cigar {
 
     my $length = 0;
      while ($cigar =~ /(\d*)([A-Z])/g) {
-        $length += ($1 || 1);
+        $length += ($1 || 1) if $2 ne 'I';
     }
     return $length;
 }

--- a/modules/t/genomicAlignTree.t
+++ b/modules/t/genomicAlignTree.t
@@ -1,0 +1,130 @@
+#!/usr/bin/env perl
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2020] EMBL-European Bioinformatics Institute
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use Bio::EnsEMBL::Compara::DnaFrag;
+use Bio::EnsEMBL::Compara::GenomeDB;
+use Bio::EnsEMBL::Compara::GenomicAlign;
+use Bio::EnsEMBL::Compara::GenomicAlignGroup;
+use Bio::EnsEMBL::Compara::GenomicAlignTree;
+use Bio::EnsEMBL::Compara::Graph::NewickParser;
+
+my $length_no_gaps = 20;
+my $length_with_gaps = 8;
+my $full_aln_string = 'T' x $length_no_gaps;
+my $gap_aln_string = ('T' x ($length_with_gaps/2)) . ('-' x ($length_no_gaps-$length_with_gaps)) . ('T' x ($length_with_gaps/2));
+my @restrict_pos = ($length_with_gaps/2+2, $length_no_gaps-$length_with_gaps/2-1);
+my $length_restricted = $restrict_pos[1] - $restrict_pos[0] + 1;
+
+my $tree_string = '(((((A,B)C,D)E,(F,G)H)I,J)K,L)M;';
+my %dnafrags;
+{
+    my $tree = Bio::EnsEMBL::Compara::Graph::NewickParser::parse_newick_into_tree($tree_string);
+    foreach my $node (@{$tree->get_all_nodes}) {
+        my $name = $node->name;
+        my $gdb = new Bio::EnsEMBL::Compara::GenomeDB(
+            -NAME => $name,
+            # We hijack the assembly field to record whether this is an ancestor or not
+            -ASSEMBLY => $node->is_leaf ? 'species' : 'ancestor',
+        );
+        $dnafrags{$name} = new Bio::EnsEMBL::Compara::DnaFrag(
+            -GENOME_DB => $gdb,
+            -NAME => 'chr',
+        );
+    }
+}
+
+
+sub make_tree_with_gaps {
+    my $nodes_with_gaps = shift;
+    my $gat = Bio::EnsEMBL::Compara::Graph::NewickParser::parse_newick_into_tree($tree_string, 'Bio::EnsEMBL::Compara::GenomicAlignTree');
+    foreach my $node (@{$gat->get_all_nodes}) {
+        my $ga = new Bio::EnsEMBL::Compara::GenomicAlign(
+            -DNAFRAG => $dnafrags{$node->name},
+            -DNAFRAG_START => 1,
+            -DNAFRAG_END => $nodes_with_gaps->{$node->name} ? $length_with_gaps : $length_no_gaps,
+            -DNAFRAG_STRAND => 1,
+            -ALIGNED_SEQUENCE => $nodes_with_gaps->{$node->name} ? $gap_aln_string : $full_aln_string,
+        );
+        my $gag = new Bio::EnsEMBL::Compara::GenomicAlignGroup(
+            -GENOMIC_ALIGN_ARRAY => [$ga],
+        );
+        $node->genomic_align_group($gag);
+    }
+    return $gat;
+}
+
+sub check_restrict {
+    my ($set_gaps, $expect_gaps) = @_;
+    my %nodes_with_gaps = map {$_ => 1} @$set_gaps;
+    my $tree = make_tree_with_gaps(\%nodes_with_gaps);
+    my $rtree = $tree->restrict_between_alignment_positions(@restrict_pos, 'skip_empty_GenomicAligns');
+    my %expected_gaps = map {$_ => 1} @$expect_gaps;
+    subtest join('', @$set_gaps, (scalar(@$expect_gaps) ? ('/', @$expect_gaps) : ())) => sub {
+        $tree->print;
+        $rtree->print;
+        foreach my $node (@{$rtree->get_all_nodes}) {
+            note $node->name;
+            note $node->_toString;
+            my $gag = $node->genomic_align_group;
+            if ($node->is_leaf) {
+                is($gag->genome_db->assembly, 'species', 'Leaf is not ancestral_sequences');
+            } else {
+                is($gag->genome_db->assembly, 'ancestor', 'Internal node is ancestral_sequences');
+                is($node->get_child_count, 2, 'Internal node is binary');
+            }
+            if ($expected_gaps{$gag->genome_db->name}) {
+                # restrict_between_alignment_positions has correctly left this node in, but it is only gaps
+                is($gag->dnafrag_start, $restrict_pos[0]-1, 'dnafrag_start');
+                is($gag->dnafrag_end, $restrict_pos[0]-2, 'dnafrag_end');
+                is(length($gag->aligned_sequence), $length_restricted, 'alignment length');
+                is(length($gag->original_sequence), 0, 'empty sequence');
+
+            } elsif($nodes_with_gaps{$gag->genome_db->name}) {
+                # restrict_between_alignment_positions should have removed this node
+                fail($node->name . '(' . $gag->genome_db->name . ') is still present');
+
+            } else {
+                is($gag->dnafrag_start, $restrict_pos[0], 'dnafrag_start');
+                is($gag->dnafrag_end, $restrict_pos[1], 'dnafrag_end');
+                is(length($gag->aligned_sequence), $length_restricted, 'alignment length');
+                is(length($gag->original_sequence), $length_restricted, 'sequence length');
+            }
+        }
+    };
+}
+
+subtest 'Bio::EnsEMBL::Compara::GenomicAlignTree::restrict_between_alignment_positions' => sub {
+    # The gaps should all disappear after restriction / minimisation
+    check_restrict(['A'], []);
+    check_restrict(['A', 'B'], []);
+    check_restrict(['A', 'C'], []);
+    check_restrict(['A', 'D'], []);
+    check_restrict(['A', 'B', 'C', 'D'], []);
+    check_restrict(['J'], []);
+    check_restrict(['J', 'K'], []);
+    check_restrict(['L'], []);
+    # Some gaps should be retained because they hold the tree together
+    check_restrict(['C'], ['C']);
+    check_restrict(['K'], ['K']);
+    check_restrict(['M'], ['M']);
+};
+
+done_testing;

--- a/scripts/debug/Ortheus.py
+++ b/scripts/debug/Ortheus.py
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Script to mimic Ortheus and return the output of a previous run"""
+
 import os
 import subprocess
 import sys
@@ -28,6 +30,7 @@ pid = 85677
 ref_fasta_dir = '/path/to/worker_muffato_mammals_epo_with4x_101.95260'
 
 def read_file(filename):
+    """Helper method to read a whole file"""
     with open(filename, 'r') as fh:
         return fh.read()
 

--- a/scripts/debug/Ortheus.py
+++ b/scripts/debug/Ortheus.py
@@ -27,7 +27,7 @@ species_list = "60 98 98 108 108 108 134 134 135 135 135 147 153 174 179 180 190
 pid = 85677
 
 # This is where you have saved Ortheus' output from a previous run
-ref_fasta_dir = '/path/to/worker_muffato_mammals_epo_with4x_101.95260'
+ref_fasta_dir = '/path/to/worker_muffato_mammals_epo_with_ext_104.95260'
 
 def read_file(filename):
     """Helper method to read a whole file"""

--- a/scripts/debug/Ortheus.py
+++ b/scripts/debug/Ortheus.py
@@ -44,7 +44,7 @@ for i in range(4, 4+len(species_list)):
     ref_file_content = read_file(os.path.join(ref_fasta_dir, os.path.basename(fn)))
     assert new_file_content == ref_file_content
 
-# Copy some the reference output files
+# Copy some of the reference output files
 subprocess.check_call(['cp', os.path.join(ref_fasta_dir, 'output.%d.mfa' % pid), sys.argv[-3]])
 subprocess.check_call(['cp', os.path.join(ref_fasta_dir, 'output.score'), os.path.curdir])
 
@@ -58,4 +58,3 @@ with open(sys.argv[-1], 'w') as fh:
     print >> fh, tl[0],
     # The second line has paths, which have to be edited
     print >> fh, tl[1].replace(ref_tmpdir, expected_tmpdir),
-

--- a/scripts/debug/Ortheus.py
+++ b/scripts/debug/Ortheus.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python2
+
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2020] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import sys
+
+# Set here the expected inputs, which you can find in the Ortheus command line
+species_tree = '(((((((327:0.0585842,457:0.0598399):0.0310988,(180:0.00823412,179:0.0124659):0.09194331):0.00755855,(((334:0.0638217,214:0.064933836):0.0036732,190:0.0702538):0.0105362,((((174:0.01004235,134:0.010315324):0.0109081,212:0.0204159):0.016895,213:0.0365203):0.0231325,155:0.0629363):0.016747061):0.02896091):0.00360012,108:0.1033556):0.000861311,((((((((221:0.00217461,210:0.00336539):0.00431221,150:0.00659779):0.00185473,209:0.00857453):0.00841622,60:0.0171585):0.00275526,199:0.0196199):0.0111247,(((222:0.00407792,317:0.00410208):0.00351067,(198:0.00206424,361:0.00219576):0.0052648):0.00408468,153:0.0116608):0.01847121):0.0177918,225:0.0540072):0.0276482537,206:0.07598296):0.0211581):0.0001,(((293:0.08132458,383:0.08146022):0.00503641,(((((((443:0.00217466,147:0.00243534):0.00869776,(224:0.00173498,456:0.00390502):0.00956724):0.0169365,(((342:0.00249523,337:0.00262477):0.0001,286:0.00189147):0.0031008,392:0.00583909):0.0225753):0.00548926,435:0.0321916):0.0376598,((((445:0.00277412,422:0.00333588):0.00495005,452:0.00838995):0.01316161,397:0.020255):9.06327e-06,449:0.018974):0.0433334):0.0108219,(211:0.046385437,394:0.0474265):0.028304):0.0001,407:0.0773769):0.00881201):0.00204002,(((434:0.0434658,429:0.04457849):0.01562144,(((379:0.000795536,135:0.00108446):0.000328819,372:0.000971181):9.97128e-05,285:0.00108401):0.0568382):0.00695254,(((387:0.008825,240:0.009225):0.00225289,(416:0.00238575,237:0.00274425):0.00852647):0.0378966,396:0.054702):0.0156824):0.0167101):0.0172095):0.00431128,98:0.1029919);'
+species_list = "60 98 98 108 108 108 134 134 135 135 135 147 153 174 179 180 190 190 198 211 212 222 237 285 285 285 317 327 327 334 334 361 372 372 372 379 379 379 387 394 396 407 407 407 416 429 434 434 434 435 443".split()
+pid = 85677
+
+# This is where you have saved Ortheus' output from a previous run
+ref_fasta_dir = '/path/to/worker_muffato_mammals_epo_with4x_101.95260'
+
+def read_file(filename):
+    with open(filename, 'r') as fh:
+        return fh.read()
+
+# Check that we are being called with the correct arguments
+assert sys.argv[-4-len(species_list):-4] == species_list
+assert sys.argv[-4-len(species_list)-2] == species_tree
+
+for i in range(4, 4+len(species_list)):
+    fn = sys.argv[i]
+    new_file_content = read_file(fn)
+    ref_file_content = read_file(os.path.join(ref_fasta_dir, os.path.basename(fn)))
+    assert new_file_content == ref_file_content
+
+# Copy some the reference output files
+subprocess.check_call(['cp', os.path.join(ref_fasta_dir, 'output.%d.mfa' % pid), sys.argv[-3]])
+subprocess.check_call(['cp', os.path.join(ref_fasta_dir, 'output.score'), os.path.curdir])
+
+# And edit the reference tree file
+expected_tmpdir = os.path.dirname(sys.argv[4])
+with open(os.path.join(ref_fasta_dir, 'output.%d.tree' % pid), 'r') as fh:
+    tl = fh.readlines()
+ref_tmpdir = os.path.dirname(tl[1].split()[0])
+with open(sys.argv[-1], 'w') as fh:
+    # The first line is the tree and should remain the same
+    print >> fh, tl[0],
+    # The second line has paths, which have to be edited
+    print >> fh, tl[1].replace(ref_tmpdir, expected_tmpdir),
+

--- a/travisci/python-linter_harness.sh
+++ b/travisci/python-linter_harness.sh
@@ -24,13 +24,13 @@ export MYPYPATH=$MYPYPATH:$PWD/src/python/lib
 
 PYLINT_OUTPUT_FILE=$(mktemp)
 PYLINT_ERRORS=$(mktemp)
-find "${PYTHON_SOURCE_LOCATIONS[@]}" -type f -name "*.py" -print0 | xargs -0 pylint --rcfile pylintrc --verbose | tee "$PYLINT_OUTPUT_FILE"
+find "${PYTHON_SOURCE_LOCATIONS[@]}" -type f -name "*.py" \! -name "Ortheus.py" -print0 | xargs -0 pylint --rcfile pylintrc --verbose | tee "$PYLINT_OUTPUT_FILE"
 grep -v "\-\-\-\-\-\-\-\-\-" "$PYLINT_OUTPUT_FILE" | grep -v "Your code has been rated" | grep -v "\n\n" | sed '/^$/d' > "$PYLINT_ERRORS"
 ! [ -s "$PYLINT_ERRORS" ]
 rt1=$?
 rm "$PYLINT_OUTPUT_FILE" "$PYLINT_ERRORS"
 
-find "${PYTHON_SOURCE_LOCATIONS[@]}" -type f -name "*.py" -print0 | xargs -0 mypy --config-file mypy.ini --namespace-packages
+find "${PYTHON_SOURCE_LOCATIONS[@]}" -type f -name "*.py" \! -name "Ortheus.py" -print0 | xargs -0 mypy --config-file mypy.ini --namespace-packages
 rt2=$?
 
 if [[ ($rt1 -eq 0) && ($rt2 -eq 0) ]]; then


### PR DESCRIPTION
## Description

We have faced several issues in the EPO and Pecan pipelines:
- ENSCOMPARASW-3913: some ancestral genomic_aligns are longer than the leaves
- ENSCOMPARASW-2054: some cigar lines don't match the sequence (i.e. have a wrong number of `M`s)
- ENSCOMPARASW-4072: some trees are not binary

plus other tickets that have been closed (dismissed) in the past.

## Overview of changes

This PR is a collection of many related changes, which I have reordered in three sections, see below.

### Misc. changes about cigar lines

[→ diff](
https://github.com/Ensembl/ensembl-compara/compare/99796663d24e4d14c9d8109ca79a597030d5ab46..886836a23e4e9250b981fcdbdb8a0427da462d9d)

- Don't store `NULL` as a cigar line
- Don't count `I` elements when computing the alignment length
- New method to compute the sequence length from a cigar line
- Small changes in `assert_valid_cigar`

### A simplification of `RunnableDB::Ortheus`'s Fasta parser

Commit: ccbbe82a8831990fd6f024dda8b74a32670fa124

The Runnable was parsing the Fasta file line by line, assembling the sequence, etc, at the same time it was building the block. I find it much simpler to call a parser and get the sequences one by one. It makes the code more straightforward and easier to read / maintain.

I chose the ensembl-io parser because it reads and returns the sequences one at a time, as opposite to the BioPerl parser, which loads the entire file in memory first.

### The actual bugfixes and safeguards against future bugs

[→ diff](https://github.com/Ensembl/ensembl-compara/compare/ccbbe82a8831990fd6f024dda8b74a32670fa124..bugfix/epo_cigar_line)

- Quite a big diff because Ortheus, Pecan, and LowCoverageAlignment (or whatever new name it will get) now have extra code to check that the alignment is sane:
  - the cigar-line M elements match the sequence length
  - all alignment strings (from the cigar lines) are equal
  - (almost) all trees are binary. There is one case when a ternary node is allowed

  The checks run in the `write_output` transaction, right after storing the alignments, and fetch what has just been stored. If anything is wrong they will backup the temp directory, and create additional reports about the block, the tree, etc, to facilitate debugging. The transaction fails and the database is rolled back, and remains clean.
  I have run these pipelines on _all_ clades (except the pig breeds) and they're all clean run - no such errors. I would still keep the code around for a few releases just in case an error happens again ? I know it's a lot of code... I can remove these commits if you prefer.
  We know that in some cases the error magically goes away upon rerunning, so we may not even notice that there's been a failure (if `retry_count` is > 0)... I can mark the error as non-transient to force eHive to switch the job to `FAILED` if you prefer ?
- To help debugging I have added a script to fake Ortheus' output. It will reformat / return the output of a previous run of Ortheus (which you can find in the backup made by the pipeline upon error). To set it up in your pipeline do this:
  ```bash
  $ tweak_pipeline.pl -url $EHIVE_URL -tweak "analysis[ortheus%].param[ortheus_bin_dir]=$ENSEMBL_CVS_ROOT_DIR/ensembl-compara/scripts/debug"
  ```
  For that reason, I made `RunnableDB::Ortheus` list the sequences always in the same order
- All three analyses now cleanup the worker's temp directory _before_ starting writing data. Previously it was done at the end of `write_output` meaning that if anything went wrong during the job execution, the directory was *not* cleaned. I believe this makes the `tmp_work_dir` functionality of Pecan redundant (which was added exactly because we noticed that there were some leftover files), but I have left it here for now.
- `GenomicAlignTree::restrict_between_alignment_positions` was leaving some internal nodes unrestricted (full length) when they would have become gap-only. This caused the length discrepancy errors. It now restricts _all_ nodes.
- `GenomicAlignTree::restrict_between_alignment_positions` could return a tree with `ancestral_sequences` genomic-aligns as leaves. This may happen if Ortheus thinks that the LCA of two gaps is a non-gap character (true story). These nodes are now removed too and the tree minimised, so that the output tree complies to these rules:
  - binary
  - all nodes are restricted
  - all internal nodes are `ancestral_sequences`
  - all leaves are extant species
  - no leaf is gap-only
- There is a unit-test for  `GenomicAlignTree::restrict_between_alignment_positions`. Given a template tree, I put gaps in various nodes, restrict the tree, and check that the restriction follows the rules above.
- `GenomicAlignTree::annotate_node_type` (only used by the REST API) has been updated to cater for the only case where a node can be ternary. By the way, this only happens in EPO-Extension, when the tree has exactly 3 sequences, because `semphy` builds unrooted trees.
- Tiny but important bugfix in `RunnableDB::Ortheus::detect_pecan_ortheus_errors`. The parsing of the error was expecting some trailing lines that are printed by Ortheus, but these lines are not there when Pecan is run directly. This can be simply recovered by checking whether there a stack trace was being recorded, and register it. This means that the Pecan Runnable (which uses this function) could not automatically process the errors and dataflow to the next analysis / discard the sequences. Although e101 was more complex than e103 because it had a lot more species, I believe that it played a role in making the e101 run of Pecan so difficult and yield a ~20-25% lower coverage on average.
- Added another Pecan exception: `java.lang.ArrayIndexOutOfBoundsException`
- `RunnableDB::Ortheus::split_if_empty_ancestral_seq` now knows that internal nodes too can be gap-only, and splits the tree around them (in up to 3 pieces). Before it could only do that for the root node (recursively). It also shrinks the alignment by removing gap-only columns. This code is now called when the block is large (>1Mbp) and the Runnable needs to split it in chunks.
- `RunnableDB::Ortheus` now does the infamous `sleep(30)` when it detects some missing / empty output files. I had those cases in my tests: MEMLIMIT that are not recorded on the right jobs.

## Testing

As I've said I have rerun the pipelines on almost all clades, and there is a unit test for an important function of `GenomicAlignTree`

## Notes

The sections could perhaps be different pull-requests, if you find it clearer ?