### PR TITLE
Bugfixes and updates on the Reference pipeline

### DIFF
--- a/conf/references/allowed_species.json
+++ b/conf/references/allowed_species.json
@@ -57,7 +57,7 @@
     "paramecium_tetraurelia",
     "petromyzon_marinus",
     "phascolarctos_cinereus",
-    "physcomitrella_patens",
+    "physcomitrium_patens",
     "phytophthora_infestans",
     "plasmodium_falciparum",
     "prolemur_simus",

--- a/conf/references/mlss_conf.xml
+++ b/conf/references/mlss_conf.xml
@@ -38,7 +38,7 @@
       <genome name="nematostella_vectensis"/>
       <genome name="adineta_vaga"/>
       <!-- Plants -->
-      <genome name="physcomitrella_patens"/>
+      <genome name="physcomitrium_patens"/>
       <genome name="oryza_sativa"/>
       <genome name="vitis_vinifera"/>
       <genome name="ostreococcus_lucimarinus"/>

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/GenomeDBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/GenomeDBAdaptor.pm
@@ -412,7 +412,11 @@ sub fetch_by_core_DBAdaptor {
     my $was_connected = $core_dba->dbc->connected;
     my $species_name = $core_dba->get_MetaContainer->get_production_name();
     my $species_assembly = $core_dba->assembly_name();
+    # genebuild.last_geneset_update is optional, but is how vertebrates typically track geneset changes. If
+    # that does not exist, fall back to genebuild.start_date, which is how EG tend to track changes, and is
+    # mandatory.
     my $species_genebuild = $core_dba->get_MetaContainer->single_value_by_key('genebuild.last_geneset_update');
+    $species_genebuild = $core_dba->get_MetaContainer->single_value_by_key('genebuild.start_date') unless $species_genebuild;
     $core_dba->dbc->disconnect_if_idle() unless $was_connected;
     return undef unless $species_name;
     return $self->fetch_by_name_assembly_genebuild($species_name, $species_assembly, $species_genebuild, $component);

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/SeqMemberAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/SeqMemberAdaptor.pm
@@ -15,17 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::DBSQL::SeqMemberAdaptor
@@ -34,20 +23,6 @@ Bio::EnsEMBL::Compara::DBSQL::SeqMemberAdaptor
 
 Adaptor to retrieve SeqMember objects.
 Most of the methods are shared with the GeneMemberAdaptor.
-
-=head1 INHERITANCE TREE
-
-  Bio::EnsEMBL::Compara::DBSQL::SeqMemberAdaptor
-  +- Bio::EnsEMBL::Compara::DBSQL::MemberAdaptor
-
-=head1 AUTHORSHIP
-
-Ensembl Team. Individual contributions can be found in the GIT log.
-
-=head1 APPENDIX
-
-The rest of the documentation details each of the object methods.
-Internal methods are usually preceded with an underscore (_)
 
 =cut
 
@@ -413,13 +388,12 @@ sub store {
     $sth->finish;
   } else {
     $sth->finish;
-    #UNIQUE(stable_id) prevented insert since seq_member was already inserted
-    #so get seq_member_id with select
-    my $sth2 = $self->prepare("SELECT seq_member_id, sequence_id, genome_db_id FROM seq_member WHERE stable_id=?");
-    $sth2->execute($member->stable_id);
-    my($id, $sequence_id, $genome_db_id) = $sth2->fetchrow_array();
-    warn("SeqMemberAdaptor: insert failed, but seq_member_id select failed too") unless($id);
-    # throw(sprintf('%s already exists and belongs to a different species (%s) ! Stable IDs must be unique across the whole set of species', $member->stable_id, $self->db->get_GenomeDBAdaptor->fetch_by_dbID($genome_db_id)->name )) if $genome_db_id and $member->genome_db_id and $genome_db_id != $member->genome_db_id;
+    # UNIQUE(genome_db_id, stable_id) has prevented the insertion because this seq_member is already
+    # present. Fetch the seq_member_id via SELECT.
+    my $sth2 = $self->prepare("SELECT seq_member_id, sequence_id FROM seq_member WHERE genome_db_id=? AND stable_id=?");
+    $sth2->execute($member->genome_db_id, $member->stable_id);
+    my($id, $sequence_id) = $sth2->fetchrow_array();
+    throw("SeqMemberAdaptor: insert failed, but seq_member_id select failed too") unless($id);
     $member->dbID($id);
     $member->sequence_id($sequence_id) if ($sequence_id) and $member->isa('Bio::EnsEMBL::Compara::SeqMember');
     $sth2->finish;

--- a/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
@@ -182,7 +182,12 @@ sub db_adaptor {
             $self->name( $meta_container->get_production_name );
             $self->assembly( $dba->assembly_name );
             $self->taxon_id( $meta_container->get_taxonomy_id );
-            $self->genebuild( $meta_container->single_value_by_key('genebuild.last_geneset_update') );
+            # genebuild.last_geneset_update is optional, but is how vertebrates typically track geneset
+            # changes. If that does not exist, fall back to genebuild.start_date, which is how EG tend t
+            # track changes, and is mandatory.
+            my $genebuild = $meta_container->single_value_by_key('genebuild.last_geneset_update');
+            $genebuild = $meta_container->single_value_by_key('genebuild.start_date') unless $genebuild;
+            $self->genebuild( $genebuild );
             $self->has_karyotype( $genome_container->has_karyotype );
             $self->is_good_for_alignment( 0 );  # Cannot be inferred without the dnafrags
             $self->strain_name( $strain_name );

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -184,9 +184,10 @@ sub core_pipeline_analyses {
                 'meta_host'             => $self->o('meta_host'),
                 'allowed_species_file'  => $self->o('config_dir') . '/allowed_species.json',
                 'perc_threshold'        => $self->o('perc_threshold'),
-                'division'              => 'vertebrates',
+                'division'              => '',  # our references cover every division
                 'master_db'             => '#ref_db#',
             },
+            -rc_name    => '1Gb_job',
             -flow_into  => {
                 '2->A' => [ 'update_reference_genome' ],
                 '3->A' => [ 'retire_reference' ],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -184,7 +184,7 @@ sub core_pipeline_analyses {
                 'meta_host'             => $self->o('meta_host'),
                 'allowed_species_file'  => $self->o('config_dir') . '/allowed_species.json',
                 'perc_threshold'        => $self->o('perc_threshold'),
-                'division'              => '',  # our references cover every division
+                'division'              => undef,  # our references cover every division
                 'master_db'             => '#ref_db#',
             },
             -rc_name    => '1Gb_job',

--- a/modules/Bio/EnsEMBL/Compara/Utils/ReferenceDatabase.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/ReferenceDatabase.pm
@@ -128,7 +128,7 @@ sub _update_reference_genome_db {
                 $match = Bio::EnsEMBL::Compara::Utils::MasterDatabase::dnafrags_match_core_slices($stored_genome_db, $species_dba);
             }
             my $msg = "\n\n** Reference GenomeDB with this name [$species_production_name], assembly" .
-                " [$this_assembly] and genebuild.last_geneset_update [$this_genebuild] is already in the compara DB **\n";
+                " [$this_assembly] and genebuild.last_geneset_update/start_date [$this_genebuild] is already in the compara DB **\n";
             if ($match) {
                 $msg .= "** And it has the right set of DnaFrags **\n";
                 $msg .= "** You can use the --force option to update the other GenomeDB fields IF YOU REALLY NEED TO!! **\n\n";

--- a/sql/patch_104_105_d.sql
+++ b/sql/patch_104_105_d.sql
@@ -1,0 +1,33 @@
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_104_105_d.sql
+#
+# Title: Allow duplicates in stable_id.
+#
+# Description:
+#   stable_id can have duplicates, but make sure this does not happen in the same genome
+
+ALTER TABLE gene_member DROP UNIQUE (stable_id);
+ALTER TABLE gene_member ADD CONSTRAINT genome_stable_id UNIQUE (genome_db_id, stable_id);
+ALTER TABLE gene_member ADD KEY (stable_id);
+
+ALTER TABLE seq_member DROP UNIQUE (stable_id);
+ALTER TABLE seq_member ADD CONSTRAINT genome_stable_id UNIQUE (genome_db_id, stable_id);
+ALTER TABLE seq_member ADD KEY (stable_id);
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_104_105_d.sql|add_genome_stable_id_key');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1036,7 +1036,8 @@ CREATE TABLE gene_member (
 --  FOREIGN KEY (dnafrag_id) REFERENCES dnafrag(dnafrag_id),
 
   PRIMARY KEY (gene_member_id),
-  UNIQUE KEY (stable_id),
+  CONSTRAINT genome_stable_id UNIQUE (genome_db_id, stable_id),
+  KEY (stable_id),
   KEY (source_name),
   KEY (canonical_member_id),
   KEY dnafrag_id_start (dnafrag_id,dnafrag_start),
@@ -1140,7 +1141,8 @@ CREATE TABLE seq_member (
 --  FOREIGN KEY (dnafrag_id) REFERENCES dnafrag(dnafrag_id),
 
   PRIMARY KEY (seq_member_id),
-  UNIQUE KEY (stable_id),
+  CONSTRAINT genome_stable_id UNIQUE (genome_db_id, stable_id),
+  KEY (stable_id),
   KEY (source_name),
   KEY (sequence_id),
   KEY (gene_member_id),
@@ -2288,4 +2290,5 @@ INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_104_105_b.sql|homology_enum');
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_104_105_c.sql|drop_dnafrag_fk');
-
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_104_105_d.sql|add_genome_stable_id_key');


### PR DESCRIPTION
## Description

Several small fixes to make `UpdateReferenceDatabase` pipeline ready to load all references from every division (but `bacteria`).

**Related JIRA tickets:**
- ENSCOMPARASW-4360 (partial)
- ENSCOMPARASW-4260

## Overview of changes
#### Change 1
- Revert commit 7b6bf9d: the species was renamed in e104 and I mistakenly thought it was a typo.

#### Change 2
- `genebuild.last_geneset_update` is an optional `meta` tag that it is usually only present in vertebrates. Follow the same procedure as Production: if the tag is not present, use `genebuild.start_date` instead (mandatory tag).

#### Change 3
- Make `UpdateGenomesFromMetadataFactory.pm` runnable able to handle metadata information from all divisions. For this, `division` needs to be an empty string because it will use the pipeline-wide parameters instead if not provided.

#### Change 4
- `stable_id` still needs to be unique, but limit this uniqueness per `genome_db_id` to support multiple `stable_ids` in other assemblies of the same species.

## Testing
I've created a small references database with 6 vertebrates from e102 and then updated them from e104, and everything has worked without issues: [mysql://ensro@mysql-ens-compara-prod-2:4522/jalvarez_update_prev_references](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-2&port=4522&dbname=jalvarez_update_prev_references)
A first attempt to load all the references can be found here: [mysql://ensro@mysql-ens-compara-prod-2:4522/jalvarez_update_references_104](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-2&port=4522&dbname=jalvarez_update_references_104), but there are still some things that need to be addressed/fixed to make it fully work.

## Notes
- Couldn't think of a better approach for `stable_id`: the ideal would be to prevent duplicates in `stable_id` *for two different species* (as it was before) but allow it if the species are the same (but different assembly), but that is not possible with the current schema.
- Taken the opportunity to update some PODs