### PR TITLE
Deactivate File::Find nlink optimisation

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/GeneMemberHomologyStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/GeneMemberHomologyStats.pm
@@ -48,7 +48,12 @@ sub fetch_input {
     
     my $homology_files= [];
     my $wanted = sub { _wanted($homology_files, $member_type) };
-    find($wanted, $basedir);
+
+    {
+        local $File::Find::dont_use_nlink = 1;
+        find($wanted, $basedir);
+    }
+
     print "Found " . scalar @$homology_files . " homology dump files to scan..\n\n" if $self->debug;
     $self->param('homology_files', $homology_files);
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/SplitOrthoTreeOutput.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/SplitOrthoTreeOutput.pm
@@ -114,6 +114,8 @@ sub _get_mlss_filehandle {
 sub orthotree_files {
     my $self = shift;
 
+    local $File::Find::dont_use_nlink = 1;
+
     my @files;
     my $orthotree_dir = $self->param_required('orthotree_dir');
     find(sub {

--- a/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
@@ -159,7 +159,11 @@ sub query_file_tree {
     # grab the list of files in the $dir
     my $filelist = [];
     my $wanted = sub { _wanted($filelist, ($ext || '.+')) };
-    find($wanted, $dir);
+
+    {
+        local $File::Find::dont_use_nlink = 1;
+        find($wanted, $dir);
+    }
 
     # sort files - important for unit testing (esp travis-ci)
     # as different versions of File::Find traverse in different order


### PR DESCRIPTION
## Description

There is an optimisation in File::Find that may incorrectly prevent searching in subdirectories.
This is switched off by default in current versions of Perl, but may need to be explicitly deactivated
in older versions.

## Overview of changes
In production pipeline modules, the variable `$File::Find::dont_use_nlink`
is locally set to `1` to avoid potentially inaccurate file listings.

## Testing
This was tested by rerunning the protein-tree pipeline step `split_tree_homologies`
to confirm that accurate input orthotree file listings were being generated.

## Notes
See: https://perldoc.perl.org/File::Find#$dont_use_nlink
