### PR TITLE
Allow for shared collection definition

### DIFF
--- a/conf/references/mlss_conf.xml
+++ b/conf/references/mlss_conf.xml
@@ -22,6 +22,7 @@
     </collection>
 
     <collection name="default">
+      <base_collection name="shared"/>
       <!-- Vertebrates -->
       <genome name="mus_musculus"/>
       <genome name="anolis_carolinensis"/>
@@ -59,6 +60,7 @@
     </collection>
 
     <collection name="vertebrata">
+      <base_collection name="shared"/>
       <!-- Myxini -->
       <genome name="eptatretus_burgeri"/>
       <!-- Hyperoartia -->
@@ -100,6 +102,7 @@
     </collection>
 
     <collection name="mammalia">
+      <base_collection name="shared"/>
       <!-- Outgroups -->
       <genome name="ciona_intestinalis"/>
       <genome name="dasypus_novemcinctus"/>

--- a/scripts/pipeline/compara_db_config.rng
+++ b/scripts/pipeline/compara_db_config.rng
@@ -125,6 +125,11 @@
                   </choice>
                 </attribute>
               </optional>
+              <optional>
+                  <element name="base_collection" blockly:blockName="Include collection as base">
+                    <attribute name="name" blockly:blockName="Collection name"/>
+                  </element>
+              </optional>
               <ref name="new_named_species_set"/>
             </element>
           </oneOrMore>

--- a/scripts/pipeline/create_all_mlss.pl
+++ b/scripts/pipeline/create_all_mlss.pl
@@ -259,6 +259,10 @@ sub make_species_set_from_XML_node {
         $some_genome_dbs = ($gdb->is_current) ? [$gdb] : [];
       } elsif ($child->nodeName =~ /^#(comment|text)$/) {
         next;
+      } elsif ($child->nodeName eq 'base_collection') {
+        # include all genomes in this base collection
+        my $base_collection = find_collection_from_xml_node_attribute($child, 'name', 'base collection');
+        $some_genome_dbs = $base_collection->genome_dbs;
       } else {
         throw(sprintf('Unknown child: %s (line %d)', $child->nodeName, $child->line_number));
       }


### PR DESCRIPTION
## Description

When defining reference sets, we want to be able to include one collection in other collections (e.g. a shared collection). To address this, I've added a new `<base_collection>` attribute to our XML definition.

**Related JIRA tickets:**
- ENSCOMPARASW-4286

## Overview of changes
- Updated `create_all_mlss.pl` to handle the new `base_collection` tag
- Updated the `.rng` XML schema definition to add the new tag to the `<collection>` attribute
- Added `<base_collection/>` tags to the references XML to include the shared collection in all other collections

## Testing
- Tested the code on this database: `cp4 carlac_reference_db_test1` using this sample XML:
<details>
    <summary>Expand sample XML</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<compara_db division="test_shared">
  <collections>
    <collection name="shared">
        <genome name="homo_sapiens"/>
        <genome name="gallus_gallus"/>
        <genome name="mus_musculus"/>
    </collection>
    <collection name="shared_with_mammals">
        <base_collection name="shared"/>
        <genome name="bos_taurus"/>
        <genome name="canis_lupus_familiaris"/>
    </collection>
    <collection name="shared_with_fish">
        <base_collection name="shared"/>
        <genome name="danio_rerio"/>
    </collection>
  </collections>
</compara_db>
```
</details>

## Notes
- In `create_all_mlss.pl`, all indentation was previously with 2 spaces. I have continued that as it was harder to read when I used 4 (difficult to tell which `if/else` I'm closing, etc)
