### PR TITLE
Feature/homology annotation Datachecks

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DataCheckFan.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DataCheckFan.pm
@@ -36,11 +36,17 @@ use base ('Bio::EnsEMBL::DataCheck::Pipeline::DataCheckFan', 'Bio::EnsEMBL::Comp
 
 sub fetch_input {
     my $self = shift;
+
     $self->param('dba', $self->compara_dba);
-
-    my $prev_dba = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba( 'compara_prev' );
-    $self->param('old_server_uri', $prev_dba->url);
-
+    # The pipeline may not be in the registry_file so server_uri needs to be explicitly passed
+    unless ( $self->param('registry_file') ) {
+        $self->param('server_uri', $self->param('compara_db'));
+    }
+    # For some pipelines the previous db is irrelevant so default to same db
+    unless ( $self->param('old_server_uri') ) {
+        my $prev_dba = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba( 'compara_prev' );
+        $self->param('old_server_uri', $prev_dba->url);
+    }
     $self->SUPER::fetch_input;
 }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DataCheckFan.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DataCheckFan.pm
@@ -23,7 +23,8 @@ Bio::EnsEMBL::Compara::RunnableDB::DataCheckFan
 
 =head1 DESCRIPTION
 
-A compara runnable wrapper of Production's DataCheckFan
+A compara runnable wrapper of Production's DataCheckFan.
+For some pipelines the previous db is irrelevant so default to same db.
 
 =cut
 
@@ -42,7 +43,6 @@ sub fetch_input {
     unless ( $self->param('registry_file') ) {
         $self->param('server_uri', $self->param('compara_db'));
     }
-    # For some pipelines the previous db is irrelevant so default to same db
     unless ( $self->param('old_server_uri') ) {
         my $prev_dba = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba( 'compara_prev' );
         $self->param('old_server_uri', $prev_dba->url);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/ParsePAFforBHs.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/ParsePAFforBHs.pm
@@ -74,7 +74,7 @@ sub write_output {
                 $self->compara_dba->dbc->do("SET FOREIGN_KEY_CHECKS = 0");
                 $self->_write_homologies($mlss, $rbh_entry, 'homolog_rbbh', $no_refmem);
                 $self->compara_dba->dbc->do("SET FOREIGN_KEY_CHECKS = 1");
-            }, 0, 0 );
+            } );
         }
         # if no rbbh a bbh will have to do
         if ( ! scalar @$rbh ) {
@@ -86,7 +86,7 @@ sub write_output {
                     $self->compara_dba->dbc->do("SET FOREIGN_KEY_CHECKS = 0");
                     $self->_write_homologies($mlss, $bbh_entry, 'homolog_bbh', $no_refmem);
                     $self->compara_dba->dbc->do("SET FOREIGN_KEY_CHECKS = 1");
-                }, 0, 0 );
+                } );
             }
 
             if ( ! scalar @$bbh ) {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/ParsePAFforBHs.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/ParsePAFforBHs.pm
@@ -60,6 +60,7 @@ sub write_output {
     my $query_mem_adap = $self->compara_dba->get_SeqMemberAdaptor;
 
     # MLSS will not exist for hit_gdb: it is a reference and belongs to a different db
+    my $ss   = $self->_create_species_set($self->compara_dba->get_GenomeDBAdaptor->fetch_by_dbID($query_gdb_id), $ref_db->get_GenomeDBAdaptor->fetch_by_dbID($hit_gdb_id));
     my $mlss = $self->_create_superficial_mlss($self->compara_dba->get_GenomeDBAdaptor->fetch_by_dbID($query_gdb_id), $ref_db->get_GenomeDBAdaptor->fetch_by_dbID($hit_gdb_id));
 
     foreach my $member ( @$seq_member_ids ) {
@@ -73,7 +74,7 @@ sub write_output {
                 $self->compara_dba->dbc->do("SET FOREIGN_KEY_CHECKS = 0");
                 $self->_write_homologies($mlss, $rbh_entry, 'homolog_rbbh', $no_refmem);
                 $self->compara_dba->dbc->do("SET FOREIGN_KEY_CHECKS = 1");
-            }, 1, 1 );
+            }, 0, 0 );
         }
         # if no rbbh a bbh will have to do
         if ( ! scalar @$rbh ) {
@@ -85,7 +86,7 @@ sub write_output {
                     $self->compara_dba->dbc->do("SET FOREIGN_KEY_CHECKS = 0");
                     $self->_write_homologies($mlss, $bbh_entry, 'homolog_bbh', $no_refmem);
                     $self->compara_dba->dbc->do("SET FOREIGN_KEY_CHECKS = 1");
-                }, 1, 1 );
+                }, 0, 0 );
             }
 
             if ( ! scalar @$bbh ) {
@@ -101,7 +102,8 @@ sub _write_homologies {
     # Conversion of PAFs to Homology objects
     my $homology_adap = $self->compara_dba->get_HomologyAdaptor;
     my $homology      = $paf->create_homology($type, $mlss);
-
+    $homology->dbID($paf->query_member_id . $paf->hit_member_id);
+print Dumper $homology->dbID;
     $homology_adap->store($homology, $no_refmem);
 
 }
@@ -125,12 +127,7 @@ sub _create_superficial_mlss {
         );
         $method_adap->store($method);
     }
-    unless ($species_set) {
-        $species_set = Bio::EnsEMBL::Compara::SpeciesSet->new(
-            -genome_dbs => [$gdb1, $gdb2]
-        );
-        $species_adap->store($species_set);
-    }
+
     my $method_link_species_set = Bio::EnsEMBL::Compara::MethodLinkSpeciesSet->new(
         -adaptor             => $mlss_adap,
         -method              => $method,
@@ -138,6 +135,20 @@ sub _create_superficial_mlss {
     );
     $mlss_adap->store($method_link_species_set);
     return $method_link_species_set;
+}
+
+sub _create_species_set {
+    my ($self, $gdb1, $gdb2) = @_;
+
+    my $species_adap = $self->compara_dba->get_SpeciesSetAdaptor;
+    my $species_set  = $species_adap->fetch_by_GenomeDBs([$gdb1, $gdb2]);
+    unless ($species_set) {
+        $species_set = Bio::EnsEMBL::Compara::SpeciesSet->new(
+            -genome_dbs => [$gdb1, $gdb2],
+            -name       => $gdb1->name . "-" . $gdb2->name,
+        );
+        $species_adap->store($species_set);
+    }
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/ParsePAFforBHs.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/ParsePAFforBHs.pm
@@ -102,8 +102,8 @@ sub _write_homologies {
     # Conversion of PAFs to Homology objects
     my $homology_adap = $self->compara_dba->get_HomologyAdaptor;
     my $homology      = $paf->create_homology($type, $mlss);
+
     $homology->dbID($paf->query_member_id . $paf->hit_member_id);
-print Dumper $homology->dbID;
     $homology_adap->store($homology, $no_refmem);
 
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/SplitMembers.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/SplitMembers.pm
@@ -39,7 +39,7 @@ sub param_defaults {
     my ($self) = @_;
     return {
         %{$self->SUPER::param_defaults},
-        'step'   => 200,
+        'step'   => 1000,
     }
 }
 


### PR DESCRIPTION
## Description

In the Rapid Release the datachecks are not going to be run manually on each per species compara database so the datachecks need to be within the pipeline.

**Related JIRA tickets:**
- ENSCOMPARASW-4344

## Overview of changes
There are unrelated changes in this PR that were picked up and fixed/altered during the DC testing process. These are minor bugfix/improvements: 
[83bb665](https://github.com/Ensembl/ensembl-compara/commit/83bb66505751e0030542dda28e0072b8f054614f)
[518a7cd](https://github.com/Ensembl/ensembl-compara/commit/518a7cdbd4a220e851a35b1e77ef022fdc344a05)
The rest of the changes are tweaks and additions to the pipeline config and datacheck runnables to make the pipeline work.

#### Change 1
- Parameter and tweaks in `HomologyAnnotation_conf`: new results table, DC specific parameters, `tweaks_analyses` sub to manipulate runnable dataflows and parameters from the DC `Parts/`. Turn off `jira_ticket_creation` and pass specific parameters to specific runnables only.

#### Change 2
- `DatacheckFan` was hard coded to expect only `compara_prev` registry alias as `old_server_uri` - fine for release db dcs - not much good for rapid release. To note, the DCs as production have them always expect an `old_server_uri` - so this defaults as `compara_db` even if `compara_db` is the current pipeline/db.

## Testing
Travis & [pipeline here](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-compara-prod-10&port=4648&dbname=cristig_homology_annot_dcs&passwd=xxxxx)

## Notes
The incorporation of DCs into the references pipeline is more than likely going to require the same sorts of tweaks.
