### PR TITLE
Feature/homology annotation - Copy data per genome to per-rr-species database

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -124,11 +124,12 @@ sub executable_locations {
         'emf2maf_program'                   => $self->check_exe_in_ensembl('ensembl-compara/scripts/dumps/emf2maf.pl'),
         'epo_stats_report_exe'              => $self->check_exe_in_ensembl('ensembl-compara/scripts/production/epo_stats.pl'),
         'populate_new_database_exe'         => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/populate_new_database.pl'),
+        'populate_per_genome_database_exe'  => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/populate_per_genome_database.pl'),
         'create_datacheck_tickets_exe'      => $self->check_exe_in_ensembl('ensembl-compara/scripts/jira_tickets/create_datacheck_tickets.pl'),
         'copy_ancestral_core_exe'           => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/copy_ancestral_core.pl'),
 
         # Other dependencies (non executables)
-        'schema_file'                       => $self->check_file_in_ensembl('ensembl-compara/sql/table.sql'),
+        'schema_file_sql'                   => $self->check_file_in_ensembl('ensembl-compara/sql/table.sql'),
         'core_schema_sql'                   => $self->check_file_in_ensembl('ensembl/sql/table.sql'),
         'tree_stats_sql'                    => $self->check_file_in_ensembl('ensembl-compara/sql/tree-stats-as-stn_tags.sql'),
     };

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
@@ -69,9 +69,11 @@ sub default_options {
         # Directory for diamond and fasta files for query genome
         'members_dumps_dir' => $self->o('dump_path'),
         # Compara schema file path
-        'schema_file' => $self->o('schema_file'),
+        'schema_file' => $self->o('schema_file_sql'),
         # Path to db_cmd.pl script
-        'db_cmd_path'   => $self->o('hive_root_dir') . '/scripts/db_cmd.pl',
+        'db_cmd_path' => $self->o('hive_root_dir') . '/scripts/db_cmd.pl',
+        # Copy databases program
+        'copy_program' => $self->o('populate_per_genome_database_exe'),
 
         # Set mandatory databases
         'compara_db'   => $self->pipeline_url(),
@@ -110,6 +112,15 @@ sub default_options {
         'failures_fatal'   => 1, # no DC failure tolerance
         'old_server_uri'   => $self->o('compara_db'),
         'db_name'          => $self->o('dbowner') . '_' . $self->o('pipeline_name'),
+
+        # DB copy list of tables for per-species rapid release
+        'table_list' => [
+            "genome_db",
+            "method_link_species_set",
+            "gene_member",
+            "peptide_align_feature",
+            "homology",
+        ],
 
         # DIAMOND e-hive parameters
         'blast_factory_capacity'   => 50,

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
@@ -113,7 +113,7 @@ sub default_options {
         'old_server_uri'   => $self->o('compara_db'),
         'db_name'          => $self->o('dbowner') . '_' . $self->o('pipeline_name'),
 
-        # DB copy list of tables for per-species rapid release
+        # List of tables to copy to per-species compara database
         'table_list' => [
             "genome_db",
             "method_link_species_set",

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PerSpeciesCopyFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PerSpeciesCopyFactory.pm
@@ -51,6 +51,17 @@ sub pipeline_analyses_create_and_copy_per_species_db {
                 'db_cmd_path'  => $self->o('db_cmd_path'),
                 'schema_file'  => $self->o('schema_file'),
             },
+            -flow_into => {
+                2 => [ 'copy_per_species_db' ],
+            },
+        },
+
+        {   -logic_name => 'copy_per_species_db',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::CopyPerSpeciesComparaDB',
+            -parameters => {
+                'program'    => $self->o('copy_program'),
+                'table_list' => $self->o('table_list'),
+            }
         },
 
     ];

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/CopyPerSpeciesComparaDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/CopyPerSpeciesComparaDB.pm
@@ -38,7 +38,7 @@ use base ('Bio::EnsEMBL::Hive::RunnableDB::SystemCmd');
 sub fetch_input {
     my $self = shift;
 
-    my @table_list = @{ $self->param('table_list') };
+    my @table_list = @{ $self->param_required('table_list') };
     my @cmd;
 
     push @cmd, $self->param_required('program');
@@ -46,7 +46,7 @@ sub fetch_input {
     push @cmd, '--compara_db', $self->param_required('per_species_db');
     push @cmd, '--tables', join(',', @table_list);
     push @cmd, '--genome_name', $self->param('genome_name') if $self->param('genome_name');
-    push @cmd, '--copy_dna', unless $self->param('skip_dna');
+    push @cmd, '--copy_dna' unless $self->param('skip_dna');
 
     $self->param('cmd', \@cmd);
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/CopyPerSpeciesComparaDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/CopyPerSpeciesComparaDB.pm
@@ -1,0 +1,55 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::CopyPerSpeciesComparaDB
+
+=head1 DESCRIPTION
+
+Runs the ensembl-compara/scripts/pipeline/populate_per_genome_database.pl
+script.
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::CopyPerSpeciesComparaDB;
+
+use warnings;
+use strict;
+use Bio::EnsEMBL::Registry;
+use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
+
+use base ('Bio::EnsEMBL::Hive::RunnableDB::SystemCmd');
+
+sub fetch_input {
+    my $self = shift;
+
+    my @table_list = @{ $self->param('table_list') };
+    my @cmd;
+
+    push @cmd, $self->param_required('program');
+    push @cmd, '--pipeline_db', $self->dbc->url();
+    push @cmd, '--compara_db', $self->param_required('per_species_db');
+    push @cmd, '--tables', join(',', @table_list);
+    push @cmd, '--genome_name', $self->param('genome_name') if $self->param('genome_name');
+    push @cmd, '--copy_dna', unless $self->param('skip_dna');
+
+    $self->param('cmd', \@cmd);
+
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
@@ -76,8 +76,7 @@ sub write_output {
     my $dba = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba( $new_db );
     # Check to see if compara_db already exists with tables to avoid overwriting
     if ( table_exists( $dba->dbc, 'genome_db' ) ) {
-        $self->dataflow_output_id( { 'per_species_db' => $new_db }, 2 );
-        $self->complete_early( "Completing early because compara schema is already in place" );
+        $self->warn( "Compara schema is already in place" );
     }
     # Insert compara schema
     else {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
@@ -60,7 +60,7 @@ sub write_output {
     my $password = Bio::EnsEMBL::Compara::Utils::Registry::get_rw_pass( $host );
 
     my $server_uri  = "mysql://" . $rw_user . ":" . $password . "@" . $host . ":" . $port;
-    my $new_db_name = $genome_name . "_" . "compara" . "_" . $release;
+    my $new_db_name = $genome_name . "_compara_" . $release;
     my $new_db      = $server_uri . "/" . $new_db_name;
     # To optionally dataflow to the next runnable if needed: e.g. to copy
     $self->param('per_species_db', $new_db);

--- a/scripts/pipeline/populate_per_genome_database.pl
+++ b/scripts/pipeline/populate_per_genome_database.pl
@@ -52,8 +52,6 @@ the --insert-ignore option.
 
 Prints help message and exits.
 
-=over
-
 =item B<--pipeline_db pipeline_db_url>
 
 The pipeline database url.
@@ -66,19 +64,17 @@ The per-species compara database url.
 The URL format is:
 mysql://username[:passwd]@host[:port]/db_name
 
-=over
-
 =item B<--genome_name genome_name>
 
 The genome_name as used in database.
 E.g. --genome_name homo_sapiens
 
-=over
-
 =item B<--copy_dna>
 
 Flag to copy dna.
 Without flag, dna will not be copied.
+
+=back
 
 =cut
 

--- a/scripts/pipeline/populate_per_genome_database.pl
+++ b/scripts/pipeline/populate_per_genome_database.pl
@@ -1,0 +1,295 @@
+#!/usr/bin/env perl
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+use warnings;
+use strict;
+
+=head1 NAME
+
+populate_per_genome_database.pl
+
+=head1 DESCRIPTION
+
+This script copies from pipeline db to an empty per-species compara db.
+
+This script only copies the data from the tables corresponding to the provided
+compara_db for the provided list of tables.
+
+=head1 SYNOPSIS
+
+perl populate_per_genome_database.pl --help
+
+perl populate_per_genome_database.pl
+    --pipeline_db pipeline_db_url
+    --compara_db per_species_db_url
+    --tables "genome_db,method_link_species_set_id..."
+
+=head1 REQUIREMENTS
+
+This script uses mysql, mysqldump and mysqlimport programs.
+It requires at least version 4.1.12 of mysqldump as it uses
+the --insert-ignore option.
+
+=head1 ARGUMENTS
+
+=over
+
+=item B<[--help]>
+
+Prints help message and exits.
+
+=over
+
+=item B<--pipeline_db pipeline_db_url>
+
+The pipeline database url.
+The URL format is:
+mysql://username[:passwd]@host[:port]/db_name
+
+=item B<--compara_db per_species_db_url>
+
+The per-species compara database url.
+The URL format is:
+mysql://username[:passwd]@host[:port]/db_name
+
+=over
+
+=item B<--genome_name genome_name>
+
+The genome_name as used in database.
+E.g. --genome_name homo_sapiens
+
+=over
+
+=item B<--copy_dna>
+
+Flag to copy dna.
+Without flag, dna will not be copied.
+
+=cut
+
+use Getopt::Long;
+use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
+use Bio::EnsEMBL::Compara::Utils::CopyData qw(:table_copy);
+
+my ( $help, $pipeline_db, $compara_db, @list_of_tables, $genome_name, $dnafrag );
+GetOptions(
+    "help"          => \$help,
+    "pipeline_db=s" => \$pipeline_db,
+    "compara_db=s"  => \$compara_db,
+    "tables=s"      => \@list_of_tables,
+    "genome_name=s" => \$genome_name,
+    "copy_dna"      => \$dnafrag,
+);
+
+@list_of_tables = split(/,/,join(',',@list_of_tables));
+my %tables      =  map { $_ => 1 } @list_of_tables;
+
+my $pipeline_dba = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba( $pipeline_db );
+my $compara_dba  = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba( $compara_db );
+
+# Copy ncbi tables
+copy_table( $pipeline_dba->dbc, $compara_dba->dbc, "ncbi_taxa_node" );
+copy_table( $pipeline_dba->dbc, $compara_dba->dbc, "ncbi_taxa_name" );
+copy_table( $pipeline_dba->dbc, $compara_dba->dbc, "meta" );
+
+# Collect necessary genome_name as provided or from db
+$genome_name = $genome_name ? $genome_name : ( $compara_dba->dbc->dbname =~ /([a-z0-9_])_compara_/i );
+my $genome_db = $pipeline_dba->get_GenomeDBAdaptor->fetch_by_name_assembly( $genome_name );
+
+$compara_dba->dbc->do("SET FOREIGN_KEY_CHECKS = 0");
+
+if ( defined $tables{'genome_db'} ) {
+    copy_genome_db( $compara_dba, $genome_db );
+}
+
+if ( defined $tables{'method_link_species_set'} or defined $tables{'species_set'} ) {
+    copy_mlss_and_ss( $pipeline_dba, $compara_dba, $genome_db );
+}
+
+if ( defined $tables{'gene_member'} or defined $tables{'seq_member'} ) {
+    copy_gene_and_seq_members( $pipeline_dba, $compara_dba, $genome_db, $dnafrag );
+}
+
+if ( defined $tables{'peptide_align_feature'} ) {
+    copy_pafs( $pipeline_dba, $compara_dba, $genome_db->dbID );
+}
+
+if ( defined $tables{'homology'} or defined $tables{'homology_member'} ) {
+    copy_homology_and_members( $pipeline_dba, $compara_dba, $genome_db );
+}
+
+$compara_dba->dbc->do("SET FOREIGN_KEY_CHECKS = 1");
+
+
+exit(0);
+
+=head2 copy_genome_db
+
+    Arg[1]      : Bio::EnsEMBL::Compara::DBSQL::DBAdaptor $to_dba (Mandatory)
+    Arg[2]      : Bio::EnsEMBL::Compara::DBSQL::GenomeDBAdaptor $genome_db (Mandatory)
+    Description : copy from $from_dba to $to_dba just the genome_db which
+                  correspond to $genome_db only.
+    Returns     : None
+    Exceptions  : None
+
+=cut
+
+sub copy_genome_db {
+    my ($to_dba, $genome_db) = @_;
+
+    my $genome_dba = $to_dba->get_GenomeDBAdaptor;
+    $genome_dba->store( $genome_db );
+}
+
+=head2 copy_mlss_and_ss
+
+    Arg[1]      : Bio::EnsEMBL::Compara::DBSQL::DBAdaptor $from_dba (Mandatory)
+    Arg[2]      : Bio::EnsEMBL::Compara::DBSQL::DBAdaptor $to_dba (Mandatory)
+    Arg[3]      : Bio::EnsEMBL::Compara::DBSQL::GenomeDBAdaptor $genome_db (Mandatory)
+    Description : copy from $from_dba to $to_dba just the method_link_species_set
+                  and species_sets which correspond to $genome_db_id only.
+    Returns     : None
+    Exceptions  : None
+
+=cut
+
+sub copy_mlss_and_ss {
+    my ($from_dba, $to_dba, $genome_db) = @_;
+
+    my $from_mlss_adap = $from_dba->get_MethodLinkSpeciesSetAdaptor;
+    my $to_mlss_adap   = $to_dba->get_MethodLinkSpeciesSetAdaptor;
+
+    my $mlsss = $from_mlss_adap->fetch_all_by_GenomeDB( $genome_db );
+    foreach my $mlss ( @$mlsss ) {
+        $to_mlss_adap->store( $mlss );
+    }
+}
+
+=head2 copy_gene_and_seq_members
+
+    Arg[1]      : Bio::EnsEMBL::Compara::DBSQL::DBAdaptor $from_dba (Mandatory)
+    Arg[2]      : Bio::EnsEMBL::Compara::DBSQL::DBAdaptor $to_dba (Mandatory)
+    Arg[3]      : Bio::EnsEMBL::Compara::DBSQL::GenomeDBAdaptor $genome_db (Mandatory)
+    Arg[4]      : $dnafrag default: undef (Optional)
+    Description : copy from $from_dba to $to_dba just the gene_member and
+                  seq_members which correspond to $genome_db_id only. Optionally
+                  copies across dnafrags if required.
+    Returns     : None
+    Exceptions  : None
+
+=cut
+
+sub copy_gene_and_seq_members {
+    my ($from_dba, $to_dba, $genome_db, $dnafrag) = @_;
+
+    my $from_gene_adap = $from_dba->get_GeneMemberAdaptor;
+    my $to_gene_adap   = $to_dba->get_GeneMemberAdaptor;
+
+    my $from_dna_adap = $from_dba->get_DnaFragAdaptor;
+    my $to_dna_adap   = $to_dba->get_DnaFragAdaptor;
+
+    my $from_sm_adap = $from_dba->get_SeqMemberAdaptor;
+    my $to_sm_adap   = $to_dba->get_SeqMemberAdaptor;
+
+    my $from_seq_adap = $from_dba->get_SequenceAdaptor;
+    my $to_seq_adap   = $to_dba->get_SequenceAdaptor;
+
+    my $seq_members = $from_sm_adap->fetch_all_canonical_by_GenomeDB( $genome_db );
+    foreach my $seq_member ( @$seq_members ) {
+        # For some reason $seq_member->gene_member returns undef attribute.
+        # May be linked to intentional missing dnafrag for homology etc.
+        my $gene_member = $from_gene_adap->fetch_by_dbID( $seq_member->gene_member_id );
+        $to_gene_adap->store( $gene_member );
+        my $sequence = $from_seq_adap->fetch_by_dbID( $seq_member->sequence_id );
+        $to_seq_adap->store( $sequence );
+        $to_sm_adap->store( $seq_member );
+        # For rapid release as of e103-e104 only canonical peptides are used -
+        # when pairwise alignments are introduced, dnafrags will also need to be copied
+        if ( $dnafrag ) {
+            copy_dnafrags( $from_dba, $to_dba, $genome_db->dbID );
+        }
+    }
+}
+
+=head2 copy_pafs
+
+    Arg[1]      : Bio::EnsEMBL::Compara::DBSQL::DBAdaptor $from_dba (Mandatory)
+    Arg[2]      : Bio::EnsEMBL::Compara::DBSQL::DBAdaptor $to_dba (Mandatory)
+    Arg[3]      : $genome_db_id (Mandatory)
+    Description : copy from $from_dba to $to_dba just the peptide_align_features
+                  which correspond to $genome_db_id only.
+    Returns     : None
+    Exceptions  : None
+
+=cut
+
+sub copy_pafs {
+    my ($from_dba, $to_dba, $genome_db_id) = @_;
+
+    my $constraint = "hgenome_db_id = $genome_db_id OR qgenome_db_id = $genome_db_id";
+
+    copy_data( $from_dba->dbc, $to_dba->dbc, 'peptide_align_feature', "SELECT peptide_align_feature.* FROM peptide_align_feature WHERE $constraint" );
+}
+
+=head2 copy_homology_and_members
+
+    Arg[1]      : Bio::EnsEMBL::Compara::DBSQL::DBAdaptor $from_dba (Mandatory)
+    Arg[2]      : Bio::EnsEMBL::Compara::DBSQL::DBAdaptor $to_dba (Mandatory)
+    Arg[3]      : Bio::EnsEMBL::Compara::DBSQL::GenomeDBAdaptor $genome_db (Mandatory)
+    Description : copy from $from_dba to $to_dba just the homology and homology_members
+                  which correspond to $genome_db_id only.
+    Returns     : None
+    Exceptions  : None
+
+=cut
+
+sub copy_homology_and_members {
+    my ($from_dba, $to_dba, $genome_db) = @_;
+
+    my $from_mlss_adap = $from_dba->get_MethodLinkSpeciesSetAdaptor;
+    my $mlsss          = $from_mlss_adap->fetch_all_by_GenomeDB( $genome_db );
+
+    foreach my $mlss ( @$mlsss ) {
+        my $mlss_id = $mlss->dbID;
+        my $constraint = "method_link_species_set_id = $mlss_id";
+        copy_table( $from_dba->dbc, $to_dba->dbc, 'homology', $constraint );
+        copy_data( $from_dba->dbc, $to_dba->dbc, 'homology_member', "SELECT homology_member.* FROM homology_member JOIN homology USING (homology_id) WHERE $constraint" );
+    }
+}
+
+=head2 copy_dnafrags
+
+    Arg[1]      : Bio::EnsEMBL::Compara::DBSQL::DBAdaptor $from_dba
+    Arg[2]      : Bio::EnsEMBL::Compara::DBSQL::DBAdaptor $to_dba
+    Arg[3]      : $genome_db_id (Mandatory)
+    Description : copy from $from_dba to $to_dba all the DnaFrags which
+                  correspond to $genome_db_id only.
+    Returns     : None
+    Exceptions  : None
+
+=cut
+
+sub copy_dnafrags {
+    my ($from_dba, $to_dba, $genome_db_id) = @_;
+
+    my $constraint = "genome_db_id = ".($genome_db->dbID);
+    copy_table( $from_dba->dbc, $to_dba->dbc, 'dnafrag', $constraint );
+    copy_data( $from_dba->dbc, $to_dba->dbc, 'dnafrag_alt_region', "SELECT dnafrag_alt_region.* FROM dnafrag_alt_region JOIN dnafrag USING (dnafrag_id) WHERE $constraint" );
+}
+
+1;


### PR DESCRIPTION
## Description

Once the per-species compara db has been created, we need to copy only the corresponding genome_db data from the pipeline to it

**Related JIRA tickets:**
- ENSCOMPARASW-3754
- ENSCOMPARASW-4398

## Overview of changes

New script and new runnable to copy to the per species specific compara database

#### Change 1
- New copy script particular to RR - similar to `populate_new_database.pl` but with some major differences since we cannot use the same subroutines. Where possible the API has been used as a more stable/ less sql based method to copy/store some objects. I believe the time difference between methods negligible on these capped pipeline databases. Some flexibility has been included to carry use across other future rapid release pipelines - although further subroutines specific to the tables will need to be added.

#### Change 2
- New complimentary wrapper to new RR copy script to run the script command.
- Included in the `Bio::EnsEMBL::Compara::PipeConfig::Parts::PerSpeciesCopyFactory`

#### Change 3
- Minor bugfixes along the way

## Testing
- Complete db here: `mysql-ens-compara-prod-2 verasper_variegatus_compara_104`
- Clean pipeline [here](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-compara-prod-4&port=4401&dbname=cristig_homology_annotation_copy_db&passwd=xxxxx)
## Notes
I had to change the syntax for `get_port`, `get_rw_user` etc back ([see last PR commit here](https://github.com/Ensembl/ensembl-compara/commit/216bf7280a58039e101c7e48fb3e6329368487b2#diff-4ad9f0281aadc12823dffdde14685c7947f8c2a1fa2509e18295a606e0b96498L39-L62)) because it could not find them - not sure of the cause. Will accept comments to make it work :+1: - although I am guessing it is because the methods have not been exported in `Utils/Registry.pm`.
