### PR TITLE
Update registry and some resource classes

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpFastaDatabases.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpFastaDatabases.pm
@@ -45,7 +45,7 @@ sub pipeline_analyses_dump_fasta_dbs {
         {   -logic_name => 'dump_full_fasta',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::DumpMembersIntoFasta',
             -hive_capacity  => 10,
-            -rc_name    => '500Mb_job',
+            -rc_name    => '1Gb_job',
             -flow_into  => ['split_fasta_into_parts', 'make_diamond_db'],
         },
 
@@ -55,6 +55,7 @@ sub pipeline_analyses_dump_fasta_dbs {
             -parameters => {
                 'num_parts' => $self->o('num_fasta_parts'),
             },
+            -rc_name    => '500Mb_job',
         },
 
         {   -logic_name => 'make_diamond_db',
@@ -65,6 +66,7 @@ sub pipeline_analyses_dump_fasta_dbs {
                 # db_name should be #fasta_name# with .fasta removed from the end - hive can do that
                 'db_name'     => '#expr( ($_ = #fasta_name#) and $_ =~ s/\.fasta$// and $_)expr#',
             },
+            -rc_name    => '500Mb_job',
         },
     ];
 }

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -236,6 +236,7 @@ sub core_pipeline_analyses {
                 'compara_db' => '#ref_db#',
             },
             -hive_capacity => 10,
+            -rc_name       => '500Mb_job',
             -flow_into     => ['load_members'],
         },
 
@@ -269,7 +270,7 @@ sub core_pipeline_analyses {
                 'allow_missing_coordinates'     => $self->o('allow_missing_coordinates'),
                 'allow_missing_exon_boundaries' => $self->o('allow_missing_exon_boundaries')
             },
-            -rc_name   => '4Gb_job',
+            -rc_name   => '1Gb_job',
             -flow_into => ['dump_full_fasta'],
         },
 


### PR DESCRIPTION
## Description

Add non-vertebrates to our registry and update the resource classes of several analyses in `UpdateReferenceDatabase` pipeline after a complete run.

**Related JIRA tickets:**
- ENSCOMPARASW-4360
- ENSCOMPARASW-4392

## Overview of changes
#### Change 1
- Added non-vertebrates servers to the registry (using `mirror`, as requested by Production) and remove `master`, since it is not required.

#### Change 2
- During my first tests of the `UpdateReferenceDatabase` pipeline, I realised some analyses were requesting much higher resources than they were using, and a few needed a little bit more, so I have updated them.

## Testing
Here is the last, complete run, that justifies the resource class changes: [jalvarez_update_references_103](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-3&port=4523&dbname=jalvarez_update_references_103)

## Notes
- For the registry I have tried to mimic the registry for Pan.
- I have considered create `_himem` versions of some analyses instead of changing their resource class, but I don't think it is worth it so far.