### PR TITLE
Dump & delete wga_expected tags

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -673,6 +673,7 @@ sub core_pipeline_analyses {
             -rc_name    => '500Mb_job',
             -flow_into  => [
                 'email_tree_stats_report',
+                'wga_expected_dumps',
                 WHEN( '#homology_dumps_shared_dir#' => 'copy_dumps_to_shared_loc' ),
             ],
         },
@@ -3722,6 +3723,13 @@ sub core_pipeline_analyses {
                 'cmd'         => '/bin/bash -c "mkdir -p #homology_dumps_shared_dir# && rsync -rtOp #homology_dumps_dir#/ #homology_dumps_shared_dir#"',
             },
             -rc_name    => '500Mb_job',
+        },
+
+        {   -logic_name => 'wga_expected_dumps',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::DumpWGAExpectedTags',
+            -parameters => {
+                'wga_expected_file'  => '#dump_dir#/wga_expected.mlss_tags.tsv',
+            },
         },
 
             @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::CAFE::pipeline_analyses_cafe($self) },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -348,6 +348,7 @@ sub core_pipeline_analyses {
                 -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
                 -flow_into  => [ 
                     'notify_pipeline_completed',
+                    'wga_expected_dumps',                    
                     WHEN( '#homology_dumps_shared_dir#' => 'copy_dumps_to_shared_loc' ), 
                 ],
             },
@@ -1338,6 +1339,13 @@ sub core_pipeline_analyses {
                 'input_query'   => 'SELECT stable_id, gene_member_id, dnafrag_id, dnafrag_start, dnafrag_end, dnafrag_strand FROM gene_member WHERE genome_db_id = #genome_db_id# ORDER BY dnafrag_id, dnafrag_start',
             },
         },
+
+        {   -logic_name => 'wga_expected_dumps',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::DumpWGAExpectedTags',
+            -parameters => {
+                'wga_expected_file'  => '#dump_dir#/wga_expected.mlss_tags.tsv',
+            },
+        },        
 
         @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::CAFE::pipeline_analyses_cafe_with_full_species_tree($self) },
         @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneMemberHomologyStats::pipeline_analyses_hom_stats($self) },

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/DumpWGAExpectedTags.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/DumpWGAExpectedTags.pm
@@ -1,0 +1,71 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::DumpWGAExpectedTags
+
+=head1 DESCRIPTION
+
+A runnable to dump wga_expected tag and delete it from a database.
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::DumpWGAExpectedTags;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub run {
+    my ($self) = shift @_;
+   
+    $self->dump_wga_expected();
+
+    $self->delete_wga_expected();
+}
+
+
+sub dump_wga_expected {
+    my ($self) = shift @_;
+
+    my $dump_file = $self->param_required('wga_expected_file');
+    open( my $fh_out, '>', $dump_file ) || die "Could not open output file $dump_file";
+    print $fh_out "method_link_species_set_id\twga_expected\n";
+
+    my $sql = "SELECT method_link_species_set_id, value FROM method_link_species_set_tag WHERE tag = 'wga_expected'";
+    my $sth = $self->compara_dba->dbc->prepare($sql);
+    $sth->execute();
+    while (my @row = $sth->fetchrow_array()) {
+        print "Dumping mlss_id " . $row[0] . " wga_expected tag into $dump_file\n" if $self->debug;
+        print $fh_out join("\t", @row) . "\n";
+    }
+    $sth->finish;
+    close($fh_out);
+}
+
+sub delete_wga_expected {
+	my ($self) = shift @_;
+
+	print "Deleting wga_expected tag\n" if $self->debug;
+	my $sql = "DELETE FROM method_link_species_set_tag WHERE tag = 'wga_expected'";
+	$self->compara_dba->dbc->do($sql);
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/DumpWGAExpectedTags.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/DumpWGAExpectedTags.pm
@@ -21,7 +21,7 @@ Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::DumpWGAExpectedTags
 
 =head1 DESCRIPTION
 
-A runnable to dump wga_expected tag and delete it from a database.
+Dumps 'wga_expected' tags to the specified TSV file and deletes them from the database.
 
 =cut
 
@@ -34,7 +34,7 @@ use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
 
 sub run {
-    my ($self) = shift @_;
+    my $self = shift;
    
     $self->dump_wga_expected();
 
@@ -43,7 +43,7 @@ sub run {
 
 
 sub dump_wga_expected {
-    my ($self) = shift @_;
+    my $self = shift;
 
     my $dump_file = $self->param_required('wga_expected_file');
     open( my $fh_out, '>', $dump_file ) || die "Could not open output file $dump_file";
@@ -61,7 +61,7 @@ sub dump_wga_expected {
 }
 
 sub delete_wga_expected {
-	my ($self) = shift @_;
+	my $self = shift;
 
 	print "Deleting wga_expected tag\n" if $self->debug;
 	my $sql = "DELETE FROM method_link_species_set_tag WHERE tag = 'wga_expected'";

--- a/modules/t/DumpWGAExpectedTags.t
+++ b/modules/t/DumpWGAExpectedTags.t
@@ -1,0 +1,82 @@
+#!/usr/bin/env perl
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use Bio::EnsEMBL::Test::MultiTestDB;
+use Bio::EnsEMBL::Hive::DBSQL::DBConnection;
+use Bio::EnsEMBL::Hive::Utils::Test qw(standaloneJob);
+
+use File::Temp qw/tempfile/;
+
+# Check module can be seen and compiled
+use_ok('Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::DumpWGAExpectedTags');
+
+# Load test DB
+my $multi_db = Bio::EnsEMBL::Test::MultiTestDB->new( "test_master" );
+my $compara_dba = $multi_db->get_DBAdaptor( "compara" );
+my $dbc = Bio::EnsEMBL::Hive::DBSQL::DBConnection->new(-dbconn => $compara_dba->dbc);
+my $compara_db = $dbc->url;
+
+# Number of tags before calling the module
+my $sql1 = "SELECT COUNT(*) AS total_rows FROM method_link_species_set_tag";
+my $db_vals1 = $dbc->db_handle->selectrow_hashref($sql1);
+my $all_count = $db_vals1->{total_rows};
+
+my $sql2 = "SELECT COUNT(*) AS wga_exp_rows FROM method_link_species_set_tag WHERE tag = 'wga_expected'";
+my $db_vals2 = $dbc->db_handle->selectrow_hashref($sql2);
+my $we_count = $db_vals2->{wga_exp_rows};
+
+my ($wefh, $test_wga_expected_file) = tempfile();
+standaloneJob(
+    'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::DumpWGAExpectedTags', # module
+    { # input param hash
+        'wga_expected_file' => $test_wga_expected_file,
+        'compara_db'        => $compara_db,
+    }
+);
+
+# Check that output file exists and is correct
+my $exp_output = [
+    "method_link_species_set_id\twga_expected\n",
+    "101\t1\n",
+    "102\t0\n",
+    "104\t0\n",
+    "105\t1\n",
+    "106\t1\n",
+];
+
+open( my $fh, '<', $test_wga_expected_file) or die "Cannot open $test_wga_expected_file for reading\n";
+my @got_output = <$fh>;
+
+is_deeply( \@got_output, $exp_output, 'wga_expected tags dumped correctly to a file' );
+
+# Check that wga_expected tags are deleted from the database and no others
+my $sql3 = "SELECT COUNT(*) AS wga_exp_rows_after FROM method_link_species_set_tag WHERE tag = 'wga_expected'";
+my $db_vals3 = $dbc->db_handle->selectrow_hashref($sql3);
+my $we_count_after = $db_vals3->{wga_exp_rows_after};
+
+my $sql4 = "SELECT COUNT(*) AS total_rows_after FROM method_link_species_set_tag";
+my $db_vals4 = $dbc->db_handle->selectrow_hashref($sql4);
+my $all_count_after = $db_vals4->{total_rows_after};
+
+is( $we_count_after, 0, 'All wga_expected tags deleted from the method_link_species_set_tag table' );
+is( $all_count_after, $all_count - $we_count, 'The number of remaining entries in method_link_species_set_tag correct' );
+
+done_testing();

--- a/modules/t/test-genome-DBs/test_master/compara/method_link_species_set_tag.txt
+++ b/modules/t/test-genome-DBs/test_master/compara/method_link_species_set_tag.txt
@@ -1,0 +1,6 @@
+101	wga_expected	1
+102	wga_expected	0
+103	avg_protein_gene_split_perc_id	0
+104	wga_expected	0
+105	wga_expected	1
+106	wga_expected	1


### PR DESCRIPTION
## Description

In e104, the `wga_expected` tags from protein and ncRNA trees clashed and caused issues in `MergeDBIntoRelease` pipeline. To prevent this in the future, I added an analysis at the end of `ProteinTrees` and `ncRNAtrees` pipelines which dumps the `wga_expected` tags and deletes them from corresponding pipeline databases.

**Related JIRA tickets:**
- ENSCOMPARASW-4295

## Overview of changes
- Created a runnable `DumpWGAExpectedTags.pm`.
- Modified `ProteinTrees_conf.pm` and `ncRNAtrees_conf.pm` accordingly.
- Wrote unit tests `DumpWGAExpected.t` and added some db entries for testing to `method_link_species_set_tag.txt`.

#### Change 1
- `DumpWGAExpectedTags.pm` is supposed to dump the `wga_expected` tags into a file (`.../dumps/wga_expected.mlss_tags.tsv`) and delete the tags from the database.

#### Change 2
- `ProteinTrees_conf.pm` and `ncRNAtrees_conf.pm` have been updated to include a new `wga_expected_dumps` analysis at their ends. 

## Testing
- **Unit tests:** `DumpWGAExpectedTags.t` loads some `wga_expected` and non-`wga_expected` tags from `method_link_species_set_tag.txt`, checks if the output file is correct and checks if the number of entries in the `method_link_species_set_tag` table is correct after deleting `wga_expected` tags.
- **Integration tests:** Tested on a copy of e104 [Plants ProteinTrees](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-compara-prod-7&port=4617&dbname=ivana_copy_plants_protein_trees_104&passwd=xxxxx) and [Vertebrates ncRNAtrees](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-compara-prod-7&port=4617&dbname=ivana_copy_vertebrates_ncrna_trees_104&passwd=xxxxx) db. Since the `wga_expected` tags had already been deleted from the Vertebrates db, I added some entries for testing. In both cases, `wga_expected.mlss_tags.tsv` was correct and no `wga_expected` tags were in the `mlss_tag` table. 

## Notes
- As I'm writing this, I realised that `notify_pipeline_completed` (ncRNA) might send an email before `wga_expected_dumps` finishes. I'm not sure if this is of particular concern. I'd say that `copy_dumps_to_shared_loc` might still be running as well.
- This is an updated PR of the #279. (I messed up with `commit` and `rebase` so at one point #279 included unrelated commits from other PRs.) This updated version encompasses commits and  suggestions by J. Alvarez-Jarreta related to his review of #279.