### PR TITLE
Do not store genome components of reference genomes by default

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ReferenceGenomes/UpdateReferenceGenome.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ReferenceGenomes/UpdateReferenceGenome.pm
@@ -1,4 +1,3 @@
-
 =head1 LICENSE
 
 See the NOTICE file distributed with this work for additional information
@@ -38,13 +37,14 @@ use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 sub param_defaults {
     return {
         'force' => 0,
+        'store_components'  => 0,
     };
 }
 
 sub write_output{
     my $self = shift @_;
 
-    my ($new_ref_gdb, $comp_gdbs, $dnafrag_count) = @{ Bio::EnsEMBL::Compara::Utils::ReferenceDatabase::update_reference_genome($self->compara_dba(), $self->param('species_name'), -FORCE => $self->param('force') )};
+    my ($new_ref_gdb, $comp_gdbs, $dnafrag_count) = @{ Bio::EnsEMBL::Compara::Utils::ReferenceDatabase::update_reference_genome($self->compara_dba(), $self->param('species_name'), -FORCE => $self->param('force'), -STORE_COMPONENTS => $self->param('store_components') )};
     $self->dataflow_output_id( {genome_db_id => $new_ref_gdb->dbID}, 1 );
 }
 

--- a/modules/t/MultiTestDB.conf.default
+++ b/modules/t/MultiTestDB.conf.default
@@ -30,6 +30,7 @@
     'test_ref_human_1' => {'core' => 'Bio::EnsEMBL::DBSQL::DBAdaptor'},
     'test_ref_human_2' => {'core' => 'Bio::EnsEMBL::DBSQL::DBAdaptor'},
     'test_ref_mouse'   => {'core' => 'Bio::EnsEMBL::DBSQL::DBAdaptor'},
+    'test_ref_wheat'   => {'core' => 'Bio::EnsEMBL::DBSQL::DBAdaptor'},
     'test_fake_mouse'  => {'core' => 'Bio::EnsEMBL::DBSQL::DBAdaptor'},
     'homology_annotation' => {'compara' => 'Bio::EnsEMBL::Compara::DBSQL::DBAdaptor'},
     'mysqlimport_test' => {'compara' => 'Bio::EnsEMBL::Compara::DBSQL::DBAdaptor'},

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/analysis.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/analysis.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/analysis.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/analysis_description.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/analysis_description.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/analysis_description.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/assembly.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/assembly.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/assembly.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/attrib_type.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/attrib_type.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/attrib_type.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/coord_system.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/coord_system.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/coord_system.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/density_type.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/density_type.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/density_type.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/exon.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/exon.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/exon.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/exon_transcript.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/exon_transcript.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/exon_transcript.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/external_synonym.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/external_synonym.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/external_synonym.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/gene.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/gene.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/gene.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/gene_attrib.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/gene_attrib.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/gene_attrib.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/genome_statistics.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/genome_statistics.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/genome_statistics.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/identity_xref.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/identity_xref.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/identity_xref.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/meta.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/meta.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/meta.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/meta_coord.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/meta_coord.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/meta_coord.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/misc_set.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/misc_set.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/misc_set.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/protein_feature.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/protein_feature.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/protein_feature.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/repeat_consensus.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/repeat_consensus.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/repeat_consensus.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/repeat_feature.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/repeat_feature.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/repeat_feature.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/seq_region.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/seq_region.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/seq_region.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/seq_region_attrib.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/seq_region_attrib.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/seq_region_attrib.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/table.sql
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/table.sql
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/table.sql

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/transcript.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/transcript.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/transcript.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/translation.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/translation.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/translation.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/translation_attrib.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/translation_attrib.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/translation_attrib.txt

--- a/modules/t/test-genome-DBs/test_ref_wheat/core/unmapped_reason.txt
+++ b/modules/t/test-genome-DBs/test_ref_wheat/core/unmapped_reason.txt
@@ -1,0 +1,1 @@
+../../triticum_aestivum/core/unmapped_reason.txt


### PR DESCRIPTION
## Description

Added new flag to store the genome components (`store_components`) that defaults to 0.

## Testing
I'm running the reference pipeline again to test it works: [jalvarez_update_references_103_fresh](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-3&port=4523&dbname=jalvarez_update_references_103_fresh). All jobs in `update_reference_genome` have finished and the genome components are not in the `genome_db` table.

## Notes
- The idea of this PR is just to share the approach I have opted for to see if you would prefer something slightly different.
- In the pipeline the flag is named `no_components`, but I have thought this new name is more readable.