### PR TITLE
Bugfix/duplicate jira blocker links

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
@@ -293,10 +293,10 @@ sub fetch_tickets {
 =cut
 
 sub get_ticket {
-    my $self, $key_or_id = @_;
-    my $url = my $url = "https://www.ebi.ac.uk/panda/jira/rest/api/latest/issue/$key_or_id"
+    my ( $self, $key_or_id ) = @_;
+    my $url = "https://www.ebi.ac.uk/panda/jira/rest/api/latest/issue/$key_or_id";
     my $ticket = $self->_http_request('GET', $url);
-    return $ticket;
+    return $ticket->{fields};
 }
 
 =head2 link_tickets
@@ -330,13 +330,13 @@ sub link_tickets {
         my $link_exists = 0;
         foreach my $i ( @{$inward_ticket->{issuelinks}} ){
             if ($i->{type}->{name} eq $link_type && $i->{outwardIssue}->{key} eq $outward_key) {
-                my $link_exists = 1;
+                $link_exists = 1;
                 last;
             }
         }
         if ( $link_exists == 1 ) {
-            $self->{_logger}->info("Issue link already exists. Doing nothing.\n")
-            return
+            $self->{_logger}->info("Issue link already exists. Doing nothing.\n");
+            return;
         }
         my $link_content = {
             "type"         => { "name" => $link_type },

--- a/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
@@ -327,16 +327,11 @@ sub link_tickets {
                                            'Issue split', 'Related', 'Relates', 'Required');
     if (exists $jira_link_types{$link_type}) {
         my $inward_ticket = $self->get_ticket($inward_key);
-        my $link_exists = 0;
         foreach my $link ( @{$inward_ticket->{issuelinks}} ){
             if ($link->{type}->{name} eq $link_type && $link->{outwardIssue}->{key} eq $outward_key) {
-                $link_exists = 1;
-                last;
+                $self->{_logger}->info("Issue link already exists. Doing nothing.\n");
+                return;
             }
-        }
-        if ( $link_exists ) {
-            $self->{_logger}->info("Issue link already exists. Doing nothing.\n");
-            return;
         }
         my $link_content = {
             "type"         => { "name" => $link_type },

--- a/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
@@ -328,8 +328,8 @@ sub link_tickets {
     if (exists $jira_link_types{$link_type}) {
         my $inward_ticket = $self->get_ticket($inward_key);
         my $link_exists = 0;
-        foreach my $i ( @{$inward_ticket->{issuelinks}} ){
-            if ($i->{type}->{name} eq $link_type && $i->{outwardIssue}->{key} eq $outward_key) {
+        foreach my $link ( @{$inward_ticket->{issuelinks}} ){
+            if ($link->{type}->{name} eq $link_type && $link->{outwardIssue}->{key} eq $outward_key) {
                 $link_exists = 1;
                 last;
             }

--- a/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
@@ -326,6 +326,18 @@ sub link_tickets {
     my %jira_link_types = map { $_ => 1 } ('After', 'Before', 'Blocks', 'Cloners', 'Duplicate',
                                            'Issue split', 'Related', 'Relates', 'Required');
     if (exists $jira_link_types{$link_type}) {
+        my $inward_ticket = $self->get_ticket($inward_key);
+        my $link_exists = 0;
+        foreach my $i ( @{$inward_ticket->{issuelinks}} ){
+            if ($i->{type}->{name} eq $link_type && $i->{outwardIssue}->{key} eq $outward_key) {
+                my $link_exists = 1;
+                last;
+            }
+        }
+        if ( $link_exists == 1 ) {
+            $self->{_logger}->info("Issue link already exists. Doing nothing.\n")
+            return
+        }
         my $link_content = {
             "type"         => { "name" => $link_type },
             "inwardIssue"  => { "key"  => $inward_key },

--- a/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
@@ -334,7 +334,7 @@ sub link_tickets {
                 last;
             }
         }
-        if ( $link_exists == 1 ) {
+        if ( $link_exists ) {
             $self->{_logger}->info("Issue link already exists. Doing nothing.\n");
             return;
         }

--- a/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/JIRA.pm
@@ -282,6 +282,23 @@ sub fetch_tickets {
     return $tickets;
 }
 
+=head2 get_ticket
+
+  Arg[1]      : string - JIRA ticket key or ID
+  Example     : my $ticket = $jira_adaptor->get_ticket('ENSCOMPARASW-4300');
+  Description : Returns JIRA ticket JSON representation from API
+  Return type : hashref of JIRA ticket JSON representation
+  Exceptions  : none
+
+=cut
+
+sub get_ticket {
+    my $self, $key_or_id = @_;
+    my $url = my $url = "https://www.ebi.ac.uk/panda/jira/rest/api/latest/issue/$key_or_id"
+    my $ticket = $self->_http_request('GET', $url);
+    return $ticket;
+}
+
 =head2 link_tickets
 
   Arg[-LINK_TYPE]   : string - an issue link type

--- a/scripts/jira_tickets/create_datacheck_tickets.pl
+++ b/scripts/jira_tickets/create_datacheck_tickets.pl
@@ -128,12 +128,10 @@ my $dc_task_keys = $jira_adaptor->create_tickets(
     -UPDATE             => $update,
     -DRY_RUN            => $dry_run
 );
-
 # Create a blocker issue link between the newly created datacheck ticket and the
 # handover ticket if it doesn't already exist
 my $blocked_ticket_key = find_labeled_ticket($jira_adaptor, 'Handover_anchor');
 $jira_adaptor->link_tickets('Blocks', $dc_task_keys->[0], $blocked_ticket_key, $dry_run);
-
 
 sub parse_datachecks {
     my $dc_file = shift;

--- a/scripts/jira_tickets/create_datacheck_tickets.pl
+++ b/scripts/jira_tickets/create_datacheck_tickets.pl
@@ -132,17 +132,7 @@ my $dc_task_keys = $jira_adaptor->create_tickets(
 # Create a blocker issue link between the newly created datacheck ticket and the
 # handover ticket if it doesn't already exist
 my $blocked_ticket_key = find_labeled_ticket($jira_adaptor, 'Handover_anchor');
-my $dc_ticket = $jira_adaptor->get_ticket($dc_task_keys->[0]);
-my $blocker_exists;
-foreach my $i ( @{$dc_ticket->{issuelinks}} ){
-    if ($i->{type}->{name} eq 'Blocks' && $i->{outwardIssue}->{key} eq $blocked_ticket_key) {
-        my $blocker_exists = 1;
-        last;
-    }
-}
-if ( $blocker_exists != 1 ) {
-    $jira_adaptor->link_tickets('Blocks', $dc_ticket->{key}, $blocked_ticket_key, $dry_run);
-}
+$jira_adaptor->link_tickets('Blocks', $dc_task_keys->[0], $blocked_ticket_key, $dry_run);
 
 
 sub parse_datachecks {


### PR DESCRIPTION
## Description

When using the --update flag, tickets are reopened if they already exist. However, the blocker link that is created against the 'Handover of release DB' ticket is created again, resulting in duplicate links. Update the script : don't add a new link if it already exists.

**Related JIRA tickets:**
- ENSCOMPARASW-4300

## Overview of changes

#### Change 1
- Added  a `get_ticket` method to `JIRA.pm` which returns the JSON representation of a JIRA ticket from the API endpoint `GET /rest/api/3/issue/{issueIdOrKey}`

#### Change 2
- In `link_tickets` use the issue JSON for the inward ticket to look for `issuelinks` and check for any exisiting link with the same `name` and `outwardIssue` `key`

## Testing
`create_datacheck_tickets.pl` run on `/hps/nobackup2/production/ensembl/jalvarez/metazoa_datachecks_104/tapfile/ForeignKeysCompara.tap` against release `104`.

