### PR TITLE
Bugfix - LastZ post-netting dependencies

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAligner_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAligner_conf.pm
@@ -280,7 +280,7 @@ sub core_pipeline_analyses {
 			       5 => [ 'create_alignment_chains_jobs' ],
 			       6 => [ 'create_alignment_nets_jobs' ],
 			       10 => [ 'create_filter_duplicates_net_jobs' ],
-			       9 => [ 'remove_partial_blocks' ],
+			       9 => [ 'detect_component_mlsss' ],
 			      },
 	       -rc_name => '1Gb_job',
   	    },
@@ -505,7 +505,7 @@ sub core_pipeline_analyses {
 	       -logic_name => 'remove_inconsistencies_after_net',
 	       -module     => 'Bio::EnsEMBL::Compara::RunnableDB::PairAligner::RemoveAlignmentDataInconsistencies',
 	       -flow_into => {
-			       1 => [ 'update_max_alignment_length_after_net' ],
+			       1 => [ 'remove_inconsistencies_after_net_fd' ],
 			   },
  	       -wait_for =>  [ 'alignment_nets', 'alignment_nets_himem', 'alignment_nets_hugemem', 'create_alignment_nets_jobs' ],    # Needed because of bi-directional netting: 2 jobs in create_alignment_nets_jobs can result in 1 job here
 	       -rc_name => '1Gb_job',
@@ -546,13 +546,10 @@ sub core_pipeline_analyses {
               -rc_name => $self->o('filter_duplicates_himem_rc_name'),
            },
 
-           {  -logic_name    => 'remove_partial_blocks',
-              -module        => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
-              -parameters    => {
-                                'sql' => "DELETE FROM genomic_align_block WHERE genomic_align_block_id NOT IN (SELECT genomic_align_block_id FROM genomic_align)"
-                                },
+           {  -logic_name    => 'remove_inconsistencies_after_net_fd',
+              -module        => 'Bio::EnsEMBL::Compara::RunnableDB::PairAligner::RemoveAlignmentDataInconsistencies',
               -flow_into     => {
-                   1 => [ 'detect_component_mlsss' ],
+                   1 => [ 'update_max_alignment_length_after_net' ],
                },
               -wait_for      => [ 'create_filter_duplicates_net_jobs', 'filter_duplicates_net', 'filter_duplicates_net_himem' ],
            },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAligner_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAligner_conf.pm
@@ -573,6 +573,7 @@ sub core_pipeline_analyses {
               -module     => 'Bio::EnsEMBL::Compara::RunnableDB::PairAligner::SetInternalIdsSlow',
               -analysis_capacity => 1,
               -rc_name => '8Gb_job',
+              -can_be_empty  => 1,
           },
 
         {   -logic_name => 'detect_component_mlsss',
@@ -581,7 +582,7 @@ sub core_pipeline_analyses {
                 'do_pairwise_gabs'          => $self->o('do_pairwise_gabs'),
                 'do_compare_to_previous_db' => $self->o('do_compare_to_previous_db'),
             },
-            -wait_for   => [ 'set_internal_ids_collection' ],
+            -wait_for   => [ 'set_internal_ids_collection', 'set_internal_ids_slow' ],
             -flow_into  => {
                 '3->A' => [ 'lift_to_principal' ],
                 'A->2' => [ 'run_healthchecks' ],


### PR DESCRIPTION
## Description

I have found that the analyses were not running in the right order / waiting for the correct ones. Those issues were introduced in #164 and #187

## Overview of changes

- `remove_partial_blocks` could leave blocks with a single `genomic_align`. Use our dedicated Runnable to clean this up, and renamed it to `remove_inconsistencies_after_net_fd` to match the other analyses
- moved it to the `update_max_alignment_length_after_net` flow so that it gets the correct sort of input_id (`method_link_species_set_id`)
- run it before `update_max_alignment_length_after_net` so that the latter has the correct length
- this also fixes the problem that `remove_partial_blocks` would actually start immediately in unidirectional mode as it was only waiting for analyses filled in in bidirectional mode
- `detect_component_mlsss` should wait for `set_internal_ids_slow` too, even if it is rarely used

## Testing

I have run of the pipeline in unidirectional and bidirectional modes

## Diagrams

### Before
![Before](https://user-images.githubusercontent.com/623458/100097761-e9d34600-2e54-11eb-8f0f-4437a680d242.png)

### After
![After](https://user-images.githubusercontent.com/623458/100097821-00799d00-2e55-11eb-9864-a42592b4ab2c.png)
