### PR TITLE
Offset members by genome_db_id

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -73,6 +73,7 @@ sub default_options {
         'store_others'                => 0,
         'store_exon_coordinates'      => 0,
         'store_related_pep_sequences' => 0, # do we want CDS sequences as well as protein sequences?
+        'offset_ids'                  => 1, # offset member ids by the genome_db_id?
 
         # member HC options
         'allow_ambiguity_codes'         => 1,
@@ -217,6 +218,7 @@ sub core_pipeline_analyses {
                 'store_ncrna'                 => $self->o('store_ncrna'),
                 'store_others'                => $self->o('store_others'),
                 'store_exon_coordinates'      => $self->o('store_exon_coordinates'),
+                'offset_ids'                  => $self->o('offset_ids'),
             },
             -hive_capacity => 10,
             -rc_name => '4Gb_job',

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers.pm
@@ -147,7 +147,7 @@ sub run {
 
     if ($self->param('offset_ids')) {
         my $genome_db_id = $self->param_required('genome_db_id');
-        my $start_id = $genome_db_id * 100000000;
+        my $start_id = $genome_db_id * 10000000;
         $compara_dba->dbc->sql_helper->transaction(-CALLBACK => sub {
             $compara_dba->dbc->do("UPDATE gene_member JOIN (SELECT \@rank := $start_id) r
                 SET gene_member_id = \@rank := (\@rank + 1) WHERE genome_db_id = $genome_db_id");

--- a/sql/patch_104_105_e.sql
+++ b/sql/patch_104_105_e.sql
@@ -1,0 +1,30 @@
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_104_105_e.sql
+#
+# Title: Add ON UPDATE CASCADE between member ids.
+#
+# Description:
+#   Add ON UPDATE CASCADE option between seq_member and gene_member main IDs
+
+ALTER TABLE gene_member ADD FOREIGN KEY (canonical_member_id) REFERENCES seq_member(seq_member_id) ON UPDATE CASCADE;
+
+ALTER TABLE seq_member DROP FOREIGN KEY seq_member_ibfk_4;
+ALTER TABLE seq_member ADD FOREIGN KEY (gene_member_id) REFERENCES gene_member(gene_member_id) ON UPDATE CASCADE;
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_104_105_e.sql|member_id_fk_cascade');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1016,16 +1016,16 @@ CREATE TABLE sequence (
 */
 
 CREATE TABLE gene_member (
-  gene_member_id              INT unsigned NOT NULL AUTO_INCREMENT, # unique internal id
+  gene_member_id              bigint unsigned NOT NULL AUTO_INCREMENT, # unique internal id
   stable_id                   varchar(128) NOT NULL, # e.g. ENSP000001234 or P31946
   version                     INT UNSIGNED DEFAULT 0,
   source_name                 ENUM('ENSEMBLGENE', 'EXTERNALGENE') NOT NULL,
   taxon_id                    INT unsigned NOT NULL, # FK taxon.taxon_id
   genome_db_id                INT unsigned, # FK genome_db.genome_db_id
   biotype_group               ENUM('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group','current_notdumped','notcurrent') NOT NULL DEFAULT 'coding',
-  canonical_member_id         INT unsigned, # FK seq_member.seq_member_id
+  canonical_member_id         bigint unsigned, # FK seq_member.seq_member_id
   description                 text DEFAULT NULL,
-  dnafrag_id                  bigint unsigned, # FK dnafrag.dnafrag_id
+  dnafrag_id                  bigint unsigned,
   dnafrag_start               INT UNSIGNED,
   dnafrag_end                 INT UNSIGNED,
   dnafrag_strand              TINYINT,
@@ -1071,7 +1071,7 @@ CREATE TABLE gene_member (
 */
 
 CREATE TABLE gene_member_hom_stats (
-  gene_member_id              INT unsigned NOT NULL, # FK gene_member.gene_member_id
+  gene_member_id              bigint unsigned NOT NULL, # FK gene_member.gene_member_id
   collection                  varchar(40) NOT NULL,
   `families`                 INT unsigned NOT NULL default 0,
   `gene_trees`               tinyint(1) unsigned NOT NULL default 0,
@@ -1117,14 +1117,14 @@ CREATE TABLE gene_member_hom_stats (
 */
 
 CREATE TABLE seq_member (
-  seq_member_id               INT unsigned NOT NULL AUTO_INCREMENT, # unique internal id
+  seq_member_id               bigint unsigned NOT NULL AUTO_INCREMENT, # unique internal id
   stable_id                   varchar(128) NOT NULL, # e.g. ENSP000001234 or P31946
   version                     INT UNSIGNED DEFAULT 0,
   source_name                 ENUM('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   taxon_id                    INT unsigned NOT NULL, # FK taxon.taxon_id
   genome_db_id                INT unsigned, # FK genome_db.genome_db_id
   sequence_id                 INT unsigned, # FK sequence.sequence_id
-  gene_member_id              INT unsigned, # FK gene_member.gene_member_id
+  gene_member_id              bigint unsigned, # FK gene_member.gene_member_id
   has_transcript_edits        tinyint(1) DEFAULT 0 NOT NULL,
   has_translation_edits       tinyint(1) DEFAULT 0 NOT NULL,
   description                 text DEFAULT NULL,
@@ -1137,7 +1137,7 @@ CREATE TABLE seq_member (
   FOREIGN KEY (taxon_id) REFERENCES ncbi_taxa_node(taxon_id),
   FOREIGN KEY (genome_db_id) REFERENCES genome_db(genome_db_id),
   FOREIGN KEY (sequence_id) REFERENCES sequence(sequence_id),
-  FOREIGN KEY (gene_member_id) REFERENCES gene_member(gene_member_id),
+  FOREIGN KEY (gene_member_id) REFERENCES gene_member(gene_member_id) ON UPDATE CASCADE,
 --  FOREIGN KEY (dnafrag_id) REFERENCES dnafrag(dnafrag_id),
 
   PRIMARY KEY (seq_member_id),
@@ -1150,6 +1150,13 @@ CREATE TABLE seq_member (
   KEY dnafrag_id_end (dnafrag_id,dnafrag_end),
   KEY seq_member_gene_member_id_end (seq_member_id,gene_member_id)
 ) MAX_ROWS = 100000000 COLLATE=latin1_swedish_ci ENGINE=MyISAM;
+
+
+/**
+Add foreign key constrain between seq_member and gene_member tables now that the former as been created
+*/
+
+ALTER TABLE gene_member ADD FOREIGN KEY (canonical_member_id) REFERENCES seq_member(seq_member_id) ON UPDATE CASCADE;
 
 
 /**
@@ -1170,8 +1177,8 @@ CREATE TABLE seq_member (
 */
 
 CREATE TABLE exon_boundaries (
-	gene_member_id   INT UNSIGNED NOT NULL,
-	seq_member_id    INT UNSIGNED NOT NULL,
+	gene_member_id   bigint UNSIGNED NOT NULL,
+	seq_member_id    bigint UNSIGNED NOT NULL,
 	dnafrag_start    INT UNSIGNED NOT NULL,
 	dnafrag_end      INT UNSIGNED NOT NULL,
 	sequence_length  INT UNSIGNED NOT NULL,
@@ -1202,7 +1209,7 @@ CREATE TABLE exon_boundaries (
 */
 
 CREATE TABLE seq_member_projection_stable_id (
-  target_seq_member_id      INT unsigned NOT NULL,
+  target_seq_member_id      bigint unsigned NOT NULL,
   source_stable_id          VARCHAR(128) NOT NULL,
 
   FOREIGN KEY (target_seq_member_id) REFERENCES seq_member(seq_member_id),
@@ -1231,8 +1238,8 @@ sql       SELECT ss.stable_id, gs.name, st.stable_id, gt.name, identity FROM seq
 */
 
 CREATE TABLE seq_member_projection (
-  source_seq_member_id      INT unsigned NOT NULL,
-  target_seq_member_id      INT unsigned NOT NULL,
+  source_seq_member_id      bigint unsigned NOT NULL,
+  target_seq_member_id      bigint unsigned NOT NULL,
   identity                  float(5,2) DEFAULT NULL,
 
   FOREIGN KEY (source_seq_member_id) REFERENCES seq_member(seq_member_id),
@@ -1301,7 +1308,7 @@ CREATE TABLE `external_db` (
 */
 
 CREATE TABLE `member_xref` (
-  `gene_member_id` INT unsigned NOT NULL,
+  `gene_member_id` bigint unsigned NOT NULL,
   `dbprimary_acc` varchar(10) NOT NULL,
   `external_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`gene_member_id`,`dbprimary_acc`,`external_db_id`),
@@ -1326,7 +1333,7 @@ CREATE TABLE `member_xref` (
 */
 
 CREATE TABLE other_member_sequence (
-  seq_member_id                   INT unsigned NOT NULL, # unique internal id
+  seq_member_id               bigint unsigned NOT NULL, # unique internal id
   seq_type                    VARCHAR(40) NOT NULL,
   length                      INT UNSIGNED NOT NULL,
   sequence                    mediumtext NOT NULL,
@@ -1375,8 +1382,8 @@ CREATE TABLE other_member_sequence (
 CREATE TABLE peptide_align_feature (
 
   peptide_align_feature_id    bigint  unsigned NOT NULL AUTO_INCREMENT, # unique internal id
-  qmember_id                  INT unsigned NOT NULL, # FK seq_member.seq_member_id
-  hmember_id                  INT unsigned NOT NULL, # FK seq_member.seq_member_id
+  qmember_id                  bigint unsigned NOT NULL, # FK seq_member.seq_member_id
+  hmember_id                  bigint unsigned NOT NULL, # FK seq_member.seq_member_id
   qgenome_db_id               INT unsigned, # FK genome.genome_id
   hgenome_db_id               INT unsigned, # FK genome.genome_id
   qstart                      INT UNSIGNED DEFAULT 0 NOT NULL,
@@ -1460,7 +1467,7 @@ CREATE TABLE family (
 
 CREATE TABLE family_member (
   family_id                   INT unsigned NOT NULL, # FK family.family_id
-  seq_member_id               INT unsigned NOT NULL, # FK seq_member.seq_member_id
+  seq_member_id               bigint unsigned NOT NULL, # FK seq_member.seq_member_id
   cigar_line                  mediumtext,
 
   FOREIGN KEY (family_id) REFERENCES family(family_id),
@@ -1512,7 +1519,7 @@ CREATE TABLE gene_align (
 */
 CREATE TABLE gene_align_member (
        gene_align_id         INT unsigned NOT NULL,
-       seq_member_id         INT unsigned NOT NULL,
+       seq_member_id         bigint unsigned NOT NULL,
        cigar_line            mediumtext,
 
   FOREIGN KEY (gene_align_id) REFERENCES gene_align(gene_align_id),
@@ -1552,7 +1559,7 @@ CREATE TABLE gene_tree_node (
   left_index                      INT UNSIGNED NOT NULL DEFAULT 0,
   right_index                     INT UNSIGNED NOT NULL DEFAULT 0,
   distance_to_parent              double default 1 NOT NULL,
-  seq_member_id                   INT unsigned,
+  seq_member_id                   bigint unsigned,
 
   FOREIGN KEY (root_id) REFERENCES gene_tree_node(node_id),
   FOREIGN KEY (parent_id) REFERENCES gene_tree_node(node_id),
@@ -1789,7 +1796,7 @@ CREATE TABLE gene_tree_node_attr (
 CREATE TABLE gene_member_qc (
   gene_member_stable_id       varchar(128) NOT NULL,
   genome_db_id                INT unsigned NOT NULL,
-  seq_member_id               INT unsigned,
+  seq_member_id               bigint unsigned,
   n_species                   INT,
   n_orth                      INT,
   avg_cov                     FLOAT,
@@ -1884,7 +1891,7 @@ CREATE TABLE hmm_profile (
 --   KEY (hmm_id)
 
 CREATE TABLE hmm_annot (
-  seq_member_id              INT unsigned NOT NULL,
+  seq_member_id              bigint unsigned NOT NULL,
   model_id                   varchar(40) DEFAULT NULL,
   evalue                     float,
 
@@ -2134,8 +2141,8 @@ The alignment will be:<br />
 
 CREATE TABLE homology_member (
   homology_id                 bigint unsigned NOT NULL, # FK homology.homology_id
-  gene_member_id              INT unsigned NOT NULL, # FK gene_member.gene_member_id
-  seq_member_id               INT unsigned, # FK seq_member.seq_member_id
+  gene_member_id              bigint unsigned NOT NULL, # FK gene_member.gene_member_id
+  seq_member_id               bigint unsigned, # FK seq_member.seq_member_id
   cigar_line                  mediumtext,
   perc_cov                    float unsigned default 0,
   perc_id                     float unsigned default 0,
@@ -2292,3 +2299,5 @@ INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_104_105_c.sql|drop_dnafrag_fk');
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_104_105_d.sql|add_genome_stable_id_key');
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_104_105_e.sql|member_id_fk_cascade');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1016,14 +1016,14 @@ CREATE TABLE sequence (
 */
 
 CREATE TABLE gene_member (
-  gene_member_id              bigint unsigned NOT NULL AUTO_INCREMENT, # unique internal id
+  gene_member_id              INT unsigned NOT NULL AUTO_INCREMENT, # unique internal id
   stable_id                   varchar(128) NOT NULL, # e.g. ENSP000001234 or P31946
   version                     INT UNSIGNED DEFAULT 0,
   source_name                 ENUM('ENSEMBLGENE', 'EXTERNALGENE') NOT NULL,
   taxon_id                    INT unsigned NOT NULL, # FK taxon.taxon_id
   genome_db_id                INT unsigned, # FK genome_db.genome_db_id
   biotype_group               ENUM('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group','current_notdumped','notcurrent') NOT NULL DEFAULT 'coding',
-  canonical_member_id         bigint unsigned, # FK seq_member.seq_member_id
+  canonical_member_id         INT unsigned, # FK seq_member.seq_member_id
   description                 text DEFAULT NULL,
   dnafrag_id                  bigint unsigned,
   dnafrag_start               INT UNSIGNED,
@@ -1071,7 +1071,7 @@ CREATE TABLE gene_member (
 */
 
 CREATE TABLE gene_member_hom_stats (
-  gene_member_id              bigint unsigned NOT NULL, # FK gene_member.gene_member_id
+  gene_member_id              INT unsigned NOT NULL, # FK gene_member.gene_member_id
   collection                  varchar(40) NOT NULL,
   `families`                 INT unsigned NOT NULL default 0,
   `gene_trees`               tinyint(1) unsigned NOT NULL default 0,
@@ -1117,14 +1117,14 @@ CREATE TABLE gene_member_hom_stats (
 */
 
 CREATE TABLE seq_member (
-  seq_member_id               bigint unsigned NOT NULL AUTO_INCREMENT, # unique internal id
+  seq_member_id               INT unsigned NOT NULL AUTO_INCREMENT, # unique internal id
   stable_id                   varchar(128) NOT NULL, # e.g. ENSP000001234 or P31946
   version                     INT UNSIGNED DEFAULT 0,
   source_name                 ENUM('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   taxon_id                    INT unsigned NOT NULL, # FK taxon.taxon_id
   genome_db_id                INT unsigned, # FK genome_db.genome_db_id
   sequence_id                 INT unsigned, # FK sequence.sequence_id
-  gene_member_id              bigint unsigned, # FK gene_member.gene_member_id
+  gene_member_id              INT unsigned, # FK gene_member.gene_member_id
   has_transcript_edits        tinyint(1) DEFAULT 0 NOT NULL,
   has_translation_edits       tinyint(1) DEFAULT 0 NOT NULL,
   description                 text DEFAULT NULL,
@@ -1177,8 +1177,8 @@ ALTER TABLE gene_member ADD FOREIGN KEY (canonical_member_id) REFERENCES seq_mem
 */
 
 CREATE TABLE exon_boundaries (
-	gene_member_id   bigint UNSIGNED NOT NULL,
-	seq_member_id    bigint UNSIGNED NOT NULL,
+	gene_member_id   INT UNSIGNED NOT NULL,
+	seq_member_id    INT UNSIGNED NOT NULL,
 	dnafrag_start    INT UNSIGNED NOT NULL,
 	dnafrag_end      INT UNSIGNED NOT NULL,
 	sequence_length  INT UNSIGNED NOT NULL,
@@ -1209,7 +1209,7 @@ CREATE TABLE exon_boundaries (
 */
 
 CREATE TABLE seq_member_projection_stable_id (
-  target_seq_member_id      bigint unsigned NOT NULL,
+  target_seq_member_id      INT unsigned NOT NULL,
   source_stable_id          VARCHAR(128) NOT NULL,
 
   FOREIGN KEY (target_seq_member_id) REFERENCES seq_member(seq_member_id),
@@ -1238,8 +1238,8 @@ sql       SELECT ss.stable_id, gs.name, st.stable_id, gt.name, identity FROM seq
 */
 
 CREATE TABLE seq_member_projection (
-  source_seq_member_id      bigint unsigned NOT NULL,
-  target_seq_member_id      bigint unsigned NOT NULL,
+  source_seq_member_id      INT unsigned NOT NULL,
+  target_seq_member_id      INT unsigned NOT NULL,
   identity                  float(5,2) DEFAULT NULL,
 
   FOREIGN KEY (source_seq_member_id) REFERENCES seq_member(seq_member_id),
@@ -1308,7 +1308,7 @@ CREATE TABLE `external_db` (
 */
 
 CREATE TABLE `member_xref` (
-  `gene_member_id` bigint unsigned NOT NULL,
+  `gene_member_id` INT unsigned NOT NULL,
   `dbprimary_acc` varchar(10) NOT NULL,
   `external_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`gene_member_id`,`dbprimary_acc`,`external_db_id`),
@@ -1333,7 +1333,7 @@ CREATE TABLE `member_xref` (
 */
 
 CREATE TABLE other_member_sequence (
-  seq_member_id               bigint unsigned NOT NULL, # unique internal id
+  seq_member_id                   INT unsigned NOT NULL, # unique internal id
   seq_type                    VARCHAR(40) NOT NULL,
   length                      INT UNSIGNED NOT NULL,
   sequence                    mediumtext NOT NULL,
@@ -1382,8 +1382,8 @@ CREATE TABLE other_member_sequence (
 CREATE TABLE peptide_align_feature (
 
   peptide_align_feature_id    bigint  unsigned NOT NULL AUTO_INCREMENT, # unique internal id
-  qmember_id                  bigint unsigned NOT NULL, # FK seq_member.seq_member_id
-  hmember_id                  bigint unsigned NOT NULL, # FK seq_member.seq_member_id
+  qmember_id                  INT unsigned NOT NULL, # FK seq_member.seq_member_id
+  hmember_id                  INT unsigned NOT NULL, # FK seq_member.seq_member_id
   qgenome_db_id               INT unsigned, # FK genome.genome_id
   hgenome_db_id               INT unsigned, # FK genome.genome_id
   qstart                      INT UNSIGNED DEFAULT 0 NOT NULL,
@@ -1467,7 +1467,7 @@ CREATE TABLE family (
 
 CREATE TABLE family_member (
   family_id                   INT unsigned NOT NULL, # FK family.family_id
-  seq_member_id               bigint unsigned NOT NULL, # FK seq_member.seq_member_id
+  seq_member_id               INT unsigned NOT NULL, # FK seq_member.seq_member_id
   cigar_line                  mediumtext,
 
   FOREIGN KEY (family_id) REFERENCES family(family_id),
@@ -1519,7 +1519,7 @@ CREATE TABLE gene_align (
 */
 CREATE TABLE gene_align_member (
        gene_align_id         INT unsigned NOT NULL,
-       seq_member_id         bigint unsigned NOT NULL,
+       seq_member_id         INT unsigned NOT NULL,
        cigar_line            mediumtext,
 
   FOREIGN KEY (gene_align_id) REFERENCES gene_align(gene_align_id),
@@ -1559,7 +1559,7 @@ CREATE TABLE gene_tree_node (
   left_index                      INT UNSIGNED NOT NULL DEFAULT 0,
   right_index                     INT UNSIGNED NOT NULL DEFAULT 0,
   distance_to_parent              double default 1 NOT NULL,
-  seq_member_id                   bigint unsigned,
+  seq_member_id                   INT unsigned,
 
   FOREIGN KEY (root_id) REFERENCES gene_tree_node(node_id),
   FOREIGN KEY (parent_id) REFERENCES gene_tree_node(node_id),
@@ -1796,7 +1796,7 @@ CREATE TABLE gene_tree_node_attr (
 CREATE TABLE gene_member_qc (
   gene_member_stable_id       varchar(128) NOT NULL,
   genome_db_id                INT unsigned NOT NULL,
-  seq_member_id               bigint unsigned,
+  seq_member_id               INT unsigned,
   n_species                   INT,
   n_orth                      INT,
   avg_cov                     FLOAT,
@@ -1891,7 +1891,7 @@ CREATE TABLE hmm_profile (
 --   KEY (hmm_id)
 
 CREATE TABLE hmm_annot (
-  seq_member_id              bigint unsigned NOT NULL,
+  seq_member_id              INT unsigned NOT NULL,
   model_id                   varchar(40) DEFAULT NULL,
   evalue                     float,
 
@@ -2141,8 +2141,8 @@ The alignment will be:<br />
 
 CREATE TABLE homology_member (
   homology_id                 bigint unsigned NOT NULL, # FK homology.homology_id
-  gene_member_id              bigint unsigned NOT NULL, # FK gene_member.gene_member_id
-  seq_member_id               bigint unsigned, # FK seq_member.seq_member_id
+  gene_member_id              INT unsigned NOT NULL, # FK gene_member.gene_member_id
+  seq_member_id               INT unsigned, # FK seq_member.seq_member_id
   cigar_line                  mediumtext,
   perc_cov                    float unsigned default 0,
   perc_id                     float unsigned default 0,


### PR DESCRIPTION
## Description

Add a `genome_db_id`-based offset of members to avoid clashes between the reference and the homology annotation pipelines.

**Related JIRA tickets:**
- ENSCOMPARASW-4075

## Overview of changes
#### Change 1
- The `member_id` is done cleanly by two single queries thanks to the update in the schema to `ON UPDATE CASCADE`, and using a variable to do an offset autoincrement per `genome_db_id`.

#### Change 2
- Added `offset_id` flag to preserve previous behaviour as default.

#### Change 3
- Both `gene_member_id` and `seq_member_id` are now `BIGINT` to avoid having to change this in quite some time, allowing plenty of room for many genomes as well as members.

## Testing
I have done several tests but one that you can have a look at is [jalvarez_update_prev_references_104](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-2&port=4522&dbname=jalvarez_update_prev_references_104), in which I loaded a few e102 genomes first and then added some more references from e104 (updating the previous references when required). The reference database is in `cp3`: `jalvarez_reference_db_test_update`.

## Notes
- I have opted for a change in the schema only in the two affected tables for now. In the future, if required, we could extend this to any other tables we may want to update automatically as well.
- Bear in mind this change only works with `InnoDB` (which is the one we use internally as default).
- That specific test has been also used to make a decision regarding ENSCOMPARASW-4287.