### PR TITLE
base_location parameter (analysis create_default_pairwise_mlss in EPOwExt)

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/FindPairwiseMlssLocation.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/EpoExtended/FindPairwiseMlssLocation.pm
@@ -278,7 +278,7 @@ sub anchor_counts {
     return $self->param('anchor_counts') if $self->param('anchor_counts');
 
     print "fetching anchor counts\n" if $self->debug;
-    my $base_dba = $self->get_cached_compara_dba('base_location');
+    my $base_dba = $self->param('base_location') ? $self->get_cached_compara_dba('base_location') : $self->compara_dba;
     my $anchor_count_sql = "SELECT d.genome_db_id, COUNT(*) FROM anchor_align a JOIN dnafrag d USING(dnafrag_id) GROUP BY d.genome_db_id";
     my $anchor_counts = $base_dba->dbc->sql_helper->execute_into_hash( -SQL => $anchor_count_sql);
     $self->param('anchor_counts', $anchor_counts);


### PR DESCRIPTION
Edited definition of `base_location` parameter which affects `create_default_pairwise_mlss` analysis in `EPOwExt` pipeline

## Description

`EPOwExt` failed for Primates and Mammals 105 at the analysis `create_default_pairwise_mlss` due to undefined `base_location` parameter. Jorge realised it was due to changes in `release/104`, in particular that the `base_location` was not correctly defined at this place (as well).
 
**Related JIRA tickets:**
- ENSCOMPARASW-4669

## Overview of changes
- Defined `base_location` as in line 104

## Testing
- Not tested

## Notes
- Shall I initialise one pipeline and try to run it until this analysis? 
- Are we sure this sorts out the problem of prematurely released semaphores?
