### PR TITLE
Bugfix/prune supertrees

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/GeneAlignAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/GeneAlignAdaptor.pm
@@ -158,6 +158,7 @@ sub store {
 =head2 delete
 
  Arg [1]    : Bio::EnsEMBL::Compara::AlignedMemberSet $aln
+ Arg [2]    : (optional) arrayref of members to remove
  Example    : $AlignedMemberAdaptor->delete($aln)
  Description: Deletes an AlignedMemberSet object from a Compara database
  Returntype : none
@@ -174,5 +175,32 @@ sub delete {
     $self->dbc->do('DELETE FROM gene_align_member WHERE gene_align_id = ?', undef, $dbID);
     $self->dbc->do('DELETE FROM gene_align        WHERE gene_align_id = ?', undef, $dbID);
 }
+
+=head2 delete_members
+
+ Arg [1]    : Bio::EnsEMBL::Compara::AlignedMemberSet $aln
+ Arg [2]    : (optional) arrayref of members to remove
+ Example    : $AlignedMemberAdaptor->delete_members($aln, [$member1, $member2])
+ Description: Deletes some members from an AlignedMemberSet object
+ Returntype : none
+ Exceptions : none
+ Caller     : general
+
+=cut
+
+sub delete_members {
+    my ($self, $aln, $members) = @_;
+
+    assert_ref_or_dbID($aln, 'Bio::EnsEMBL::Compara::AlignedMemberSet', 'aln');
+    my $dbID = ref($aln) ? $aln->dbID : $aln;
+
+    my $sql = 'DELETE FROM gene_align_member WHERE gene_align_id = ? AND seq_member_id = ?';
+    my $delete_sth = $self->dbc->prepare($sql);
+    foreach my $member ( @$members ) {
+        $delete_sth->execute($dbID, $member->dbID);
+    }
+}
+
+
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/GeneTreeNode.pm
+++ b/modules/Bio/EnsEMBL/Compara/GeneTreeNode.pm
@@ -313,8 +313,7 @@ sub is_leaf {
         return 1;
     } elsif ( $child_count == 1 && $self->tree->tree_type eq 'supertree' ) {
         my $child = $self->children->[0];
-        return 1 if $child->node_id == $child->root->node_id;
-        return 0;
+        return ($child->node_id == $child->root->node_id);
     } else {
         return 0;
     }

--- a/modules/Bio/EnsEMBL/Compara/GeneTreeNode.pm
+++ b/modules/Bio/EnsEMBL/Compara/GeneTreeNode.pm
@@ -312,7 +312,9 @@ sub is_leaf {
     if ( $child_count == 0 ) {
         return 1;
     } elsif ( $child_count == 1 && $self->tree->tree_type eq 'supertree' ) {
-        return 1;
+        my $child = $self->children->[0];
+        return 1 if $child->node_id == $child->root->node_id;
+        return 0;
     } else {
         return 0;
     }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ReindexMembers/DeleteOldMember.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ReindexMembers/DeleteOldMember.pm
@@ -65,6 +65,11 @@ sub run {
                 $dbc->do('DELETE FROM gene_align_member WHERE gene_align_id = ?', undef, $gene_align_id);
                 $dbc->do('DELETE FROM gene_align        WHERE gene_align_id = ?', undef, $gene_align_id);
             }
+
+            # remove from supertree alignments - we clean the supertree itself in "delete_tree" analysis
+            $dbc->do('DELETE m FROM gene_align_member m JOIN gene_tree_root r USING(gene_align_id)
+                      WHERE r.tree_type = "supertree" AND m.seq_member_id = ?;', undef, $self->param('seq_member_id'));
+
             $dbc->do('DELETE FROM gene_member_qc                  WHERE gene_member_stable_id = ?', undef, $self->param('gene_member_stable_id'));
             $dbc->do('DELETE FROM member_xref                     WHERE gene_member_id = ?',        undef, $self->param('gene_member_id'));
             $dbc->do('DELETE FROM gene_member_hom_stats           WHERE gene_member_id = ?',        undef, $self->param('gene_member_id'));
@@ -78,4 +83,3 @@ sub run {
 }
 
 1;
-


### PR DESCRIPTION
## Description

The `$gene_tree_adaptor->delete_tree` method did not consider whether the tree being deleted was a subtree linked to a supertree. This can result in supertrees with unlinked leaf nodes, which breaks our supertree model and subsequent `$tree->expand_subtrees` calls. Here, supertree handling is introduced. Deleted trees are checked for supertree links and handled accordingly. If subtree deletion would result in:
- <2 subtrees remaining, the whole supertree is removed, leaving the other subtrees
- \>=2 subtrees, the supertree is pruned to remove unlinked leaves. The supertree's alignment is also pruned to remove members from the deleted subtree.

**Related JIRA tickets:**
- ENSCOMPARASW-4339
- ENSCOMPARASW-4338

## Overview of changes

#### _clean_supertree method
- automatically detect subtrees in the `delete_tree` method and pass off to a new `_clean_supertree` method
- clean the supertree using the rules described above

#### GeneAlignMemberAdaptor->delete_members
- new method to delete some members from a gene_align objects to help with cleaning of the supertree alignment

#### Improved detection of supertree leaves
- old code defined as a node with 0 children, but this doesn't hold true for supertrees
- leaves are now defined as 
    - for non-supertrees : node with 0 children
    - for supertrees : node with 1 child, where that child is a root node

## Testing
Many runs of the reindexing pipeline with manual checking of resulting trees and alignments

