### PR TITLE
Add (many) more checks on imported homologies

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Flatfiles/MySQLImportHomologies.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Flatfiles/MySQLImportHomologies.pm
@@ -153,7 +153,7 @@ sub write_output {
     my $num_tries = 0;
     until ($import_done) {
         $num_tries++;
-        die "Import failed 20 times in a row... Something else must be wrong\n" if $num_tries > 20;
+        die "Import failed 10 times in a row... Something else must be wrong\n" if $num_tries > 10;
         my $import_cmd = "mysql --host=$host --port=$port --user=$user --password=$pass --local-infile=1 $dbname -e \"$import_query\" --max_allowed_packet=1024M";
         my $command = $self->run_command($import_cmd);
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Flatfiles/MySQLImportHomologies.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Flatfiles/MySQLImportHomologies.pm
@@ -262,15 +262,19 @@ sub hc_homology_import {
     if ( $exp_vals->{total_rows} != $db_vals->{gtn_count} ) {
         $self->warning("The number of gene_tree_node_ids written in the homology table (" . $db_vals->{gtn_count} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")");
         return 0;
-    } elsif ( $exp_vals->{min_gtn} != $db_vals->{min_gtn} || $exp_vals->{max_gtn} != $exp_vals->{max_gtn} || $db_vals->{avg_gtn} != $db_vals->{avg_gtn} ) {
+    } elsif ( $exp_vals->{min_gtn} != $db_vals->{min_gtn} || $exp_vals->{max_gtn} != $db_vals->{max_gtn} || $exp_vals->{avg_gtn} != $db_vals->{avg_gtn} ) {
         $self->warning("Some truncated gene_tree_node_ids have been detected in the homology table:\n" . hc_report($exp_vals, $db_vals, 'gtn'));
         return 0;
     }
 
     # check homology.gene_tree_root_id
-    die "The number of gene_tree_root_ids written in the homology table (" . $db_vals->{gtr_count} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")" if $exp_vals->{total_rows} != $db_vals->{gtr_count};
-    die "Some truncated gene_tree_root_ids have been detected in the homology table:\n" . hc_report($exp_vals, $db_vals, 'gtr')
-        unless $exp_vals->{min_gtr} == $db_vals->{min_gtr} && $exp_vals->{max_gtr} == $exp_vals->{max_gtr} && $exp_vals->{avg_gtr} == $db_vals->{avg_gtr};
+    if ( $exp_vals->{total_rows} != $db_vals->{gtr_count} ) {
+        $self->warning("The number of gene_tree_root_ids written in the homology table (" . $db_vals->{gtr_count} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")");
+        return 0;
+    } elsif ( $exp_vals->{min_gtr} != $db_vals->{min_gtr} || $exp_vals->{max_gtr} != $db_vals->{max_gtr} || $exp_vals->{avg_gtr} != $db_vals->{avg_gtr} ) {
+        $self->warning("Some truncated gene_tree_root_ids have been detected in the homology table:\n" . hc_report($exp_vals, $db_vals, 'gtr'));
+        return 0;
+    }
 
     # check optional homology attributes: goc, wga, high_conf
     if ( $self->param('goc_expected') && $exp_vals->{total_rows} != $db_vals->{goc_count} ) {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Flatfiles/MySQLImportHomologies.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Flatfiles/MySQLImportHomologies.pm
@@ -150,7 +150,7 @@ sub write_output {
     my $num_tries = 0;
     until ($import_done) {
         $num_tries++;
-        die "Import failed 20 times in a row... Something else must be wrong..\n" if $num_tries > 20;
+        die "Import failed 20 times in a row... Something else must be wrong\n" if $num_tries > 20;
         my $import_cmd = "mysql --host=$host --port=$port --user=$user --password=$pass --local-infile=1 $dbname -e \"$import_query\" --max_allowed_packet=1024M";
         my $command = $self->run_command($import_cmd);
 
@@ -248,7 +248,7 @@ sub hc_homology_import {
 
     # check homology.species_tree_node_id
     if ( $exp_vals->{total_rows} != $db_vals->{stn_count} ) {
-        $self->warning("The number of species_tree_nodes written in the homology table (" . $db_vals->{stn_count} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")");
+        $self->warning("The number of species_tree_node_ids written in the homology table (" . $db_vals->{stn_count} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")");
         return 0;
     } elsif ( $exp_vals->{min_stn} != $db_vals->{min_stn} || $exp_vals->{max_stn} != $db_vals->{max_stn} || $exp_vals->{avg_stn} != $db_vals->{avg_stn} ) {
         $self->warning("Some truncated species_tree_node_ids have been detected in the homology table:\n" . hc_report($exp_vals, $db_vals, 'stn'));
@@ -257,7 +257,7 @@ sub hc_homology_import {
 
     # check homology.gene_tree_node_id
     if ( $exp_vals->{total_rows} != $db_vals->{gtn_count} ) {
-        $self->warning("The number of gene_tree_nodes written in the homology table (" . $db_vals->{gtn_count} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")");
+        $self->warning("The number of gene_tree_node_ids written in the homology table (" . $db_vals->{gtn_count} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")");
         return 0;
     } elsif ( $exp_vals->{min_gtn} != $db_vals->{min_gtn} || $exp_vals->{max_gtn} != $exp_vals->{max_gtn} || $db_vals->{avg_gtn} != $db_vals->{avg_gtn} ) {
         $self->warning("Some truncated gene_tree_node_ids have been detected in the homology table:\n" . hc_report($exp_vals, $db_vals, 'gtn'));
@@ -265,7 +265,7 @@ sub hc_homology_import {
     }
 
     # check homology.gene_tree_root_id
-    die "The number of gene_tree_roots written in the homology table (" . $db_vals->{gtr_count} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")" if $exp_vals->{total_rows} != $db_vals->{gtr_count};
+    die "The number of gene_tree_root_ids written in the homology table (" . $db_vals->{gtr_count} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")" if $exp_vals->{total_rows} != $db_vals->{gtr_count};
     die "Some truncated gene_tree_root_ids have been detected in the homology table:\n" . hc_report($exp_vals, $db_vals, 'gtr')
         unless $exp_vals->{min_gtr} == $db_vals->{min_gtr} && $exp_vals->{max_gtr} == $exp_vals->{max_gtr} && $exp_vals->{avg_gtr} == $db_vals->{avg_gtr};
 
@@ -286,7 +286,7 @@ sub hc_homology_import {
 
     # HOMOLOGY_MEMBER check
     my $homology_id_start = $self->param_required('homology_id_start');
-    my $homology_id_end   = $homology_id_start + $total_rows - 1; # TODO: do we need -1?
+    my $homology_id_end   = $homology_id_start + $total_rows - 1;
     my $hm_sql = "SELECT COUNT(*) AS total_hm_rows, SUM(gene_member_id IS NOT NULL) AS gm_count,
                MIN(gene_member_id) as min_gm, MAX(gene_member_id) as max_gm, AVG(gene_member_id) as avg_gm,
                SUM(seq_member_id IS NOT NULL) AS sm_count, MIN(seq_member_id) as min_sm, MAX(seq_member_id) as max_sm,

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Flatfiles/MySQLImportHomologies.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Flatfiles/MySQLImportHomologies.pm
@@ -250,7 +250,7 @@ sub hc_homology_import {
     if ( $exp_vals->{total_rows} != $db_vals->{stn_count} ) {
         $self->warning("The number of species_tree_nodes written in the homology table (" . $db_vals->{stn_count} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")");
         return 0;
-    } elsif ( $exp_vals->{min_stn} != $db_vals->{min_stn} || $exp_vals->{max_stn} != $exp_vals->{max_stn} || $exp_vals->{avg_stn} != $db_vals->{avg_stn} ) {
+    } elsif ( $exp_vals->{min_stn} != $db_vals->{min_stn} || $exp_vals->{max_stn} != $db_vals->{max_stn} || $exp_vals->{avg_stn} != $db_vals->{avg_stn} ) {
         $self->warning("Some truncated species_tree_node_ids have been detected in the homology table:\n" . hc_report($exp_vals, $db_vals, 'stn'));
         return 0;
     }
@@ -259,7 +259,7 @@ sub hc_homology_import {
     if ( $exp_vals->{total_rows} != $db_vals->{gtn_count} ) {
         $self->warning("The number of gene_tree_nodes written in the homology table (" . $db_vals->{gtn_count} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")");
         return 0;
-    } elsif ( $exp_vals->{min_gtn} != $db_vals->{min_gtn} || $exp_vals->{max_gtn} != $exp_vals->{max_gtn} || $exp_vals->{avg_gtn} != $db_vals->{avg_gtn} ) {
+    } elsif ( $exp_vals->{min_gtn} != $db_vals->{min_gtn} || $exp_vals->{max_gtn} != $exp_vals->{max_gtn} || $db_vals->{avg_gtn} != $db_vals->{avg_gtn} ) {
         $self->warning("Some truncated gene_tree_node_ids have been detected in the homology table:\n" . hc_report($exp_vals, $db_vals, 'gtn'));
         return 0;
     }
@@ -309,7 +309,7 @@ sub hc_homology_import {
     if ( $total_hm_rows != $db_vals->{gm_count} ) {
         $self->warning("The number of gene_member_ids written in the homology_member table (" . $db_vals->{gm_count} . ") doesn't match the number of lines in the homology flat file (" . $total_hm_rows . ")");
         return 0;
-    } elsif ( $exp_vals->{min_gm} != $db_vals->{min_gm} || $exp_vals->{max_gm} != $exp_vals->{max_gm} || $exp_vals->{avg_gm} != $db_vals->{avg_gm} ) {
+    } elsif ( $exp_vals->{min_gm} != $db_vals->{min_gm} || $exp_vals->{max_gm} != $db_vals->{max_gm} || $exp_vals->{avg_gm} != $db_vals->{avg_gm} ) {
         $self->warning("Some truncated gene_member_ids have been detected in the homology_member table:\n" . hc_report($exp_vals, $db_vals, 'gm'));
         return 0;
     }
@@ -318,7 +318,7 @@ sub hc_homology_import {
     if ( $total_hm_rows != $db_vals->{sm_count} ){
         $self->warning("The number of seq_member_ids written in the homology_member table (" . $db_vals->{sm_count} . ") doesn't match the number of lines in the homology flat file (" . $total_hm_rows . ")");
         return 0;
-    } elsif ( $exp_vals->{min_sm} != $db_vals->{min_sm} || $exp_vals->{max_sm} != $exp_vals->{max_sm} || $exp_vals->{avg_sm} != $db_vals->{avg_sm} ) {
+    } elsif ( $exp_vals->{min_sm} != $db_vals->{min_sm} || $exp_vals->{max_sm} != $db_vals->{max_sm} || $exp_vals->{avg_sm} != $db_vals->{avg_sm} ) {
         $self->warning("Some truncated seq_member_ids have been detected in the homology_member table:\n" . hc_report($exp_vals, $db_vals, 'sm'));
         return 0;
     }
@@ -327,21 +327,21 @@ sub hc_homology_import {
     if ( $total_hm_rows != $db_vals->{cov_count} ) {
         $self->warning("The number of perc_cov values written in the homology_member table (" . $db_vals->{cov_count} . ") doesn't match the number of lines in the homology flat file (" . $total_hm_rows . ")");
         return 0;
-    } elsif ( $exp_vals->{min_cov} != $db_vals->{min_cov} || $exp_vals->{max_cov} != $exp_vals->{max_cov} || $exp_vals->{avg_cov} != $db_vals->{avg_cov} ) {
+    } elsif ( $exp_vals->{min_cov} != $db_vals->{min_cov} || $exp_vals->{max_cov} != $db_vals->{max_cov} || $exp_vals->{avg_cov} != $db_vals->{avg_cov} ) {
         $self->warning("Some truncated perc_cov values have been detected in the homology_member table:\n" . hc_report($exp_vals, $db_vals, 'cov'));
         return 0;
     }
     if ( $total_hm_rows != $db_vals->{id_count} ) {
         $self->warning("The number of perc_id values written in the homology_member table (" . $db_vals->{id_count} . ") doesn't match the number of lines in the homology flat file (" . $total_hm_rows . ")");
         return 0;
-    } elsif ( $exp_vals->{min_id} != $db_vals->{min_id} || $exp_vals->{max_id} != $exp_vals->{max_id} || $exp_vals->{avg_id} != $db_vals->{avg_id} ) {
+    } elsif ( $exp_vals->{min_id} != $db_vals->{min_id} || $exp_vals->{max_id} != $db_vals->{max_id} || $exp_vals->{avg_id} != $db_vals->{avg_id} ) {
         $self->warning("Some truncated perc_id values have been detected in the homology_member table:\n" . hc_report($exp_vals, $db_vals, 'id'));
         return 0;
     }
     if ( $total_hm_rows != $db_vals->{pos_count} ) {
         $self->warning("The number of perc_pos values written in the homology_member table (" . $db_vals->{pos_count} . ") doesn't match the number of lines in the homology flat file (" . $total_hm_rows . ")");
         return 0;
-    } elsif ( $exp_vals->{min_pos} != $db_vals->{min_pos} || $exp_vals->{max_pos} != $exp_vals->{max_pos} || $exp_vals->{avg_pos} != $db_vals->{avg_pos} ) {
+    } elsif ( $exp_vals->{min_pos} != $db_vals->{min_pos} || $exp_vals->{max_pos} != $db_vals->{max_pos} || $exp_vals->{avg_pos} != $db_vals->{avg_pos} ) {
         $self->warning("Some truncated perc_pos values have been detected in the homology_member table:\n" . hc_report($exp_vals, $db_vals, 'pos'));
         return 0;
     }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Flatfiles/MySQLImportHomologies.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Flatfiles/MySQLImportHomologies.pm
@@ -31,6 +31,9 @@ package Bio::EnsEMBL::Compara::RunnableDB::Flatfiles::MySQLImportHomologies;
 
 use warnings;
 use strict;
+
+use List::Util qw(min max);
+
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
 
@@ -354,58 +357,40 @@ sub gather_hc_stats {
     my ( $self, $exp_vals, $row ) = @_;
 
     # homology table fields
-    $exp_vals->{min_stn} =  smallest([$row->{species_tree_node_id}, ($exp_vals->{min_stn}||10**12)]);
-    $exp_vals->{max_stn} =  largest( [$row->{species_tree_node_id}, ($exp_vals->{max_stn}||0)]);
+    $exp_vals->{min_stn} =  min $row->{species_tree_node_id}, ($exp_vals->{min_stn}||10**12);
+    $exp_vals->{max_stn} =  max $row->{species_tree_node_id}, ($exp_vals->{max_stn}||0);
     $exp_vals->{sum_stn} += $row->{species_tree_node_id};
 
-    $exp_vals->{min_gtn} =  smallest([$row->{gene_tree_node_id}, ($exp_vals->{min_gtn}||10**12)]);
-    $exp_vals->{max_gtn} =  largest( [$row->{gene_tree_node_id}, ($exp_vals->{max_gtn}||0)]);
+    $exp_vals->{min_gtn} =  min $row->{gene_tree_node_id}, ($exp_vals->{min_gtn}||10**12);
+    $exp_vals->{max_gtn} =  max $row->{gene_tree_node_id}, ($exp_vals->{max_gtn}||0);
     $exp_vals->{sum_gtn} += $row->{gene_tree_node_id};
 
-    $exp_vals->{min_gtr} =  smallest([$row->{gene_tree_root_id}, ($exp_vals->{min_gtr}||10**12)]);
-    $exp_vals->{max_gtr} =  largest( [$row->{gene_tree_root_id}, ($exp_vals->{max_gtr}||0)]);
+    $exp_vals->{min_gtr} =  min $row->{gene_tree_root_id}, ($exp_vals->{min_gtr}||10**12);
+    $exp_vals->{max_gtr} =  max $row->{gene_tree_root_id}, ($exp_vals->{max_gtr}||0);
     $exp_vals->{sum_gtr} += $row->{gene_tree_root_id};
 
     # homology_member table fields
-    $exp_vals->{min_gm} =  smallest([$row->{gene_member_id}, $row->{homology_gene_member_id}, ($exp_vals->{min_gm}||10**12)]);
-    $exp_vals->{max_gm} =  largest( [$row->{gene_member_id}, $row->{homology_gene_member_id}, ($exp_vals->{max_gm}||0)]);
+    $exp_vals->{min_gm} =  min $row->{gene_member_id}, $row->{homology_gene_member_id}, ($exp_vals->{min_gm}||10**12);
+    $exp_vals->{max_gm} =  max $row->{gene_member_id}, $row->{homology_gene_member_id}, ($exp_vals->{max_gm}||0);
     $exp_vals->{sum_gm} += ($row->{gene_member_id} + $row->{homology_gene_member_id});
 
-    $exp_vals->{min_sm} =  smallest([$row->{seq_member_id}, $row->{homology_seq_member_id}, ($exp_vals->{min_sm}||10**12)]);
-    $exp_vals->{max_sm} =  largest( [$row->{seq_member_id}, $row->{homology_seq_member_id}, ($exp_vals->{max_sm}||0)]);
+    $exp_vals->{min_sm} =  min $row->{seq_member_id}, $row->{homology_seq_member_id}, ($exp_vals->{min_sm}||10**12);
+    $exp_vals->{max_sm} =  max $row->{seq_member_id}, $row->{homology_seq_member_id}, ($exp_vals->{max_sm}||0);
     $exp_vals->{sum_sm} += ($row->{seq_member_id} + $row->{homology_seq_member_id});
 
-    $exp_vals->{min_cov} =  smallest([$row->{perc_cov}, $row->{homology_perc_cov}, ($exp_vals->{min_cov}||101)]);
-    $exp_vals->{max_cov} =  largest( [$row->{perc_cov}, $row->{homology_perc_cov}, ($exp_vals->{max_cov}||0)]);
+    $exp_vals->{min_cov} =  min $row->{perc_cov}, $row->{homology_perc_cov}, ($exp_vals->{min_cov}||101);
+    $exp_vals->{max_cov} =  max $row->{perc_cov}, $row->{homology_perc_cov}, ($exp_vals->{max_cov}||0);
     $exp_vals->{sum_cov} += ($row->{perc_cov} + $row->{homology_perc_cov});
 
-    $exp_vals->{min_id} =  smallest([$row->{perc_id}, $row->{homology_perc_id}, ($exp_vals->{min_id}||101)]);
-    $exp_vals->{max_id} =  largest( [$row->{perc_id}, $row->{homology_perc_id}, ($exp_vals->{max_id}||0)]);
+    $exp_vals->{min_id} =  min $row->{perc_id}, $row->{homology_perc_id}, ($exp_vals->{min_id}||101);
+    $exp_vals->{max_id} =  max $row->{perc_id}, $row->{homology_perc_id}, ($exp_vals->{max_id}||0);
     $exp_vals->{sum_id} += ($row->{perc_id} + $row->{homology_perc_id});
 
-    $exp_vals->{min_pos} =  smallest([$row->{perc_pos}, $row->{homology_perc_pos}, ($exp_vals->{min_pos}||101)]);
-    $exp_vals->{max_pos} =  largest( [$row->{perc_pos}, $row->{homology_perc_pos}, ($exp_vals->{max_pos}||0)]);
+    $exp_vals->{min_pos} =  min $row->{perc_pos}, $row->{homology_perc_pos}, ($exp_vals->{min_pos}||101);
+    $exp_vals->{max_pos} =  max $row->{perc_pos}, $row->{homology_perc_pos}, ($exp_vals->{max_pos}||0);
     $exp_vals->{sum_pos} += ($row->{perc_pos} + $row->{homology_perc_pos});
 
     return $exp_vals;
-}
-
-sub largest {
-    my $list = shift;
-    my $largest = shift @$list;
-    foreach my $i ( @$list ) {
-        $largest = $i if $i > $largest;
-    }
-    return $largest;
-}
-
-sub smallest {
-    my $list = shift;
-    my $smallest = shift @$list;
-    foreach my $i ( @$list ) {
-        $smallest = $i if $i < $smallest;
-    }
-    return $smallest;
 }
 
 sub cleanup_vals {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Flatfiles/MySQLImportHomologies.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Flatfiles/MySQLImportHomologies.pm
@@ -104,6 +104,7 @@ sub write_output {
 
     # iterate over homology input and format it for later mysqlimport
     my $h_count = 0;
+    my $hc_exp_vals;
     my $homology_id_start = $self->param_required('homology_id_start');
     while ( my $line = <$hom_fh> ) {
         my $row = map_row_to_header($line, \@header_cols);
@@ -118,7 +119,10 @@ sub write_output {
         my ( $homology_row, $homology_member_rows ) = $self->split_row_for_homology_tables($row, $this_homology_id);
         print $h_csv $homology_row;
         print $hm_csv $homology_member_rows;
+
+        # gather stats for healthchecks
         $h_count++;
+        $hc_exp_vals = $self->gather_hc_stats($hc_exp_vals, $row);
     }
     close $h_csv;
     close $hm_csv;
@@ -146,13 +150,19 @@ sub write_output {
     my $num_tries = 0;
     until ($import_done) {
         $num_tries++;
+        die "Import failed 20 times in a row... Something else must be wrong..\n" if $num_tries > 20;
         my $import_cmd = "mysql --host=$host --port=$port --user=$user --password=$pass --local-infile=1 $dbname -e \"$import_query\" --max_allowed_packet=1024M";
         my $command = $self->run_command($import_cmd);
 
+        # Make sure all the homologies have been copied correctly
+        $hc_exp_vals->{total_rows} = $h_count;
+        my $hc_passed = $self->hc_homology_import($hc_exp_vals);
+        print "HC " . ( $hc_passed ? 'PASSED' : 'FAILED' ) . "\n\n" if $self->debug;
+
         # Check what has happened
-        if ($command->err =~ /Lock wait timeout exceeded/) {
+        if ($command->err =~ /Lock wait timeout exceeded/ || !$hc_passed) {
             # Try importing the data again but in replace mode, just in case some rows were half-copied
-            print "Received 'Lock wait timeout exceeded'. Retrying...\n" if $self->{debug};
+            print ($hc_passed ? "Received 'Lock wait timeout exceeded'." : "The imported data appeared corrupted.") . " Retrying...\n" if $self->debug;
             if (! $replace) {
                 $import_query =~ s/  INTO / REPLACE INTO /g;
                 $replace = 1;
@@ -165,13 +175,6 @@ sub write_output {
         }
     }
     $self->warning("'homology' and 'homology_member' data imported successfully after $num_tries attempts\n");
-
-    # Make sure all the homologies have been copied correctly
-    my $mlss_id = $self->param_required('mlss_id');
-    my $h_rows = $self->compara_dba->dbc->sql_helper->execute_single_result(
-        -SQL => "SELECT COUNT(*) FROM homology WHERE method_link_species_set_id = $mlss_id"
-    );
-    die "The number of lines in the homology flat file ($h_count) doesn't match the number of rows written in the homology table ($h_rows)" if $h_count != $h_rows;
 }
 
 sub split_row_for_homology_tables {
@@ -206,6 +209,224 @@ sub split_row_for_homology_tables {
     }
 
     return ( $homology_row, $homology_member_rows );
+}
+
+sub hc_homology_import {
+    my ( $self, $exp_vals ) = @_;
+
+    my $total_rows = $exp_vals->{total_rows};
+    my $total_hm_rows = $total_rows*2;
+    $exp_vals->{avg_stn} = $exp_vals->{sum_stn}/$total_rows;
+    $exp_vals->{avg_gtn} = $exp_vals->{sum_gtn}/$total_rows;
+    $exp_vals->{avg_gtr} = $exp_vals->{sum_gtr}/$total_rows;
+
+    $exp_vals->{avg_gm}  = $exp_vals->{sum_gm}/$total_hm_rows;
+    $exp_vals->{avg_sm}  = $exp_vals->{sum_sm}/$total_hm_rows;
+    $exp_vals->{avg_cov} = $exp_vals->{sum_cov}/$total_hm_rows;
+    $exp_vals->{avg_id}  = $exp_vals->{sum_id}/$total_hm_rows;
+    $exp_vals->{avg_pos} = $exp_vals->{sum_pos}/$total_hm_rows;
+    $exp_vals = cleanup_vals($exp_vals);
+
+    # HOMOLOGY check : HC number of rows and specific fields in homology table
+    my $mlss_id = $self->param_required('mlss_id');
+    my $sql = "SELECT COUNT(*) AS total_rows, SUM(species_tree_node_id IS NOT NULL) AS stn_count,
+               MIN(species_tree_node_id) as min_stn, MAX(species_tree_node_id) as max_stn, AVG(species_tree_node_id) as avg_stn,
+               SUM(gene_tree_node_id IS NOT NULL) AS gtn_count, SUM(gene_tree_root_id IS NOT NULL) AS gtr_count,
+               MIN(gene_tree_node_id) as min_gtn, MAX(gene_tree_node_id) as max_gtn, AVG(gene_tree_node_id) as avg_gtn,
+               MIN(gene_tree_root_id) as min_gtr, MAX(gene_tree_root_id) as max_gtr, AVG(gene_tree_root_id) as avg_gtr,
+               SUM(goc_score IS NOT NULL) AS goc_count, SUM(wga_coverage IS NOT NULL) AS wga_count,
+               SUM(is_high_confidence IS NOT NULL) AS hc_count
+               FROM homology WHERE method_link_species_set_id = $mlss_id";
+    my $db_vals = $self->compara_dba->dbc->db_handle->selectrow_hashref($sql);
+    $db_vals = cleanup_vals($db_vals);
+
+    # check homology row counts
+    if ( $exp_vals->{total_rows} != $db_vals->{total_rows} ) {
+        $self->warning("The number of rows written in the homology table (" . $db_vals->{total_rows} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")");
+        return 0;
+    }
+
+    # check homology.species_tree_node_id
+    if ( $exp_vals->{total_rows} != $db_vals->{stn_count} ) {
+        $self->warning("The number of species_tree_nodes written in the homology table (" . $db_vals->{stn_count} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")");
+        return 0;
+    } elsif ( $exp_vals->{min_stn} != $db_vals->{min_stn} || $exp_vals->{max_stn} != $exp_vals->{max_stn} || $exp_vals->{avg_stn} != $db_vals->{avg_stn} ) {
+        $self->warning("Some truncated species_tree_node_ids have been detected in the homology table:\n" . hc_report($exp_vals, $db_vals, 'stn'));
+        return 0;
+    }
+
+    # check homology.gene_tree_node_id
+    if ( $exp_vals->{total_rows} != $db_vals->{gtn_count} ) {
+        $self->warning("The number of gene_tree_nodes written in the homology table (" . $db_vals->{gtn_count} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")");
+        return 0;
+    } elsif ( $exp_vals->{min_gtn} != $db_vals->{min_gtn} || $exp_vals->{max_gtn} != $exp_vals->{max_gtn} || $exp_vals->{avg_gtn} != $db_vals->{avg_gtn} ) {
+        $self->warning("Some truncated gene_tree_node_ids have been detected in the homology table:\n" . hc_report($exp_vals, $db_vals, 'gtn'));
+        return 0;
+    }
+
+    # check homology.gene_tree_root_id
+    die "The number of gene_tree_roots written in the homology table (" . $db_vals->{gtr_count} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")" if $exp_vals->{total_rows} != $db_vals->{gtr_count};
+    die "Some truncated gene_tree_root_ids have been detected in the homology table:\n" . hc_report($exp_vals, $db_vals, 'gtr')
+        unless $exp_vals->{min_gtr} == $db_vals->{min_gtr} && $exp_vals->{max_gtr} == $exp_vals->{max_gtr} && $exp_vals->{avg_gtr} == $db_vals->{avg_gtr};
+
+    # check optional homology attributes: goc, wga, high_conf
+    if ( $self->param('goc_expected') && $exp_vals->{total_rows} != $db_vals->{goc_count} ) {
+        $self->warning("The number of goc_scores written in the homology table (" . $db_vals->{goc_count} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")");
+        return 0;
+    }
+    if ( $self->param('wga_expected') && $exp_vals->{total_rows} != $db_vals->{wga_count} ) {
+        $self->warning("The number of wga_coverage values written in the homology table (" . $db_vals->{wga_count} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")");
+        return 0;
+    }
+    if ( $self->param('high_conf_expected') &&  $exp_vals->{total_rows} != $db_vals->{hc_count} ) {
+        $self->warning("The number of high_conf scores written in the homology table (" . $db_vals->{hc_count} . ") doesn't match the number of lines in the homology flat file (" . $exp_vals->{total_rows} . ")");
+        return 0;
+    }
+
+
+    # HOMOLOGY_MEMBER check
+    my $homology_id_start = $self->param_required('homology_id_start');
+    my $homology_id_end   = $homology_id_start + $total_rows - 1; # TODO: do we need -1?
+    my $hm_sql = "SELECT COUNT(*) AS total_hm_rows, SUM(gene_member_id IS NOT NULL) AS gm_count,
+               MIN(gene_member_id) as min_gm, MAX(gene_member_id) as max_gm, AVG(gene_member_id) as avg_gm,
+               SUM(seq_member_id IS NOT NULL) AS sm_count, MIN(seq_member_id) as min_sm, MAX(seq_member_id) as max_sm,
+               AVG(seq_member_id) as avg_sm, SUM(perc_cov IS NOT NULL) AS cov_count,
+               MIN(perc_cov) as min_cov, MAX(perc_cov) as max_cov, AVG(perc_cov) as avg_cov,
+               SUM(perc_id IS NOT NULL) AS id_count, MIN(perc_id) as min_id, MAX(perc_id) as max_id,
+               AVG(perc_id) as avg_id, SUM(perc_pos IS NOT NULL) AS pos_count, MIN(perc_pos) as min_pos,
+               MAX(perc_pos) as max_pos, AVG(perc_pos) as avg_pos
+               FROM homology_member WHERE homology_id BETWEEN $homology_id_start AND $homology_id_end";
+    $db_vals = $self->compara_dba->dbc->db_handle->selectrow_hashref($hm_sql);
+    $db_vals = cleanup_vals($db_vals);
+
+    # check homology row counts
+    if ( $total_hm_rows != $db_vals->{total_hm_rows} ) {
+        $self->warning("The number of rows written in the homology_member table (" . $db_vals->{total_hm_rows} . ") doesn't match the number of lines in the homology flat file (" . $total_hm_rows . ")");
+        return 0;
+    }
+
+    # check homology_member.gene_member_id
+    if ( $total_hm_rows != $db_vals->{gm_count} ) {
+        $self->warning("The number of gene_member_ids written in the homology_member table (" . $db_vals->{gm_count} . ") doesn't match the number of lines in the homology flat file (" . $total_hm_rows . ")");
+        return 0;
+    } elsif ( $exp_vals->{min_gm} != $db_vals->{min_gm} || $exp_vals->{max_gm} != $exp_vals->{max_gm} || $exp_vals->{avg_gm} != $db_vals->{avg_gm} ) {
+        $self->warning("Some truncated gene_member_ids have been detected in the homology_member table:\n" . hc_report($exp_vals, $db_vals, 'gm'));
+        return 0;
+    }
+
+    # check homology_member.seq_member_id
+    if ( $total_hm_rows != $db_vals->{sm_count} ){
+        $self->warning("The number of seq_member_ids written in the homology_member table (" . $db_vals->{sm_count} . ") doesn't match the number of lines in the homology flat file (" . $total_hm_rows . ")");
+        return 0;
+    } elsif ( $exp_vals->{min_sm} != $db_vals->{min_sm} || $exp_vals->{max_sm} != $exp_vals->{max_sm} || $exp_vals->{avg_sm} != $db_vals->{avg_sm} ) {
+        $self->warning("Some truncated seq_member_ids have been detected in the homology_member table:\n" . hc_report($exp_vals, $db_vals, 'sm'));
+        return 0;
+    }
+
+    # check homology_member.perc_%
+    if ( $total_hm_rows != $db_vals->{cov_count} ) {
+        $self->warning("The number of perc_cov values written in the homology_member table (" . $db_vals->{cov_count} . ") doesn't match the number of lines in the homology flat file (" . $total_hm_rows . ")");
+        return 0;
+    } elsif ( $exp_vals->{min_cov} != $db_vals->{min_cov} || $exp_vals->{max_cov} != $exp_vals->{max_cov} || $exp_vals->{avg_cov} != $db_vals->{avg_cov} ) {
+        $self->warning("Some truncated perc_cov values have been detected in the homology_member table:\n" . hc_report($exp_vals, $db_vals, 'cov'));
+        return 0;
+    }
+    if ( $total_hm_rows != $db_vals->{id_count} ) {
+        $self->warning("The number of perc_id values written in the homology_member table (" . $db_vals->{id_count} . ") doesn't match the number of lines in the homology flat file (" . $total_hm_rows . ")");
+        return 0;
+    } elsif ( $exp_vals->{min_id} != $db_vals->{min_id} || $exp_vals->{max_id} != $exp_vals->{max_id} || $exp_vals->{avg_id} != $db_vals->{avg_id} ) {
+        $self->warning("Some truncated perc_id values have been detected in the homology_member table:\n" . hc_report($exp_vals, $db_vals, 'id'));
+        return 0;
+    }
+    if ( $total_hm_rows != $db_vals->{pos_count} ) {
+        $self->warning("The number of perc_pos values written in the homology_member table (" . $db_vals->{pos_count} . ") doesn't match the number of lines in the homology flat file (" . $total_hm_rows . ")");
+        return 0;
+    } elsif ( $exp_vals->{min_pos} != $db_vals->{min_pos} || $exp_vals->{max_pos} != $exp_vals->{max_pos} || $exp_vals->{avg_pos} != $db_vals->{avg_pos} ) {
+        $self->warning("Some truncated perc_pos values have been detected in the homology_member table:\n" . hc_report($exp_vals, $db_vals, 'pos'));
+        return 0;
+    }
+
+    # other than that, it passes.. ;)
+    return 1;
+}
+
+sub gather_hc_stats {
+    my ( $self, $exp_vals, $row ) = @_;
+
+    # homology table fields
+    $exp_vals->{min_stn} =  smallest([$row->{species_tree_node_id}, ($exp_vals->{min_stn}||10**12)]);
+    $exp_vals->{max_stn} =  largest( [$row->{species_tree_node_id}, ($exp_vals->{max_stn}||0)]);
+    $exp_vals->{sum_stn} += $row->{species_tree_node_id};
+
+    $exp_vals->{min_gtn} =  smallest([$row->{gene_tree_node_id}, ($exp_vals->{min_gtn}||10**12)]);
+    $exp_vals->{max_gtn} =  largest( [$row->{gene_tree_node_id}, ($exp_vals->{max_gtn}||0)]);
+    $exp_vals->{sum_gtn} += $row->{gene_tree_node_id};
+
+    $exp_vals->{min_gtr} =  smallest([$row->{gene_tree_root_id}, ($exp_vals->{min_gtr}||10**12)]);
+    $exp_vals->{max_gtr} =  largest( [$row->{gene_tree_root_id}, ($exp_vals->{max_gtr}||0)]);
+    $exp_vals->{sum_gtr} += $row->{gene_tree_root_id};
+
+    # homology_member table fields
+    $exp_vals->{min_gm} =  smallest([$row->{gene_member_id}, $row->{homology_gene_member_id}, ($exp_vals->{min_gm}||10**12)]);
+    $exp_vals->{max_gm} =  largest( [$row->{gene_member_id}, $row->{homology_gene_member_id}, ($exp_vals->{max_gm}||0)]);
+    $exp_vals->{sum_gm} += ($row->{gene_member_id} + $row->{homology_gene_member_id});
+
+    $exp_vals->{min_sm} =  smallest([$row->{seq_member_id}, $row->{homology_seq_member_id}, ($exp_vals->{min_sm}||10**12)]);
+    $exp_vals->{max_sm} =  largest( [$row->{seq_member_id}, $row->{homology_seq_member_id}, ($exp_vals->{max_sm}||0)]);
+    $exp_vals->{sum_sm} += ($row->{seq_member_id} + $row->{homology_seq_member_id});
+
+    $exp_vals->{min_cov} =  smallest([$row->{perc_cov}, $row->{homology_perc_cov}, ($exp_vals->{min_cov}||101)]);
+    $exp_vals->{max_cov} =  largest( [$row->{perc_cov}, $row->{homology_perc_cov}, ($exp_vals->{max_cov}||0)]);
+    $exp_vals->{sum_cov} += ($row->{perc_cov} + $row->{homology_perc_cov});
+
+    $exp_vals->{min_id} =  smallest([$row->{perc_id}, $row->{homology_perc_id}, ($exp_vals->{min_id}||101)]);
+    $exp_vals->{max_id} =  largest( [$row->{perc_id}, $row->{homology_perc_id}, ($exp_vals->{max_id}||0)]);
+    $exp_vals->{sum_id} += ($row->{perc_id} + $row->{homology_perc_id});
+
+    $exp_vals->{min_pos} =  smallest([$row->{perc_pos}, $row->{homology_perc_pos}, ($exp_vals->{min_pos}||101)]);
+    $exp_vals->{max_pos} =  largest( [$row->{perc_pos}, $row->{homology_perc_pos}, ($exp_vals->{max_pos}||0)]);
+    $exp_vals->{sum_pos} += ($row->{perc_pos} + $row->{homology_perc_pos});
+
+    return $exp_vals;
+}
+
+sub largest {
+    my $list = shift;
+    my $largest = shift @$list;
+    foreach my $i ( @$list ) {
+        $largest = $i if $i > $largest;
+    }
+    return $largest;
+}
+
+sub smallest {
+    my $list = shift;
+    my $smallest = shift @$list;
+    foreach my $i ( @$list ) {
+        $smallest = $i if $i < $smallest;
+    }
+    return $smallest;
+}
+
+sub cleanup_vals {
+    my $vals = shift;
+
+    # round any floating point nums to 4 places
+    foreach my $key ( keys %$vals ) {
+        if ( $vals->{$key} =~ /\./ ) {
+            $vals->{$key} = sprintf("%.4f", $vals->{$key});
+        }
+    }
+    return $vals;
+}
+
+sub hc_report {
+    my ( $exp_vals, $db_vals, $type ) = @_;
+    my $report = "             expected\tgot\n";
+    $report .= "- min values : " . $exp_vals->{"min_$type"} . "\t" . $db_vals->{"min_$type"} . "\n";
+    $report .= "- max values : " . $exp_vals->{"max_$type"} . "\t" . $db_vals->{"max_$type"} . "\n";
+    $report .= "- avg values : " . $exp_vals->{"avg_$type"} . "\t" . $db_vals->{"avg_$type"} . "\n";
+    return $report;
 }
 
 1;


### PR DESCRIPTION
## Description

Checks on homology imports have not gone beyond basic row counting. In e104, several truncated rows were discovered, which were not being detected by that check. I have added a check on all fields in both `homology` and `homology_member` tables. This includes checking the min, max and avg values for each column, in order to try to detect truncated values.

**Related JIRA tickets:**
- ENSCOMPARASW-4296

## Overview of changes
- stats from each field are collected from each row of the flatfile to form a hash of expected values
- comparison of counts and range stats are performed for each field in the database after import
- if there's a failure, a small report will be printed
- if there's a failure, the import will be automatically retried in `REPLACE INTO` mode

## Testing
- testing was done using a homology dump file from e104 (truncated to 200 lines) and a `standaloneJob.pl`
- I added some code just before the HC was run to pause execution in order to give me time to go mess up the database to simulate: (a) missing complete rows, (b) missing some fields from some rows, (c) truncated values in some rows
- in all cases, it was detected by the HC and handled accordingly
- the reimport with `REPLACE` always fixed the issue I had introduced

## Notes
Regarding floating point numbers : I could have used `ROUND` or `FLOOR` or something in my SQL commands, but since rounding of numbers can be done in so many different ways, I thought it was safest to let Perl do all rounding using `sprintf` - at least this way all numbers will be treated in the same way.