### PR TITLE
Orthofinder in references pipeline

### DIFF
--- a/conf/software/LSF.codon.json
+++ b/conf/software/LSF.codon.json
@@ -50,6 +50,8 @@
     "ortheus_c_exe"             : ["check_exe_in_compara", "ortheus/rc3/bin/ortheus_core"],
     "ortheus_lib_dir"           : ["check_dir_in_compara", "ortheus/rc3"],
     "ortheus_py"                : ["check_exe_in_compara", "ortheus/rc3/bin/Ortheus.py"],
+    "orthofinder_exe"           : ["check_exe_in_cellar", "orthofinder/2.5.4/bin/orthofinder"],
+    "orthofinder_dir"           : ["check_dir_in_cellar", "orthofinder/2.5.4/bin/"],
     "pantherScore_path"         : ["check_dir_in_cellar", "pantherscore/1.03"],
     "parse_examl_exe"           : ["check_exe_in_cellar", "examl/3.0.17/bin/parse-examl"],
     "parsimonator_exe"          : ["check_exe_in_cellar", "parsimonator/1.0.2/bin/parsimonator-SSE3"],

--- a/conf/software/LSF.codon.json
+++ b/conf/software/LSF.codon.json
@@ -51,7 +51,6 @@
     "ortheus_lib_dir"           : ["check_dir_in_compara", "ortheus/rc3"],
     "ortheus_py"                : ["check_exe_in_compara", "ortheus/rc3/bin/Ortheus.py"],
     "orthofinder_exe"           : ["check_exe_in_cellar", "orthofinder/2.5.4/bin/orthofinder"],
-    "orthofinder_dir"           : ["check_dir_in_cellar", "orthofinder/2.5.4/bin/"],
     "pantherScore_path"         : ["check_dir_in_cellar", "pantherscore/1.03"],
     "parse_examl_exe"           : ["check_exe_in_cellar", "examl/3.0.17/bin/parse-examl"],
     "parsimonator_exe"          : ["check_exe_in_cellar", "parsimonator/1.0.2/bin/parsimonator-SSE3"],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -62,7 +62,6 @@ sub default_options {
         'shared_fasta_dir' => $self->o('shared_hps_dir') . '/reference_fasta_symlinks/',
 
         # orthofinder executable
-        'orthofinder_dir' => $self->o('orthofinder_dir'),
         'orthofinder_exe' => $self->o('orthofinder_exe'),
 
         # update from metadata options
@@ -388,8 +387,7 @@ sub core_pipeline_analyses {
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
             -parameters => {
                 'orthofinder_exe' => $self->o('orthofinder_exe'),
-                'orthofinder_dir' => $self->o('orthofinder_dir'),
-                'cmd'             => 'cd #orthofinder_dir#; #orthofinder_exe# -f #symlink_dir#',
+                'cmd'             => '#orthofinder_exe# -t 16 -a 8 -f #symlink_dir#',
             },
             -rc_name    => '128Gb_16c_job',
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -387,7 +387,6 @@ sub core_pipeline_analyses {
         {   -logic_name => 'run_orthofinder',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
             -parameters => {
-                'shared_user'     => $self->o('shared_user'),
                 'orthofinder_exe' => $self->o('orthofinder_exe'),
                 'orthofinder_dir' => $self->o('orthofinder_dir'),
                 'cmd'             => 'cd #orthofinder_dir#; #orthofinder_exe# -f #symlink_dir#',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -62,8 +62,8 @@ sub default_options {
         'shared_fasta_dir' => $self->o('shared_hps_dir') . '/reference_fasta_symlinks/',
 
         # orthofinder executable
-        'orthofinder_dir' => '/hps/software/users/ensembl/compara/cristig/OrthoFinder',
-        'orthofinder_exe' => '/hps/software/users/ensembl/compara/cristig/OrthoFinder/orthofinder',
+        'orthofinder_dir' => $self->o('orthofinder_dir'),
+        'orthofinder_exe' => $self->o('orthofinder_exe'),
 
         # update from metadata options
         'list_genomes_script'    => $self->check_exe_in_ensembl('ensembl-metadata/misc_scripts/get_list_genomes_for_division.pl'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -113,6 +113,12 @@ sub default_options {
     };
 }
 
+sub resource_classes {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::resource_classes('include_multi_threaded')},  # inherit the standard resource classes, incl. multi-threaded
+    };
+}
 
 sub pipeline_create_commands {
     my ($self) = @_;
@@ -386,7 +392,7 @@ sub core_pipeline_analyses {
                 'orthofinder_dir' => $self->o('orthofinder_dir'),
                 'cmd'             => 'cd #orthofinder_dir#; #orthofinder_exe# -f #symlink_dir#',
             },
-            -rc_name    => '132Gb_job',
+            -rc_name    => '128Gb_16c_job',
         },
 
         {   -logic_name => 'backup_ref_db_again',

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PassFastaDumpsPerCollection.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PassFastaDumpsPerCollection.pm
@@ -62,6 +62,7 @@ sub write_output {
         foreach my $fasta_file ( @fastas ) {
             $self->dataflow_output_id( { 'symlink_dir' => $dir, 'target_file' => $fasta_file, 'cleanup_symlinks' => 1 }, 1 );
         }
+        $self->dataflow_output_id( { 'symlink_dir' => $dir }, 2);
     }
 }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PassFastaDumpsPerCollection.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PassFastaDumpsPerCollection.pm
@@ -62,7 +62,7 @@ sub write_output {
         foreach my $fasta_file ( @fastas ) {
             $self->dataflow_output_id( { 'symlink_dir' => $dir, 'target_file' => $fasta_file, 'cleanup_symlinks' => 1 }, 1 );
         }
-        $self->dataflow_output_id( { 'symlink_dir' => $dir }, 2);
+        $self->dataflow_output_id({ 'symlink_dir' => $dir }, 2);
     }
 }
 


### PR DESCRIPTION
## Description

We need to run orthofinder on each of the references collections once the collection directories have symlinked the appropriate fasta files.

**Related JIRA tickets:**
- ENSCOMPARASW-4451

## Overview of changes

#### Change 1
-  New dataflow from factory to pass entire collection directories on branch 2

#### Change 2
- Pipeline rewire/semaphore to flow from reference collection analysis
- New analysis in pipe config hive system command to run orthofinder

## Testing

[In pipeline form](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-compara-prod-10&port=4648&dbname=cristig_orthofinder_test_104&passwd=xxxxx)

## Notes
New run_orthofinder analysis fails at the moment because it is not viable to request the resources at this time for testing. Further testing saved for stable linuxbrew installation of orthofinder because command may need to be adjusted to fit.
