### PR TITLE
Updated registry for e105 Vertebrates

### DIFF
--- a/conf/vertebrates/production_reg_conf.pl
+++ b/conf/vertebrates/production_reg_conf.pl
@@ -51,8 +51,8 @@ Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertann
 my @metazoa_overlap_species = qw(drosophila_melanogaster caenorhabditis_elegans);
 Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@metazoa_overlap_species);
 my $metazoa_overlap_cores = {
-    'drosophila_melanogaster' => [ 'mysql-ens-vertannot-staging', "drosophila_melanogaster_core_104_9" ],
-    'caenorhabditis_elegans'  => [ 'mysql-ens-vertannot-staging', "caenorhabditis_elegans_core_104_269" ],
+    'drosophila_melanogaster' => [ 'mysql-ens-vertannot-staging', "drosophila_melanogaster_core_105_9" ],
+    'caenorhabditis_elegans'  => [ 'mysql-ens-vertannot-staging', "caenorhabditis_elegans_core_105_269" ],
 };
 Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $metazoa_overlap_cores );
 
@@ -61,7 +61,7 @@ Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $metazoa_overlap_cores );
 # previous release core databases will be required by PrepareMasterDatabaseForRelease, LoadMembers and MercatorPecan
 *Bio::EnsEMBL::Compara::Utils::Registry::load_previous_core_databases = sub {
     Bio::EnsEMBL::Registry->load_registry_from_db(
-        -host   => 'mysql-ens-sta-1-b',
+        -host   => 'mysql-ens-sta-1',
         -port   => 4519,
         -user   => 'ensro',
         -pass   => '',
@@ -84,61 +84,61 @@ my $compara_dbs = {
     # 'compara_curr_3'   => [ 'mysql-ens-compara-prod-3', "ensembl_compara_$curr_release" ],
 
     # homology dbs
-    'compara_members'         => [ 'mysql-ens-compara-prod-1',  'carlac_vertebrates_load_members_104' ],
-    'compara_ptrees'          => [ 'mysql-ens-compara-prod-1',  'carlac_default_vertebrates_protein_trees_104' ],
-    'compara_nctrees'         => [ 'mysql-ens-compara-prod-5',  'carlac_default_vertebrates_ncrna_trees_104' ],
-    'murinae_ptrees'          => [ 'mysql-ens-compara-prod-2',  'carlac_vertebrates_murinae_protein_reindexed_trees_104' ],
-    'murinae_nctrees'         => [ 'mysql-ens-compara-prod-2',  'carlac_vertebrates_murinae_ncrna_reindexed_trees_104' ],
-    'murinae_ptrees_prev'     => [ 'mysql-ens-compara-prod-8',  'jalvarez_murinae_vertebrates_protein_trees_103' ],
-    'murinae_nctrees_prev'    => [ 'mysql-ens-compara-prod-7',  'jalvarez_murinae_vertebrates_ncrna_trees_103' ],
-    'pig_breeds_ptrees'       => [ 'mysql-ens-compara-prod-3',  'carlac_vertebrates_pig_breeds_protein_reindexed_trees_104' ],
-    'pig_breeds_nctrees'      => [ 'mysql-ens-compara-prod-3',  'carlac_vertebrates_pig_breeds_ncrna_reindexed_trees_104' ],
-    'pig_breeds_ptrees_prev'  => [ 'mysql-ens-compara-prod-4',  'jalvarez_pig_breeds_vertebrates_protein_trees_103' ],
-    'pig_breeds_nctrees_prev' => [ 'mysql-ens-compara-prod-10', 'jalvarez_pig_breeds_vertebrates_ncrna_trees_103' ],
+    #'compara_members'         => [ 'mysql-ens-compara-prod-1',  'carlac_vertebrates_load_members_104' ],
+    #'compara_ptrees'          => [ 'mysql-ens-compara-prod-1',  'carlac_default_vertebrates_protein_trees_104' ],
+    #'compara_nctrees'         => [ 'mysql-ens-compara-prod-5',  'carlac_default_vertebrates_ncrna_trees_104' ],
+    #'murinae_ptrees'          => [ 'mysql-ens-compara-prod-2',  'carlac_vertebrates_murinae_protein_reindexed_trees_104' ],
+    #'murinae_nctrees'         => [ 'mysql-ens-compara-prod-2',  'carlac_vertebrates_murinae_ncrna_reindexed_trees_104' ],
+    'murinae_ptrees_prev'     => [ 'mysql-ens-compara-prod-2',  'carlac_vertebrates_murinae_protein_reindexed_trees_104' ],
+    'murinae_nctrees_prev'    => [ 'mysql-ens-compara-prod-2',  'carlac_vertebrates_murinae_ncrna_reindexed_trees_104' ],
+    #'pig_breeds_ptrees'       => [ 'mysql-ens-compara-prod-3',  'carlac_vertebrates_pig_breeds_protein_reindexed_trees_104' ],
+    #'pig_breeds_nctrees'      => [ 'mysql-ens-compara-prod-3',  'carlac_vertebrates_pig_breeds_ncrna_reindexed_trees_104' ],
+    'pig_breeds_ptrees_prev'  => [ 'mysql-ens-compara-prod-3',  'carlac_vertebrates_pig_breeds_protein_reindexed_trees_104' ],
+    'pig_breeds_nctrees_prev' => [ 'mysql-ens-compara-prod-3',  'carlac_vertebrates_pig_breeds_ncrna_reindexed_trees_104' ],
 
     # LASTZ dbs
-    'lastz_batch_1'    => [ 'mysql-ens-compara-prod-2', 'carlac_vertebrates_lastz_batch1_104' ],
+    #'lastz_batch_1'    => [ 'mysql-ens-compara-prod-2', 'carlac_vertebrates_lastz_batch1_104' ],
     'unidir_lastz'     => [ 'mysql-ens-compara-prod-1', 'ensembl_vertebrates_unidirectional_lastz' ],
 
     # EPO dbs
     ## mammals
-    'mammals_epo_w_ext'    => [ 'mysql-ens-compara-prod-4', 'jalvarez_mammals_epo_with2x_103' ],
+    #'mammals_epo_w_ext'    => [ 'mysql-ens-compara-prod-4', 'jalvarez_mammals_epo_with2x_103' ],
     'mammals_epo_prev'     => [ 'mysql-ens-compara-prod-4', 'jalvarez_mammals_epo_with2x_103' ],
     'mammals_epo_anchors'  => [ 'mysql-ens-compara-prod-2', 'waakanni_generate_anchors_mammals_93' ],
 
     ## sauropsids
     'sauropsids_epo_w_ext'   => [ 'mysql-ens-compara-prod-4', 'carlac_sauropsids_epo_with_ext_104' ],
-    'sauropsids_epo_prev'    => [ 'mysql-ens-compara-prod-7', 'jalvarez_sauropsids_epo_update_103' ],
+    'sauropsids_epo_prev'    => [ 'mysql-ens-compara-prod-4', 'carlac_sauropsids_epo_with_ext_104' ],
     'sauropsids_epo_anchors' => [ 'mysql-ens-compara-prod-1', 'mm14_4saur_gen_anchors_hacked_86' ],
 
     ## fish
     'fish_epo_w_ext'    => [ 'mysql-ens-compara-prod-3', 'carlac_fish_epo_update_104' ],
-    'fish_epo_prev'     => [ 'mysql-ens-compara-prod-7', 'jalvarez_fish_epo_update_103' ],
+    'fish_epo_prev'     => [ 'mysql-ens-compara-prod-3', 'carlac_fish_epo_update_104' ],
     'fish_epo_anchors'  => [ 'mysql-ens-compara-prod-8', 'muffato_generate_anchors_fish_100' ],
 
     ## primates
-    'primates_epo_w_ext'    => [ 'mysql-ens-compara-prod-7', 'jalvarez_primates_epo_with2x_103' ],
-    'primates_epo_prev'     => [ 'mysql-ens-compara-prod-4', 'jalvarez_mammals_epo_with2x_103' ],  # Primates are reused from mammals of the *same release* (same anchors and subset of species)
+    #'primates_epo_w_ext'    => [ 'mysql-ens-compara-prod-7', 'jalvarez_primates_epo_with2x_103' ],
+    #'primates_epo_prev'     => [ 'mysql-ens-compara-prod-4', 'jalvarez_mammals_epo_with2x_103' ],  # Primates are reused from mammals of the *same release* (same anchors and subset of species)
     'primates_epo_anchors'  => [ 'mysql-ens-compara-prod-2', 'waakanni_generate_anchors_mammals_93' ],
 
     ## pig strains
-    'pig_breeds_epo_w_ext'     => [ 'mysql-ens-compara-prod-1', 'jalvarez_pig_breeds_epo_with2x_103' ],
-    'pig_breeds_epo_prev'      => [ 'mysql-ens-compara-prod-4', 'jalvarez_mammals_epo_with2x_103' ],  # Pig breeds are reused from mammals of the *same release* (same anchors and subset of species)
+    #'pig_breeds_epo_w_ext'     => [ 'mysql-ens-compara-prod-1', 'jalvarez_pig_breeds_epo_with2x_103' ],
+    #'pig_breeds_epo_prev'      => [ 'mysql-ens-compara-prod-4', 'jalvarez_mammals_epo_with2x_103' ],  # Pig breeds are reused from mammals of the *same release* (same anchors and subset of species)
     'pig_breeds_epo_anchors'   => [ 'mysql-ens-compara-prod-2', 'waakanni_generate_anchors_mammals_93' ],
 
     ## murinae
-    'murinae_epo'          => [ 'mysql-ens-compara-prod-4', 'jalvarez_murinae_epo_103' ],
+    #'murinae_epo'          => [ 'mysql-ens-compara-prod-4', 'jalvarez_murinae_epo_103' ],
     'murinae_epo_prev'     => [ 'mysql-ens-compara-prod-4', 'jalvarez_murinae_epo_103' ],
     'murinae_epo_anchors'  => [ 'mysql-ens-compara-prod-2', 'waakanni_generate_anchors_mammals_93' ],
 
     # other alignments
-    'amniotes_pecan'      => [ 'mysql-ens-compara-prod-3', 'carlac_amniotes_pecan_update_104' ],
-    'amniotes_pecan_prev' => [ 'mysql-ens-compara-prod-6', 'jalvarez_amniotes_mercator_pecan_103' ],
+    #'amniotes_pecan'      => [ 'mysql-ens-compara-prod-3', 'carlac_amniotes_pecan_update_104' ],
+    'amniotes_pecan_prev' => [ 'mysql-ens-compara-prod-3', 'carlac_amniotes_pecan_update_104' ],
 
-    'compara_syntenies'   => [ 'mysql-ens-compara-prod-2', 'jalvarez_vertebrates_synteny_104' ],
+    #'compara_syntenies'   => [ 'mysql-ens-compara-prod-2', 'jalvarez_vertebrates_synteny_104' ],
 
     # miscellaneous
-    'alt_allele_projection' => [ 'mysql-ens-compara-prod-3', 'carlac_vertebrates_alt_allele_import_104' ],
+    #'alt_allele_projection' => [ 'mysql-ens-compara-prod-3', 'carlac_vertebrates_alt_allele_import_104' ],
 };
 
 Bio::EnsEMBL::Compara::Utils::Registry::add_compara_dbas( $compara_dbs );
@@ -149,18 +149,18 @@ my $ancestral_dbs = {
     'ancestral_prev' => [ 'mysql-ens-compara-prod-1', "ensembl_ancestral_$prev_release" ],
     'ancestral_curr' => [ 'mysql-ens-compara-prod-1', "ensembl_ancestral_$curr_release" ],
 
-    'mammals_ancestral'    => [ 'mysql-ens-compara-prod-4', 'jalvarez_mammals_ancestral_core_103' ],
-    'primates_ancestral'   => [ 'mysql-ens-compara-prod-7', 'jalvarez_primates_ancestral_core_103' ],
+    #'mammals_ancestral'    => [ 'mysql-ens-compara-prod-4', 'jalvarez_mammals_ancestral_core_103' ],
+    #'primates_ancestral'   => [ 'mysql-ens-compara-prod-7', 'jalvarez_primates_ancestral_core_103' ],
     'sauropsids_ancestral' => [ 'mysql-ens-compara-prod-4', 'carlac_sauropsids_ancestral_core_104' ],
     'fish_ancestral'       => [ 'mysql-ens-compara-prod-3', 'carlac_fish_ancestral_core_104' ],
-    'murinae_ancestral'    => [ 'mysql-ens-compara-prod-4', 'jalvarez_murinae_ancestral_core_103' ],
+    #'murinae_ancestral'    => [ 'mysql-ens-compara-prod-4', 'jalvarez_murinae_ancestral_core_103' ],
 };
 
 Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $ancestral_dbs );
 
 # NCBI taxonomy database (also maintained by production team):
 Bio::EnsEMBL::Compara::Utils::Registry::add_taxonomy_dbas({
-    'ncbi_taxonomy' => [ 'mysql-ens-sta-1', "ncbi_taxonomy_$curr_release" ],
+    'ncbi_taxonomy' => [ 'mysql-ens-sta-1-b', "ncbi_taxonomy_$curr_release" ],
 });
 
 # -------------------------------------------------------------------

--- a/conf/vertebrates/production_reg_conf.pl
+++ b/conf/vertebrates/production_reg_conf.pl
@@ -51,8 +51,8 @@ Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertann
 my @metazoa_overlap_species = qw(drosophila_melanogaster caenorhabditis_elegans);
 Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@metazoa_overlap_species);
 my $metazoa_overlap_cores = {
-    'drosophila_melanogaster' => [ 'mysql-ens-vertannot-staging', "drosophila_melanogaster_core_105_9" ],
-    'caenorhabditis_elegans'  => [ 'mysql-ens-vertannot-staging', "caenorhabditis_elegans_core_105_269" ],
+    'drosophila_melanogaster' => [ 'mysql-ens-vertannot-staging', "drosophila_melanogaster_core_" . $curr_release . "_9" ],
+    'caenorhabditis_elegans'  => [ 'mysql-ens-vertannot-staging', "caenorhabditis_elegans_core_" . $curr_release . "_269" ],
 };
 Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $metazoa_overlap_cores );
 
@@ -84,25 +84,25 @@ my $compara_dbs = {
     # 'compara_curr_3'   => [ 'mysql-ens-compara-prod-3', "ensembl_compara_$curr_release" ],
 
     # homology dbs
-    #'compara_members'         => [ 'mysql-ens-compara-prod-1',  'carlac_vertebrates_load_members_104' ],
-    #'compara_ptrees'          => [ 'mysql-ens-compara-prod-1',  'carlac_default_vertebrates_protein_trees_104' ],
-    #'compara_nctrees'         => [ 'mysql-ens-compara-prod-5',  'carlac_default_vertebrates_ncrna_trees_104' ],
-    #'murinae_ptrees'          => [ 'mysql-ens-compara-prod-2',  'carlac_vertebrates_murinae_protein_reindexed_trees_104' ],
-    #'murinae_nctrees'         => [ 'mysql-ens-compara-prod-2',  'carlac_vertebrates_murinae_ncrna_reindexed_trees_104' ],
+    #'compara_members'         => [ 'mysql-ens-compara-prod-1',  '' ],
+    #'compara_ptrees'          => [ 'mysql-ens-compara-prod-X',  '' ],
+    #'compara_nctrees'         => [ 'mysql-ens-compara-prod-X',  '' ],
+    #'murinae_ptrees'          => [ 'mysql-ens-compara-prod-X',  '' ],
+    #'murinae_nctrees'         => [ 'mysql-ens-compara-prod-X',  '' ],
     'murinae_ptrees_prev'     => [ 'mysql-ens-compara-prod-2',  'carlac_vertebrates_murinae_protein_reindexed_trees_104' ],
     'murinae_nctrees_prev'    => [ 'mysql-ens-compara-prod-2',  'carlac_vertebrates_murinae_ncrna_reindexed_trees_104' ],
-    #'pig_breeds_ptrees'       => [ 'mysql-ens-compara-prod-3',  'carlac_vertebrates_pig_breeds_protein_reindexed_trees_104' ],
-    #'pig_breeds_nctrees'      => [ 'mysql-ens-compara-prod-3',  'carlac_vertebrates_pig_breeds_ncrna_reindexed_trees_104' ],
+    #'pig_breeds_ptrees'       => [ 'mysql-ens-compara-prod-X',  '' ],
+    #'pig_breeds_nctrees'      => [ 'mysql-ens-compara-prod-X',  '' ],
     'pig_breeds_ptrees_prev'  => [ 'mysql-ens-compara-prod-3',  'carlac_vertebrates_pig_breeds_protein_reindexed_trees_104' ],
     'pig_breeds_nctrees_prev' => [ 'mysql-ens-compara-prod-3',  'carlac_vertebrates_pig_breeds_ncrna_reindexed_trees_104' ],
 
     # LASTZ dbs
-    #'lastz_batch_1'    => [ 'mysql-ens-compara-prod-2', 'carlac_vertebrates_lastz_batch1_104' ],
+    #'lastz_batch_1'    => [ 'mysql-ens-compara-prod-X', '' ],
     'unidir_lastz'     => [ 'mysql-ens-compara-prod-1', 'ensembl_vertebrates_unidirectional_lastz' ],
 
     # EPO dbs
     ## mammals
-    #'mammals_epo_w_ext'    => [ 'mysql-ens-compara-prod-4', 'jalvarez_mammals_epo_with2x_103' ],
+    #'mammals_epo_w_ext'    => [ 'mysql-ens-compara-prod-X', '' ],
     'mammals_epo_prev'     => [ 'mysql-ens-compara-prod-4', 'jalvarez_mammals_epo_with2x_103' ],
     'mammals_epo_anchors'  => [ 'mysql-ens-compara-prod-2', 'waakanni_generate_anchors_mammals_93' ],
 
@@ -117,28 +117,28 @@ my $compara_dbs = {
     'fish_epo_anchors'  => [ 'mysql-ens-compara-prod-8', 'muffato_generate_anchors_fish_100' ],
 
     ## primates
-    #'primates_epo_w_ext'    => [ 'mysql-ens-compara-prod-7', 'jalvarez_primates_epo_with2x_103' ],
-    #'primates_epo_prev'     => [ 'mysql-ens-compara-prod-4', 'jalvarez_mammals_epo_with2x_103' ],  # Primates are reused from mammals of the *same release* (same anchors and subset of species)
+    #'primates_epo_w_ext'    => [ 'mysql-ens-compara-prod-X', '' ],
+    #'primates_epo_prev'     => [ 'mysql-ens-compara-prod-X', '' ],  # Primates are reused from mammals of the *same release* (same anchors and subset of species)
     'primates_epo_anchors'  => [ 'mysql-ens-compara-prod-2', 'waakanni_generate_anchors_mammals_93' ],
 
     ## pig strains
-    #'pig_breeds_epo_w_ext'     => [ 'mysql-ens-compara-prod-1', 'jalvarez_pig_breeds_epo_with2x_103' ],
-    #'pig_breeds_epo_prev'      => [ 'mysql-ens-compara-prod-4', 'jalvarez_mammals_epo_with2x_103' ],  # Pig breeds are reused from mammals of the *same release* (same anchors and subset of species)
+    #'pig_breeds_epo_w_ext'     => [ 'mysql-ens-compara-prod-X', '' ],
+    #'pig_breeds_epo_prev'      => [ 'mysql-ens-compara-prod-X', '' ],  # Pig breeds are reused from mammals of the *same release* (same anchors and subset of species)
     'pig_breeds_epo_anchors'   => [ 'mysql-ens-compara-prod-2', 'waakanni_generate_anchors_mammals_93' ],
 
     ## murinae
-    #'murinae_epo'          => [ 'mysql-ens-compara-prod-4', 'jalvarez_murinae_epo_103' ],
+    #'murinae_epo'          => [ 'mysql-ens-compara-prod-X', '' ],
     'murinae_epo_prev'     => [ 'mysql-ens-compara-prod-4', 'jalvarez_murinae_epo_103' ],
     'murinae_epo_anchors'  => [ 'mysql-ens-compara-prod-2', 'waakanni_generate_anchors_mammals_93' ],
 
     # other alignments
-    #'amniotes_pecan'      => [ 'mysql-ens-compara-prod-3', 'carlac_amniotes_pecan_update_104' ],
+    #'amniotes_pecan'      => [ 'mysql-ens-compara-prod-X', '' ],
     'amniotes_pecan_prev' => [ 'mysql-ens-compara-prod-3', 'carlac_amniotes_pecan_update_104' ],
 
-    #'compara_syntenies'   => [ 'mysql-ens-compara-prod-2', 'jalvarez_vertebrates_synteny_104' ],
+    #'compara_syntenies'   => [ 'mysql-ens-compara-prod-X', '' ],
 
     # miscellaneous
-    #'alt_allele_projection' => [ 'mysql-ens-compara-prod-3', 'carlac_vertebrates_alt_allele_import_104' ],
+    #'alt_allele_projection' => [ 'mysql-ens-compara-prod-X', '' ],
 };
 
 Bio::EnsEMBL::Compara::Utils::Registry::add_compara_dbas( $compara_dbs );
@@ -149,11 +149,11 @@ my $ancestral_dbs = {
     'ancestral_prev' => [ 'mysql-ens-compara-prod-1', "ensembl_ancestral_$prev_release" ],
     'ancestral_curr' => [ 'mysql-ens-compara-prod-1', "ensembl_ancestral_$curr_release" ],
 
-    #'mammals_ancestral'    => [ 'mysql-ens-compara-prod-4', 'jalvarez_mammals_ancestral_core_103' ],
-    #'primates_ancestral'   => [ 'mysql-ens-compara-prod-7', 'jalvarez_primates_ancestral_core_103' ],
+    #'mammals_ancestral'    => [ 'mysql-ens-compara-prod-X', '' ],
+    #'primates_ancestral'   => [ 'mysql-ens-compara-prod-X', '' ],
     'sauropsids_ancestral' => [ 'mysql-ens-compara-prod-4', 'carlac_sauropsids_ancestral_core_104' ],
     'fish_ancestral'       => [ 'mysql-ens-compara-prod-3', 'carlac_fish_ancestral_core_104' ],
-    #'murinae_ancestral'    => [ 'mysql-ens-compara-prod-4', 'jalvarez_murinae_ancestral_core_103' ],
+    #'murinae_ancestral'    => [ 'mysql-ens-compara-prod-X', '' ],
 };
 
 Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $ancestral_dbs );


### PR DESCRIPTION
## Description

Registry before running any production pipelines. I thought it might be more convenient to review changes this way.  

**Related JIRA tickets:**
- ENSCOMPARASW-4530

## Overview of changes
C/P from [Release plan e105](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Release+plan+e105)

List of species updated invertebrates:
- Canis lupus familiaris (reference)
- Rattus norvegicus (reference)
- Ovis aries (reference)
- Xenopus tropicalis
- Primates 
    - Papio anubis (primates)
    - Callithrix jaccus (primates)
    - Pongo abelii  (primates)

List of multiple alignment to be run
- Primate EPO - EPO extended
- Mouse EPO 
- Mammals EPO - EPO extended
- Mercator Pecan
- Pig alignment

## Notes
At some places (sauropsids and fish EPO i.e. where we're not computing EPOs this release), I put the same curr and prev db. I did that because I saw in 104 registry e.g.
`'mammals_epo_w_ext'    => [ 'mysql-ens-compara-prod-4', 'jalvarez_mammals_epo_with2x_103' ],`
`'mammals_epo_prev'     => [ 'mysql-ens-compara-prod-4', 'jalvarez_mammals_epo_with2x_103' ],`

Also, I commented out ancestral dbs for which I think will be produced this release.
