### PR TITLE
DCs on per-species compara_db

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PerSpeciesCopyFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PerSpeciesCopyFactory.pm
@@ -37,6 +37,13 @@ use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf; # For WHEN and INPUT_PLUS
 sub pipeline_analyses_create_and_copy_per_species_db {
     my ($self) = @_;
 
+    my %dc_parameters = (
+        'datacheck_groups' => $self->o('datacheck_groups'),
+        'db_type'          => $self->o('db_type'),
+        'old_server_uri'   => $self->o('compara_db'),
+        'registry_file'    => undef,
+    );
+
     return [
 
         {   -logic_name => 'create_db_factory',
@@ -52,7 +59,8 @@ sub pipeline_analyses_create_and_copy_per_species_db {
                 'schema_file'  => $self->o('schema_file'),
             },
             -flow_into => {
-                2 => [ 'copy_per_species_db' ],
+                '2->A' => [ 'copy_per_species_db' ],
+                'A->2'  => { 'datacheck_factory' => { 'compara_db' => '#per_species_db#', %dc_parameters } },
             },
         },
 


### PR DESCRIPTION
## Description

Datachecks needed on per-species `compara_db` following copy analysis

**Related JIRA tickets:**
- ENSCOMPARASW-4444

## Overview of changes
`create_per_species_db` flows to the `datacheck_factory` with semaphore on `copy_per_species_db`.

## Testing
This was tested in whole pipeline run. See `datacheck_factory` for clear evidence on the two different `compara_dbs` used (pipeline and per-species). [Pipeline here](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-compara-prod-3&port=4523&dbname=cristig_homology_annotation_end_dcs&passwd=xxxxx).

## Notes
Some DCs failed, but were expected to, these were forgiven in the pipeline for a complete run through.
