### PR TITLE
Updated plant registry for 104

### DIFF
--- a/conf/plants/production_reg_conf.pl
+++ b/conf/plants/production_reg_conf.pl
@@ -56,7 +56,7 @@ Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertann
 # previous release core databases will be required by PrepareMasterDatabaseForRelease and LoadMembers only
  *Bio::EnsEMBL::Compara::Utils::Registry::load_previous_core_databases = sub {
      Bio::EnsEMBL::Registry->load_registry_from_db(
-         -host   => 'mysql-ens-sta-3',
+         -host   => 'mysql-ens-sta-3-b',
          -port   => 4160,
          -user   => 'ensro',
          -pass   => '',
@@ -66,7 +66,7 @@ Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertann
      Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species, Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX);
      Bio::EnsEMBL::Compara::Utils::Registry::remove_multi(undef, Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX);
      Bio::EnsEMBL::Registry->load_registry_from_db(
-         -host   => 'mysql-ens-sta-1',
+         -host   => 'mysql-ens-sta-1-b',
          -port   => 4519,
          -user   => 'ensro',
          -pass   => '',

--- a/conf/plants/production_reg_conf.pl
+++ b/conf/plants/production_reg_conf.pl
@@ -54,26 +54,26 @@ Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertann
 # ---------------------- PREVIOUS CORE DATABASES---------------------------------
 
 # previous release core databases will be required by PrepareMasterDatabaseForRelease and LoadMembers only
-# *Bio::EnsEMBL::Compara::Utils::Registry::load_previous_core_databases = sub {
-#     Bio::EnsEMBL::Registry->load_registry_from_db(
-#         -host   => 'mysql-ens-sta-3',
-#         -port   => 4160,
-#         -user   => 'ensro',
-#         -pass   => '',
-#         -db_version     => $prev_release,
-#         -species_suffix => Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX,
-#     );
-#     Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species, Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX);
-#     Bio::EnsEMBL::Compara::Utils::Registry::remove_multi(undef, Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX);
-#     Bio::EnsEMBL::Registry->load_registry_from_db(
-#         -host   => 'mysql-ens-sta-1',
-#         -port   => 4519,
-#         -user   => 'ensro',
-#         -pass   => '',
-#         -db_version     => $prev_release,
-#         -species_suffix => Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX,
-#     );
-# };
+ *Bio::EnsEMBL::Compara::Utils::Registry::load_previous_core_databases = sub {
+     Bio::EnsEMBL::Registry->load_registry_from_db(
+         -host   => 'mysql-ens-sta-3',
+         -port   => 4160,
+         -user   => 'ensro',
+         -pass   => '',
+         -db_version     => $prev_release,
+         -species_suffix => Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX,
+     );
+     Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species, Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX);
+     Bio::EnsEMBL::Compara::Utils::Registry::remove_multi(undef, Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX);
+     Bio::EnsEMBL::Registry->load_registry_from_db(
+         -host   => 'mysql-ens-sta-1',
+         -port   => 4519,
+         -user   => 'ensro',
+         -pass   => '',
+         -db_version     => $prev_release,
+         -species_suffix => Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX,
+     );
+ };
 #------------------------COMPARA DATABASE LOCATIONS----------------------------------
 
 
@@ -84,11 +84,11 @@ my $compara_dbs = {
     'compara_prev'   => [ 'mysql-ens-compara-prod-5', "ensembl_compara_plants_${prev_eg_release}_${prev_release}" ],
 
     # homology dbs
-    'compara_members'  => [ 'mysql-ens-compara-prod-7', 'cristig_plants_load_members_103'],
-    'compara_ptrees'   => [ 'mysql-ens-compara-prod-5', 'cristig_plants_plants_protein_trees_103' ],
+    #'compara_members'  => [ 'mysql-ens-compara-prod-7', 'cristig_plants_load_members_103'],
+    #'compara_ptrees'   => [ 'mysql-ens-compara-prod-5', 'cristig_plants_plants_protein_trees_103' ],
 
     # LASTZ dbs
-    'lastz_batch_1' => [ 'mysql-ens-compara-prod-3', 'cristig_plants_lastz_batch1_103' ],
+    #'lastz_batch_1' => [ 'mysql-ens-compara-prod-3', 'cristig_plants_lastz_batch1_103' ],
 
     # LASTZ dbs to merge in e105 or later
     # Wheat "strains" alignments
@@ -100,11 +100,11 @@ my $compara_dbs = {
     #'lastz_tdic'    => [ 'mysql-ens-compara-prod-8', 'muffato_plants_self_lastz_tdic_103' ],
 
     # synteny
-    'compara_syntenies' => [ 'mysql-ens-compara-prod-10', 'cristig_plants_synteny_103' ],
+    #'compara_syntenies' => [ 'mysql-ens-compara-prod-10', 'cristig_plants_synteny_103' ],
 
     # EPO dbs
     ## rice
-    'rice_epo_high_low' => [ 'mysql-ens-compara-prod-5', "ensembl_compara_plants_${prev_eg_release}_${prev_release}" ],
+    #'rice_epo_high_low' => [ 'mysql-ens-compara-prod-5', "ensembl_compara_plants_${prev_eg_release}_${prev_release}" ],
     'rice_epo_prev'     => [ 'mysql-ens-compara-prod-5', "ensembl_compara_plants_${prev_eg_release}_${prev_release}" ],
     'rice_epo_anchors'  => [ 'mysql-ens-compara-prod-5', 'cristig_generate_anchors_rice_99' ],
 };
@@ -123,7 +123,7 @@ Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $ancestral_dbs );
 
 # NCBI taxonomy database (also maintained by production team):
 Bio::EnsEMBL::Compara::Utils::Registry::add_taxonomy_dbas({
-    'ncbi_taxonomy' => [ 'mysql-ens-sta-3-b', "ncbi_taxonomy_$curr_release" ],
+    'ncbi_taxonomy' => [ 'mysql-ens-sta-3', "ncbi_taxonomy_$curr_release" ],
 });
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
## Description

Updated 104/ensembl-compara/conf/plants/production_reg_conf.pl

**Related JIRA tickets:**
- ENSCOMPARASW-4185

## Overview of changes
Commented out or removed comments throughout the script

#### Change #1
- Uncommented code in ---PREVIOUS CORE DATABASES---

#### Change #2
- In --COMPARA DATABASE LOCATIONS---, commented out all except keys and values for: 
- 'compara_master'
- 'compara_curr'
- 'compara_prev'
- 'rice_epo_prev'
- 'rice_epo_anchors'

#### Change #3
- set 'ncbi_taxonomy' => [ 'mysql-ens-sta-3', "ncbi_taxonomy_$curr_release" ] (used to be 'mysql-ens-sta-3b')

## Testing
None

## Notes
None.
