### PR TITLE
Feature/homology annotation Symlink fastafiles for orthofinder

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/SpeciesSetAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/SpeciesSetAdaptor.pm
@@ -408,6 +408,26 @@ sub fetch_collection_by_name {
     return $self->_find_most_recent($all_ss);
 }
 
+=head2 fetch_collection_by_name
+
+  Arg [1]     : none
+  Example     : my $collections = $species_set_adaptor->fetch_all_current_collections();
+  Description : Fetches all the current "collection" SpeciesSet objects
+  Returntype  : arrayref of Bio::EnsEMBL::Compara::SpeciesSet
+  Exceptions  : none
+  Caller      : general
+
+=cut
+
+sub fetch_all_current_collections {
+    my ($self) = @_;
+
+    my $curr_ss;
+    my $all_objects = $self->fetch_all();
+
+    return [ map { ($_->is_current and $_->name =~ /^collection/) ? $_ : () } @$all_objects ];
+}
+
 
 =head2 update_collection
 

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/SpeciesSetAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/SpeciesSetAdaptor.pm
@@ -408,14 +408,12 @@ sub fetch_collection_by_name {
     return $self->_find_most_recent($all_ss);
 }
 
-=head2 fetch_collection_by_name
+=head2 fetch_all_current_collections
 
-  Arg [1]     : none
   Example     : my $collections = $species_set_adaptor->fetch_all_current_collections();
   Description : Fetches all the current "collection" SpeciesSet objects
   Returntype  : arrayref of Bio::EnsEMBL::Compara::SpeciesSet
   Exceptions  : none
-  Caller      : general
 
 =cut
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -128,6 +128,7 @@ sub executable_locations {
         'populate_per_genome_database_exe'  => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/populate_per_genome_database.pl'),
         'create_datacheck_tickets_exe'      => $self->check_exe_in_ensembl('ensembl-compara/scripts/jira_tickets/create_datacheck_tickets.pl'),
         'copy_ancestral_core_exe'           => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/copy_ancestral_core.pl'),
+        'symlink_fasta_exe'                 => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/symlink_fasta.py'),
 
         # Other dependencies (non executables)
         'schema_file_sql'                   => $self->check_file_in_ensembl('ensembl-compara/sql/table.sql'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -131,8 +131,6 @@ sub pipeline_create_commands {
         # In case it doesn't exist yet
         'mkdir -p ' . $self->o('ref_member_dumps_dir'),
         'mkdir -p ' . $self->o('shared_fasta_dir'),
-        # The files are going to be accessed by many processes in parallel
-        #$self->pipeline_create_commands_lfs_setstripe('ref_member_dumps_dir'), #not available in codon
         # To store the Datachecks results
         $self->db_cmd($results_table_sql),
     ];
@@ -348,7 +346,6 @@ sub core_pipeline_analyses {
                 'symlink_dir'          => $self->o('shared_fasta_dir'),
                 'ref_member_dumps_dir' => $self->o('ref_member_dumps_dir'),
             },
-            -rc_name    => '500Mb_job',
             -flow_into  => [ 'symlink_fasta_to_shared_loc' ],
             -wait_for   => [ 'create_reference_sets' ],
         },
@@ -359,7 +356,6 @@ sub core_pipeline_analyses {
             -parameters => {
                 'symlink_fasta_exe' => $self->o('symlink_fasta_exe'),
             },
-            -rc_name    => '500Mb_job',
         },
 
         {   -logic_name => 'backup_ref_db_again',

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PassFastaDumpsPerCollection.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PassFastaDumpsPerCollection.pm
@@ -1,0 +1,67 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::PassFastaDumpsPerCollection
+
+=head1 DESCRIPTION
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::PassFastaDumpsPerCollection;
+
+use warnings;
+use strict;
+use Bio::EnsEMBL::Registry;
+use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
+use Data::Dumper;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+sub fetch_input {
+    my $self = shift;
+
+    my $base_dir = $self->param('symlink_dir');
+    my $ss_adap  = $self->compara_dba->get_SpeciesSetAdaptor;
+    my $collections = $ss_adap->fetch_all_current_collections;
+    my %collection_set;
+    foreach my $collection ( @$collections ) {
+        my $gdbs = $collection->genome_dbs;
+        my $collection_name = $collection->name;
+        $collection_name =~ s/^collection-//;
+        my @dir_locs = map {$_->_get_members_dump_path($self->param('ref_member_dumps_dir'))} @$gdbs;
+        my $symlink_dir = $base_dir . $collection_name;
+        $collection_set{$symlink_dir} = [ @dir_locs ] unless $collection_name =~ /shared/;
+    }
+    $self->param('fasta_collections', \%collection_set);
+}
+
+sub write_output {
+    my $self = shift;
+
+    my $collection_set = $self->param('fasta_collections');
+    foreach my $dir ( sort keys %$collection_set ) {
+
+        my @fastas = @{$collection_set->{$dir}};
+        foreach my $fasta_file ( @fastas ) {
+            $self->dataflow_output_id( { 'symlink_dir' => $dir, 'target_file' => $fasta_file, 'cleanup_symlinks' => 1 }, 1 );
+        }
+    }
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PassFastaDumpsPerCollection.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PassFastaDumpsPerCollection.pm
@@ -21,6 +21,8 @@ Bio::EnsEMBL::Compara::RunnableDB::PassFastaDumpsPerCollection
 
 =head1 DESCRIPTION
 
+Factory to flow the list of fasta files per collection.
+
 =cut
 
 package Bio::EnsEMBL::Compara::RunnableDB::PassFastaDumpsPerCollection;
@@ -29,7 +31,6 @@ use warnings;
 use strict;
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
-use Data::Dumper;
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 

--- a/scripts/pipeline/symlink_fasta.py
+++ b/scripts/pipeline/symlink_fasta.py
@@ -54,12 +54,11 @@ if target_dir:
         # Skip split fasta files
         if re.search(r'split\b', fasta_file):
             continue
-        else:
-            file_prefix = os.path.basename(fasta_file)
-            symlink_path = os.path.join(symlink_dir, file_prefix)
-            if not os.path.exists(symlink_path):
-                print('New symlink: {0} created for target: {1}'.format(symlink_path, fasta_file))
-                os.symlink(fasta_file, symlink_path)
+        file_prefix = os.path.basename(fasta_file)
+        symlink_path = os.path.join(symlink_dir, file_prefix)
+        if not os.path.exists(symlink_path):
+            print('New symlink: {0} created for target: {1}'.format(symlink_path, fasta_file))
+            os.symlink(fasta_file, symlink_path)
 else:
     file_prefix = os.path.basename(target_file)
     symlink_path = os.path.join(symlink_dir, file_prefix)

--- a/scripts/pipeline/symlink_fasta.py
+++ b/scripts/pipeline/symlink_fasta.py
@@ -22,7 +22,6 @@ import glob
 import os
 import re
 import sys
-
 from pathlib import Path
 
 parser = argparse.ArgumentParser()
@@ -54,8 +53,8 @@ if target_dir:
         # Skip split fasta files
         if re.search(r'split\b', fasta_file):
             continue
-        file_prefix = os.path.basename(fasta_file)
-        symlink_path = os.path.join(symlink_dir, file_prefix)
+        file_name = os.path.basename(fasta_file)
+        symlink_path = os.path.join(symlink_dir, file_name)
         if not os.path.exists(symlink_path):
             print('New symlink: {0} created for target: {1}'.format(symlink_path, fasta_file))
             os.symlink(fasta_file, symlink_path)

--- a/scripts/pipeline/symlink_fasta.py
+++ b/scripts/pipeline/symlink_fasta.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Script to create and optionally cleanup symlinks in a central location"""
+
+import argparse
+import glob
+import os
+import re
+import sys
+
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-c', '--cleanup_symlinks', action='store_true')
+parser.add_argument('-s', '--symlink_dir')
+group = parser.add_mutually_exclusive_group(required=True)
+# Only one of target_dir or target_file can be specified
+group.add_argument('-d', '--target_dir')
+group.add_argument('-t', '--target_file')
+opts = parser.parse_args(sys.argv[1:])
+
+target_dir = opts.target_dir
+symlink_dir = opts.symlink_dir
+target_file = opts.target_file
+
+# Create symlink directory if doesn't exist
+Path(symlink_dir).mkdir(parents=True, exist_ok=True)
+
+# Clean up the broken symlinks - these should be due to genome retirement
+if opts.cleanup_symlinks:
+    for link in glob.glob(os.path.join(symlink_dir, '**/*.fasta'), recursive=True):
+        if not os.path.exists(os.readlink(link)):
+            print('Broken symlink: {0} to be removed'.format(link))
+            os.remove(link)
+
+# Collect all the genome fasta files and symlink them
+if target_dir:
+    for fasta_file in glob.glob(os.path.join(target_dir, '**/*.fasta'), recursive=True):
+        # Skip split fasta files
+        if re.search(r'split\b', fasta_file):
+            continue
+        else:
+            file_prefix = os.path.basename(fasta_file)
+            symlink_path = os.path.join(symlink_dir, file_prefix)
+            if not os.path.exists(symlink_path):
+                print('New symlink: {0} created for target: {1}'.format(symlink_path, fasta_file))
+                os.symlink(fasta_file, symlink_path)
+else:
+    file_prefix = os.path.basename(target_file)
+    symlink_path = os.path.join(symlink_dir, file_prefix)
+    if not os.path.exists(symlink_path):
+        print('New symlink: {0} created for target: {1}'.format(symlink_path, target_file))
+        os.symlink(target_file, symlink_path)

--- a/src/python/lib/ensembl/compara/runnable/SymlinkFasta.py
+++ b/src/python/lib/ensembl/compara/runnable/SymlinkFasta.py
@@ -15,14 +15,11 @@
 
 """Runnable to symlink a fasta file into a set directory.
 
-This runnable symlinks a fasta file into a designated directory.
-
 Optionally cleans up broken symlinks first. By default cleanup_symlinks is False.
 
 """
 
 import subprocess
-
 from typing import Dict
 
 import eHive
@@ -33,7 +30,7 @@ class SymlinkFasta(eHive.BaseRunnable):
     def param_defaults(self) -> Dict[str, bool]:
         """set default parameters"""
         return {
-            'cleanup_symlinks' : False,
+            'cleanup_symlinks': False,
         }
 
     def run(self) -> None:
@@ -45,17 +42,12 @@ class SymlinkFasta(eHive.BaseRunnable):
         symlink_dir = self.param_required('symlink_dir')
         cleanup_symlinks = self.param('cleanup_symlinks')
 
-        # Either target_file or target_dir must be passed as parameters
-        if all(v is not None for v in {self.param('target_file'), self.param('target_dir')}):
-            raise ValueError('target_file and target_dir parameters are mutually exclusive')
-        if all(v is None for v in {self.param('target_file'), self.param('target_dir')}):
-            raise ValueError('Expected either target_file or target_dir parameters')
         if self.param('target_file') is not None:
             target = '--target_file {0}'.format(self.param('target_file'))
         else:
             target = '--target_dir {0}'.format(self.param('target_dir'))
 
-        # Commandline eo exectute symlink_exe script
+        # Run symlink_exe script
         cmd = ' '.join([symlink_exe, target, '--symlink_dir', symlink_dir])
         if cleanup_symlinks is not None:
             cmd += ' --cleanup_symlinks'
@@ -64,4 +56,4 @@ class SymlinkFasta(eHive.BaseRunnable):
     def write_output(self) -> None:
         """dataflow shared_dir"""
 
-        self.dataflow( {'symlink_dir': self.param_required('symlink_dir')}, 1)
+        self.dataflow({'symlink_dir': self.param_required('symlink_dir')}, 1)

--- a/src/python/lib/ensembl/compara/runnable/SymlinkFasta.py
+++ b/src/python/lib/ensembl/compara/runnable/SymlinkFasta.py
@@ -1,0 +1,68 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runnable to symlink a fasta file into a set directory.
+
+This runnable symlinks a fasta file into a designated directory.
+
+Optionally cleans up broken symlinks first. By default cleanup_symlinks is False.
+
+"""
+
+import subprocess
+import sys
+
+from typing import Dict
+
+import eHive
+
+class SymlinkFasta(eHive.BaseRunnable):
+    """Symlinks a fasta file into a specified directory"""
+
+    def param_defaults(self) -> Dict[str, bool]:
+        """set default parameters"""
+        return {
+            'cleanup_symlinks' : False,
+        }
+
+    def run(self) -> None:
+        """grab fasta and symlink"""
+
+        # Executable script to run
+        symlink_exe = self.param_required('symlink_fasta_exe')
+        # Directory path to symlink fasta files in single level directory
+        symlink_dir = self.param_required('symlink_dir')
+        cleanup_symlinks = self.param('cleanup_symlinks')
+
+        # Either target_file or target_dir must be passed as parameters
+        if all(v is not None for v in {self.param('target_file'), self.param('target_dir')}):
+            raise ValueError('target_file and target_dir parameters are mutually exclusive')
+        if all(v is None for v in {self.param('target_file'), self.param('target_dir')}):
+            raise ValueError('Expected either target_file or target_dir parameters')
+        if self.param('target_file') is not None:
+            target = '--target_file {0}'.format(self.param('target_file'))
+        else:
+            target = '--target_dir {0}'.format(self.param('target_dir'))
+
+        # Commandline eo exectute symlink_exe script
+        cmd = ' '.join([symlink_exe, target, '--symlink_dir', symlink_dir])
+        if cleanup_symlinks is not None:
+            cmd += ' --cleanup_symlinks'
+        subprocess.run(cmd, check=True, shell=True)
+
+    def write_output(self) -> None:
+        """dataflow shared_dir"""
+
+        self.dataflow( {'symlink_dir': self.param_required('symlink_dir')}, 1)

--- a/src/python/lib/ensembl/compara/runnable/SymlinkFasta.py
+++ b/src/python/lib/ensembl/compara/runnable/SymlinkFasta.py
@@ -22,7 +22,6 @@ Optionally cleans up broken symlinks first. By default cleanup_symlinks is False
 """
 
 import subprocess
-import sys
 
 from typing import Dict
 


### PR DESCRIPTION
## Description

OrthoFinder requires all the input fasta files to be located in the same directory. Repeating this data would be a space waster- so instead we symlink them all to one directory - per collection.

**Related JIRA tickets:**
- ENSCOMPARASW-4464

## Overview of changes
This PR mainly encompasses some new features rather than changes, with an attempt at "blackbox style" and moving away from perl dependency.

#### Change 1
- Alteration to pipeconfig to include new analyses- factory runnable to flow dumped fasta files and new symlinking analysis

#### Change 2
- (Unavoidable) Perl runnable factory to collect fasta files for each genome in a collection

#### Change 3
- Python runnable script to call python symlinking script
- Python symlinking script is a blackbox-style (attempt) script that can be executed with parameters and has no dependencies

## Testing
[Tested in pipeline form](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-compara-prod-7&port=4617&dbname=cristig_update_references_104&passwd=xxxxx)

## Notes
lsf-striping apparently isn't available on codon
Included in PR is part of DC fix (arrayref `old_server_uri`)
