### PR TITLE
Two bugfixes and added symlink to ancestral sequences

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
@@ -207,7 +207,8 @@ sub pipeline_wide_parameters {
 
         # ancestral alleles
         'anc_tmp_dir'    => "#work_dir#/ancestral_alleles",
-        'anc_output_dir' => "#dump_dir#/fasta/ancestral_alleles",
+        'anc_output_basedir' => 'fasta/ancestral_alleles',
+        'anc_output_dir'     => "#work_dir#/#anc_output_basedir#",
         'ancestral_dump_program' => $self->o('ancestral_dump_program'),
         'ancestral_stats_program' => $self->o('ancestral_stats_program'),
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
@@ -15,8 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::PipeConfig::DumpAllForRelease_conf
@@ -127,17 +125,6 @@ sub default_options {
         	DumpAncestralAlleles => {
         		compara_db => '#compara_db#',
         	},
-        },
-
-        # define which files will each method_type generate in the FTP structure
-        # this will be used to generate a bash script to copy old data
-        ftp_locations => {
-        	LASTZ_NET => ['maf/ensembl-compara/pairwise_alignments'],
-        	EPO => ['emf/ensembl-compara/multiple_alignments', 'maf/ensembl-compara/multiple_alignments'],
-        	EPO_EXTENDED => ['emf/ensembl-compara/multiple_alignments', 'maf/ensembl-compara/multiple_alignments'],
-        	PECAN => ['emf/ensembl-compara/multiple_alignments', 'maf/ensembl-compara/multiple_alignments'],
-        	GERP_CONSTRAINED_ELEMENT => ['bed/ensembl-compara'],
-        	GERP_CONSERVATION_SCORE => ['compara/conservation_scores'],
         },
 
         # DumpMultiAlign options
@@ -331,9 +318,6 @@ sub pipeline_analyses {
 
         {	-logic_name => 'create_ftp_skeleton',
         	-module     => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::FTPSkeleton',
-        	-parameters => {
-        		'ftp_locations' => $self->o('ftp_locations'),
-        	},
         	-flow_into => [ 'symlink_prev_dumps' ],
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
@@ -180,6 +180,9 @@ sub pipeline_wide_parameters {
     return {
         %{$self->SUPER::pipeline_wide_parameters},          # here we inherit anything from the base class
 
+        'curr_release'      => $self->o('ensembl_release'),
+        'curr_eg_release'   => $self->o('eg_release'),
+
         'registry'        => '#reg_conf#',
         'dump_root'       => $self->o('dump_root' ),
         'dump_dir'        => $self->o('dump_dir'),
@@ -254,7 +257,6 @@ sub pipeline_analyses {
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::CreateDumpJobs',
             -input_ids  => [ {
                     'compara_db'           => $self->o('compara_db'),
-                    'curr_release'         => $self->o('ensembl_release'),
                     'reuse_prev_rel'       => $self->o('reuse_prev_rel'),
                     'reg_conf'             => $self->o('reg_conf'),
                     'updated_mlss_ids'     => $self->o('updated_mlss_ids'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
@@ -208,7 +208,7 @@ sub pipeline_wide_parameters {
         # ancestral alleles
         'anc_tmp_dir'    => "#work_dir#/ancestral_alleles",
         'anc_output_basedir' => 'fasta/ancestral_alleles',
-        'anc_output_dir'     => "#work_dir#/#anc_output_basedir#",
+        'anc_output_dir'     => "#dump_dir#/#anc_output_basedir#",
         'ancestral_dump_program' => $self->o('ancestral_dump_program'),
         'ancestral_stats_program' => $self->o('ancestral_stats_program'),
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
@@ -62,6 +62,8 @@ sub default_options {
         # Location of the previous dumps
         'ftp_root'     => '/nfs/production/panda/ensembl/production/ensemblftp/',
 
+        'prev_rel_ftp_root' => $self->o('ftp_root') . '/release-' . $self->o('prev_release'),
+
         'compara_db'   => 'compara_curr', # can be URL or reg alias
         'ancestral_db' => undef,
 
@@ -180,9 +182,6 @@ sub pipeline_wide_parameters {
     return {
         %{$self->SUPER::pipeline_wide_parameters},          # here we inherit anything from the base class
 
-        'curr_release'      => $self->o('ensembl_release'),
-        'curr_eg_release'   => $self->o('eg_release'),
-
         'registry'        => '#reg_conf#',
         'dump_root'       => $self->o('dump_root' ),
         'dump_dir'        => $self->o('dump_dir'),
@@ -192,6 +191,7 @@ sub pipeline_wide_parameters {
         'genome_dumps_dir'=> $self->o('genome_dumps_dir'),
         'warehouse_dir'   => $self->o('warehouse_dir'),
         'uniprot_file'    => $self->o('uniprot_file'),
+        'prev_rel_ftp_root' => $self->o('prev_rel_ftp_root'),
 
         # tree params
         'dump_trees_capacity' => $self->o('dump_trees_capacity'),
@@ -258,6 +258,7 @@ sub pipeline_analyses {
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::CreateDumpJobs',
             -input_ids  => [ {
                     'compara_db'           => $self->o('compara_db'),
+                    'curr_release'         => $self->o('ensembl_release'),
                     'reuse_prev_rel'       => $self->o('reuse_prev_rel'),
                     'reg_conf'             => $self->o('reg_conf'),
                     'updated_mlss_ids'     => $self->o('updated_mlss_ids'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAncestralAlleles_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAncestralAlleles_conf.pm
@@ -69,7 +69,8 @@ sub pipeline_wide_parameters {
         'ancestral_db' => $self->o('ancestral_db'),
 
         'dump_dir' => $self->o('dump_dir'),
-        'anc_output_dir' => "#dump_dir#/fasta/ancestral_alleles",
+        'anc_output_basedir' => "fasta/ancestral_alleles",
+        'anc_output_dir'     => "#dump_dir#/#anc_output_basedir#",
         'anc_tmp_dir' => "#dump_dir#/tmp",
 
         'genome_dumps_dir' => $self->o('genome_dumps_dir'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -64,6 +64,7 @@ sub shared_default_options {
 
         # EG release number
         'eg_release'            => Bio::EnsEMBL::ApiVersion::software_version()-53,
+        'prev_eg_release'       => Bio::EnsEMBL::ApiVersion::software_version()-54,
 
         # TODO: make a $self method that checks whether this already exists, to prevent clashes like in the LastZ pipeline
         # NOTE: hps_dir and warehouse_dir are expected to be defined in the meadow JSON file

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/DumpAllForRelease_conf.pm
@@ -50,6 +50,8 @@ sub default_options {
         'dump_dir'         => $self->o('dump_root') . '/release-' . $self->o('eg_release'),
 
         'division'         => 'metazoa',
+
+        'prev_rel_ftp_root' => $self->o('ftp_root') . '/release-' . $self->o('prev_eg_release') . '/' . $self->o('division'),
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/DumpAllForRelease_conf.pm
@@ -52,6 +52,8 @@ sub default_options {
         'dump_dir'         => $self->o('dump_root') . '/release-' . $self->o('eg_release'),
 
         'division'          => 'pan',
+
+        'prev_rel_ftp_root' => $self->o('ftp_root') . '/release-' . $self->o('prev_eg_release') . '/pan_ensembl',
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/DumpAllForRelease_conf.pm
@@ -54,6 +54,8 @@ sub default_options {
 
         'division'          => 'plants',
         'epo_reference_species' => ['oryza_sativa'],
+
+        'prev_rel_ftp_root' => $self->o('ftp_root') . '/release-' . $self->o('prev_eg_release') . '/' . $self->o('division'),
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/CreateDumpJobs.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/CreateDumpJobs.pm
@@ -17,7 +17,7 @@ limitations under the License.
 
 =head1 NAME
 
-Bio::EnsEMBL::Compara::RunnableDB::CreateDumpJobs
+Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::CreateDumpJobs
 
 =head1 SYNOPSIS
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/CreateDumpJobs.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/CreateDumpJobs.pm
@@ -15,10 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-=pod
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::CreateDumpJobs
@@ -164,10 +160,12 @@ sub write_output {
 	return 1 unless ( $self->param_required('reuse_prev_rel') );
 
 	my $copy_jobs = $self->param('copy_jobs');
-	return 1 unless $copy_jobs->[0];
+    my $copy_ancestral_alleles = (($self->param_required('division') eq 'vertebrates') && ! $self->param('dump_ancestral_alleles')) || 0;
+    return 1 unless (@$copy_jobs || $copy_ancestral_alleles);
 	print "\n\nTO COPY: \n";
 	print '(' . join(', ', @$copy_jobs) . ")\n";
-	$self->dataflow_output_id( { mlss_ids => $copy_jobs }, 8 );
+    print "ancestral alleles\n" if $copy_ancestral_alleles;
+    $self->dataflow_output_id( { mlss_ids => $copy_jobs, copy_ancestral_alleles => $copy_ancestral_alleles }, 8 );
 }
 
 sub _dump_multialign_jobs {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/FTPSkeleton.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/FTPSkeleton.pm
@@ -51,6 +51,7 @@ sub param_defaults {
         	GERP_CONSTRAINED_ELEMENT => ['bed/ensembl-compara'],
             GERP_CONSERVATION_SCORE  => ['compara/conservation_scores'],
         },
+        copy_ancestral_alleles => 0,
     }
 }
 
@@ -77,6 +78,11 @@ sub fetch_input {
 			}
 		}
 	}
+
+    if ($self->param_required('copy_ancestral_alleles')) {
+        my $basedir = $self->param_required('anc_output_basedir');
+        $mlss_dump_dirs{$basedir} = 'ANCESTRAL_ALLELES';
+    }
 
     $self->param('base_dump_dirs', \@base_dump_dirs);
 	$self->param('mlss_dump_dirs', \%mlss_dump_dirs);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/FTPSkeleton.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/FTPSkeleton.pm
@@ -15,10 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-=pod
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::FTPSkeleton
@@ -40,9 +36,7 @@ use warnings;
 use strict;
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
-use Data::Dumper;
 
-# use base ('Bio::EnsEMBL::Hive::RunnableDB::SystemCmd');
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
 sub param_defaults {
@@ -55,7 +49,7 @@ sub param_defaults {
         	EPO_EXTENDED => ['emf/ensembl-compara/multiple_alignments', 'maf/ensembl-compara/multiple_alignments'],
         	PECAN => ['emf/ensembl-compara/multiple_alignments', 'maf/ensembl-compara/multiple_alignments'],
         	GERP_CONSTRAINED_ELEMENT => ['bed/ensembl-compara'],
-        	# GERP_CONSERVATION_SCORE => ['compara/conservation_scores'],
+            GERP_CONSERVATION_SCORE  => ['compara/conservation_scores'],
         },
     }
 }
@@ -112,10 +106,8 @@ sub _mlss_dirs {
 
 	my $mlss_adaptor = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor;
 	my @these_mlsses = map { $mlss_adaptor->fetch_by_dbID($_) } @{ $self->param_required('mlss_ids') };
-	# my @mlss_dirs;
 	my %mlss_dirs;
 	foreach my $mlss ( @these_mlsses ) {
-		# push( @mlss_dirs, $mlss->filename ) if $mlss->method->type eq $method_type;
 		$mlss_dirs{ $mlss->filename } = $mlss->dbID if $mlss->method->type eq $method_type;
 	}
 	return \%mlss_dirs;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/PatchLastzDump.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/PatchLastzDump.pm
@@ -15,10 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-=pod
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::PatchLastzDump
@@ -37,18 +33,9 @@ use warnings;
 use strict;
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
-use Data::Dumper;
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
-# sub param_defaults {
-#     my $self = shift;
-#     return {
-#         %{$self->SUPER::param_defaults},
-        
-# 		'compara_db' => '#patch_db#',
-# 	}
-# }
 
 sub fetch_input {
 	my $self = shift;
@@ -72,8 +59,16 @@ sub fetch_input {
 
 	# where dump tarball of full lastz lives (from previous release)
 	my $ftp_root = $self->param_required('ftp_root');
-	my $prev_release = $self->param_required('curr_release') - 1;
-	my $prev_rel_tarball = "$ftp_root/release-$prev_release/$lastz_dump_path/$mlss_filename*";
+    my $division = $self->param_required('division');
+    my $prev_rel_tarball;
+    if ($division eq 'vertebrates') {
+        my $prev_release = $self->param_required('curr_release') - 1;
+        $prev_rel_tarball = "$ftp_root/release-$prev_release/$lastz_dump_path/$mlss_filename*";
+    } else {
+        my $prev_eg_release = $self->param_required('curr_eg_release') - 1;
+        my $div_folder = ($division =~ /^pan($|[^a-z])/) ? 'pan_ensembl' : $division;
+        $prev_rel_tarball = "$ftp_root/release-$prev_eg_release/$div_folder/$lastz_dump_path/$mlss_filename*";
+    }
 
 	my @tarballs = glob "$prev_rel_tarball";
 	die "Cannot find previous release tarball for mlss_id $mlss_id : $prev_rel_tarball\n" unless defined $tarballs[0];

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/PatchLastzDump.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/PatchLastzDump.pm
@@ -58,17 +58,8 @@ sub fetch_input {
 	$self->param( 'patch_dump_dir', $patch_dump_dir );
 
 	# where dump tarball of full lastz lives (from previous release)
-	my $ftp_root = $self->param_required('ftp_root');
-    my $division = $self->param_required('division');
-    my $prev_rel_tarball;
-    if ($division eq 'vertebrates') {
-        my $prev_release = $self->param_required('curr_release') - 1;
-        $prev_rel_tarball = "$ftp_root/release-$prev_release/$lastz_dump_path/$mlss_filename*";
-    } else {
-        my $prev_eg_release = $self->param_required('curr_eg_release') - 1;
-        my $div_folder = ($division =~ /^pan($|[^a-z])/) ? 'pan_ensembl' : $division;
-        $prev_rel_tarball = "$ftp_root/release-$prev_eg_release/$div_folder/$lastz_dump_path/$mlss_filename*";
-    }
+    my $prev_rel_ftp_root = $self->param_required('prev_rel_ftp_root');
+    my $prev_rel_tarball = "$prev_rel_ftp_root/$lastz_dump_path/$mlss_filename*";
 
 	my @tarballs = glob "$prev_rel_tarball";
 	die "Cannot find previous release tarball for mlss_id $mlss_id : $prev_rel_tarball\n" unless defined $tarballs[0];

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/SymlinkPreviousDumps.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/SymlinkPreviousDumps.pm
@@ -36,18 +36,9 @@ sub fetch_input {
 
 	my $ftp_root = $self->param_required('ftp_root');
 	my $dump_dir = $self->param_required('dump_dir');
-    my $division = $self->param_required('division');
+    my $prev_rel_ftp_root = $self->param_required('prev_rel_ftp_root');
 
-    my ($prev_rel_ftp_root, @cmds, %missing_dump_mlsses);
-
-    if ($division eq 'vertebrates') {
-        my $prev_release = $self->param_required('curr_release') - 1;
-        $prev_rel_ftp_root = "$ftp_root/release-$prev_release";
-    } else {
-        my $prev_eg_release = $self->param_required('curr_eg_release') - 1;
-        $prev_rel_ftp_root = "$ftp_root/release-$prev_eg_release/$division";
-        $prev_rel_ftp_root .= '_ensembl' if ($division =~ /^pan($|[^a-z])/);
-    }
+    my (@cmds, %missing_dump_mlsses);
 
 	# first, symlink * from the mlss-specific dirs
 	my $mlss_dump_dirs = $self->param_required('mlss_dump_dirs');

--- a/scripts/dumps/verify_ftp_dumps.pl
+++ b/scripts/dumps/verify_ftp_dumps.pl
@@ -144,7 +144,7 @@ foreach my $mlss ( @$mlsses ) {
 }
 
 if (scalar(keys %existing_files)) {
-    die "Found files that do not belong to any MethodLinkSpeciesSet:\n" . join('\n', keys %existing_files), "\n\n";
+    die "Some FTP dump files do not belong to any MethodLinkSpeciesSet:\n" . join("\n", keys %existing_files), "\n\n";
 }
 
 print "All MethodLinkSpeciesSets found in FTP\n\n";

--- a/scripts/dumps/verify_ftp_dumps.pl
+++ b/scripts/dumps/verify_ftp_dumps.pl
@@ -22,21 +22,33 @@ use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
 use Getopt::Long;
 
-my ( $help, $reg_conf, $compara_db, $ftp_root, $release, $division );
+my ( $help, $reg_conf, $compara_db, $ftp_root, $release, $eg_release, $division );
 GetOptions(
     "help"         => \$help,
     "reg_conf=s"   => \$reg_conf,
     "compara_db=s" => \$compara_db,
     "ftp_root=s"   => \$ftp_root,
     "release=i"    => \$release,
+    "eg_release=i" => \$eg_release,
     "division=s"   => \$division,
 );
 
+$reg_conf = $ENV{COMPARA_REG_PATH} unless $reg_conf;
 $release  = $ENV{CURR_ENSEMBL_RELEASE} unless $release;
-$ftp_root = $ENV{ENSEMBL_FTP} . "/release-$release/" unless $ftp_root;
+$eg_release = $ENV{CURR_EG_RELEASE} unless $eg_release;
+$division = $ENV{COMPARA_DIV} unless $division;
 
-die "FTP root '$ftp_root' does not exist\n" unless -e $ftp_root;
+if (! $ftp_root) {
+    if ($division eq 'vertebrates') {
+        $ftp_root = $ENV{ENSEMBL_FTP} . "/release-$release/";
+    } else {
+        $ftp_root = $ENV{ENSEMBL_FTP} . "/release-$eg_release/$division";
+        $ftp_root .= '_ensembl' if ($division =~ /^pan($|[^a-z])/);
+    }
+}
+
 die &helptext if ( $help || !($reg_conf && $compara_db && $division) );
+die "FTP root '$ftp_root' does not exist\n" unless -e $ftp_root;
 
 my %ftp_file_per_mlss = (
 	LASTZ_NET                => 'maf/ensembl-compara/pairwise_alignments/#mlss_filename#*.tar*',
@@ -50,13 +62,24 @@ my %ftp_file_per_mlss = (
     ENSEMBL_ORTHOLOGUES      => 'tsv/ensembl-compara/homologies/#species_name#/*',
     ENSEMBL_PARALOGUES       => 'tsv/ensembl-compara/homologies/#species_name#/*',
     SPECIES_TREE             => 'compara/species_trees/*.nh',
+    CACTUS_HAL               => 'compara/species_trees/*.nh',
 );
+
+# Get every dumped file present in the ftp_root
+my @existing_files;
+my %ftp_paths = map { $_ => 1 } values %ftp_file_per_mlss;
+foreach my $path (keys %ftp_paths) {
+    $path =~ s/#\w+#\*?/*/;
+    push @existing_files, glob "$ftp_root/$path";
+}
+my %existing_files = map { $_ => 1 } @existing_files;
 
 my $registry = 'Bio::EnsEMBL::Registry';
 $registry->load_all($reg_conf, 0, 0, 0, "throw_if_missing") if $reg_conf;
 my $dba = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba( $compara_db );
 my $mlsses = $dba->get_MethodLinkSpeciesSetAdaptor->fetch_all_current;
 
+# Remove from the list of existing files those corresponding to each current MLSS
 foreach my $mlss ( @$mlsses ) {
     my $file_for_type = $ftp_file_per_mlss{$mlss->method->type};
     next unless defined $file_for_type;
@@ -75,6 +98,7 @@ foreach my $mlss ( @$mlsses ) {
             @files = glob $file_for_type;
         }
         die "Could not find file for MethodLinkSpeciesSet dbID " . $mlss->dbID . " (" . $mlss->name . "): $file_for_type" unless scalar(@files) && -e $files[0];
+        delete @existing_files{@files};
     } elsif ( $file_for_type =~ /#collection_name#/ ) {
         my $collection_name = $mlss->species_set->name;
         $collection_name =~ s/collection-//;
@@ -82,6 +106,7 @@ foreach my $mlss ( @$mlsses ) {
         $file_for_type = "$ftp_root/$file_for_type";
         my @files = glob $file_for_type;
         die "Could not find file for MethodLinkSpeciesSet dbID " . $mlss->dbID . " (" . $mlss->name . "): $file_for_type" unless scalar(@files) && -e $files[0];
+        delete @existing_files{@files};
     } elsif ( $file_for_type =~ /#clusterset_id#/ ) {
         my $clusterset_id = 'default';
         if ( $division eq 'vertebrates' ) {
@@ -93,6 +118,7 @@ foreach my $mlss ( @$mlsses ) {
         $file_for_type = "$ftp_root/$file_for_type";
         my @files = glob $file_for_type;
         die "Could not find file for MethodLinkSpeciesSet dbID " . $mlss->dbID . " (" . $mlss->name . "): $file_for_type" unless scalar(@files) && -e $files[0];
+        delete @existing_files{@files};
     } elsif ( $file_for_type =~ /#species_name#/ ) {
         $file_for_type = "$ftp_root/$file_for_type";
         foreach my $gdb ( @{ $mlss->species_set->genome_dbs } ) {
@@ -107,19 +133,26 @@ foreach my $mlss ( @$mlsses ) {
                 @files = glob $this_collection_species_file_for_type;
                 die "Could not find file for MethodLinkSpeciesSet dbID " . $mlss->dbID . " (" . $mlss->name . "): $this_species_file_for_type" unless scalar(@files) && -e $files[0];
             }
+            delete @existing_files{@files};
         }
     } else {
         $file_for_type = "$ftp_root/$file_for_type";
         my @files = glob $file_for_type;
         die "Could not find file for MethodLinkSpeciesSet dbID " . $mlss->dbID . " (" . $mlss->name . "): $file_for_type" unless scalar(@files) && -e $files[0];
+        delete @existing_files{@files};
     }
 }
+
+if (scalar(keys %existing_files)) {
+    die "Found files that do not belong to any MethodLinkSpeciesSet:\n" . join('\n', keys %existing_files), "\n\n";
+}
+
 print "All MethodLinkSpeciesSets found in FTP\n\n";
 
 sub helptext {
 	my $msg = <<HELPEND;
 
-Usage: perl verify_ftp_dumps.pl --reg_conf <registry config> --compara_db <alias or url> -division <division> [--release <release number> --ftp_root <path to FTP root>]
+Usage: perl verify_ftp_dumps.pl --compara_db <alias or url> [--reg_conf <registry config> --division <division> --release <release number> --eg_release <eg release number> --ftp_root <path to FTP root>]
 
 HELPEND
 	return $msg;


### PR DESCRIPTION
## Description

Fixed `DumpAllForRelease` pipeline that was copying retired LastZs and previous release vertebrates MLSS dumps instead of the corresponding division for non-vertebrates. Improved `verify_ftp_dumps.pl` to detect these scenarios. Incorporated last manual step to symlink ancestral alleles.

**Related JIRA tickets:**
- ENSCOMPARASW-4380
- ENSCOMPARASW-4382
- ENSCOMPARASW-4387

## Overview of changes
#### Change 1
- Fixed `PatchLastzDump` and `SymlinkPreviousDumps` to use `release-$PREV_EG_RELEASE/$COMPARA_DIV` instead of `release-$CURR_ENSEMBL_RELEASE` for NV divisions.

#### Change 2
- `verify_ftp_dumps.pl` now gets the list of all dumped files, loops over each current MLSS to see if the files are present, and will comply if at the end there are any files left that do not belong to any current MLSS. I have tried to implement the fastest approach I could think of.

#### Change 3
- Flowing `LASTZ_NET` entry in `mlss_dumps_dirs` was making the next analysis, `symlink_prev_dumps`, to symlink all previous release LastZs. It was not only making passing `archived_dumps` MLSS ids redundant, but it was also copying retired LastZs. I have removed it from the dataflow.

#### Change 4
- Added to the pipeline the last manual step remaining: the manual symlink of the ancestral alleles. This involves changes in both `CreateDumpJobs` and `FTPSkeleton` runnables.

## Testing
I have created two new pipelines, [jalvarez_vertebrates_dump_all_for_release_104_test](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-9&port=4647&dbname=jalvarez_vertebrates_dump_all_for_release_104_test) and [jalvarez_metazoa_dump_all_for_release_104_test](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-9&port=4647&dbname=jalvarez_metazoa_dump_all_for_release_104_test), and run the analyses that I have updated. I have checked the dumped files and now only current MLSSs are copied from a previous release, and the copy comes from the corresponding FTP dump directory.

For `verify_ftp_dumps.pl`, I have tested it with the vertebrates e104 FTP dumps and it has flagged all the retired LastZs correctly.

## Notes
- When this PR is merged I will update the [confluence document](https://www.ebi.ac.uk/seqdb/confluence/pages/viewpage.action?spaceKey=EnsCom&title=Flat+file+dumps) to remove the step regarding Ancestral alleles manual symlink.
- I haven't been able to figure out a good approach to add the ancestral alleles to `verify_ftp_dumps.pl` since these are not linked to any MLSS. Any ideas are welcome :)
