### PR TITLE
Link ancestral sequences correctly when gathering Align Slices

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/AlignSliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/AlignSliceAdaptor.pm
@@ -400,7 +400,6 @@ sub _combine_genomic_align_trees {
           push @{$species_order->[$prev_species_index]->{genomic_align_ids}}, @{$pending_ancestral_species->{genomic_align_ids}};
           undef $pending_ancestral_species;
         }
-        ## DEBUG info
         # _debug_info("NODE LINK", $species_order, $species_counter);
 
       ## 2. If there is no info about right node or this points to a node not found in next tree,
@@ -424,7 +423,6 @@ sub _combine_genomic_align_trees {
             undef $pending_ancestral_species;
           }
         }
-        ## DEBUG info
         # _debug_info($debug_msg, $species_order, $species_counter);
 
       ## 3. If the species is in $species_order but next tree has a different order, link the node
@@ -439,7 +437,6 @@ sub _combine_genomic_align_trees {
           push @{$species_order->[$prev_species_index]->{genomic_align_ids}}, @{$pending_ancestral_species->{genomic_align_ids}};
           undef $pending_ancestral_species;
         }
-        ## DEBUG info
         # _debug_info("OUT-OF-ORDER NODE LINK", $species_order, $species_counter);
 
       ## 4. Insert/append this species if not found in $species_order
@@ -466,7 +463,6 @@ sub _combine_genomic_align_trees {
           # Update the existing species names
           $existing_species_names{$this_genome_db->name} = $species_counter;
         }
-        ## DEBUG info
         # _debug_info($debug_msg, $species_order, $species_counter);
       } else {
         $match = 0;

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/AlignSliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/AlignSliceAdaptor.pm
@@ -15,24 +15,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
-Bio::EnsEMBL::Compara::DBSQL::AlignSliceAdaptor - An AlignSlice can be used to map genes from one species onto another one. This adaptor is used to fetch all the data needed for an AlignSlice from the database.
+Bio::EnsEMBL::Compara::DBSQL::AlignSliceAdaptor
 
-=head1 INHERITANCE
+=head1 DESCRIPTION
 
-This module inherits attributes and methods from Bio::EnsEMBL::DBSQL::BaseAdaptor
+An AlignSlice can be used to map genes from one species onto another one. This
+adaptor is used to fetch all the data needed for an AlignSlice from the database.
 
 =head1 SYNOPSIS
 
@@ -65,22 +55,8 @@ This module inherits attributes and methods from Bio::EnsEMBL::DBSQL::BaseAdapto
           "expanded"
       );
 
-=head1 OBJECT ATTRIBUTES
-
-=over
-
-=item db (from SUPER class)
-
-=back
-
-=head1 APPENDIX
-
-The rest of the documentation details each of the object methods. Internal methods are usually preceded with a _
-
 =cut
 
-
-# Let the code begin...
 
 package Bio::EnsEMBL::Compara::DBSQL::AlignSliceAdaptor;
 
@@ -95,8 +71,6 @@ use Bio::EnsEMBL::Compara::AlignSlice;
 
 our @ISA = qw(Bio::EnsEMBL::DBSQL::BaseAdaptor);
 
-use Data::Dumper;
-#$Data::Dumper::Pad = '<br>';
 
 =head2 fetch_by_Slice_MethodLinkSpeciesSet
 
@@ -187,9 +161,7 @@ sub fetch_by_Slice_MethodLinkSpeciesSet {
 
   #Get the species tree for PECAN or HAL alignments
   if ($method_link_species_set->method->class =~ /GenomicAlignBlock.multiple_alignment/ and  @$genomic_align_blocks) {
-#      print Dumper $genomic_align_blocks->[0];
     my $first_genomic_align_block = $genomic_align_blocks->[0];
-#    print Dumper $first_genomic_align_block;
     my $genomic_align_tree = $first_genomic_align_block->get_GenomicAlignTree;
     
     #want to create species_order
@@ -197,14 +169,9 @@ sub fetch_by_Slice_MethodLinkSpeciesSet {
   } elsif ($method_link_species_set->method->class =~ /GenomicAlignTree/ and @$genomic_align_blocks) {
     my $genomic_align_tree_adaptor = $self->db->get_GenomicAlignTreeAdaptor;
     foreach my $this_genomic_align_block (@$genomic_align_blocks) {
-#       print $this_genomic_align_block->reference_genomic_align, "\n";
       my $this_genomic_align_tree = $genomic_align_tree_adaptor->
           fetch_by_GenomicAlignBlock($this_genomic_align_block);
       push(@$genomic_align_trees, $this_genomic_align_tree);
-#       $this_genomic_align_tree->print();
-#       foreach my $this_ga (@{$this_genomic_align_tree->get_all_sorted_genomic_align_nodes}) {
-#         print $this_ga->genomic_align->genome_db->name(), "\n";
-#       }
 
     }
     my $last_node_id = undef;
@@ -225,23 +192,10 @@ sub fetch_by_Slice_MethodLinkSpeciesSet {
     foreach my $this_genomic_align_tree (@$genomic_align_trees) {
       my $next_genomic_align_tree = $tree_order->{$this_genomic_align_tree->node_id}->{next};
       next if (!$next_genomic_align_tree);
-# # #       print STDERR "\nBEFORE:\n - ", join("\n - ", map {
-# # #               $_->{genome_db}->name." (".($_->{right_node_id} or "***").")  [".
-# # #               join(" : ", @{$_->{genomic_align_ids}})."]"
-# # #           } @$species_order), "\n";
       _combine_genomic_align_trees($species_order, $this_genomic_align_tree, $next_genomic_align_tree);
-#       $next_genomic_align_tree->print();
-# # #       print STDERR "\nAFTER:\n - ", join("\n - ", map {
-# # #               $_->{genome_db}->name." (".($_->{right_node_id} or "***").")  [".
-# # #               join(" : ", @{$_->{genomic_align_ids}})."]"
-# # #           } @$species_order), "\n";
-# # #       <STDIN>;
-
     }
   }
 
-
-  #print Dumper { "gabs::AlignSliceAdaptor::254" => $genomic_align_blocks };
   my $align_slice = new Bio::EnsEMBL::Compara::AlignSlice(
           -adaptor => $self,
           -reference_Slice => $reference_slice,
@@ -398,16 +352,12 @@ sub _combine_genomic_align_trees {
   my $species_counter = 0;
   my $existing_node_ids; # Lists all node_ids in the next tree
   my $existing_right_node_ids;
-  my $next_species_names; # Lists all species names in the next tree
   my $existing_species_names; # Lists all species names in the $species_order tracks
 
   ## Initialise values
   foreach my $this_genomic_align_node (@{$next_tree->get_all_sorted_genomic_align_nodes}) {
     my $this_node_id = $this_genomic_align_node->node_id;
     $existing_node_ids->{$this_node_id} = 1;
-    push(@$next_species_names, $this_genomic_align_node->genomic_align_group->genome_db->name)
-        if ($this_genomic_align_node->genomic_align_group and 
-            $this_genomic_align_node->genomic_align_group->genome_db->name ne "ancestral_sequences");
   }
   foreach my $species_def (@$species_order) {
     my $right_node_id = $species_def->{right_node_id};
@@ -442,8 +392,7 @@ sub _combine_genomic_align_trees {
 
       ## 1. Use info from species_right_node_id if available
       if (defined($species_right_node_id) and $species_right_node_id == $this_node_id) {
-          $species_order->[$species_counter]->{right_node_id} = $this_right_node_id;
-          # #         $species_order->[$species_counter]->{last_node} = $this_genomic_align_node;
+        $species_order->[$species_counter]->{right_node_id} = $this_right_node_id;
         push (@{$species_order->[$species_counter]->{genomic_align_ids}}, @$these_genomic_align_ids);
         ## DEBUG info
         # print "NODE LINK!\n";
@@ -461,7 +410,7 @@ sub _combine_genomic_align_trees {
             genome_db => $this_genome_db,
             right_node_id => $this_right_node_id,
             genomic_align_ids => [@$these_genomic_align_ids],
-          });
+        });
         ## DEBUG info
         # print "FORCE INSERT!\n";
         # for (my $i = 0; $i<@$species_order; $i++) {
@@ -497,7 +446,7 @@ sub _combine_genomic_align_trees {
             genome_db => $this_genome_db,
             right_node_id => $this_right_node_id,
             genomic_align_ids => [@$these_genomic_align_ids],
-          });
+        });
         ## DEBUG info
         # print "INSERT!\n";
         # for (my $i = 0; $i<@$species_order; $i++) {
@@ -522,7 +471,7 @@ sub _combine_genomic_align_trees {
             genome_db => $this_genome_db,
             right_node_id => $this_right_node_id,
             genomic_align_ids => [@$these_genomic_align_ids],
-        });
+      });
       $species_counter++;
       ## DEBUG info
       # print "APPEND!\n";
@@ -537,7 +486,6 @@ sub _combine_genomic_align_trees {
     ## DEBUG info
     # print "[ENTER]";
     # <STDIN>;
-    shift(@$next_species_names);
   }
 
   return;

--- a/scripts/dumps/DumpAlignSlice.pl
+++ b/scripts/dumps/DumpAlignSlice.pl
@@ -76,7 +76,8 @@ the one set in ENSEMBL_REGISTRY will be used if defined, if not
 =item B<[--dbname compara_db_name]>
 
 the name of compara DB in the registry_configuration_file or any
-of its aliases. Default is "compara_curr".
+of its aliases.
+Default "compara_curr"
 
 =back
 
@@ -94,7 +95,8 @@ Query coordinate system. Default is "chromosome"
 
 =item B<--seq_region region_name>
 
-Query region name, i.e. the chromosome name. Default 13.
+Query region name, i.e. the chromosome name.
+Default 13
 
 =item B<--seq_region_start start>
 
@@ -106,7 +108,8 @@ Default 32906519
 
 =item B<[--seq_region_strand strand]>
 
-The strand of the query. It can be either +1 or -1. Default is +1.
+The strand of the query. It can be either +1 or -1.
+Default +1
 
 =back
 
@@ -116,7 +119,8 @@ The strand of the query. It can be either +1 or -1. Default is +1.
 
 =item B<[--alignment_type method_link_name]>
 
-The type of alignment. Default is "EPO".
+The type of alignment.
+Default "EPO"
 
 =item B<[--set_of_species species1:species2:species3:...]>
 
@@ -129,7 +133,7 @@ registry_configuration_file or any of its aliases
 
 Pre-defined name for the set of species used. For multiple alignment sets only.
 eg "mammals" or "primates" for EPO alignments; "amniotes" for PECAN alignments.
-Default is "mammals".
+Default "mammals"
 
 =item B<[--[no]condensed]>
 

--- a/scripts/dumps/DumpAlignSlice.pl
+++ b/scripts/dumps/DumpAlignSlice.pl
@@ -14,15 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 DumpAlignSlice.pl
@@ -103,15 +94,19 @@ Query coordinate system. Default is "chromosome"
 
 =item B<--seq_region region_name>
 
-Query region name, i.e. the chromosome name
+Query region name, i.e. the chromosome name. Default 13.
 
 =item B<--seq_region_start start>
 
+Default 32906420
+
 =item B<--seq_region_end end>
+
+Default 32906519
 
 =item B<[--seq_region_strand strand]>
 
-The strand of the query. It can be either +1 or -1. Default is -1.
+The strand of the query. It can be either +1 or -1. Default is +1.
 
 =back
 
@@ -121,7 +116,7 @@ The strand of the query. It can be either +1 or -1. Default is -1.
 
 =item B<[--alignment_type method_link_name]>
 
-The type of alignment. Default is "BLASTZ_NET"
+The type of alignment. Default is "EPO".
 
 =item B<[--set_of_species species1:species2:species3:...]>
 
@@ -130,12 +125,18 @@ and build fake multiple one. Default is "mouse:rat". The names
 should correspond to the name of the core database in the
 registry_configuration_file or any of its aliases
 
+=item B<[--species_set_name name]>
+
+Pre-defined name for the set of species used. For multiple alignment sets only.
+eg "mammals" or "primates" for EPO alignments; "amniotes" for PECAN alignments.
+Default is "mammals".
+
 =item B<[--[no]condensed]>
 
 By default, the AlignSlice is created in "expanded" mode. Use
 this option for getting the AlignSlice in "condensed" mode
 
-=item B<[--[no]solve_overlpping]>
+=item B<[--[no]solve_overlapping]>
 
 By default, the AlignSlice ignores overlapping alignments. 
 This option will reconciliate them by means of a fake
@@ -202,9 +203,11 @@ perl DumpAlignSlice.pl
     [--coord_system coordinates_name]
         Query coordinate system. Default is "chromosome"
     --seq_region region_name
-        Query region name, i.e. the chromosome name
+        Query region name, i.e. the chromosome name. Default 13.
     --seq_region_start start
+        Default 32906420
     --seq_region_end end
+        Default 32906519
     [--seq_region_strand strand]
         Can be 1 or -1. Default is "+1"
 
@@ -254,7 +257,7 @@ use Bio::AlignIO;
 use Bio::LocatableSeq;
 use Getopt::Long;
 use Pod::Usage;
-#chr7:73549956-73613012
+
 my $reg_conf;
 my $dbname = "compara";
 my $query_species = "human";

--- a/scripts/dumps/DumpAlignSlice.pl
+++ b/scripts/dumps/DumpAlignSlice.pl
@@ -76,7 +76,7 @@ the one set in ENSEMBL_REGISTRY will be used if defined, if not
 =item B<[--dbname compara_db_name]>
 
 the name of compara DB in the registry_configuration_file or any
-of its aliases. Uses "compara" by default.
+of its aliases. Default is "compara_curr".
 
 =back
 
@@ -195,7 +195,7 @@ perl DumpAlignSlice.pl
         ~/.ensembl_init will be used.
     [--dbname compara_db_name]
         the name of compara DB in the registry_configuration_file or any
-        of its aliases. Uses "compara" by default.
+        of its aliases. Default is "compara_curr".
 
   For the query slice:
     [--species query_species]
@@ -259,7 +259,7 @@ use Getopt::Long;
 use Pod::Usage;
 
 my $reg_conf;
-my $dbname = "compara";
+my $dbname = "compara_curr";
 my $query_species = "human";
 my $coord_system = "chromosome";
 my $seq_region = "13";


### PR DESCRIPTION
## Description

EPO alignments have been displayed incorrectly for ages (most likely since e86). For instance, there were cases when one or more species were displayed twice [[link](http://nov2020.archive.ensembl.org/Pongo_abelii/Location/Compara_Alignments/Image?align=1628&db=core&r=9%3A133995000-134052000)] or the ancestral sequences were displaying the wrong information [[link](https://www.ensembl.org/Pongo_abelii/Location/Compara_Alignments/Image?align=1944&db=core&r=9:133995000-134053000)] (see the left part of the ancestral sequence above gorilla). This PR fixes this issue.

**Related JIRA tickets:**
- ENSCOMPARASW-4081

## Overview of changes
- Fixed the bugs located in `AlignSliceAdaptor.pm`:
    - The ancestral sequences were merged without checking whether they were parent of the same species or not. Now that is resolved not merging them unless they are linked by `right_node_id == node_id`.
    - If two trees had differed in the species order, the method would duplicate these species. I have decided to preserve the order of the first tree when conflicts are found, and just merge the information of the species (and their ancestral sequences) properly.
- Updated PODs for both `scripts/dumps/DumpAlignSlice.pl` and `modules/Bio/EnsEMBL/Compara/DBSQL/AlignSliceAdaptor.pm`, and code clean-up in the latter.
- The `DEBUG info` code has been quite useful, so I have updated it in case it is required again in the future (made it easier to print more information if required).
- Changed default `dbname` in `DumpAlignSlice.pl` to `compara_curr` as it is what we will use most times.

## Testing
I have tested the script in both `release/104` and this branch for the issues found in primates EPO and murinae EPO. For the former:
```
perl $ENSEMBL_CVS_ROOT_DIR/ensembl-compara/scripts/dumps/DumpAlignSlice.pl --species pongo_abelii --seq_region 9 --seq_region_start 133995000 --seq_region_end 134053000 --alignment_type EPO --species_set_name primates --reg_conf $COMPARA_REG_PATH
```
If you compare both output files, you will notice the `ancestral_sequence` for `gorilla_gorilla` was including an alignment when there is none for the actual species, and now that section is located in the `ancestral_sequence` for `homo_sapiens` (its correct place).
And the latter:
```
perl $ENSEMBL_CVS_ROOT_DIR/ensembl-compara/scripts/dumps/DumpAlignSlice.pl --species mus_musculus --seq_region 4 --seq_region_start 136370000 --seq_region_end 136450000 --alignment_type EPO --species_set_name murinae --reg_conf $COMPARA_REG_PATH
```
In this case the species only appear once, instead of multiple times, and their information is combined as expected.

## Notes
Although I'm well known to be quite picky with the indentation, I have tried to leave as much of the previous code as untouched as possible so it is easier to track the actual important changes.