### PR TITLE
Feature/homology annotation

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/PeptideAlignFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/PeptideAlignFeatureAdaptor.pm
@@ -365,7 +365,7 @@ sub filter_top_PAFs {
 
     foreach my $hit_genome_db_id (keys %by_query) {
         foreach my $sub_features (values %{$by_query{$hit_genome_db_id}}) {
-            my @pafList = sort sort_by_score_evalue_pid_and_alnlen @$sub_features;
+            my @pafList = sort sort_by_all_the_scores @$sub_features;
             my $rank = 1;
             my $prevPaf = undef;
             foreach my $paf (@pafList) {
@@ -413,11 +413,12 @@ sub store_PAFS {
 }
 
 
-sub sort_by_score_evalue_pid_and_alnlen {
+sub sort_by_all_the_scores {
     $b->score <=> $a->score ||
         $a->evalue <=> $b->evalue ||
             $b->perc_ident <=> $a->perc_ident ||
-                $b->alignment_length <=> $a->alignment_length;
+                $b->perc_pos <=> $a->perc_pos ||
+                    $b->alignment_length <=> $a->alignment_length;
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PeptideAlignFeature.pm
+++ b/modules/Bio/EnsEMBL/Compara/PeptideAlignFeature.pm
@@ -94,10 +94,23 @@ sub create_aligned_member {
     $aligned_member_2->gene_member_id($self->hit_member->gene_member->dbID);
     $aligned_member_2->seq_member_id($self->hit_member_id);
 
+    $self->qlength($self->query_member->seq_length);
+    $self->hlength($self->hit_member->seq_length ? $self->hit_member->seq_length : $self->qlength);
+
     # Assign cigar_line to each member
     my $cigar_line = Bio::EnsEMBL::Compara::Utils::Cigars::collapse_cigar(Bio::EnsEMBL::Compara::Utils::Cigars::expand_cigar($self->cigar_line));
     $aligned_member_1->cigar_line($cigar_line);
     $aligned_member_2->cigar_line($cigar_line);
+
+    # Assign perc_* to aligned_members
+    my $perc_cov_1 = $self->alignment_length < $self->qlength ? (( 100/$self->qlength ) * $self->alignment_length) : 100;
+    my $perc_cov_2 = $self->alignment_length < $self->hlength ? (( 100/$self->hlength ) * $self->alignment_length) : 100;
+    $aligned_member_1->perc_cov($perc_cov_1);
+    $aligned_member_1->perc_id($self->perc_ident);
+    $aligned_member_1->perc_pos($self->perc_pos);
+    $aligned_member_2->perc_cov($perc_cov_2);
+    $aligned_member_2->perc_id($self->perc_ident);
+    $aligned_member_2->perc_pos($self->perc_pos);
 
     # Reassign query_member and hit_member with AlignedMembers
     $self->query_member($aligned_member_1);
@@ -121,8 +134,6 @@ sub create_homology {
     $homology->add_Member($self->hit_member);
     $homology->description($type) if $type;
     $homology->is_tree_compliant(0);
-
-    $homology->update_alignment_stats;
 
     return $homology;
 }

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PerSpeciesCopyFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PerSpeciesCopyFactory.pm
@@ -61,6 +61,7 @@ sub pipeline_analyses_create_and_copy_per_species_db {
             -parameters => {
                 'program'    => $self->o('copy_program'),
                 'table_list' => $self->o('table_list'),
+                'skip_dna'   => $self->o('skip_dna'),
             }
         },
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
@@ -36,6 +36,7 @@ use strict;
 
 use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
 use Bio::EnsEMBL::Compara::Utils::Database qw/ table_exists /;
+use Bio::EnsEMBL::Utils::Exception qw( warning );
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
@@ -76,7 +77,7 @@ sub write_output {
     my $dba = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba( $new_db );
     # Check to see if compara_db already exists with tables to avoid overwriting
     if ( table_exists( $dba->dbc, 'genome_db' ) ) {
-        $self->warn( "Compara schema is already in place" );
+        $self->warning( "Compara schema is already in place" );
     }
     # Insert compara schema
     else {


### PR DESCRIPTION
## Description

The diamond results as they were favoured high `perc_ids` across local alignments regardless of the size of the aligned region. We would prefer a high `perc_id` in favour of covering as much of the query sequence as possible.

**Related JIRA tickets:**
- ENSCOMPARASW-4415

## Overview of changes

#### Change 1
- There were a couple of small bugfixes following untested commited review suggestions - see bugfix commit

#### Change 2
- The `PeptideAlignFeature` and `PeptideAlignFeatureAdaptor` were altered to take into account the `alignment_length` for sorting and with a cut off of 50% coverage. Furthermore the stats that are included in the `homology_member` table are explicitly stored negating the previous `update_alignment_stats` method.

## Testing
The pipeline was run cleanly through using a few parameter tweaks to pick the best. The distribution of `perc_id` was discussed during a scrum. See attached rainbow histogram.
[homology_dist_plot.pdf](https://github.com/Ensembl/ensembl-compara/files/6384194/homology_dist_plot.pdf)

## Notes
We may want to include a cut off for the `perc_id` in the future. This was discussed because we are not looking to provide a blastp tool - however as shown in histogram, the number of results below 25% `perc_id` are likely real, but very distant homologies for now - when the scope of data provided by this pipeline changes, it will be the most appropriate time to include these cut offs.
