### PR TITLE
Feature/homology annotation Incorporate datachecks into reference update pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -94,6 +94,7 @@ sub default_options {
         'output_dir_path'  => $self->o('pipeline_dir') . '/datachecks/',
         'overwrite_files'  => 1,
         'failures_fatal'   => 1, # no DC failure tolerance
+        'ref_dbname'       => 'ensembl_compara_references', # to be manually passed in init if differs
     };
 }
 
@@ -355,6 +356,6 @@ sub tweak_analyses {
     $analyses_by_name->{'datacheck_fan'}->{'-parameters'}->{'old_server_uri'} = '#ref_db#';
     $analyses_by_name->{'datacheck_fan'}->{'-flow_into'}->{0} = ['jira_ticket_creation'];
     $analyses_by_name->{'datacheck_fan_high_mem'}->{'-flow_into'}->{0} = ['jira_ticket_creation'];
-    $analyses_by_name->{'store_results'}->{'-parameters'}->{'dbname'} = 'ensembl_compara_references';
+    $analyses_by_name->{'store_results'}->{'-parameters'}->{'dbname'} = '#ref_dbname#';
 }
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -34,6 +34,7 @@ use Bio::EnsEMBL::Hive::Version 2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpFastaDatabases;
+use Bio::EnsEMBL::Compara::PipeConfig::Parts::DataCheckFactory;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
 
@@ -86,20 +87,41 @@ sub default_options {
         'create_all_mlss_exe' => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/create_all_mlss.pl'),
         'allowed_species_file'  => $self->check_file_in_ensembl('ensembl-compara/conf/' . $self->o('division') . '/allowed_species.json'),
         'xml_file'            => $self->check_file_in_ensembl('ensembl-compara/conf/' . $self->o('division') . '/mlss_conf.xml'),
+
+        # whole dc options
+        'datacheck_groups' => ['compara_references'],
+        'db_type'          => ['compara'],
+        'output_dir_path'  => $self->o('pipeline_dir') . '/datachecks/',
+        'overwrite_files'  => 1,
+        'failures_fatal'   => 1, # no DC failure tolerance
     };
 }
 
 
 sub pipeline_create_commands {
     my ($self) = @_;
+
+    my $results_table_sql = q/
+        CREATE TABLE datacheck_results (
+            submission_job_id INT,
+            dbname VARCHAR(255) NOT NULL,
+            passed INT,
+            failed INT,
+            skipped INT,
+            INDEX submission_job_id_idx (submission_job_id)
+        );
+    /;
+
     return [
         @{$self->SUPER::pipeline_create_commands},  # here we inherit creation of database, hive tables and compara tables
-        $self->pipeline_create_commands_rm_mkdir(['pipeline_dir', 'backups_dir']),
+        $self->pipeline_create_commands_rm_mkdir(['pipeline_dir', 'backups_dir', 'output_dir_path']),
 
         # In case it doesn't exist yet
         'mkdir -p ' . $self->o('ref_member_dumps_dir'),
         # The files are going to be accessed by many processes in parallel
         $self->pipeline_create_commands_lfs_setstripe('ref_member_dumps_dir'),
+        # To store the Datachecks results
+        $self->db_cmd($results_table_sql),
     ];
 }
 
@@ -115,6 +137,10 @@ sub pipeline_wide_parameters {
 
         'backups_dir'       => $self->o('backups_dir'),
         'members_dumps_dir' => $self->o('ref_member_dumps_dir'),
+
+        'output_dir_path'  => $self->o('output_dir_path'),
+        'overwrite_files'  => $self->o('overwrite_files'),
+        'failures_fatal'   => $self->o('failures_fatal'),
     };
 }
 
@@ -296,7 +322,10 @@ sub core_pipeline_analyses {
                 'src_db_conn' => '#ref_db#',
                 'output_file' => '#backups_dir#/compara_references.post#release#.sql'
             },
-            -flow_into  => [ 'copy_backups_to_warehouse' ],
+            -flow_into  => {
+                '1->A'  => { 'datacheck_factory' => { 'datacheck_groups' => $self->o('datacheck_groups'), 'db_type' => $self->o('db_type'), 'compara_db' => '#ref_db#', 'registry_file' => undef }},
+                'A->1'  => [ 'copy_backups_to_warehouse' ],
+            },
             -rc_name    => '1Gb_job',
         },
 
@@ -310,6 +339,7 @@ sub core_pipeline_analyses {
         },
 
         @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpFastaDatabases::pipeline_analyses_dump_fasta_dbs($self) },
+        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::DataCheckFactory::pipeline_analyses_datacheck_factory($self) },
     ];
 }
 
@@ -318,5 +348,13 @@ sub tweak_analyses {
     my $analyses_by_name = shift;
 
     $analyses_by_name->{'dump_full_fasta'}->{'-parameters'}->{'compara_db'} = '#ref_db#';
+    delete $analyses_by_name->{'datacheck_fan'}->{'-flow_into'}->{2};
+    delete $analyses_by_name->{'datacheck_fan_high_mem'}->{'-flow_into'}->{2};
+    $analyses_by_name->{'datacheck_factory'}->{'-parameters'}->{'compara_db'} = '#ref_db#';
+    $analyses_by_name->{'datacheck_fan'}->{'-parameters'}->{'compara_db'} = '#ref_db#';
+    $analyses_by_name->{'datacheck_fan'}->{'-parameters'}->{'old_server_uri'} = '#ref_db#';
+    $analyses_by_name->{'datacheck_fan'}->{'-flow_into'}->{0} = ['jira_ticket_creation'];
+    $analyses_by_name->{'datacheck_fan_high_mem'}->{'-flow_into'}->{0} = ['jira_ticket_creation'];
+    $analyses_by_name->{'store_results'}->{'-parameters'}->{'dbname'} = 'ensembl_compara_references';
 }
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -356,6 +356,6 @@ sub tweak_analyses {
     $analyses_by_name->{'datacheck_fan'}->{'-parameters'}->{'old_server_uri'} = '#ref_db#';
     $analyses_by_name->{'datacheck_fan'}->{'-flow_into'}->{0} = ['jira_ticket_creation'];
     $analyses_by_name->{'datacheck_fan_high_mem'}->{'-flow_into'}->{0} = ['jira_ticket_creation'];
-    $analyses_by_name->{'store_results'}->{'-parameters'}->{'dbname'} = '#ref_dbname#';
+    $analyses_by_name->{'store_results'}->{'-parameters'}->{'dbname'} = $self->o('ref_dbname');
 }
 1;


### PR DESCRIPTION
## Description

In the Rapid Release the datachecks are not going to be run manually on each per species compara database so the datachecks need to be within the pipeline.

**Related JIRA tickets:**
- ENSCOMPARASW-4343

## Overview of changes
Parameter and tweaks in `UpdateReferenceDatabase_conf`: new results table, DC specific parameters, tweaks_analyses sub to manipulate runnable dataflows and parameters from the DC Parts/. Turn off `jira_ticket_creation` and pass specific parameters to specific runnables only.

## Testing
In[ this pipeline ](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-compara-prod-10&port=4648&dbname=cristig_update_references_dcs&passwd=xxxxx)using `mysql-ens-compara-prod-3 jalvarez_reference_db_test_rename_2` as test ref_db.

## Notes
Not all the dcs passed (which was expected and a little intentional), these were forgiven so that the whole pipeline could complete.
I am initially basing this against `feature/homology_annotation_ja` because the changes are rebased onto changes made in this branch. I can swap this back over to `feature/homology_annotation` once @JAlvarezJarreta PR is submitted and approved or we could consider approving and merging this into `feature/homology_annotation_ja`.
