### PR TITLE
Prevent rapid release reference comparing to self

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/BlastFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/BlastFactory.pm
@@ -91,6 +91,7 @@ sub write_output {
 
     my $step              = $self->param('step');
     my @query_member_list = @{$self->param('query_members')};
+    my $gdb_adaptor       = $self->compara_dba->get_GenomeDBAdaptor;
     my @funnel_output;
 
     foreach my $genome ( @query_member_list ) {
@@ -106,6 +107,8 @@ sub write_output {
         $self->dataflow_output_id( { 'genome_db_id' => $genome_db_id, 'ref_taxa' => $ref_taxa }, 1 );
 
         foreach my $ref ( @$ref_dirs ) {
+            # Skip the reference genome if it is the same as the query genome
+            next if $ref->{'ref_gdb'}->name eq $gdb_adaptor->fetch_by_dbID($genome_db_id)->name;
             # Obtain the diamond indexed file for the reference, this is the only file we need from
             # each reference at this point
             my $ref_dmnd_path = $ref->{'ref_dmnd'};

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/RefFromFastaFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/RefFromFastaFactory.pm
@@ -51,10 +51,13 @@ sub fetch_input {
     my $ref_dump_dir  = $self->param_required('ref_dump_dir');
     my $ref_taxa      = $self->param('ref_taxa') ? $self->param('ref_taxa') : 'default';
     my $ref_dir_paths = collect_species_set_dirs($ref_dba, $ref_taxa, $ref_dump_dir);
+    my $gdb_adaptor   = $self->compara_dba->get_GenomeDBAdaptor;
+
     my @all_paths;
 
     foreach my $ref_gdb_dir ( @$ref_dir_paths ) {
-
+        # Skip the reference genome if it is the same as the target genome
+        next if $ref_gdb_dir->{'ref_gdb'}->name eq $gdb_adaptor->fetch_by_dbID($self->param_required('genome_db_id'))->name;
         my $ref_gdb_id   = $ref_gdb_dir->{'ref_gdb'}->dbID;
         my $ref_splitfa  = $ref_gdb_dir->{'ref_splitfa'};
         my @ref_splitfas = glob($ref_splitfa . "/*.fasta");


### PR DESCRIPTION
## Description

If references can come from the rapid release, then they need to be prevented from running against themselves as rapid release queries.

**Related JIRA tickets:**
- ENSCOMPARASW-4446

## Overview of changes

Small necessary code additions in order to prevent the rapid release query comparing against itself as a reference.
Additional bug fixes spotted during PR #287  canonical `seq_members` were not being wholly copied. Reverted to a more simple method of copying. This was tested in the same pipeline.

## Testing
[See pipeline run here.](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-compara-prod-3&port=4523&dbname=cristig_homology_annotation_no_self&passwd=xxxxx)
Database checked for any matches against itself and that `species_sets` are not contaminated with itself.

## Notes

There will still be a duplicate entry for the same genome, but hopefully different assembly/genebuild in the `genome_db` table. See ENSCOMPARASW-3545.