### PR TITLE
Add `ibsub` to initPipeline command

### DIFF
--- a/scripts/production/batch_lastz.pl
+++ b/scripts/production/batch_lastz.pl
@@ -170,7 +170,7 @@ unless ($jira_off) {
 my ( @cmd_list, $ticket_list );
 foreach my $group ( @$mlss_groups ) {
     my $this_mlss_list = '"[' . join(',', @{$group->{mlss_ids}}) . ']"';
-    my $cmd = "init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::${division_pkg_name}::Lastz_conf -mlss_id_list $this_mlss_list -pipeline_name ${division}_lastz_batch${index}_${release} -host mysql-ens-compara-prod-X -port XXXX";
+    my $cmd = "ibsub init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::${division_pkg_name}::Lastz_conf -mlss_id_list $this_mlss_list -pipeline_name ${division}_lastz_batch${index}_${release} -host mysql-ens-compara-prod-X -port XXXX";
     push @cmd_list, $cmd;
     unless ($jira_off) {
         # Copy the template and add the specific details for this group


### PR DESCRIPTION
## Description

Migration to `codon` means `initPipeline` commands can't be run directly on login nodes and need to be submitted to the cluster. The command in this ticket should reflect that. 

## Overview of changes

#### Change 1
- Added `ibsub` to the start of the command string 
