### PR TITLE
Data check member_ids in compara_references update pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -226,7 +226,7 @@ sub core_pipeline_analyses {
                 '3->A' => [ 'retire_reference' ],
                 '4->A' => [ 'rename_reference_genome' ],
                 '5->A' => [ 'verify_genome' ],
-                'A->1' => [ 'pre_collection_dc_dummy' ],
+                'A->1' => [ 'flow_pre_collection_dcs' ],
             },
         },
 
@@ -299,7 +299,7 @@ sub core_pipeline_analyses {
             -rc_name       => '16Gb_job',
         },
 
-        {   -logic_name    => 'pre_collection_dc_dummy',
+        {   -logic_name    => 'flow_pre_collection_dcs',
             -module        => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into     => {
                 '1->A' =>  { 'datacheck_fan' => { 'db_type' => $self->o('db_type'), 'compara_db' => '#ref_db#', 'registry_file' => undef, 'datacheck_names' => $self->o('offset_ids') ? $self->o('dc_names') : [] } },

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DataCheckFan.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DataCheckFan.pm
@@ -38,6 +38,9 @@ use base ('Bio::EnsEMBL::DataCheck::Pipeline::DataCheckFan', 'Bio::EnsEMBL::Comp
 sub fetch_input {
     my $self = shift;
 
+    unless ( scalar @{$self->param('datacheck_names')} > 0 ) {
+        $self->complete_early("No datachecks to run");
+    }
     $self->param('dba', $self->compara_dba);
     # The pipeline may not be in the registry_file so server_uri needs to be explicitly passed
     unless ( $self->param('registry_file') ) {


### PR DESCRIPTION
## Description

The idea is to create a DC similar to the one that checks that genomic_align_block_id is within the MLSS offset range for member ids (genome_db_id * 10000000). Or add this to the DC where the mentioned check happens, whatever is more convenient.

The complexity of this ticket resides on the fact that this DC should only be run in this pipeline if the flag offset_ids is set (if not, we know the DC will fail).

**Related JIRA tickets:**
- ENSCOMPARASW-4386

## Overview of changes
- Pipeline alteration to ensure datacheck_factory only flows critical datachecks
- Dataflow rearrangement including dummy analysis to flow directly to `datacheck_fan` bypassing `datacheck_factory` and not waiting until the end to run.
- The `datacheck_names` parameter is only passed if `offset_ids => 1`. 
- `complete_early` in `datacheck_fan` when there is no `datacheck_names` passed. 

## Testing
Tested with and without offset. See number difference between botched pipeline runs in `datacheck_fan`:
[no offset](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-compara-prod-10&port=4648&dbname=cristig_update_references_dcs_no_offset&passwd=xxxxx)
[offset](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-compara-prod-10&port=4648&dbname=cristig_update_references_dcs_3&passwd=xxxxx)

## Notes
Both test runs have failed DCs - this is expected because the testing reference db is a mess.
[Related PR in ensembl-datachecks here.](https://github.com/Ensembl/ensembl-datacheck/pull/355) <- Will not run until this is approved and merged.
