### PR TITLE
Feature/homology annotation create per-species database

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -128,6 +128,7 @@ sub executable_locations {
         'copy_ancestral_core_exe'           => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/copy_ancestral_core.pl'),
 
         # Other dependencies (non executables)
+        'schema_file'                       => $self->check_file_in_ensembl('ensembl-compara/sql/table.sql'),
         'core_schema_sql'                   => $self->check_file_in_ensembl('ensembl/sql/table.sql'),
         'tree_stats_sql'                    => $self->check_file_in_ensembl('ensembl-compara/sql/tree-stats-as-stn_tags.sql'),
     };

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
@@ -69,9 +69,8 @@ sub default_options {
         # Directory for diamond and fasta files for query genome
         'members_dumps_dir' => $self->o('dump_path'),
         # Compara schema file path
-        'schema_file' => $self->check_file_in_ensembl('ensembl-compara/sql/table.sql'),
+        'schema_file' => $self->o('schema_file'),
         # Path to db_cmd.pl script
-        'hive_root_dir' => $ENV{'EHIVE_ROOT_DIR'},
         'db_cmd_path'   => $self->o('hive_root_dir').'/scripts/db_cmd.pl',
 
         # Set mandatory databases
@@ -243,7 +242,7 @@ sub core_pipeline_analyses {
         {   -logic_name => 'create_mlss_and_batch_members',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::CreateSuperficialMLSS',
             -flow_into  => {
-                2 => [ { 'parse_paf_for_rbbh' => { 'member_id_list' => '#member_id_list#', 'target_genome_db_id' => '#ref_genome_db_id#', 'genome_db_id' => '#genome_db_id#' } }],
+                2 => { 'parse_paf_for_rbbh' => { 'member_id_list' => '#member_id_list#', 'target_genome_db_id' => '#ref_genome_db_id#', 'genome_db_id' => '#genome_db_id#' } },
             }
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
@@ -71,7 +71,7 @@ sub default_options {
         # Compara schema file path
         'schema_file' => $self->o('schema_file'),
         # Path to db_cmd.pl script
-        'db_cmd_path'   => $self->o('hive_root_dir').'/scripts/db_cmd.pl',
+        'db_cmd_path'   => $self->o('hive_root_dir') . '/scripts/db_cmd.pl',
 
         # Set mandatory databases
         'compara_db'   => $self->pipeline_url(),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PerSpeciesCopyFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PerSpeciesCopyFactory.pm
@@ -31,7 +31,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Parts::PerSpeciesCopyFactory;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version 2.5;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf; # For WHEN and INPUT_PLUS
 
 sub pipeline_analyses_create_and_copy_per_species_db {
@@ -47,7 +47,7 @@ sub pipeline_analyses_create_and_copy_per_species_db {
         {   -logic_name => 'create_per_species_db',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::NewPerSpeciesComparaDB',
             -parameters => {
-                'curr_release' => $self->o('rel_with_suffix'),
+                'curr_release' => $self->o('ensembl_release'),
                 'db_cmd_path'  => $self->o('db_cmd_path'),
                 'schema_file'  => $self->o('schema_file'),
             },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PerSpeciesCopyFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PerSpeciesCopyFactory.pm
@@ -51,7 +51,6 @@ sub pipeline_analyses_create_and_copy_per_species_db {
                 'db_cmd_path'  => $self->o('db_cmd_path'),
                 'schema_file'  => $self->o('schema_file'),
             },
-            #-flow_into  => [ 'copy_species_db' ],
         },
 
     ];

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PerSpeciesCopyFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PerSpeciesCopyFactory.pm
@@ -1,0 +1,60 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Parts::PerSpeciesCopyFactory
+
+=head1 DESCRIPTION
+
+    This is a partial PipeConfig for creating and copying independent
+    species-specific compara databases
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Parts::PerSpeciesCopyFactory;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf; # For WHEN and INPUT_PLUS
+
+sub pipeline_analyses_create_and_copy_per_species_db {
+    my ($self) = @_;
+
+    return [
+
+        {   -logic_name => 'create_db_factory',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::SpeciesListFactory',
+            -flow_into  => [ 'create_per_species_db' ],
+        },
+
+        {   -logic_name => 'create_per_species_db',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::NewPerSpeciesComparaDB',
+            -parameters => {
+                'curr_release' => $self->o('rel_with_suffix'),
+                'db_cmd_path'  => $self->o('db_cmd_path'),
+                'schema_file'  => $self->o('schema_file'),
+            },
+            #-flow_into  => [ 'copy_species_db' ],
+        },
+
+    ];
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/CreateSuperficialMLSS.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/CreateSuperficialMLSS.pm
@@ -43,7 +43,6 @@ use warnings;
 use strict;
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
-use Data::Dumper;
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
@@ -64,9 +63,7 @@ sub run {
 
     foreach my $pair ( @$genome_pairs ) {
         my $hit_gdb_id   = $pair->{'ref_genome_db_id'};
-        print Dumper $hit_gdb_id;
         my $query_gdb_id = $pair->{'genome_db_id'};
-        print Dumper $query_gdb_id;
         my $seq_members    = $self->compara_dba->get_SeqMemberAdaptor->fetch_all_canonical_by_GenomeDB($query_gdb_id);
         my @seq_member_ids = map {$_->dbID} @$seq_members;
         my @sorted_seq_ids = sort { $a <=> $b } @seq_member_ids;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/SpeciesListFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/SpeciesListFactory.pm
@@ -1,0 +1,52 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::SpeciesListFactory
+
+=head1 DESCRIPTION
+
+Simple species_list factory to dataflow from the species_list parameter:
+the genome_name and genome_db_ids.
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::SpeciesListFactory;
+
+use warnings;
+use strict;
+use Bio::EnsEMBL::Registry;
+use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+sub write_output {
+    my $self = shift;
+
+    my $species_list = $self->param_required('species_list');
+    my $genome_dba   = $self->compara_dba->get_GenomeDBAdaptor;
+
+    foreach my $genome_name ( @$species_list ) {
+        # There can only be one of each species_name in each pipeline
+        my @genome_db    = @{$genome_dba->fetch_all_by_name($genome_name)};
+        my $genome_db_id = $genome_db[0]->dbID;
+        $self->dataflow_output_id( { 'genome_name' => $genome_name, 'genome_db_id' => $genome_db_id }, 1 );
+    }
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/SpeciesListFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/SpeciesListFactory.pm
@@ -42,10 +42,8 @@ sub write_output {
     my $genome_dba   = $self->compara_dba->get_GenomeDBAdaptor;
 
     foreach my $genome_name ( @$species_list ) {
-        # There can only be one of each species_name in each pipeline
-        my @genome_db    = @{$genome_dba->fetch_all_by_name($genome_name)};
-        my $genome_db_id = $genome_db[0]->dbID;
-        $self->dataflow_output_id( { 'genome_name' => $genome_name, 'genome_db_id' => $genome_db_id }, 1 );
+        my $genome_db = $genome_dba->fetch_by_name_assembly($genome_name);
+        $self->dataflow_output_id( { 'genome_name' => $genome_name, 'genome_db_id' => $genome_db->dbID }, 1 );
     }
 }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
@@ -1,0 +1,99 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::NewPerSpeciesComparaDB
+
+=head1 DESCRIPTION
+
+Creates new MySQL compara database for a single genome_name
+E.g. standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::NewPerSpeciesComparaDB \
+    -homology_host mysql-ens-compara-prod-2 \
+    -genome_name canis_lupus_familiaris \
+    -curr_release 103
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::NewPerSpeciesComparaDB;
+
+use warnings;
+use strict;
+
+use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
+use Bio::EnsEMBL::Compara::Utils::Database qw/ table_exists /;
+use Data::Dumper;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+sub param_defaults {
+    my $self = shift;
+
+    return {
+        %{$self->SUPER::param_defaults()},
+        'homology_host'  => 'mysql-ens-compara-prod-2',
+    };
+}
+
+sub fetch_input {
+    my $self = shift;
+
+    my $release     = $self->param_required( 'curr_release' );
+    my $genome_name = $self->param_required( 'genome_name' );
+    my $host        = $self->param_required( 'homology_host' );
+    # Keep input to fewer parameters
+    my $port     = Bio::EnsEMBL::Compara::Utils::Registry::get_port( $host );
+    my $rw_user  = Bio::EnsEMBL::Compara::Utils::Registry::get_rw_user( $host );
+    my $password = Bio::EnsEMBL::Compara::Utils::Registry::get_rw_pass( $host );
+
+    my $server_uri  = "mysql://" . $rw_user . ":" . $password . "@" . $host . ":" . $port;
+    my $new_db_name = $genome_name . "_" . "compara" . "_" . $release;
+    my $new_db      = $server_uri . "/" . $new_db_name;
+    print Dumper $new_db if $self->debug;
+    # To optionally dataflow to the next runnable if needed: e.g. to copy
+    $self->param('per_species_db', $new_db);
+
+    my $schema_file = $self->param( 'schema_file' );
+    my $db_cmd_path = $self->param( 'db_cmd_path' );
+
+    my @cmd;
+    my $sql = "CREATE DATABASE IF NOT EXISTS $new_db_name";
+    my $cmd = $db_cmd_path . " -url " . $server_uri . " -sql '" . $sql . "'";
+    print Dumper $cmd if $self->debug;
+    $self->run_command( $cmd, { die_on_failure => 1 } );
+
+    my $dba = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba( $new_db );
+    # Check to see if compara_db already exists with tables to avoid overwriting
+    if ( table_exists( $dba->dbc, 'genome_db' ) ) {
+        $self->complete_early( "Completing early because compara schema is already in place" );
+    }
+    # Insert compara schema
+    else {
+        $cmd = $db_cmd_path . " -url " . $new_db . " < " . $schema_file;
+        print Dumper $cmd if $self->debug;
+        $self->run_command( $cmd, { die_on_failure => 1 } );
+    }
+}
+
+sub write_output {
+    my $self = shift;
+    $self->SUPER::write_output();
+
+    $self->dataflow_output_id( { 'per_species_db' => $self->param('per_species_db') }, 2 );
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
@@ -61,7 +61,7 @@ sub fetch_input {
     my $password = get_rw_pass( $host );
 
     my $server_uri  = "mysql://" . $rw_user . ":" . $password . "@" . $host . ":" . $port;
-    my $new_db_name = $genome_name . "_" . "compara" . "_" . $release;
+    my $new_db_name = $genome_name . "_compara_" . $release;
     my $new_db      = $server_uri . "/" . $new_db_name;
     # To optionally dataflow to the next runnable if needed: e.g. to copy
     $self->param('per_species_db', $new_db);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
@@ -36,7 +36,7 @@ use strict;
 
 use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
 use Bio::EnsEMBL::Compara::Utils::Database qw/ table_exists /;
-use Data::Dumper;
+use Bio::EnsEMBL::Compara::Utils::Registry qw/ get_port get_rw_user get_rw_pass /;
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
@@ -56,24 +56,22 @@ sub fetch_input {
     my $genome_name = $self->param_required( 'genome_name' );
     my $host        = $self->param_required( 'homology_host' );
     # Keep input to fewer parameters
-    my $port     = Bio::EnsEMBL::Compara::Utils::Registry::get_port( $host );
-    my $rw_user  = Bio::EnsEMBL::Compara::Utils::Registry::get_rw_user( $host );
-    my $password = Bio::EnsEMBL::Compara::Utils::Registry::get_rw_pass( $host );
+    my $port     = get_port( $host );
+    my $rw_user  = get_rw_user( $host );
+    my $password = get_rw_pass( $host );
 
     my $server_uri  = "mysql://" . $rw_user . ":" . $password . "@" . $host . ":" . $port;
     my $new_db_name = $genome_name . "_" . "compara" . "_" . $release;
     my $new_db      = $server_uri . "/" . $new_db_name;
-    print Dumper $new_db if $self->debug;
     # To optionally dataflow to the next runnable if needed: e.g. to copy
     $self->param('per_species_db', $new_db);
 
-    my $schema_file = $self->param( 'schema_file' );
-    my $db_cmd_path = $self->param( 'db_cmd_path' );
+    my $schema_file = $self->param_required( 'schema_file' );
+    my $db_cmd_path = $self->param_required( 'db_cmd_path' );
 
     my @cmd;
     my $sql = "CREATE DATABASE IF NOT EXISTS $new_db_name";
-    my $cmd = $db_cmd_path . " -url " . $server_uri . " -sql '" . $sql . "'";
-    print Dumper $cmd if $self->debug;
+    my $cmd = "$db_cmd_path -url $server_uri -sql '$sql'";
     $self->run_command( $cmd, { die_on_failure => 1 } );
 
     my $dba = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba( $new_db );
@@ -83,15 +81,13 @@ sub fetch_input {
     }
     # Insert compara schema
     else {
-        $cmd = $db_cmd_path . " -url " . $new_db . " < " . $schema_file;
-        print Dumper $cmd if $self->debug;
+        $cmd = "$db_cmd_path -url $new_db < $schema_file";
         $self->run_command( $cmd, { die_on_failure => 1 } );
     }
 }
 
 sub write_output {
     my $self = shift;
-    $self->SUPER::write_output();
 
     $self->dataflow_output_id( { 'per_species_db' => $self->param('per_species_db') }, 2 );
 }

--- a/modules/t/blastFactoryHomologyAnnotation.t
+++ b/modules/t/blastFactoryHomologyAnnotation.t
@@ -51,37 +51,49 @@ my $blast_db_2 = "$ref_dump_dir/rattus_norvegicus.RGSC3.4.2009-03-Ensembl.dmnd";
 
 # Expected dataflow output
 my $exp_dataflow_1 = {
-    'member_id_list'      => [ 1, 2, 3, 4, 5 ],
-    'genome_db_id'        => 135,
-    'target_genome_db_id' => 1,
-    'ref_taxa'            => $ref_taxa,
-    'blast_db'            => $blast_db_1,
-};
-my $exp_dataflow_2 = {
-    'member_id_list'      => [ 6, 7, 8, 9 ],
-    'genome_db_id'        => 135,
-    'target_genome_db_id' => 1,
-    'ref_taxa'            => $ref_taxa,
-    'blast_db'            => $blast_db_1,
-};
-my $exp_dataflow_3 = {
-    'member_id_list'      => [ 1, 2, 3, 4, 5 ],
-    'genome_db_id'        => 135,
-    'target_genome_db_id' => 3,
-    'ref_taxa'            => $ref_taxa,
-    'blast_db'            => $blast_db_2,
-};
-my $exp_dataflow_4 = {
-    'member_id_list'      => [ 6, 7, 8, 9 ],
-    'genome_db_id'        => 135,
-    'target_genome_db_id' => 3,
-    'ref_taxa'            => $ref_taxa,
-    'blast_db'            => $blast_db_2,
-};
-my $exp_dataflow_5 = {
     'genome_db_id' => 135,
-    'ref_taxa'     => $ref_taxa,
+    'ref_taxa' => 'collection-mammalia'
 };
+
+my $exp_dataflow_2 = {
+    'member_id_list'      => [ 1, 2, 3, 4, 5 ],
+    'genome_db_id'        => 135,
+    'target_genome_db_id' => 1,
+    'ref_taxa'            => $ref_taxa,
+    'blast_db'            => $blast_db_1,
+};
+
+my $exp_dataflow_3 = {
+    'member_id_list'      => [ 6, 7, 8, 9 ],
+    'genome_db_id'        => 135,
+    'target_genome_db_id' => 1,
+    'ref_taxa'            => $ref_taxa,
+    'blast_db'            => $blast_db_1,
+};
+
+my $exp_dataflow_4 = {
+    'member_id_list'      => [ 1, 2, 3, 4, 5 ],
+    'genome_db_id'        => 135,
+    'target_genome_db_id' => 3,
+    'ref_taxa'            => $ref_taxa,
+    'blast_db'            => $blast_db_2,
+};
+
+my $exp_dataflow_5 = {
+    'member_id_list'      => [ 6, 7, 8, 9 ],
+    'genome_db_id'        => 135,
+    'target_genome_db_id' => 3,
+    'ref_taxa'            => $ref_taxa,
+    'blast_db'            => $blast_db_2,
+};
+
+my $exp_dataflow_6 = {
+    'genome_db_pairs' => [
+        { 'genome_db_id' => 135, 'ref_genome_db_id' => 1 },
+        { 'genome_db_id' => 135, 'ref_genome_db_id' => 3 },
+    ]
+};
+
 # Run standalone
 standaloneJob(
     'Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::BlastFactory',
@@ -98,7 +110,7 @@ standaloneJob(
         [
             'DATAFLOW',
             $exp_dataflow_1,
-            2
+            1
         ],
         [
             'DATAFLOW',
@@ -118,8 +130,13 @@ standaloneJob(
         [
             'DATAFLOW',
             $exp_dataflow_5,
-            1
+            2
         ],
+        [
+            'DATAFLOW',
+            $exp_dataflow_6,
+            3
+        ]
     ]
 );
 


### PR DESCRIPTION
## Description

We need to create an empty compara schema database named following `species_name_compara_releasenum`.
There was also an issue with the semaphores not working as hoped.

**Related JIRA tickets:**
- ENSCOMPARASW-4397

## Overview of changes
New analyses to create an empty database and some runnable & pipe config edits to fix the semaphore issues

#### Change 1
- The `HomologyAnnotation_conf` has a couple of new parameters and a new parts added to comply with the database creation runnables

#### Change 2
- The `HomologyAnnotation_conf` has some changes to the `-flow_intos` surrounding the `diamond_factory` with parameter name changes to fit the semaphore fixes

#### Change 3
- Change in dataflows from `HomologyAnnotation::BlastFactory` & travis unit test altered to fit. Now has a funnelled flow to flow pairs of genome_dbs

#### Change 4
- Rewritten `CreateSuperficialMLSS` to be more generic and accept new parameter `genome_db_pairs` instead of individual `target_genome_db_id` and `genome_db_id`

#### Change 5
Two new runnables:
- `SpeciesListFactory`: This takes the `species_list` parameter and quickly outputs individual species_names. I have done this because we want to avoid collecting `genome_dbs` from the db because these include reference genomes that we do not want to generate per-species dbs for. An alternative was to re-use `HomologyAnnotation::SpeciesFactory` - but this wrapper around productions `SpeciesFactory` has many unnecessary connections to the core and meta databases that can be avoided with this very basic runnable.
- `NewPerSpeciesComparaDB`: Takes a `species_name` and uses hives `db_cmd.pl` to create the db and to take in the compara `table.sql` schema. Wasn't sure about the direct use of `db_cmd.pl` - there are subroutines in hive to write the command line for you - but none of these were appropriate. The aim here was to follow a similar SOP to when a main-release db is created.

## Testing
Unit tests have been altered to fit new dataflows.
Clean pipeline run [here](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-4&port=4401&dbname=cristig_homology_annotation_create_db)
Example database produced:
`mysql-ens-compara-prod-2 verasper_variegatus_compara_104`

## Notes
Left a placeholder for the database copy runnable - $self->param('per_species_db') is the parameter it could accept, which is the url of the new database as flowed by NewPerSpeciesComparaDB (ENSCOMPARASW-4398)