### PR TITLE
Introduce LoadMLSSids runnable in EPO and EPO Extended pipelines

### DIFF
--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -75,7 +75,7 @@
          },
          {
             "component": "Production tasks",
-            "description": "*GitHub*: [Plants/EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/<Division>/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::<Division>::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name rice -low_epo_mlss_id <epo-ext_mlss_id> -high_epo_mlss_id <epo_mlss_id>{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
+            "description": "*GitHub*: [Plants/EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/<Division>/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::<Division>::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name rice{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
             "summary": "Run the Rice EPOwith2x pipeline",
             "name_on_graph": "EPOwith2x:Rice"
          },

--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -75,9 +75,9 @@
          },
          {
             "component": "Production tasks",
-            "description": "*GitHub*: [Plants/EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/<Division>/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::<Division>::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name rice{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
-            "summary": "Run the Rice EPOwith2x pipeline",
-            "name_on_graph": "EPOwith2x:Rice"
+            "description": "*GitHub*: [Plants/EPOwithExt_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/<Division>/EPOwithExt_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::<Division>::EPOwithExt_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name rice{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
+            "summary": "Run the Rice EPOwithExt pipeline",
+            "name_on_graph": "EPOwithExt:Rice"
          },
          {
             "component": "Production tasks",

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -112,7 +112,7 @@
          },
          {
             "component": "Production tasks",
-            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name mammals -low_epo_mlss_id <epo-ext_mlss_id> -high_epo_mlss_id <epo_mlss_id>{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
+            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name mammals{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
             "summary": "Run the Mammal EPOwith2x pipeline",
             "name_on_graph": "EPOwith2x:Mammals"
          },
@@ -124,7 +124,7 @@
          },
          {
             "component": "Production tasks",
-            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name primates -low_epo_mlss_id <epo-ext_mlss_id> -high_epo_mlss_id <epo_mlss_id>{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
+            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name primates{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
             "summary": "Run the Primates EPOwith2x pipeline",
             "name_on_graph": "EPOwith2x:Primates"
          },
@@ -136,19 +136,19 @@
          },
          {
             "component": "Production tasks",
-            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name murinae -low_epo_mlss_id <epo-ext_mlss_id> -high_epo_mlss_id <epo_mlss_id>{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
+            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name murinae{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
             "summary": "Run the Murinae EPOwith2x pipeline",
             "name_on_graph": "EPOwith2x:Murinae"
          },
          {
             "component": "Production tasks",
-            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name pig_breeds -low_epo_mlss_id <epo-ext_mlss_id> -high_epo_mlss_id <epo_mlss_id>{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
+            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name pig_breeds{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
             "summary": "Run the Pigs EPOwith2x pipeline",
             "name_on_graph": "EPOwith2x:Pigs"
          },
          {
             "component": "Production tasks",
-            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name fish -low_epo_mlss_id <epo-ext_mlss_id> -high_epo_mlss_id <epo_mlss_id>{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
+            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name fish{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
             "summary": "Run the Fish EPOwith2x pipeline",
             "name_on_graph": "EPOwith2x:Fish"
          },
@@ -160,7 +160,7 @@
          },
          {
             "component": "Production tasks",
-            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name sauropsids -low_epo_mlss_id <epo-ext_mlss_id> -high_epo_mlss_id <epo_mlss_id>{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
+            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name sauropsids{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
             "summary": "Run the Sauropsids EPOwith2x pipeline",
             "name_on_graph": "EPOwith2x:Sauropsids"
          },

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -112,9 +112,9 @@
          },
          {
             "component": "Production tasks",
-            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name mammals{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
-            "summary": "Run the Mammal EPOwith2x pipeline",
-            "name_on_graph": "EPOwith2x:Mammals"
+            "description": "*GitHub*: [EPOwithExt_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwithExt_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwithExt_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name mammals{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
+            "summary": "Run the Mammal EPOwithExt pipeline",
+            "name_on_graph": "EPOwithExt:Mammals"
          },
          {
             "component": "Production tasks",
@@ -124,9 +124,9 @@
          },
          {
             "component": "Production tasks",
-            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name primates{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
-            "summary": "Run the Primates EPOwith2x pipeline",
-            "name_on_graph": "EPOwith2x:Primates"
+            "description": "*GitHub*: [EPOwithExt_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwithExt_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwithExt_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name primates{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
+            "summary": "Run the Primates EPOwithExt pipeline",
+            "name_on_graph": "EPOwithExt:Primates"
          },
          {
             "component": "Production tasks",
@@ -136,21 +136,21 @@
          },
          {
             "component": "Production tasks",
-            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name murinae{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
-            "summary": "Run the Murinae EPOwith2x pipeline",
-            "name_on_graph": "EPOwith2x:Murinae"
+            "description": "*GitHub*: [EPOwithExt_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwithExt_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwithExt_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name murinae{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
+            "summary": "Run the Murinae EPOwithExt pipeline",
+            "name_on_graph": "EPOwithExt:Murinae"
          },
          {
             "component": "Production tasks",
-            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name pig_breeds{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
-            "summary": "Run the Pigs EPOwith2x pipeline",
-            "name_on_graph": "EPOwith2x:Pigs"
+            "description": "*GitHub*: [EPOwithExt_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwithExt_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwithExt_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name pig_breeds{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
+            "summary": "Run the Pigs EPOwithExt pipeline",
+            "name_on_graph": "EPOwithExt:Pigs"
          },
          {
             "component": "Production tasks",
-            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name fish{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
-            "summary": "Run the Fish EPOwith2x pipeline",
-            "name_on_graph": "EPOwith2x:Fish"
+            "description": "*GitHub*: [EPOwithExt_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwithExt_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwithExt_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name fish{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
+            "summary": "Run the Fish EPOwithExt pipeline",
+            "name_on_graph": "EPOwithExt:Fish"
          },
          {
             "component": "Production tasks",
@@ -160,9 +160,9 @@
          },
          {
             "component": "Production tasks",
-            "description": "*GitHub*: [EPOwith2x_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwith2x_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name sauropsids{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
-            "summary": "Run the Sauropsids EPOwith2x pipeline",
-            "name_on_graph": "EPOwith2x:Sauropsids"
+            "description": "*GitHub*: [EPOwithExt_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwithExt_conf.pm]\n{code}init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwithExt_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name sauropsids{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
+            "summary": "Run the Sauropsids EPOwithExt pipeline",
+            "name_on_graph": "EPOwithExt:Sauropsids"
          },
          {
             "component": "Production tasks",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,7 +59,7 @@ Data-production documentation
    production/READMEs/pair_aligner_patches.rst
    production/READMEs/whole_genome_synteny.rst
    production/READMEs/epo.rst
-   production/READMEs/low_coverage_genome_aligner.rst
+   production/READMEs/extended_genome_aligner.rst
    production/READMEs/multi_align.dumps.rst
    production/READMEs/multiple_aligner.rst
    production/READMEs/base_age.rst

--- a/docs/production/READMEs/extended_genome_aligner.rst
+++ b/docs/production/READMEs/extended_genome_aligner.rst
@@ -1,12 +1,12 @@
-EPO alignment with low-coverage genomes
+EPO alignment with additional genomes
 =======================================
 
-This README describes how to set up the low coverage EPO aligner system using the init_pipeline configuration system.
+This README describes how to set up the EPO Extended aligner system using the init_pipeline configuration system.
 
 General description of the pipeline
 -----------------------------------
 
-The pipeline involves taking the high coverage EPO alignment and mapping onto the human sequence the low coverage mammalian (b)lastz alignments. 
+The pipeline involves taking the EPO alignment and mapping onto the reference sequences the additional mammalian (b)lastz alignments.
 
 Necessary code API and executables
 ----------------------------------
@@ -45,7 +45,7 @@ in bash
 Update the master database
 --------------------------
 
-The pipeline requires a "master" database. This is a compara database containing information that is required to maintain consistency across several production and release databases. See README-master_database for details on how to create an initial master database. 
+The pipeline requires a "master" database. This is a compara database containing information that is required to maintain consistency across several production and release databases. See README-master_database for details on how to create an initial master database.
 
 #. Update genome_db and dnafrag tables with any new species assembly using the update_genome.pl script.
    The reg.conf should contain the compara_master and the location of the core database
@@ -68,21 +68,21 @@ The pipeline requires a "master" database. This is a compara database containing
 Configure the pipeline
 ----------------------
 
-Modifiy ``$ENSEMBL_CVS_ROOT_DIR/ensembl-compara/modules/Bio/EnsEMBL/Compara/PipeConfig/EpoLowCoverage_conf.pm`` file if necessary.
+Modifiy ``$ENSEMBL_CVS_ROOT_DIR/ensembl-compara/modules/Bio/EnsEMBL/Compara/PipeConfig/EpoExtended_conf.pm`` file if necessary.
 Check that the default_options are set correctly.
 Options most likely to need changing are:
 
 It is recommended that the mlss_id entries are set on the command line rather than in the conf file
 
-:low_epo_mlss_id:              mlss_id of the low coverage epo alignments
-:high_epo_mlss_id:             mlss_id of the high coverage epo alignments
+:ext_mlss_id:                  mlss_id of the EPO Extended alignments
+:mlss_id:                      mlss_id of the EPO alignments
 :ce_mlss_id:                   mlss_id of the constrained elements
 :cs_mlss_id:                   mlss_id of the conservation scores
 
 :release:                      Ensembl release
-:prev_release:                 Previous ensembl release 
+:prev_release:                 Previous ensembl release
 :ensembl_cvs_root_dir:         Root directory of the ensembl checkouts
-:work_dir:                     Directory for writing files 
+:work_dir:                     Directory for writing files
 
 :pairwise_exception_location:  Location of new pairwise alignments which are not in the release compara database ie new for this release
 :pipeline_db:                  Production database
@@ -99,7 +99,6 @@ Initialize and run the pipeline
 
 ::
 
-    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EpoLowCoverage_conf --password <your_password> --low_epo_mlss_id <low-coverage mlss_id> --high_epo_mlss_id <high-coverage mlss_id> --cs_mlss_id <conservation_score_mlss_id> --ce_mlss_id <constrained_element_mlss_id> --work_dir <working_directory> --epo_db mysql://user@host:port/high_coverage_epo_db
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EpoExtended_conf --password <your_password> --work_dir <working_directory> --epo_db mysql://user@host:port/high_coverage_epo_db
 
 Sync and loop the beekeeper.pl as shown in init_pipeline.pl's output
-

--- a/docs/production/READMEs/extended_genome_aligner.rst
+++ b/docs/production/READMEs/extended_genome_aligner.rst
@@ -6,7 +6,7 @@ This README describes how to set up the EPO Extended aligner system using the in
 General description of the pipeline
 -----------------------------------
 
-The pipeline involves taking the EPO alignment and mapping onto the reference sequences the additional mammalian (b)lastz alignments.
+This pipeline involves mapping additional mammal genomes via lastz pairwise alignments (with shared reference genomes) to an existing mammal EPO multiple alignment.
 
 Necessary code API and executables
 ----------------------------------
@@ -45,7 +45,7 @@ in bash
 Update the master database
 --------------------------
 
-The pipeline requires a "master" database. This is a compara database containing information that is required to maintain consistency across several production and release databases. See README-master_database for details on how to create an initial master database.
+This pipeline requires a compara "master" database containing information that maintains consistency across several production and release databases. See README-master_database for details on how to create an initial master database.
 
 #. Update genome_db and dnafrag tables with any new species assembly using the update_genome.pl script.
    The reg.conf should contain the compara_master and the location of the core database

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpConservationScores_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpConservationScores_conf.pm
@@ -24,7 +24,7 @@ Bio::EnsEMBL::Compara::PipeConfig::DumpConservationScores_conf
 =head1 SYNOPSIS
 
     init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::DumpConservationScores_conf -host mysql-ens-compara-prod-X -port XXXX \
-        -compara_db $(mysql-ens-compara-prod-X details url ${USER}_mammals_epo_low_coverage_${CURR_ENSEMBL_RELEASE}) \
+        -compara_db $(mysql-ens-compara-prod-X details url ${USER}_mammals_epo_extended_${CURR_ENSEMBL_RELEASE}) \
         -mlss_id XXXX
 
 =head1 DESCRIPTION

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpConstrainedElements_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpConstrainedElements_conf.pm
@@ -24,7 +24,7 @@ Bio::EnsEMBL::Compara::PipeConfig::DumpConstrainedElements_conf
 =head1 SYNOPSIS
 
     init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::DumpConstrainedElements_conf -host mysql-ens-compara-prodX -port XXXX \
-        -compara_db $(mysql-ens-compara-prod-X details url ${USER}_mammals_epo_low_coverage_${CURR_ENSEMBL_RELEASE}) \
+        -compara_db $(mysql-ens-compara-prod-X details url ${USER}_mammals_epo_extended_${CURR_ENSEMBL_RELEASE}) \
         -mlss_id XXXX
 
 =head1 DESCRIPTION

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EPO_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EPO_conf.pm
@@ -15,8 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::PipeConfig::EPO_conf

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EPO_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EPO_conf.pm
@@ -21,8 +21,8 @@ Bio::EnsEMBL::Compara::PipeConfig::EPO_conf
 
 =head1 SYNOPSIS
 
-    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPO_conf.pm -host mysql-ens-compara-prod-X -port XXXX \
-        -division $COMPARA_DIV -species_set_name <species_set_name> -mlss_id <curr_epo_mlss_id>
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPO_conf -host mysql-ens-compara-prod-X -port XXXX \
+        -division $COMPARA_DIV -species_set_name <species_set_name>
 
 =head1 DESCRIPTION
 
@@ -51,6 +51,7 @@ sub default_options {
         %{$self->SUPER::default_options},
 
         'pipeline_name' => $self->o('species_set_name').'_epo_'.$self->o('rel_with_suffix'),
+        'method_type'   => 'EPO',
 
         # Databases
         'compara_master'    => 'compara_master',
@@ -123,8 +124,6 @@ sub pipeline_wide_parameters {
     return {
         %{$self->SUPER::pipeline_wide_parameters},
 
-        'mlss_id'                   => $self->o('mlss_id'),
-
         # directories
         'work_dir'              => $self->o('work_dir'),
         'feature_dir'           => $self->o('feature_dir'),
@@ -152,8 +151,13 @@ sub core_pipeline_analyses {
 
     return [
 
-        {   -logic_name => 'start_prepare_databases',
-            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+        {   -logic_name => 'load_mlss_id',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::LoadMLSSids',
+            -parameters => {
+                'method_type'      => $self->o('method_type'),
+                'species_set_name' => $self->o('species_set_name'),
+                'release'          => $self->o('ensembl_release'),
+            },
             -input_ids  => [{}],
             -flow_into  => {
                 '1->A' => [ 'copy_table_factory', 'set_internal_ids', 'drop_ancestral_db' ],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwithExt_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwithExt_conf.pm
@@ -286,7 +286,7 @@ sub tweak_analyses {
     $analyses_by_name->{'create_default_pairwise_mlss'}->{'-parameters'}->{'prev_epo_db'} = '#reuse_db#';
     delete $analyses_by_name->{'set_gerp_neutral_rate'}->{'-flow_into'}->{1};
 
-    # Make Enredo work only on the main genomes
+    # Make Enredo work only on the currently EPO aligned genomes
     $analyses_by_name->{'load_dnafrag_region'}->{'-parameters'}->{'mlss_id'} = '#mlss_id#';
 
     # link "ortheus*" analyses directly to "extended_genome_alignment"

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EpoExtended_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EpoExtended_conf.pm
@@ -17,43 +17,32 @@ limitations under the License.
 
 =head1 NAME
 
-Bio::EnsEMBL::Compara::PipeConfig::EpoLowCoverage_conf
+Bio::EnsEMBL::Compara::PipeConfig::EpoExtended_conf
 
 =head1 SYNOPSIS
 
-    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EpoLowCoverage_conf -host mysql-ens-compara-prod-X -port XXXX \
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EpoExtended_conf -host mysql-ens-compara-prod-X -port XXXX \
         -division $COMPARA_DIV -species_set_name <species_set_name> -low_epo_mlss_id <curr_epo_2x_mlss_id> \
         -base_epo_mlss_id <curr_epo_mlss_id>
 
 =head1 EXAMPLES
 
     # With GERP (mammals, sauropsids, fish):
-    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EpoLowCoverage_conf -host mysql-ens-compara-prod-X -port XXXX \
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EpoExtended_conf -host mysql-ens-compara-prod-X -port XXXX \
         -division vertebrates -species_set_name fish -low_epo_mlss_id 1333 -base_epo_mlss_id 1332
 
     # Without GERP (primates):
-    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EpoLowCoverage_conf -host mysql-ens-compara-prod-X -port XXXX \
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EpoExtended_conf -host mysql-ens-compara-prod-X -port XXXX \
         -division vertebrates -species_set_name primates -low_epo_mlss_id 1141 -base_epo_mlss_id 1134 -run_gerp 0
 
 =head1 DESCRIPTION
 
-PipeConfig file for the EPO Low Coverage (aka EPO-2X) pipeline.
-
-=head1 CONTACT
-
-Please email comments or questions to the public Ensembl
-developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-Questions may also be sent to the Ensembl help desk at
-<http://www.ensembl.org/Help/Contact>.
-
-=head1 AUTHORSHIP
-
-Ensembl Team. Individual contributions can be found in the GIT log.
+PipeConfig file for the EPO Extended (previously known as EPO-2X or EPO Low
+Coverage) pipeline.
 
 =cut
 
-package Bio::EnsEMBL::Compara::PipeConfig::EpoLowCoverage_conf;
+package Bio::EnsEMBL::Compara::PipeConfig::EpoExtended_conf;
 
 use strict;
 use warnings;
@@ -62,7 +51,7 @@ use Bio::EnsEMBL::Hive::Version 2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;           # Allow this particular config to use conditional dataflow
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::MultipleAlignerStats;
-use Bio::EnsEMBL::Compara::PipeConfig::Parts::EpoLowCoverage;
+use Bio::EnsEMBL::Compara::PipeConfig::Parts::EpoExtended;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');  # All Hive databases configuration files should inherit from HiveGeneric, directly or indirectly
 
@@ -71,7 +60,7 @@ sub default_options {
     return {
 	%{$self->SUPER::default_options},   # inherit the generic ones
 
-    'pipeline_name' => $self->o('species_set_name').'_epo_low_coverage_'.$self->o('rel_with_suffix'),
+    'pipeline_name' => $self->o('species_set_name').'_epo_extended_'.$self->o('rel_with_suffix'),
 
         'master_db' => 'compara_master',
         # Location of compara db containing EPO/EPO_EXTENDED alignment to use as a base
@@ -129,7 +118,7 @@ sub pipeline_analyses {
     my ($self) = @_;
 
     return [
-        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::EpoLowCoverage::pipeline_analyses_all($self) },
+        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::EpoExtended::pipeline_analyses_all($self) },
     ];
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EpoExtended_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EpoExtended_conf.pm
@@ -101,6 +101,8 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
     return {
             %{$self->SUPER::pipeline_wide_parameters},          # here we inherit anything from the base class
 
+            'master_db' => $self->o('master_db'),
+
             'run_gerp' => $self->o('run_gerp'),
             'genome_dumps_dir' => $self->o('genome_dumps_dir'),
             'reg_conf' => $self->o('reg_conf'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EpoExtended_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EpoExtended_conf.pm
@@ -22,18 +22,17 @@ Bio::EnsEMBL::Compara::PipeConfig::EpoExtended_conf
 =head1 SYNOPSIS
 
     init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EpoExtended_conf -host mysql-ens-compara-prod-X -port XXXX \
-        -division $COMPARA_DIV -species_set_name <species_set_name> -low_epo_mlss_id <curr_epo_2x_mlss_id> \
-        -base_epo_mlss_id <curr_epo_mlss_id>
+        -division $COMPARA_DIV -species_set_name <species_set_name>
 
 =head1 EXAMPLES
 
     # With GERP (mammals, sauropsids, fish):
     init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EpoExtended_conf -host mysql-ens-compara-prod-X -port XXXX \
-        -division vertebrates -species_set_name fish -low_epo_mlss_id 1333 -base_epo_mlss_id 1332
+        -division vertebrates -species_set_name fish
 
     # Without GERP (primates):
     init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EpoExtended_conf -host mysql-ens-compara-prod-X -port XXXX \
-        -division vertebrates -species_set_name primates -low_epo_mlss_id 1141 -base_epo_mlss_id 1134 -run_gerp 0
+        -division vertebrates -species_set_name primates -run_gerp 0
 
 =head1 DESCRIPTION
 
@@ -61,15 +60,11 @@ sub default_options {
 	%{$self->SUPER::default_options},   # inherit the generic ones
 
     'pipeline_name' => $self->o('species_set_name').'_epo_extended_'.$self->o('rel_with_suffix'),
+    'method_type'   => 'EPO_EXTENDED',
 
         'master_db' => 'compara_master',
         # Location of compara db containing EPO/EPO_EXTENDED alignment to use as a base
         'epo_db'    => $self->o('species_set_name') . '_epo',
-
-	'low_epo_mlss_id' => $self->o('low_epo_mlss_id'),   #mlss_id for low coverage epo alignment
-	'base_epo_mlss_id' => $self->o('base_epo_mlss_id'), #mlss_id for the base alignment we're topping up
-                                                        # (can be EPO or EPO_EXTENDED)
-	'mlss_id' => $self->o('low_epo_mlss_id'),   #mlss_id for low coverage epo alignment, needed for the alignment stats
 
         # Default location for pairwise alignments (can be a string or an array-ref,
         # and the database aliases can include '*' as a wildcard character)
@@ -105,12 +100,10 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
 
     return {
             %{$self->SUPER::pipeline_wide_parameters},          # here we inherit anything from the base class
-			'mlss_id' => $self->o('low_epo_mlss_id'),
+
             'run_gerp' => $self->o('run_gerp'),
             'genome_dumps_dir' => $self->o('genome_dumps_dir'),
             'reg_conf' => $self->o('reg_conf'),
-            'low_epo_mlss_id' => $self->o('low_epo_mlss_id'),
-            'base_epo_mlss_id' => $self->o('base_epo_mlss_id'),
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOAlignment.pm
@@ -229,7 +229,7 @@ return
                               },  
             },  
             {   -logic_name => 'set_neighbour_nodes',
-                -module     => 'Bio::EnsEMBL::Compara::RunnableDB::EpoLowCoverage::SetNeighbourNodes',
+                -module     => 'Bio::EnsEMBL::Compara::RunnableDB::EpoExtended::SetNeighbourNodes',
                 -rc_name    => '2Gb_job',
                 -batch_size    => 10, 
                 -hive_capacity => 20, 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EpoExtended.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EpoExtended.pm
@@ -143,13 +143,13 @@ sub pipeline_analyses_db_prepare{
                 'from_db'                    => $self->o('epo_db'),
             },
             -flow_into => {
-                1 => [ 'create_extended_genome_jobs' ],
+                1 => [ 'create_epo_extended_jobs' ],
             },
             -rc_name =>'1Gb_job',
         },
 
         # ------------------------------------------------------[Extended alignment]----------------------------------------------------------
-        {   -logic_name => 'create_extended_genome_jobs',
+        {   -logic_name => 'create_epo_extended_jobs',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
             -parameters => {
                 'inputquery' => 'SELECT genomic_align_block_id FROM genomic_align ga LEFT JOIN dnafrag USING (dnafrag_id) WHERE method_link_species_set_id = #mlss_id# AND coord_system_name != "ancestralsegment" GROUP BY genomic_align_block_id',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/EPOwithExt_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/EPOwithExt_conf.pm
@@ -19,27 +19,28 @@ limitations under the License.
 
 =head1 NAME
 
-Bio::EnsEMBL::Compara::PipeConfig::Plants::EPOwith2x_conf
+Bio::EnsEMBL::Compara::PipeConfig::Plants::EPOwithExt_conf
 
 =head1 SYNOPSIS
 
-    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Plants::EPOwith2x_conf.pm -host mysql-ens-compara-prod-X -port XXXX \
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Plants::EPOwithExt_conf.pm -host mysql-ens-compara-prod-X -port XXXX \
         -division $COMPARA_DIV -species_set_name <species_set_name> -low_epo_mlss_id <id> -high_epo_mlss_id <id>
 
 =head1 DESCRIPTION
 
-    This pipeline runs EPO and EPO2x together. For more information on each pipeline, see their respective PipeConfig files:
+    This pipeline runs EPO and EPO Extended together. For more information on
+    each pipeline, see their respective PipeConfig files:
     - Bio::EnsEMBL::Compara::PipeConfig::EPO_conf
-    - Bio::EnsEMBL::Compara::PipeConfig::EpoLowCoverage_conf
+    - Bio::EnsEMBL::Compara::PipeConfig::EpoExtended_conf
 
 =cut
 
-package Bio::EnsEMBL::Compara::PipeConfig::Plants::EPOwith2x_conf;
+package Bio::EnsEMBL::Compara::PipeConfig::Plants::EPOwithExt_conf;
 
 use strict;
 use warnings;
 
-use base ('Bio::EnsEMBL::Compara::PipeConfig::EPOwith2x_conf');
+use base ('Bio::EnsEMBL::Compara::PipeConfig::EPOwithExt_conf');
 
 sub default_options {
     my ($self) = @_;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/EPOwithExt_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/EPOwithExt_conf.pm
@@ -24,7 +24,7 @@ Bio::EnsEMBL::Compara::PipeConfig::Plants::EPOwithExt_conf
 =head1 SYNOPSIS
 
     init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Plants::EPOwithExt_conf.pm -host mysql-ens-compara-prod-X -port XXXX \
-        -division $COMPARA_DIV -species_set_name <species_set_name> -low_epo_mlss_id <id> -high_epo_mlss_id <id>
+        -division $COMPARA_DIV -species_set_name <species_set_name>
 
 =head1 DESCRIPTION
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
@@ -43,7 +43,7 @@ use warnings;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;  # for WHEN and INPUT_PLUS
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::EPOAncestral;
-use Bio::EnsEMBL::Compara::PipeConfig::Parts::EpoLowCoverage;
+use Bio::EnsEMBL::Compara::PipeConfig::Parts::EpoExtended;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
 
@@ -75,7 +75,7 @@ sub default_options {
             -species => $self->o('ancestral_sequences_name'),
             -dbname  => $self->o('dbowner') . '_' . $self->o('species_set_name') . '_ancestral_core_' . $self->o('rel_with_suffix'),
         },
-        # EpoLowCoverage parameters
+        # EpoExtended parameters
         'max_block_size'    => 1000000,  # max size of alignment before splitting
         'pairwise_location' => [ qw(compara_prev lastz_batch_* unidir_lastz) ],  # default location for pairwise alignments (can be a string or an array-ref)
         'lastz_complete'    => 0,  # set to 1 when all relevant LastZs have complete
@@ -359,7 +359,7 @@ sub core_pipeline_analyses {
             },
         },
         {   -logic_name    => 'set_neighbour_nodes',
-            -module        => 'Bio::EnsEMBL::Compara::RunnableDB::EpoLowCoverage::SetNeighbourNodes',
+            -module        => 'Bio::EnsEMBL::Compara::RunnableDB::EpoExtended::SetNeighbourNodes',
             -rc_name       => '2Gb_job',
             -batch_size    => 10,
             -hive_capacity => 20,
@@ -383,8 +383,8 @@ sub core_pipeline_analyses {
         },
 
         @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::EPOAncestral::pipeline_analyses_epo_ancestral($self) },
-        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::EpoLowCoverage::pipeline_analyses_epo2x_alignment($self) },
-        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::EpoLowCoverage::pipeline_analyses_healthcheck($self) },
+        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::EpoExtended::pipeline_analyses_epo_ext_alignment($self) },
+        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::EpoExtended::pipeline_analyses_healthcheck($self) },
     ];
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
@@ -76,8 +76,6 @@ sub default_options {
             -dbname  => $self->o('dbowner') . '_' . $self->o('species_set_name') . '_ancestral_core_' . $self->o('rel_with_suffix'),
         },
         # EpoLowCoverage parameters
-        'low_epo_mlss_id'   => undef,  # required but unused
-        'base_epo_mlss_id'  => undef,  # required but unused
         'max_block_size'    => 1000000,  # max size of alignment before splitting
         'pairwise_location' => [ qw(compara_prev lastz_batch_* unidir_lastz) ],  # default location for pairwise alignments (can be a string or an array-ref)
         'lastz_complete'    => 0,  # set to 1 when all relevant LastZs have complete

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
@@ -326,7 +326,7 @@ sub core_pipeline_analyses {
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => WHEN( '#lastz_complete#' => [ 'create_default_pairwise_mlss' ] ),
         },
-        {   -logic_name => 'create_low_coverage_genome_jobs',
+        {   -logic_name => 'create_extended_genome_jobs',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
             -parameters => {
                 'inputquery'    => 'SELECT genomic_align_block_id, #ext_mlss_id# FROM genomic_align ga LEFT JOIN dnafrag USING (dnafrag_id) WHERE method_link_species_set_id = #mlss_id# AND coord_system_name != "ancestralsegment" GROUP BY genomic_align_block_id',
@@ -334,7 +334,7 @@ sub core_pipeline_analyses {
             },
             -rc_name => '4Gb_job',
             -flow_into => {
-                '2->A' => [ 'low_coverage_genome_alignment' ],
+                '2->A' => [ 'extended_genome_alignment' ],
                 'A->1' => [ 'set_internal_ids_epo_extended' ],
             },
         },
@@ -420,16 +420,16 @@ sub tweak_analyses {
     };
     $analyses_by_name->{'create_default_pairwise_mlss'}->{'-flow_into'}->{1} = WHEN(
         '#run_gerp#' => [ 'set_gerp_neutral_rate' ],
-        ELSE            [ 'create_low_coverage_genome_jobs' ]
+        ELSE            [ 'create_extended_genome_jobs' ]
     );
     $analyses_by_name->{'set_gerp_neutral_rate'}->{'-flow_into'}->{1} = WHEN(
-        '#method_type# eq "epo"' => [ 'create_low_coverage_genome_jobs' ],
+        '#method_type# eq "epo"' => [ 'create_extended_genome_jobs' ],
         ELSE                        [ 'flow_gabs' ]
     );
     # Set MLSS id to EPO Extended to ensure correct link is flown to GERP analyses
-    $analyses_by_name->{'low_coverage_genome_alignment'}->{'-parameters'}->{'mlss_id'} = '#ext_mlss_id#';
-    $analyses_by_name->{'low_coverage_genome_alignment_himem'}->{'-parameters'}->{'mlss_id'} = '#ext_mlss_id#';
-    $analyses_by_name->{'low_coverage_genome_alignment_hugemem'}->{'-parameters'}->{'mlss_id'} = '#ext_mlss_id#';
+    $analyses_by_name->{'extended_genome_alignment'}->{'-parameters'}->{'mlss_id'} = '#ext_mlss_id#';
+    $analyses_by_name->{'extended_genome_alignment_himem'}->{'-parameters'}->{'mlss_id'} = '#ext_mlss_id#';
+    $analyses_by_name->{'extended_genome_alignment_hugemem'}->{'-parameters'}->{'mlss_id'} = '#ext_mlss_id#';
     # Run HCs on GERPs only for Mercator-Pecan and EPO Extended MLSS ids
     $analyses_by_name->{'healthcheck_factory'}->{'-flow_into'} = {
         '1->A' => WHEN (

--- a/modules/Bio/EnsEMBL/Compara/Production/Analysis/ExtendedGenomeAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/Production/Analysis/ExtendedGenomeAlignment.pm
@@ -15,19 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
-=cut
-
 =head1 NAME
 
-Bio::EnsEMBL::Compara::Production::Analysis::LowCoverageGenomeAlignment
+Bio::EnsEMBL::Compara::Production::Analysis::ExtendedGenomeAlignment
 
 =head1 DESCRIPTION
 
@@ -39,7 +29,7 @@ This module creates a new tree for those alignments which contain a segmental du
 =cut
 
 
-package Bio::EnsEMBL::Compara::Production::Analysis::LowCoverageGenomeAlignment;
+package Bio::EnsEMBL::Compara::Production::Analysis::ExtendedGenomeAlignment;
 
 use strict;
 use warnings;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/Readme.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/Readme.pm
@@ -15,16 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Hive::RunnableDB::DumpMultiAlign::Readme
@@ -112,7 +102,7 @@ sub _create_specific_readme {
     } elsif ($mlss->method->type eq "EPO") {
 	$self->_create_specific_epo_readme($compara_dba, $mlss, $species_set, $newick_species_tree);
     } elsif ($mlss->method->type eq "EPO_EXTENDED") {
-	$self->_create_specific_epo_low_coverage_readme($compara_dba, $mlss, $species_set, $newick_species_tree, $mlss_adaptor);
+	$self->_create_specific_epo_extended_readme($compara_dba, $mlss, $species_set, $newick_species_tree, $mlss_adaptor);
     } elsif ($mlss->method->type eq "LASTZ_NET") {
 	$self->_create_specific_pairaligner_readme($compara_dba, $mlss, $species_set, 'LastZ');
     } elsif ($mlss->method->type eq "BLASTZ_NET") {
@@ -173,7 +163,7 @@ uses the Pecan alignments to infer the ancestral sequences.");
 #
 #Create EPO_EXTENDED README file
 #
-sub _create_specific_epo_low_coverage_readme {
+sub _create_specific_epo_extended_readme {
     my ($self, $compara_dba, $mlss, $species_set, $newick_species_tree, $mlss_adaptor) = @_;
 
     my $high_coverage_mlss = $mlss->get_linked_mlss_by_tag('base_mlss_id');

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/DeleteEPO.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/DeleteEPO.pm
@@ -15,21 +15,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-=pod
-
 =head1 NAME
 
-Bio::EnsEMBL::Compara::RunnableDB::EpoLowCoverage::DeleteEPO
-
-=head1 SYNOPSIS
-
-
+Bio::EnsEMBL::Compara::RunnableDB::EpoExtended::DeleteEPO
 
 =cut
 
-package Bio::EnsEMBL::Compara::RunnableDB::EpoLowCoverage::DeleteEPO;
+package Bio::EnsEMBL::Compara::RunnableDB::EpoExtended::DeleteEPO;
 
 use warnings;
 use strict;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/DeleteEPO.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/DeleteEPO.pm
@@ -37,7 +37,7 @@ sub fetch_input {
     my $gaba  = $self->compara_dba->get_GenomicAlignBlockAdaptor;
     my $mlssa = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor;
 
-    my $mlss = $mlssa->fetch_by_dbID($self->param_required('base_epo_mlss_id'));
+    my $mlss = $mlssa->fetch_by_dbID($self->param_required('mlss_id'));
     my $gabs = $gaba->fetch_all_by_MethodLinkSpeciesSet($mlss);
     $self->param('genomic_align_blocks', $gabs);
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
@@ -15,35 +15,26 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
-Bio::EnsEMBL::Compara::Runnable::EpoLowCoverage::LowCoverageGenomeAlignment
+Bio::EnsEMBL::Compara::Runnable::EpoExtended::ExtendedGenomeAlignment
 
 =head1 DESCRIPTION
 
-This module acts as a layer between the Hive system and the Bio::EnsEMBL::Compara::Production::Analysis::LowCoverageGenomeAlignment module
+This module acts as a layer between the Hive system and the
+Bio::EnsEMBL::Compara::Production::Analysis::ExtendedGenomeAlignment module
 
-This module is the alternative module to Ortheus.pm for aligning low coverage (2X) genomes. This takes an existing high coverage alignment and maps the pairwise BlastZ-Net alignments of the low coverage genomes to the human sequence in the high coverage alignment. Any insertions in the low coverage alignments are removed, that is, no gaps are added to the human sequence. In regions where there are duplications, a phylogenetic tree is generated using either treeBest where there are more than 3 sequences in the alignment or semphy where there are 3 or less sequences. This module is still under development.
-
-=head1 APPENDIX
-
-The rest of the documentation details each of the object methods. 
-Internal methods are usually preceded with a _
+This module is the alternative module to Ortheus.pm to extend an existing EPO
+alignment, mapping the pairwise LastZ-Net alignments of the additional genomes
+to the reference genomes in the EPO alignment. Any insertions in the extended
+alignment are removed, that is, no gaps are added to the reference species. In
+regions where there are duplications, a phylogenetic tree is generated using
+either TreeBest where there are more than 3 sequences in the alignment or semphy
+where there are 3 or less sequences.
 
 =cut
 
-package Bio::EnsEMBL::Compara::RunnableDB::EpoLowCoverage::LowCoverageGenomeAlignment;
+package Bio::EnsEMBL::Compara::RunnableDB::EpoExtended::ExtendedGenomeAlignment;
 
 use strict;
 use warnings;
@@ -54,7 +45,7 @@ use Bio::EnsEMBL::Compara::DnaFragRegion;
 use Bio::EnsEMBL::Compara::Graph::NewickParser;
 use Bio::EnsEMBL::Compara::NestedSet;
 use Bio::EnsEMBL::Compara::GenomicAlignGroup;
-use Bio::EnsEMBL::Compara::Production::Analysis::LowCoverageGenomeAlignment;
+use Bio::EnsEMBL::Compara::Production::Analysis::ExtendedGenomeAlignment;
 use Bio::EnsEMBL::Compara::Utils::Cigars;
 use Bio::EnsEMBL::Compara::Utils::Preloader;
 use Bio::EnsEMBL::Compara::Utils::Cigars;
@@ -87,7 +78,7 @@ sub fetch_input {
   my( $self) = @_;
 
   if (!$self->param('mlss_id')) {
-    throw("MethodLinkSpeciesSet->dbID is not defined for this LowCoverageAlignment job");
+    throw("MethodLinkSpeciesSet->dbID is not defined for this ExtendedGenomeAlignment job");
   }
 
   # Set the genome dump directory
@@ -125,7 +116,7 @@ sub fetch_input {
 
     Arg        : -none-
     Example    : $self->run
-    Description: runs the  LowCoverageGenomeAlignment analysis module and 
+    Description: runs the  ExtendedGenomeAlignment analysis module and 
                   parses the results
     Returntype : none
     Exceptions : none
@@ -143,7 +134,7 @@ sub run
   #disconnect compara database
   $self->compara_dba->dbc->disconnect_if_idle;
 
-  my $tree_file = Bio::EnsEMBL::Compara::Production::Analysis::LowCoverageGenomeAlignment::run_analysis($self);
+  my $tree_file = Bio::EnsEMBL::Compara::Production::Analysis::ExtendedGenomeAlignment::run_analysis($self);
   $self->_parse_results($tree_file);
 }
 
@@ -263,7 +254,7 @@ sub _write_gerp_dataflow {
 sub _parse_results {
     my ($self, $tree_file) = @_;
 
-    #Taken from Analysis/Runnable/LowCoverageGenomeAlignment.pm module
+    #Taken from Production/Analysis/ExtendedGenomeAlignment.pm module
     print "PARSE RESULTS\n" if $self->debug;
 
     ## The output file contains one fasta aligned sequence per original sequence + ancestral sequences.

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
@@ -254,7 +254,7 @@ sub _write_gerp_dataflow {
 sub _parse_results {
     my ($self, $tree_file) = @_;
 
-    #Taken from Production/Analysis/ExtendedGenomeAlignment.pm module
+    #Taken from Compara/Production/Analysis/ExtendedGenomeAlignment.pm module
     print "PARSE RESULTS\n" if $self->debug;
 
     ## The output file contains one fasta aligned sequence per original sequence + ancestral sequences.

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ExtendedGenomeAlignment.pm
@@ -564,7 +564,7 @@ sub _parse_results {
             if ( $ga->genome_db->is_good_for_alignment ) {
                 $these_genomic_aligns = [$this_genomic_align];
             } else {
-                $these_genomic_aligns = $self->_expand_trimmed_low_coverage_alignments($ga->genome_db->dbID);
+                $these_genomic_aligns = $self->_expand_trimmed_extended_alignments($ga->genome_db->dbID);
                 $these_genomic_aligns = [$this_genomic_align] unless defined $these_genomic_aligns->[0];
             }
 		    
@@ -1204,7 +1204,7 @@ sub _update_tree_2x {
       }
     }
 
-    $these_genomic_aligns = $self->_trim_low_coverage_alignments($these_genomic_aligns, $this_leaf_genome_db);
+    $these_genomic_aligns = $self->_trim_extended_alignments($these_genomic_aligns, $this_leaf_genome_db);
 
     my $index = 0;
     if ($self->param('ga_frag')) {
@@ -1705,7 +1705,7 @@ sub get_seq_length_from_cigar {
     return $seq_pos;
 }
 
-sub _trim_low_coverage_alignments {
+sub _trim_extended_alignments {
     my ($self, $these_genomic_aligns, $this_leaf_genome_db) = @_;
         
     if ( @$these_genomic_aligns > 1 && !$this_leaf_genome_db->is_good_for_alignment ) {
@@ -1728,7 +1728,7 @@ sub _trim_low_coverage_alignments {
     return $these_genomic_aligns;
 }
 
-sub _expand_trimmed_low_coverage_alignments {
+sub _expand_trimmed_extended_alignments {
     my ($self, $genome_db_id) = @_;
     
     print " -- expanding genomic_aligns for genome_db_id $genome_db_id\n";

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/FindPairwiseMlssLocation.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/FindPairwiseMlssLocation.pm
@@ -17,7 +17,7 @@ limitations under the License.
 
 =head1 NAME
 
-Bio::EnsEMBL::Compara::RunnableDB::FindPairwiseMlssLocation
+Bio::EnsEMBL::Compara::RunnableDB::EpoExtended::FindPairwiseMlssLocation
 
 =head1 DESCRIPTION
 
@@ -30,14 +30,9 @@ Will only be looking for the pairwise alignment needed to expand the
 Stores the resulting hash in the pipeline_wide_parameters table (via a
 dataflow).
 
-=head1 APPENDIX
-
-The rest of the documentation details each of the object methods.
-Internal methods are usually preceded with a _
-
 =cut
 
-package Bio::EnsEMBL::Compara::RunnableDB::EpoLowCoverage::FindPairwiseMlssLocation;
+package Bio::EnsEMBL::Compara::RunnableDB::EpoExtended::FindPairwiseMlssLocation;
 
 use strict;
 use warnings;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ImportAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/ImportAlignment.pm
@@ -15,33 +15,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
-Bio::EnsEMBL::Compara::RunnableDB::EpoLowCoverage::ImportAlignment
+Bio::EnsEMBL::Compara::RunnableDB::EpoExtended::ImportAlignment
 
 =head1 DESCRIPTION
 
-This module imports a specified alignment. This is used in the low coverage genome alignment pipeline for importing the high coverage alignment which is used to build the low coverage genomes on.
-
-=head1 APPENDIX
-
-The rest of the documentation details each of the object methods. 
-Internal methods are usually preceded with a _
+This module imports a specified alignment. This is used in the extended genome
+alignment pipeline for importing the high coverage alignment which is used to
+build the extended genomes on.
 
 =cut
 
-package Bio::EnsEMBL::Compara::RunnableDB::EpoLowCoverage::ImportAlignment;
+package Bio::EnsEMBL::Compara::RunnableDB::EpoExtended::ImportAlignment;
 
 use strict;
 use warnings;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/SetNeighbourNodes.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/SetNeighbourNodes.pm
@@ -17,7 +17,7 @@ limitations under the License.
 
 =head1 NAME
 
-Bio::EnsEMBL::Compara::RunnableDB::EpoLowCoverage::SetNeighbourNodes
+Bio::EnsEMBL::Compara::RunnableDB::EpoExtended::SetNeighbourNodes
 
 =head1 DESCRIPTION
 
@@ -33,13 +33,13 @@ Mandatory. Root ID of the genomic align tree to set/update.
 
 =head1 EXAMPLES
 
-    standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::EpoLowCoverage::SetNeighbourNodes \
+    standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::EpoExtended::SetNeighbourNodes \
         -compara_db $(mysql-ens-compara-prod-7-ensadmin details url jalvarez_sauropsids_epo_update_103) \
         -root_id 19490000000007
 
 =cut
 
-package Bio::EnsEMBL::Compara::RunnableDB::EpoLowCoverage::SetNeighbourNodes;
+package Bio::EnsEMBL::Compara::RunnableDB::EpoExtended::SetNeighbourNodes;
 
 use strict;
 use warnings;

--- a/modules/t/CreateComparaTestDatabase.pl
+++ b/modules/t/CreateComparaTestDatabase.pl
@@ -42,7 +42,7 @@ my @pairwise_genome_db_names = ("pan_troglodytes", "mus_musculus", "tarsius_syri
 
 my $pairwise_method_link_type = '"BLASTZ_NET", "LASTZ_NET"';
 my $epo_alignment_method_link_type = "EPO";
-my $epo_low_coverage_alignment_method_link_type = "EPO_EXTENDED";
+my $epo_extended_alignment_method_link_type = "EPO_EXTENDED";
 my $pecan_alignment_method_link_type = "PECAN";
 my $constrained_element_method_link_type = "GERP_CONSTRAINED_ELEMENT";
 my $conservation_score_method_link_type = "GERP_CONSERVATION_SCORE";
@@ -54,7 +54,7 @@ my $ancestral_coord_system_name = "ancestralsegment";
 my $do_pairwise = 1;
 my $do_pecan = 1;
 my $do_epo = 1;
-my $do_epo_low_coverage = 1;
+my $do_epo_extended = 1;
 
 GetOptions('help' => \$help,
            's=s' => \$srcDB,
@@ -585,10 +585,10 @@ if ($do_epo) {
     }
 }
 
-if ($do_epo_low_coverage) {
+if ($do_epo_extended) {
     print "do EPO multiple alignment\n";
         
-    my $multi_alignment_mlss_id = _run_query_from_method_link_type_species_set_name($epo_low_coverage_alignment_method_link_type, $epo_species_set_name);
+    my $multi_alignment_mlss_id = _run_query_from_method_link_type_species_set_name($epo_extended_alignment_method_link_type, $epo_species_set_name);
 
     my $constrained_element_mlss_id = _run_query_from_method_link_type_species_set_name($constrained_element_method_link_type, $epo_species_set_name);
 

--- a/scripts/jira_tickets/compara_merged.dot
+++ b/scripts/jira_tickets/compara_merged.dot
@@ -3,20 +3,20 @@ digraph {
     "Patches against their primary assembly";
 
     "Genome dumps" -> { "Species-tree", "LastZ" };
-    "Species-tree" -> { "EPOwith2x", "Protein-trees", "Update MSA" };
-    "All LastZ" -> "EPOwith2x";
+    "Species-tree" -> { "EPOwithExt", "Protein-trees", "Update MSA" };
+    "All LastZ" -> "EPOwithExt";
     "Member loading" -> { "Protein-trees", "ncRNA-trees", "Gene-tree reindexing", "Alt-alleles import" };
-    {"All LastZ", "EPOwith2x", "Update MSA"} -> "All alignments for WGA Orthology QC";
+    {"All LastZ", "EPOwithExt", "Update MSA"} -> "All alignments for WGA Orthology QC";
     "All alignments for WGA Orthology QC" -> "Protein-trees" [fontsize="8", label="Orthologues\nonly"];
     "All alignments for WGA Orthology QC" -> "ncRNA-trees" [fontsize="8", label="Orthologues\nonly"];
     "LastZ" -> "All LastZ" -> "Synteny";
 
     "Gene-tree reindexing" -> "ncRNA-trees" [style="dashed", dir=none, fontsize="8", label="XOR"];
     "Gene-tree reindexing" -> "Protein-trees" [style="dashed", dir=none, fontsize="8", label="XOR"];
-    "EPOwith2x" -> "EPOwith2x" [style="dashed", fontsize="8", label="Anchor\nmapping\nonly", headport="Primates:e", tailport="Mammals:e"];
-    "EPOwith2x" -> "EPOwith2x" [style="dashed", fontsize="8", label="Anchor\nmapping\nonly", headport="Pigs:e", tailport="Mammals:e"];
-    "EPOwith2x" -> "Age of Base" [style="dashed", headport="Human:w", tailport="Mammals:e"];
-    "Update MSA" -> "EPOwith2x" [style="dashed", dir=none, fontsize="8", label="XOR"];
+    "EPOwithExt" -> "EPOwithExt" [style="dashed", fontsize="8", label="Anchor\nmapping\nonly", headport="Primates:e", tailport="Mammals:e"];
+    "EPOwithExt" -> "EPOwithExt" [style="dashed", fontsize="8", label="Anchor\nmapping\nonly", headport="Pigs:e", tailport="Mammals:e"];
+    "EPOwithExt" -> "Age of Base" [style="dashed", headport="Human:w", tailport="Mammals:e"];
+    "Update MSA" -> "EPOwithExt" [style="dashed", dir=none, fontsize="8", label="XOR"];
 
     // Helps laying out the graph
     {rank = same; "Genome dumps"; "Member loading"; }


### PR DESCRIPTION
## Description

The addition of the `LoadMLSSids` runnable made our pipelines less error prone since it removes the need to pass the required MLSS ids manually in the initialisation command. The incorporation of this runnable in EPO and EPO Extended pipelines is trickier since these parameters have different aliases in each pipeline. Furthermore, I have taken the opportunity to finally rename all `low_coverage` and `2x` old names to `extended` in filenames, analyses and pipeline-wide parameters.

**Related JIRA tickets:**
- ENSCOMPARASW-3782

## Overview of changes
#### Change 1
- Introduced `LoadMLSSids` in `EPO`, `EPOwithExt` and `EpoExtended` pipelines, replacing the starting first analysis as it was retrieving the GERP MLSS ids when EPO Extended MSA was involved (and `run_gerp = 1`), or it was just a dummy analysis for EPO.
- The JIRA tickets have been updated in accordance to the new initialisation commands.

#### Change 2
- Renamed `low_coverage` by `extended` and `2x` by `ext` in the filenames and main code, i.e. analysis names and pipeline parameters. Haven't touched the runnables' code as I have considered it out of the scope of this work.

## Testing
I have tried to initialise one of each pipeline with e103 MLSSs, and everything seems to have been initialised correctly:
[Murinae EPO](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-10&port=4648&dbname=jalvarez_murinae_epo_103_test), [mammals EPO with Extension](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-10&port=4648&dbname=jalvarez_mammals_epo_with_ext_103_test), [fish EPO Extended](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-10&port=4648&dbname=jalvarez_fish_epo_extended_103_test) and [sauropsids EPO update](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-10&port=4648&dbname=jalvarez_sauropsids_epo_update_103_test).
If requested, I can run these pipelines completely, although I think the changes are quite straightforward and nothing should be broken.

## Notes
The update has broken the EPO Extended functionality for incremental updates over a previous EPO Extended MSA. ENSCOMPARASW-4085 has been created to add it back.
