### PR TITLE
Update compara_members database for e105 Metazoa

### DIFF
--- a/conf/metazoa/production_reg_conf.pl
+++ b/conf/metazoa/production_reg_conf.pl
@@ -76,7 +76,7 @@ my $compara_dbs = {
     'compara_prev'   => [ 'mysql-ens-compara-prod-6', "ensembl_compara_metazoa_${prev_eg_release}_${prev_release}" ],
 
     # homology dbs
-  #  'compara_members'  => [ 'mysql-ens-compara-prod-8', 'jalvarez_metazoa_load_members_104'],
+    'compara_members'  => [ 'mysql-ens-compara-prod-6', 'twalsh_metazoa_load_members_105'],
   #  'compara_ptrees'   => [ 'mysql-ens-compara-prod-9', 'jalvarez_metazoa_metazoa_protein_trees_104' ],
 
     # LastZ dbs


### PR DESCRIPTION
## Description

Update the configuration of the compara_members database for e105 Metazoa.

**Related JIRA tickets:**
- https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-4505

## Overview of changes
Replace compara_members database 'jalvarez_metazoa_load_members_104' with 'twalsh_metazoa_load_members_105'.
