### PR TITLE
Improve performance of HomologyAnnotation pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
@@ -206,12 +206,8 @@ sub core_pipeline_analyses {
         {   -logic_name => 'backbone_fire_db_prepare',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => {
-                '1->A'  => WHEN (
-                            '#initialised#' => [ 'locate_and_add_genomes' ],
-                            ELSE                         [ 'copy_ncbi_tables_factory' ],
-                ),
+                '1->A'  => [ 'copy_ncbi_tables_factory' ],
                 'A->1'  => [ 'backbone_fire_analyses_prepare' ],
-                '8'     => { '?table_name=pipeline_wide_parameters' => { 'param_name' => 'initialised', 'param_value' => 1, 'insertion_method' => 'INSERT_IGNORE' } },
             },
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
@@ -229,7 +229,7 @@ sub core_pipeline_analyses {
             -hive_capacity => $self->o('blast_factory_capacity'),
             -flow_into     => {
                 '2->A' => [
-                    { 'diamond_blastp'      => {'genome_db_id' => '#genome_db_id#', 'ref_taxa' => '#ref_taxa#', 'member_id_list' => '#member_id_list#', 'blast_db' =>'#blast_db#', 'target_genome_db_id' => '#target_genome_db_id#' } },
+                    { 'diamond_blastp'      => { 'genome_db_id' => '#genome_db_id#', 'member_id_list' => '#member_id_list#', 'blast_db' => '#blast_db#', 'target_genome_db_id' => '#target_genome_db_id#' } },
                     { 'make_query_blast_db' => { 'genome_db_id' => '#genome_db_id#', 'ref_taxa' => '#ref_taxa#' } },
                     { 'copy_ref_genomes'    => { 'target_genome_db_id' => '#target_genome_db_id#' } }
                 ],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
@@ -231,22 +231,9 @@ sub core_pipeline_analyses {
                 '2->A' => [
                     { 'diamond_blastp'      => { 'genome_db_id' => '#genome_db_id#', 'member_id_list' => '#member_id_list#', 'blast_db' => '#blast_db#', 'target_genome_db_id' => '#target_genome_db_id#' } },
                     { 'make_query_blast_db' => { 'genome_db_id' => '#genome_db_id#', 'ref_taxa' => '#ref_taxa#' } },
-                    { 'copy_ref_genomes'    => { 'target_genome_db_id' => '#target_genome_db_id#' } }
                 ],
                 'A->2' => { 'create_mlss_and_batch_members' => { 'genome_db_id' => '#genome_db_id#', 'target_genome_db_id' => '#target_genome_db_id#', 'step' => $self->o('num_sequences_per_blast_job') }  },
             },
-        },
-
-        {   -logic_name => 'copy_ref_genomes',
-            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::MySQLTransfer',
-            -parameters => {
-                'src_db_conn'   => '#rr_ref_db#',
-                'mode'          => 'insertignore',
-                'filter_cmd'    => 'sed "s/ENGINE=MyISAM/ENGINE=InnoDB/"',
-                'table'         => 'genome_db',
-                'where'         => 'genome_db_id = #target_genome_db_id#',
-            },
-            -priority   => 20,
         },
 
         {   -logic_name => 'create_mlss_and_batch_members',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/LoadCoreMembers.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/LoadCoreMembers.pm
@@ -76,6 +76,7 @@ sub pipeline_analyses_copy_ncbi_and_core_genome_db {
                     { 'load_fresh_members_from_db' => { 'genome_db_id' => '#genome_db_id#' } },
                 ],
                 'A->1' => [ 'hc_members_globally' ],
+                '1'    => [ 'copy_ref_genomes_factory' ],
             },
         },
     #--------------------Query genome member loading------------------#
@@ -116,6 +117,28 @@ sub pipeline_analyses_copy_ncbi_and_core_genome_db {
             -module             => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::SqlHealthChecks',
             -parameters         => {
                 mode   => 'members_globally',
+            },
+        },
+    #--------------------Reference genome loading------------------#
+        {   -logic_name => 'copy_ref_genomes_factory',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
+            -parameters => {
+                'compara_db'    => '#rr_ref_db#',
+                'all_current'   => 1,
+            },
+            -flow_into  => {
+                2 => [ 'copy_ref_genomes' ],
+            },
+        },
+
+        {   -logic_name => 'copy_ref_genomes',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::MySQLTransfer',
+            -parameters => {
+                'src_db_conn'   => '#rr_ref_db#',
+                'mode'          => 'insertignore',
+                'filter_cmd'    => 'sed "s/ENGINE=MyISAM/ENGINE=InnoDB/"',
+                'table'         => 'genome_db',
+                'where'         => 'genome_db_id = #genome_db_id#',
             },
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/LoadCoreMembers.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/LoadCoreMembers.pm
@@ -72,40 +72,13 @@ sub pipeline_analyses_copy_ncbi_and_core_genome_db {
             -hive_capacity => 10,
             -rc_name       => '16Gb_job',
             -flow_into     => {
-                1 => [ 'load_query_genomedb_factory' ],
-            },
-        },
-
-    #--------------------Genome member loading------------------#
-        {   -logic_name => 'load_query_genomedb_factory',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
-            -parameters => {
-                'all_current'       => 1,
-                'extra_parameters'  => [ 'locator' ],
-            },
-            -rc_name    => '4Gb_job',
-            -flow_into  => {
-                '2->A' => {
-                    'load_genomedb' => { 'genome_db_id' => '#genome_db_id#', 'locator' => '#locator#', 'master_dbID' => '#genome_db_id#' },
-                },
+                '2->A' => [
+                    { 'load_fresh_members_from_db' => { 'genome_db_id' => '#genome_db_id#' } },
+                ],
                 'A->1' => [ 'hc_members_globally' ],
             },
         },
-
-        {   -logic_name    => 'load_genomedb',
-            -module        => 'Bio::EnsEMBL::Compara::RunnableDB::LoadOneGenomeDB',
-            -parameters    => {
-                'db_version'      => $self->o('ensembl_release'),
-                'master_db'       => $self->o('compara_db'),
-                'registry_files'  => $self->o('curr_file_sources_locs'),
-            },
-            -flow_into     => {
-                1 => [ 'load_fresh_members_from_db' ],
-            },
-            -hive_capacity => 30,
-            -rc_name       => '2Gb_job',
-        },
-
+    #--------------------Query genome member loading------------------#
         {   -logic_name    => 'load_fresh_members_from_db',
             -module        => 'Bio::EnsEMBL::Compara::RunnableDB::LoadMembers',
             -parameters    => {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/CreateSuperficialMLSS.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/CreateSuperficialMLSS.pm
@@ -95,7 +95,6 @@ sub _create_and_store_superficial_mlss {
             -genome_dbs => [$gdb1, $gdb2],
             -name       => $gdb1->name . "-" . $gdb2->name,
         );
-        $species_adap->store($species_set);
     }
 
     unless ($method) {
@@ -106,7 +105,6 @@ sub _create_and_store_superficial_mlss {
             -display_name    => 'Homologues',
             -adaptor         => $method_adap,
         );
-        $method_adap->store($method);
     }
 
     my $method_link_species_set = Bio::EnsEMBL::Compara::MethodLinkSpeciesSet->new(

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1033,7 +1033,6 @@ CREATE TABLE gene_member (
 
   FOREIGN KEY (taxon_id) REFERENCES ncbi_taxa_node(taxon_id),
   FOREIGN KEY (genome_db_id) REFERENCES genome_db(genome_db_id),
---  FOREIGN KEY (dnafrag_id) REFERENCES dnafrag(dnafrag_id),
 
   PRIMARY KEY (gene_member_id),
   CONSTRAINT genome_stable_id UNIQUE (genome_db_id, stable_id),
@@ -1138,7 +1137,6 @@ CREATE TABLE seq_member (
   FOREIGN KEY (genome_db_id) REFERENCES genome_db(genome_db_id),
   FOREIGN KEY (sequence_id) REFERENCES sequence(sequence_id),
   FOREIGN KEY (gene_member_id) REFERENCES gene_member(gene_member_id) ON UPDATE CASCADE,
---  FOREIGN KEY (dnafrag_id) REFERENCES dnafrag(dnafrag_id),
 
   PRIMARY KEY (seq_member_id),
   CONSTRAINT genome_stable_id UNIQUE (genome_db_id, stable_id),
@@ -1400,17 +1398,13 @@ CREATE TABLE peptide_align_feature (
   hit_rank                    SMALLINT UNSIGNED not null,
   cigar_line                  mediumtext,
 
-#  FOREIGN KEY (qmember_id) REFERENCES seq_member(seq_member_id),
-#  FOREIGN KEY (hmember_id) REFERENCES seq_member(seq_member_id),
   FOREIGN KEY (qgenome_db_id) REFERENCES genome_db(genome_db_id),
   FOREIGN KEY (hgenome_db_id) REFERENCES genome_db(genome_db_id),
 
   PRIMARY KEY (peptide_align_feature_id),
-#  KEY hmember_hit (hmember_id, hit_rank)
 
   KEY qmember_id  (qmember_id),
   KEY hmember_id  (hmember_id),
-#  KEY hmember_qgenome  (hmember_id, qgenome_db_id),
   KEY qmember_hgenome  (qmember_id, hgenome_db_id)
 ) MAX_ROWS = 100000000 AVG_ROW_LENGTH = 133 COLLATE=latin1_swedish_ci ENGINE=MyISAM;
 

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1405,13 +1405,13 @@ CREATE TABLE peptide_align_feature (
   FOREIGN KEY (qgenome_db_id) REFERENCES genome_db(genome_db_id),
   FOREIGN KEY (hgenome_db_id) REFERENCES genome_db(genome_db_id),
 
-  PRIMARY KEY (peptide_align_feature_id)
+  PRIMARY KEY (peptide_align_feature_id),
 #  KEY hmember_hit (hmember_id, hit_rank)
 
-#  KEY qmember_id  (qmember_id),
-#  KEY hmember_id  (hmember_id),
+  KEY qmember_id  (qmember_id),
+  KEY hmember_id  (hmember_id),
 #  KEY hmember_qgenome  (hmember_id, qgenome_db_id),
-#  KEY qmember_hgenome  (qmember_id, hgenome_db_id)
+  KEY qmember_hgenome  (qmember_id, hgenome_db_id)
 ) MAX_ROWS = 100000000 AVG_ROW_LENGTH = 133 COLLATE=latin1_swedish_ci ENGINE=MyISAM;
 
 /**


### PR DESCRIPTION
## Description

Improve the performance of homology annotation pipeline. As a side effect, the guiHive shows a much cleaner pipeline now.

**Related JIRA tickets:**
- ENSCOMPARASW-4399

## Overview of changes
#### Change 1
- When the references are added to `genome_db` table, `AUTO_INCREMENT` is set after the latest `genome_db_id`, so the pipeline can no longer be topped up without adding extra analyses, so I have removed that experimental feature.

#### Change 2
- Moved the copy of reference genomes to the beginning, and all the references are copied (it doesn't take much longer anyway and it may be useful to have them all in the future). It is now done at the same time the members of query genomes are being loaded, so no additional time is added to the pipeline.

#### Change 3
- Removed `load_query_genomedb_factory` and `load_genomedb` analyses as these two tasks were already being taken care of by `locate_and_add_genomes`.

#### Change 4
- Put back 3 indexes and 2 foreign keys for `peptide_align_feature` table to add robustness and improve performance when querying this table.

#### Minor changes
- I have removed `ref_taxa` in `diamond_blastp` because it was not being used.
- `mlss_adaptor->store()` already takes care of storing the species set and method if they are not present in the database, so I have removed the unnecessary `store()`.

## Testing
[jalvarez_homology_annotation_halibut_103_alt](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-3&port=4523&dbname=jalvarez_homology_annotation_halibut_103_alt)
