### PR TITLE
Adaptation of species tree pipeline to use components

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateSpeciesTree_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateSpeciesTree_conf.pm
@@ -235,6 +235,7 @@ sub pipeline_analyses {
           -parameters => {
               'taxonomic_ranks' => $self->o('taxonomic_ranks'),
               'custom_groups'   => $self->o('custom_groups'  ),
+              'genome_dumps_dir' => $self->o('genome_dumps_dir'),
           },
           -flow_into => {
               '2->A' => [ 'neighbour_joining_tree' ],
@@ -271,6 +272,7 @@ sub pipeline_analyses {
               'erable_exe'    => $self->o('erable_exe'),
               'unroot_script' => $self->o('unroot_script'),
               'reroot_script' => $self->o('reroot_script'),
+              'genome_dumps_dir' => $self->o('genome_dumps_dir'),
           },
           -flow_into => {
               1 => ['copy_files_to_sketch_dir'],

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/AdjustBranchLengths.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/AdjustBranchLengths.pm
@@ -52,6 +52,8 @@ sub param_defaults {
     my $self = shift;
     return {
         %{$self->SUPER::param_defaults},
+        'output_display_name'  => 0, # when genome_db_ids are replaced in the final tree, 
+        							 # use $gdb->display_name instead. default is $gdb->name
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/AdjustBranchLengths.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/AdjustBranchLengths.pm
@@ -108,7 +108,7 @@ sub run {
 		my $this_gdb_id = $1;
 		my $gdb = $genome_db_adaptor->fetch_by_dbID($this_gdb_id);
 		my $gcomp = $gdb->genome_component ? ".comp" . $gdb->genome_component : '';
-		my $species_name = $gdb->name . $gcomp;
+		my $species_name = $self->param('output_display_name') ? $gdb->display_name : $gdb->name . $gcomp;
 		$tree =~ s/gdb$this_gdb_id/$species_name/;
 	}
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/CheckSketches.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/CheckSketches.pm
@@ -49,7 +49,6 @@ use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 use Bio::EnsEMBL::Compara::Utils::DistanceMatrix;
 use File::Basename;
 use Data::Dumper;
-use Try::Tiny;
 
 sub fetch_input {
 	my $self = shift;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/CheckSketches.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/CheckSketches.pm
@@ -181,14 +181,9 @@ sub _check_for_distance_files {
 	foreach my $dfile ( @dist_files ) {
 		print " --- checking $dfile\n";
 		my $dist_matrix = Bio::EnsEMBL::Compara::Utils::DistanceMatrix->new( -file => $dfile );
-		try {
-			$dist_matrix = $dist_matrix->filter_and_convert_genome_db_ids($gdb_id_map);
-			return $dfile;
-		} catch {
-			warn "Caught error whilst parsing distance matrix file $dfile\nError: $_";
-		}
-	}	
-
+		$dist_matrix = $dist_matrix->filter_and_convert_genome_db_ids($gdb_id_map);
+		return $dfile if defined $dist_matrix;
+	}
 	return undef;
 }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/CheckSketches.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/CheckSketches.pm
@@ -49,6 +49,7 @@ use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 use Bio::EnsEMBL::Compara::Utils::DistanceMatrix;
 use File::Basename;
 use Data::Dumper;
+use Try::Tiny;
 
 sub fetch_input {
 	my $self = shift;
@@ -77,7 +78,11 @@ sub fetch_input {
 			$species_set = $ss_adaptor->fetch_by_dbID($species_set_id);
 			$self->param('collection', $species_set->name); # set this for file naming later
 		}
-		@genome_dbs = @{ $species_set->genome_dbs };
+		@genome_dbs = grep {
+			$_->name ne 'ancestral_sequences'
+			&& !($_->is_polyploid && !defined $_->genome_component)
+		} @{ $species_set->genome_dbs };
+
 	}
 
 	$self->param( 'genome_dbs', \@genome_dbs );
@@ -155,7 +160,7 @@ sub find_file_for_gdb {
 	
 	$suffixes = [''] unless defined $suffixes->[0];
 
-	my $prefix = $gdb->name . "." . $gdb->assembly;
+	my $prefix = basename($gdb->_get_genome_dump_path($self->param('genome_dumps_dir')));
 	foreach my $suffix ( @$suffixes ) {
 		my @found_files = glob "$dir/$prefix.*$suffix";
 		return $found_files[0] if $found_files[0];
@@ -169,19 +174,19 @@ sub _check_for_distance_files {
 	my $dir = $self->param_required('sketch_dir');
 	my $collection = $self->param_required('collection');
 	my @dist_files = glob "$dir/*$collection*.dists";
-	my @needed_gdb_ids = map {$_->dbID} @{ $self->param('genome_dbs') };
+	my $gdb_id_map = { map {$_->_get_genome_dump_path($self->param('genome_dumps_dir')) => $_->dbID} @{ $self->param('genome_dbs') } };
 
 	my $gdb_adaptor = $self->compara_dba->get_GenomeDBAdaptor;
 
 	foreach my $dfile ( @dist_files ) {
 		print " --- checking $dfile\n";
 		my $dist_matrix = Bio::EnsEMBL::Compara::Utils::DistanceMatrix->new( -file => $dfile );
-		$dist_matrix = $dist_matrix->convert_to_genome_db_ids($gdb_adaptor);
-
-		my @matrix_members = $dist_matrix->members;
-		my $overlap = $self->_overlap(\@needed_gdb_ids, \@matrix_members);
-		print " --- --- overlap = $overlap (" . scalar @needed_gdb_ids . " needed)\n";
-		return $dfile if $overlap >= scalar @needed_gdb_ids;
+		try {
+			$dist_matrix = $dist_matrix->filter_and_convert_genome_db_ids($gdb_id_map);
+			return $dfile;
+		} catch {
+			warn "Caught error whilst parsing distance matrix file $dfile\nError: $_";
+		}
 	}	
 
 	return undef;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/GroupSpecies.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/GroupSpecies.pm
@@ -76,8 +76,12 @@ sub fetch_input {
         $self->param('collection', $species_set->name); # set this for file naming later
     } elsif ( $collection ) {
         $species_set = $ss_adaptor->fetch_collection_by_name($collection);
+        $self->param('species_set_id', $species_set->dbID);
     }
-	my @genome_dbs = grep {$_->name ne 'ancestral_sequences'} @{ $species_set->genome_dbs };
+	my @genome_dbs = grep {
+		$_->name ne 'ancestral_sequences'
+		&& !($_->is_polyploid && ! defined $_->genome_component)
+	} @{ $species_set->genome_dbs };
 
 	my @gdb_id_list = map { $_->dbID } @genome_dbs;
 	@gdb_id_list = sort {$a <=> $b} @gdb_id_list; 
@@ -126,6 +130,7 @@ sub write_output {
 	}
     
     $self->add_or_update_pipeline_wide_parameter('outgroup_id', $self->param('outgroup_genome_db_id'));
+    $self->add_or_update_pipeline_wide_parameter('species_set_id', $self->param('species_set_id'));
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/PermuteMatrix.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/PermuteMatrix.pm
@@ -70,6 +70,7 @@ sub fetch_input {
 	my $self = shift;
 
 	my $gdb_adaptor = $self->compara_dba->get_GenomeDBAdaptor;
+	my $ss_adaptor = $self->compara_dba->get_SpeciesSetAdaptor;
 	my $ncbi_adaptor = $self->compara_dba->get_NCBITaxonAdaptor;
 	
 	# parse matrix and replace filenames with genome_db_ids
@@ -78,16 +79,27 @@ sub fetch_input {
 	my $distance_matrix = Bio::EnsEMBL::Compara::Utils::DistanceMatrix->new(
 		-file => $mash_dist_file
 	);
-	$distance_matrix = $distance_matrix->convert_to_genome_db_ids($gdb_adaptor);
+
+	my $species_set = $ss_adaptor->fetch_by_dbID($self->param_required('species_set_id'));
+	my @genome_dbs = grep {
+		$_->name ne 'ancestral_sequences'
+		&& !($_->is_polyploid && !defined $_->genome_component)
+	} @{ $species_set->genome_dbs };
+
+	my $gdb_id_map = { map {$_->_get_genome_dump_path($self->param('genome_dumps_dir')) => $_->dbID} @genome_dbs };
+
+	print " -- Converting matrix keys to DB IDs\n" if $self->debug;
+	$distance_matrix = $distance_matrix->filter_and_convert_genome_db_ids($gdb_id_map);
+	print " -- Adding taxonomic distances\n" if $self->debug;
 	$distance_matrix = $distance_matrix->add_taxonomic_distance($gdb_adaptor);
 	
 	my @gdb_ids = $distance_matrix->members;
-	# print " -- matrix genomes: " . join(", ", @gdb_ids) . "\n";
+	print "\t -- Genome DB IDs: " . join(", ", @gdb_ids) . "\n" if $self->debug;
 	my @gdbs = map { $gdb_adaptor->fetch_by_dbID($_) } @gdb_ids;
-
 	# generate submatrices
 	print " -- Detecting optimal taxonomic groupings\n" if $self->debug;
 	my @tax_groups_ids = $self->_taxonomic_groups(\@gdbs);
+	print " -- Taxonomic IDs: " . join(", ", @tax_groups_ids) . "\n" if $self->debug;
 
 	my (@prev_group_ids, %all_groups, @matrices_dataflow, $this_outgroup);
 	foreach my $group_taxon_id ( @tax_groups_ids ) {
@@ -96,8 +108,22 @@ sub fetch_input {
 
 		# extract initial submatrix for the group
 		my @group_gdbs = @{$gdb_adaptor->fetch_all_current_by_ancestral_taxon_id($group_taxon_id)};
+
+		# Make sure that the outgroup is in the list if this is the determined root taxon
+		my @excepts = ();
+		if ( $group_taxon_id == $self->param('root_id') ) {
+			print "\t -- root_id is " . $self->param('root_id') . "\n" if $self->debug;
+			my $outgroup_gdb = $gdb_adaptor->fetch_by_dbID($self->param_required('outgroup_id'));
+			push(@group_gdbs, $outgroup_gdb) unless grep{$_->dbID == $self->param_required('outgroup_id')} @group_gdbs;
+		}
+		else {
+			@excepts = ($self->param_required('outgroup_id'));
+		}
+
 		print "\t -- fetching submatrix for " . scalar @group_gdbs . " genomes\n" if $self->debug;
 		my $submatrix = $distance_matrix->prune_gdbs_from_matrix( \@group_gdbs );
+
+		print "\t -- Submatrix has " . scalar $submatrix->members . " members\n" if $self->debug;
 
 		# add an outgroup
 		if ( $group_taxon_id == $self->param('root_id') ) {
@@ -113,10 +139,11 @@ sub fetch_input {
 			next unless $prev_group_taxon->has_ancestor($current_group_taxon);
 			print "\t -- " . $prev_group_taxon->name . " is a member of this group - collapsing it\n" if $self->debug;
 			my $prev_group_gdbs = $gdb_adaptor->fetch_all_current_by_ancestral_taxon_id($prev_group);
+			print "\t -- Prev IDs: " . join(", ", map {$_->dbID} @{$prev_group_gdbs}) . "\n" if $self->debug;
 			$submatrix = $submatrix->collapse_group_in_matrix( $prev_group_gdbs, "mrg_$prev_group" );
 		}
         
-        next if Bio::EnsEMBL::Compara::Utils::DistanceMatrix->empty_submatrix($submatrix);
+        next if Bio::EnsEMBL::Compara::Utils::DistanceMatrix->empty_submatrix($submatrix, \@excepts);
 
 		# add to dataflow
 		my $mdf = { 
@@ -150,6 +177,9 @@ sub _add_outgroup {
 	my @sub_gdb_ids = $submatrix->members;
 	my $rep_gdb_id  = $sub_gdb_ids[0];
 
+	#print " -- submatrix genomes: " . join(", ", @sub_gdb_ids) . "\n" if $self->debug;
+	#print " -- fullmatrix genomes: " . join(", ", $full_matrix->members) . "\n" if $self->debug;
+
 	my ( $closest_gdb_id, $min_distance) = (undef, 100);
 	foreach my $full_key ( $full_matrix->members ) {
 		next if ( defined $self->param('blacklisted_genome_db_ids') && grep { $full_key eq $_ } @{$self->param('blacklisted_genome_db_ids')} ); # skip any that are on the naughty list
@@ -157,6 +187,7 @@ sub _add_outgroup {
 		if ( $full_matrix->distance($rep_gdb_id, $full_key) < $min_distance ) {
 			$closest_gdb_id = $full_key;
 			$min_distance = $full_matrix->distance($rep_gdb_id, $full_key);
+			#print "$full_key gives dist $min_distance\n";
 		}
 	} 
 
@@ -164,9 +195,9 @@ sub _add_outgroup {
 		print "Can't find a suitable outgroup\n";
 		return $submatrix;
 	}
-
 	foreach my $sub_key ( $submatrix->members ) {
-		$submatrix = $submatrix->distance($sub_key, $closest_gdb_id, $full_matrix->distance($sub_key, $closest_gdb_id));
+		my $old_dist = $full_matrix->distance($sub_key, $closest_gdb_id);
+		$submatrix = $submatrix->distance($sub_key, $closest_gdb_id, $old_dist);
 	}
 
 	return ($submatrix, $closest_gdb_id);
@@ -207,6 +238,7 @@ sub _taxonomic_groups {
 
 	# first, grab all the ranks for each genome_db
 	my @ranks = @{ $self->param_required('taxonomic_ranks') };
+	print "Ranks: " . join(',', @ranks) . "\n" if $self->debug;
 	foreach my $gdb ( @$gdbs ) {
 		my $this_gdb_taxon = $ncbi_adaptor->fetch_node_by_taxon_id($gdb->taxon_id);
 		foreach my $rank ( @ranks ) {
@@ -217,7 +249,9 @@ sub _taxonomic_groups {
 
     # filter ranks shared across all species
     # only ranks describing subsets of the species set should be included
+    print "Total gdbs: " . scalar(@$gdbs) . "\n" if $self->debug;
     foreach my $key ( keys %group_taxon_ids ) {
+        print "Taxon $key has " . $group_taxon_ids{$key} . "gdbs\n" if $self->debug;
         delete $group_taxon_ids{$key} if $group_taxon_ids{$key} == (scalar(@$gdbs));
         unless ((scalar keys %group_taxon_ids) < 20) {
             delete $group_taxon_ids{$key} if $group_taxon_ids{$key} < (scalar(@$gdbs)/10);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/PermuteMatrix.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/PermuteMatrix.pm
@@ -110,14 +110,14 @@ sub fetch_input {
 		my @group_gdbs = @{$gdb_adaptor->fetch_all_current_by_ancestral_taxon_id($group_taxon_id)};
 
 		# Make sure that the outgroup is in the list if this is the determined root taxon
-		my @excepts = ();
+		my $excepts = [];
 		if ( $group_taxon_id == $self->param('root_id') ) {
 			print "\t -- root_id is " . $self->param('root_id') . "\n" if $self->debug;
-			my $outgroup_gdb = $gdb_adaptor->fetch_by_dbID($self->param_required('outgroup_id'));
-			push(@group_gdbs, $outgroup_gdb) unless grep{$_->dbID == $self->param_required('outgroup_id')} @group_gdbs;
+			my $outgroup_gdb = $gdb_adaptor->fetch_by_dbID($outgroup_id);
+			push(@group_gdbs, $outgroup_gdb) unless grep{$_->dbID == $outgroup_id} @group_gdbs;
 		}
 		else {
-			@excepts = ($self->param_required('outgroup_id'));
+			$excepts = [$outgroup_id];
 		}
 
 		print "\t -- fetching submatrix for " . scalar @group_gdbs . " genomes\n" if $self->debug;
@@ -143,7 +143,7 @@ sub fetch_input {
 			$submatrix = $submatrix->collapse_group_in_matrix( $prev_group_gdbs, "mrg_$prev_group" );
 		}
         
-        next if Bio::EnsEMBL::Compara::Utils::DistanceMatrix->empty_submatrix($submatrix, \@excepts);
+        next if Bio::EnsEMBL::Compara::Utils::DistanceMatrix->empty_submatrix($submatrix, $excepts);
 
 		# add to dataflow
 		my $mdf = { 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/PermuteMatrix.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/PermuteMatrix.pm
@@ -72,6 +72,7 @@ sub fetch_input {
 	my $gdb_adaptor = $self->compara_dba->get_GenomeDBAdaptor;
 	my $ss_adaptor = $self->compara_dba->get_SpeciesSetAdaptor;
 	my $ncbi_adaptor = $self->compara_dba->get_NCBITaxonAdaptor;
+	my $outgroup_id = $self->param_required('outgroup_id');
 	
 	# parse matrix and replace filenames with genome_db_ids
 	my $mash_dist_file = $self->param_required('mash_dist_file');
@@ -127,7 +128,7 @@ sub fetch_input {
 
 		# add an outgroup
 		if ( $group_taxon_id == $self->param('root_id') ) {
-			$this_outgroup = $self->param_required('outgroup_id');
+			$this_outgroup = $outgroup_id;
 		} else {
 			($submatrix, $this_outgroup) = $self->_add_outgroup( $submatrix, $distance_matrix );
 		}

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/PermuteMatrix.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree/PermuteMatrix.pm
@@ -178,9 +178,6 @@ sub _add_outgroup {
 	my @sub_gdb_ids = $submatrix->members;
 	my $rep_gdb_id  = $sub_gdb_ids[0];
 
-	#print " -- submatrix genomes: " . join(", ", @sub_gdb_ids) . "\n" if $self->debug;
-	#print " -- fullmatrix genomes: " . join(", ", $full_matrix->members) . "\n" if $self->debug;
-
 	my ( $closest_gdb_id, $min_distance) = (undef, 100);
 	foreach my $full_key ( $full_matrix->members ) {
 		next if ( defined $self->param('blacklisted_genome_db_ids') && grep { $full_key eq $_ } @{$self->param('blacklisted_genome_db_ids')} ); # skip any that are on the naughty list
@@ -188,7 +185,6 @@ sub _add_outgroup {
 		if ( $full_matrix->distance($rep_gdb_id, $full_key) < $min_distance ) {
 			$closest_gdb_id = $full_key;
 			$min_distance = $full_matrix->distance($rep_gdb_id, $full_key);
-			#print "$full_key gives dist $min_distance\n";
 		}
 	} 
 
@@ -196,6 +192,7 @@ sub _add_outgroup {
 		print "Can't find a suitable outgroup\n";
 		return $submatrix;
 	}
+	
 	foreach my $sub_key ( $submatrix->members ) {
 		my $old_dist = $full_matrix->distance($sub_key, $closest_gdb_id);
 		$submatrix = $submatrix->distance($sub_key, $closest_gdb_id, $old_dist);

--- a/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
@@ -155,7 +155,8 @@ sub filter_and_convert_genome_db_ids {
 
 	foreach my $f1 ( keys %{ $expected_id_map } ) {
 		foreach my $f2 ( keys %{ $expected_id_map } ) {
-			die "One or both of $f1 / $f2 could not be found in the distance matrix" unless (exists $matrix->{$f1} && exists $matrix->{$f2});
+			# If one of our expected gdb_ids is missing we return undef
+			return undef unless (exists $matrix->{$f1} && exists $matrix->{$f2});
 			$gdb_matrix->distance($expected_id_map->{$f1}, $expected_id_map->{$f2}, $matrix->distance($f1, $f2));
 		};
 	}

--- a/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
@@ -97,12 +97,12 @@ sub distance {
 	my ($matrix, $s1, $s2, $new_distance) = @_;
 
 	if ( defined $new_distance ){
-	$matrix->{$s1}->{$s2} = $new_distance;
-	$matrix->{$s2}->{$s1} = $new_distance;
-	$matrix->{$s1}->{$s1} = 0;
-	$matrix->{$s2}->{$s2} = 0; # deal with diagonals
-	return $matrix;
-}
+		$matrix->{$s1}->{$s2} = $new_distance;
+		$matrix->{$s2}->{$s1} = $new_distance;
+		$matrix->{$s1}->{$s1} = 0;
+		$matrix->{$s2}->{$s2} = 0; # deal with diagonals
+		return $matrix;
+	}
 	elsif ( exists $matrix->{$s1} && exists $matrix->{$s2} ){
 		return $matrix->{$s1}->{$s2};
 	}

--- a/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
@@ -244,7 +244,6 @@ sub collapse_group_in_matrix {
 	my ($matrix, $to_collapse_full, $new_group_id) = @_;
 
 	# print "!!!! collapsing [" . join(',', map {$_->name . '(' . $_->dbID . ')'} @$to_collapse) . "] to $new_group_id\n";
-	
 	# first, check species are in the matrix
 	my @to_collapse;
 	foreach my $gdb ( @$to_collapse_full ) {

--- a/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
@@ -244,13 +244,13 @@ sub collapse_group_in_matrix {
 	my ($matrix, $to_collapse_full, $new_group_id) = @_;
 
 	# print "!!!! collapsing [" . join(',', map {$_->name . '(' . $_->dbID . ')'} @$to_collapse) . "] to $new_group_id\n";
+	
 	# first, check species are in the matrix
 	my @to_collapse;
 	foreach my $gdb ( @$to_collapse_full ) {
 		push( @to_collapse, $gdb ) if ( defined $matrix->{$gdb->dbID} );
 	}
 	return $matrix if scalar @to_collapse == 0;
-
 
 	$new_group_id ||= 'new';
 

--- a/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
@@ -96,12 +96,19 @@ sub members {
 sub distance {
 	my ($matrix, $s1, $s2, $new_distance) = @_;
 
-	return $matrix->{$s1}->{$s2} unless defined $new_distance;
+	if ( defined $new_distance ){
 	$matrix->{$s1}->{$s2} = $new_distance;
 	$matrix->{$s2}->{$s1} = $new_distance;
 	$matrix->{$s1}->{$s1} = 0;
 	$matrix->{$s2}->{$s2} = 0; # deal with diagonals
 	return $matrix;
+}
+	elsif ( exists $matrix->{$s1} && exists $matrix->{$s2} ){
+		return $matrix->{$s1}->{$s2};
+	}
+	else{
+		return undef;
+	}
 }
 
 sub parse_matrix {
@@ -130,44 +137,27 @@ sub parse_matrix {
 	return $matrix;
 }
 
-=head2 convert_to_genome_db_ids
+=head2 filter_and_convert_genome_db_ids
 
 	Arg [1] : Bio::EnsEMBL::Compara::GenomeDBAdaptor
-	Arg [2] : (optional) regex to extract species name and assembly from current id
-	Example: $matrix->convert_to_genome_db_ids( $genome_db_adaptor );
-	Example: $matrix->convert_to_genome_db_ids( $genome_db_adaptor, '(^[a-z]+)-([A-Z0-9]+)\.gz');
-	Description : Convert keys in a matrix from species names (+assemblies) to genome_db_id.
-	An optional regular expression may be passed if your filename format does not
-	follow species_name.assembly.fa standard. This regex must result in $1 = species name
-	and $2 = assembly name
+	Arg [2] : hashref of genome_db ids and expected filenames
+	Example: $matrix->filter_and_convert_genome_db_ids( $genome_db_adaptor, $genome_db_file_map );
+	Description : Convert keys in a matrix from species names (+assemblies) to genome_db_id and filter to
+		only the requested genome_db ids
 	Returntype : Bio::EnsEMBL::Compara::Utils::DistanceMatrix
 
 =cut 
 
-sub convert_to_genome_db_ids {
-	my ( $matrix, $gdb_adaptor, $opt_regex ) = @_;
-
-	# my $gdb_adaptor  = $self->compara_dba->get_GenomeDBAdaptor;
-	# my $ncbi_adaptor = $self->compara_dba->get_NCBITaxonAdaptor;
-
-	# map filenames to genome_db_ids
-	my $filename_regex = $opt_regex ? $opt_regex : '(^[A-Za-z_0-9]+)\.([A-Za-z0-9_\-\.]+)\.fa';
-
-	my %file_map;
-	foreach my $file ( $matrix->members ) {
-		my ( $species_name, $assembly_name ) = $matrix->_get_species_info_from_filename($file, $filename_regex);
-		my $this_gdb = $gdb_adaptor->fetch_by_name_assembly( $species_name, $assembly_name );
-		die "Cannot find species $species_name ($assembly_name) in compara database" unless $this_gdb;
-		$file_map{$file} = $this_gdb->dbID;
-	}
+sub filter_and_convert_genome_db_ids {
+	my ( $matrix, $expected_id_map ) = @_;
 	
 	my $gdb_matrix = Bio::EnsEMBL::Compara::Utils::DistanceMatrix->new();
-	foreach my $f1 ( $matrix->members ) {
-		my $f1_gdb_id = $file_map{$f1};
-		foreach my $f2 ( $matrix->members ) {
-			my $f2_gdb_id = $file_map{$f2};
-			$gdb_matrix->distance($f1_gdb_id, $f2_gdb_id, $matrix->distance($f1, $f2));
-		}
+
+	foreach my $f1 ( keys %{ $expected_id_map } ) {
+		foreach my $f2 ( keys %{ $expected_id_map } ) {
+			die "One or both of $f1 / $f2 could not be found in the distance matrix" unless (exists $matrix->{$f1} && exists $matrix->{$f2});
+			$gdb_matrix->distance($expected_id_map->{$f1}, $expected_id_map->{$f2}, $matrix->distance($f1, $f2));
+		};
 	}
 	return $gdb_matrix;
 }
@@ -189,7 +179,7 @@ sub _get_species_info_from_filename {
 	Example : $matrix = $matrix->add_taxonomic_distance($genome_db_adaptor)
 	Description : replace all distances in a matrix with an average of the given distance
 		and the taxonomic distance for each pair of species. This method assumes that matrix
-		ids are genome_db_ids (if they are not, convert them with $matrix->convert_to_genome_db_ids)
+		ids are genome_db_ids (if they are not, convert them with $matrix->filter_and_convert_genome_db_ids)
 	Returntype : Bio::EnsEMBL::Compara::Utils::DistanceMatrix
 
 =cut
@@ -253,13 +243,13 @@ sub collapse_group_in_matrix {
 	my ($matrix, $to_collapse_full, $new_group_id) = @_;
 
 	# print "!!!! collapsing [" . join(',', map {$_->name . '(' . $_->dbID . ')'} @$to_collapse) . "] to $new_group_id\n";
-
 	# first, check species are in the matrix
 	my @to_collapse;
 	foreach my $gdb ( @$to_collapse_full ) {
 		push( @to_collapse, $gdb ) if ( defined $matrix->{$gdb->dbID} );
 	}
 	return $matrix if scalar @to_collapse == 0;
+
 
 	$new_group_id ||= 'new';
 
@@ -367,11 +357,11 @@ sub phylip_from_matrix {
 }
 
 sub empty_submatrix {
-    my ($self, $submatrix) = @_;
+    my ($self, $submatrix, $excepts) = @_;
 
     my @members = $submatrix->members;
     foreach my $member ( @members ) {
-        return 0 unless $member =~ m/^mrg_/;
+        return 0 unless ( $member =~ m/^mrg_/ or grep { $member eq $_ } @{$excepts} );
     }
     return 1;
 }


### PR DESCRIPTION
## Description
A grasses species tree is to be generated and changes are required to make the current code work for polyploid genomes with components.

**Related JIRA tickets:**
- [ENSCOMPARASW-4432](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-4432)
- [ENSCOMPARASW-4418](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-4418)

## Overview of changes

#### Change 1
- Apply filter for polyploid genomes with components such that genome dbs for the principals are excluded.
The largest change is a new method, filter_and_convert_genome_db_ids, in modules/Bio/EnsEMBL/Compara/Utils/DistanceMatrix.pm
Code for filtering before calling this method is added to runnables in modules/Bio/EnsEMBL/Compara/RunnableDB/SpeciesTree.

#### Change 2
- A change to the names used in the tree is made to include component information. Due to newick file format restrictions the use of display_name turns out to regularly cause errors and the parameter controlling this option has been removed.

#### Change 3
- PipeConfig changes to pass `genome_dump_dirs` parameter to runnables which require it for filtering

#### Change 4
- Changes to the `empty_submatrix` subroutine in `DistanceMatrix.pm` to allow it to take an array of `genome_db_ids` which should not be used to determine "emptiness". Currently the use-case for this is to consider a submatrix empty if it includes only groups beginning `mrg_` and/or the `genome_db_id` of the overall outgroup species. 

## Testing
[Pipeline run-through with grasses](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-compara-prod-5&port=4615&dbname=agymer_grasses_species_tree&passwd=xxxxx)
[Pipeline run-through for all plants](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-compara-prod-5&port=4615&dbname=agymer_all_plants_tree&passwd=xxxxx) (This doesn't produce an ideal tree but that is unrelated to the components changes)

