### PR TITLE
Bugfix for wga_expected_dumps in ncRNA trees

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -216,6 +216,7 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'mapping_db'    => $self->o('mapping_db'),
 
         'pipeline_dir'              => $self->o('pipeline_dir'),
+        'dump_dir'                  => $self->o('dump_dir'),
         'homology_dumps_dir'        => $self->o('homology_dumps_dir'),
         'prev_homology_dumps_dir'   => $self->o('prev_homology_dumps_dir'),
         'homology_dumps_shared_dir' => $self->o('homology_dumps_shared_dir'),


### PR DESCRIPTION
## Description

`wga_expected_dumps` analysis in `ivana_murinae_vertebrates_ncrna_trees_105` failed because there was no `dump_dir` provided.

## Overview of changes
Added `dump_dir` to the pipeline-wide parameters for ncRNA trees (it used to be only in the default parameters).

## Testing
Not tested.
