### PR TITLE
Split Datacheck pipeline into integratable parts

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DataCheckFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DataCheckFactory.pm
@@ -1,0 +1,87 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Parts::DataCheckFactory
+
+=head1 DESCRIPTION
+
+    This is a part of the DataCheck pipeline containing the datacheck analyses
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Parts::DataCheckFactory;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf; # For WHEN and INPUT_PLUS
+use Bio::EnsEMBL::Compara::PipeConfig::Parts::DataCheckFan;
+
+sub pipeline_analyses_datacheck_factory {
+    my ($self) = @_;
+
+    return [
+
+        {
+            -logic_name        => 'datacheck_factory',
+            -module            => 'Bio::EnsEMBL::Compara::RunnableDB::DataCheckFactory',
+            -analysis_capacity => 10,
+            -max_retry_count   => 0,
+            -flow_into         => {
+                '2->A' => [ 'datacheck_fan' ],
+                'A->1' => [ 'datacheck_funnel' ],
+            },
+        },
+
+        {
+            -logic_name        => 'datacheck_funnel',
+            -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::DataCheckFunnel',
+            -analysis_capacity => 1,
+            -batch_size        => 100,
+            -max_retry_count   => 0,
+            -rc_name           => '2Gb_job',
+            -flow_into         => [ 'store_results' ],
+        },
+
+        {
+            -logic_name        => 'store_results',
+            -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::StoreResults',
+            -analysis_capacity => 10,
+            -max_retry_count   => 1,
+            -flow_into         => {
+                '3' => [ '?table_name=datacheck_results' ],
+                '4' => [ 'email_report' ],
+            },
+        },
+
+        {
+            -logic_name        => 'email_report',
+            -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::EmailReport',
+            -analysis_capacity => 10,
+            -batch_size        => 100,
+            -max_retry_count   => 0,
+        },
+
+        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::DataCheckFan::pipeline_analyses_datacheck_fan($self) },
+
+    ];
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DataCheckFan.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DataCheckFan.pm
@@ -1,0 +1,79 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Parts::DataCheckFan
+
+=head1 DESCRIPTION
+
+    This PipeConfig part runs datachecks in parallel
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Parts::DataCheckFan;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf; # For WHEN and INPUT_PLUS
+
+sub pipeline_analyses_datacheck_fan {
+    my ($self) = @_;
+
+    return [
+        {
+            -logic_name        => 'datacheck_fan',
+            -module            => 'Bio::EnsEMBL::Compara::RunnableDB::DataCheckFan',
+            -analysis_capacity => 100,
+            -max_retry_count   => 0,
+            -rc_name           => '500Mb_job',
+            -flow_into         => {
+                '1'  => [ '?accu_name=results&accu_address=[]' ],
+                '-1' => [ 'datacheck_fan_high_mem' ],
+                '2'  => [ 'jira_ticket_creation' ],
+            },
+        },
+
+        {
+            -logic_name        => 'datacheck_fan_high_mem',
+            -module            => 'Bio::EnsEMBL::Compara::RunnableDB::DataCheckFan',
+            -analysis_capacity => 100,
+            -max_retry_count   => 0,
+            -rc_name           => '8Gb_job',
+            -flow_into         => {
+                '1' => [ '?accu_name=results&accu_address=[]' ],
+                '2' => [ 'jira_ticket_creation' ],
+            },
+        },
+
+        {
+            -logic_name        => 'jira_ticket_creation',
+            -module            => 'Bio::EnsEMBL::Compara::RunnableDB::CreateDCJiraTickets',
+            -parameters        => {
+                release                      => '#ensembl_release#',
+                update                       => 1,
+                create_datacheck_tickets_exe => $self->o('create_datacheck_tickets_exe'),
+            },
+            -analysis_capacity => 1,
+            -max_retry_count   => 0,
+        },
+    ];
+}
+
+1;


### PR DESCRIPTION
## Description

The datacheck pipeline `DatachecksForRelease_conf` works well for the release databases, but is rigidly set in this way. We want to split the pipeline into parts so that the parallel running datachecks can be easily integrated at the end of other pipelines and run based on a specified `group` parameter.

**Related JIRA tickets:**
- ENSCOMPARASW-4345

## Overview of changes
From one file to three.

#### Change 1
- The non-parallel `run_datacheck` analyses have been removed altogether. We will never want to run the DCs linearly one after the other in release and we have a single runnable to incorporate into a pipeline if we do want to run a single specific datacheck.

#### Change 2
- The integratable parts have been split into 2 for flexible use cases. The first is the bigger `ParallelDataCheckFactory` which incorporates the whole package down to storing the results in the pipeline and emailing the results to the user, a better use for tagging on the end of pipelines.
- The second part is the smaller part that simply contains the 3 analyses: `datacheck_fan`, `datacheck_fan_high_mem` and `create_jira_tickets` - this smaller package may be better used midway through pipelines rather than at the end or when a hard-coded list of [`datacheck_names`] may be needed instead.

## Testing
The pipeline has been initialised and run and shown to work. An [example pipeline here.](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-compara-prod-10&port=4648&dbname=cristig_homology_annot_dc_test&passwd=xxxxx)

## Notes
The `jira_ticket_creation` can be easily "switched off" by passing it `test_mode=1` parameter - this may be a better use during pipeline integrated DCs with no failure tolerance.
I made some white-space changes - but given I was the original author, and I don't think they affect PR readability too much - I think these should be allowed.
I have based this against the `feature/homology_annotation` branch with the intention of cherry picking the single commit over to master - there will be no file conflicts.