### PR TITLE
Schema change to extend genebuild value

### DIFF
--- a/modules/t/test-genome-DBs/homology/compara/meta.txt
+++ b/modules/t/test-genome-DBs/homology/compara/meta.txt
@@ -70,3 +70,4 @@
 97	\N	patch	patch_103_104_b.sql|dnafrag_alt_region
 98	\N	patch	patch_103_104_c.sql|fix_int_types
 100	\N	patch	patch_104_105_a.sql|schema_version
+101	\N	patch	patch_104_105_b.sql|genebuild_varchar255

--- a/modules/t/test-genome-DBs/homology/compara/table.sql
+++ b/modules/t/test-genome-DBs/homology/compara/table.sql
@@ -288,7 +288,7 @@ CREATE TABLE `genome_db` (
   `taxon_id` int(10) unsigned DEFAULT NULL,
   `name` varchar(128) NOT NULL DEFAULT '',
   `assembly` varchar(100) NOT NULL DEFAULT '',
-  `genebuild` varchar(100) NOT NULL DEFAULT '',
+  `genebuild` varchar(255) NOT NULL DEFAULT '',
   `has_karyotype` tinyint(1) NOT NULL DEFAULT '0',
   `is_good_for_alignment` tinyint(1) NOT NULL DEFAULT '0',
   `genome_component` varchar(5) DEFAULT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=101 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=102 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/modules/t/test-genome-DBs/multi/compara/meta.txt
+++ b/modules/t/test-genome-DBs/multi/compara/meta.txt
@@ -115,3 +115,4 @@
 150	\N	patch	patch_103_104_b.sql|dnafrag_alt_region
 151	\N	patch	patch_103_104_c.sql|fix_int_types
 153	\N	patch	patch_104_105_a.sql|schema_version
+154	\N	patch	patch_104_105_b.sql|genebuild_varchar255

--- a/modules/t/test-genome-DBs/multi/compara/table.sql
+++ b/modules/t/test-genome-DBs/multi/compara/table.sql
@@ -288,7 +288,7 @@ CREATE TABLE `genome_db` (
   `taxon_id` int(10) unsigned DEFAULT NULL,
   `name` varchar(128) NOT NULL DEFAULT '',
   `assembly` varchar(100) NOT NULL DEFAULT '',
-  `genebuild` varchar(100) NOT NULL DEFAULT '',
+  `genebuild` varchar(255) NOT NULL DEFAULT '',
   `has_karyotype` tinyint(1) NOT NULL DEFAULT '0',
   `is_good_for_alignment` tinyint(1) NOT NULL DEFAULT '0',
   `genome_component` varchar(5) DEFAULT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=154 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=155 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/modules/t/test-genome-DBs/mysqlimport_test/compara/meta.txt
+++ b/modules/t/test-genome-DBs/mysqlimport_test/compara/meta.txt
@@ -9,3 +9,4 @@
 20	\N	patch	patch_103_104_b.sql|dnafrag_alt_region
 21	\N	patch	patch_103_104_c.sql|fix_int_types
 23	\N	patch	patch_104_105_a.sql|schema_version
+24	\N	patch	patch_104_105_b.sql|genebuild_varchar255

--- a/modules/t/test-genome-DBs/mysqlimport_test/compara/table.sql
+++ b/modules/t/test-genome-DBs/mysqlimport_test/compara/table.sql
@@ -288,7 +288,7 @@ CREATE TABLE `genome_db` (
   `taxon_id` int(10) unsigned DEFAULT NULL,
   `name` varchar(128) NOT NULL DEFAULT '',
   `assembly` varchar(100) NOT NULL DEFAULT '',
-  `genebuild` varchar(100) NOT NULL DEFAULT '',
+  `genebuild` varchar(255) NOT NULL DEFAULT '',
   `has_karyotype` tinyint(1) NOT NULL DEFAULT '0',
   `is_good_for_alignment` tinyint(1) NOT NULL DEFAULT '0',
   `genome_component` varchar(5) DEFAULT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=24 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=25 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/modules/t/test-genome-DBs/orth_qm_goc/compara/meta.txt
+++ b/modules/t/test-genome-DBs/orth_qm_goc/compara/meta.txt
@@ -76,3 +76,4 @@
 96	\N	patch	patch_103_104_b.sql|dnafrag_alt_region
 97	\N	patch	patch_103_104_c.sql|fix_int_types
 99	\N	patch	patch_104_105_a.sql|schema_version
+100	\N	patch	patch_104_105_b.sql|genebuild_varchar255

--- a/modules/t/test-genome-DBs/orth_qm_goc/compara/table.sql
+++ b/modules/t/test-genome-DBs/orth_qm_goc/compara/table.sql
@@ -288,7 +288,7 @@ CREATE TABLE `genome_db` (
   `taxon_id` int(10) unsigned DEFAULT NULL,
   `name` varchar(128) NOT NULL DEFAULT '',
   `assembly` varchar(100) NOT NULL DEFAULT '',
-  `genebuild` varchar(100) NOT NULL DEFAULT '',
+  `genebuild` varchar(255) NOT NULL DEFAULT '',
   `has_karyotype` tinyint(1) NOT NULL DEFAULT '0',
   `is_good_for_alignment` tinyint(1) NOT NULL DEFAULT '0',
   `genome_component` varchar(5) DEFAULT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=100 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=101 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/modules/t/test-genome-DBs/orth_qm_wga/cc21_pair_species/meta.txt
+++ b/modules/t/test-genome-DBs/orth_qm_wga/cc21_pair_species/meta.txt
@@ -76,3 +76,4 @@
 148	\N	patch	patch_103_104_b.sql|dnafrag_alt_region
 149	\N	patch	patch_103_104_c.sql|fix_int_types
 151	\N	patch	patch_104_105_a.sql|schema_version
+152	\N	patch	patch_104_105_b.sql|genebuild_varchar255

--- a/modules/t/test-genome-DBs/orth_qm_wga/cc21_pair_species/table.sql
+++ b/modules/t/test-genome-DBs/orth_qm_wga/cc21_pair_species/table.sql
@@ -288,7 +288,7 @@ CREATE TABLE `genome_db` (
   `taxon_id` int(10) unsigned DEFAULT NULL,
   `name` varchar(128) NOT NULL DEFAULT '',
   `assembly` varchar(100) NOT NULL DEFAULT '',
-  `genebuild` varchar(100) NOT NULL DEFAULT '',
+  `genebuild` varchar(255) NOT NULL DEFAULT '',
   `has_karyotype` tinyint(1) NOT NULL DEFAULT '0',
   `is_good_for_alignment` tinyint(1) NOT NULL DEFAULT '0',
   `genome_component` varchar(5) DEFAULT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=152 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=153 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/modules/t/test-genome-DBs/orth_qm_wga/cc21_prepare_orth/meta.txt
+++ b/modules/t/test-genome-DBs/orth_qm_wga/cc21_prepare_orth/meta.txt
@@ -76,3 +76,4 @@
 148	\N	patch	patch_103_104_b.sql|dnafrag_alt_region
 149	\N	patch	patch_103_104_c.sql|fix_int_types
 151	\N	patch	patch_104_105_a.sql|schema_version
+152	\N	patch	patch_104_105_b.sql|genebuild_varchar255

--- a/modules/t/test-genome-DBs/orth_qm_wga/cc21_prepare_orth/table.sql
+++ b/modules/t/test-genome-DBs/orth_qm_wga/cc21_prepare_orth/table.sql
@@ -288,7 +288,7 @@ CREATE TABLE `genome_db` (
   `taxon_id` int(10) unsigned DEFAULT NULL,
   `name` varchar(128) NOT NULL DEFAULT '',
   `assembly` varchar(100) NOT NULL DEFAULT '',
-  `genebuild` varchar(100) NOT NULL DEFAULT '',
+  `genebuild` varchar(255) NOT NULL DEFAULT '',
   `has_karyotype` tinyint(1) NOT NULL DEFAULT '0',
   `is_good_for_alignment` tinyint(1) NOT NULL DEFAULT '0',
   `genome_component` varchar(5) DEFAULT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=152 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=153 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/modules/t/test-genome-DBs/orth_qm_wga/cc21_prev_orth_test/meta.txt
+++ b/modules/t/test-genome-DBs/orth_qm_wga/cc21_prev_orth_test/meta.txt
@@ -76,3 +76,4 @@
 148	\N	patch	patch_103_104_b.sql|dnafrag_alt_region
 149	\N	patch	patch_103_104_c.sql|fix_int_types
 151	\N	patch	patch_104_105_a.sql|schema_version
+152	\N	patch	patch_104_105_b.sql|genebuild_varchar255

--- a/modules/t/test-genome-DBs/orth_qm_wga/cc21_prev_orth_test/table.sql
+++ b/modules/t/test-genome-DBs/orth_qm_wga/cc21_prev_orth_test/table.sql
@@ -288,7 +288,7 @@ CREATE TABLE `genome_db` (
   `taxon_id` int(10) unsigned DEFAULT NULL,
   `name` varchar(128) NOT NULL DEFAULT '',
   `assembly` varchar(100) NOT NULL DEFAULT '',
-  `genebuild` varchar(100) NOT NULL DEFAULT '',
+  `genebuild` varchar(255) NOT NULL DEFAULT '',
   `has_karyotype` tinyint(1) NOT NULL DEFAULT '0',
   `is_good_for_alignment` tinyint(1) NOT NULL DEFAULT '0',
   `genome_component` varchar(5) DEFAULT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=152 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=153 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/modules/t/test-genome-DBs/orth_qm_wga/cc21_select_mlss/meta.txt
+++ b/modules/t/test-genome-DBs/orth_qm_wga/cc21_select_mlss/meta.txt
@@ -76,3 +76,4 @@
 148	\N	patch	patch_103_104_b.sql|dnafrag_alt_region
 149	\N	patch	patch_103_104_c.sql|fix_int_types
 151	\N	patch	patch_104_105_a.sql|schema_version
+152	\N	patch	patch_104_105_b.sql|genebuild_varchar255

--- a/modules/t/test-genome-DBs/orth_qm_wga/cc21_select_mlss/table.sql
+++ b/modules/t/test-genome-DBs/orth_qm_wga/cc21_select_mlss/table.sql
@@ -288,7 +288,7 @@ CREATE TABLE `genome_db` (
   `taxon_id` int(10) unsigned DEFAULT NULL,
   `name` varchar(128) NOT NULL DEFAULT '',
   `assembly` varchar(100) NOT NULL DEFAULT '',
-  `genebuild` varchar(100) NOT NULL DEFAULT '',
+  `genebuild` varchar(255) NOT NULL DEFAULT '',
   `has_karyotype` tinyint(1) NOT NULL DEFAULT '0',
   `is_good_for_alignment` tinyint(1) NOT NULL DEFAULT '0',
   `genome_component` varchar(5) DEFAULT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=152 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=153 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/modules/t/test-genome-DBs/parse_pair_aligner_conf/compara/meta.txt
+++ b/modules/t/test-genome-DBs/parse_pair_aligner_conf/compara/meta.txt
@@ -42,3 +42,4 @@
 55	\N	patch	patch_103_104_b.sql|dnafrag_alt_region
 56	\N	patch	patch_103_104_c.sql|fix_int_types
 58	\N	patch	patch_104_105_a.sql|schema_version
+59	\N	patch	patch_104_105_b.sql|genebuild_varchar255

--- a/modules/t/test-genome-DBs/parse_pair_aligner_conf/compara/table.sql
+++ b/modules/t/test-genome-DBs/parse_pair_aligner_conf/compara/table.sql
@@ -288,7 +288,7 @@ CREATE TABLE `genome_db` (
   `taxon_id` int(10) unsigned DEFAULT NULL,
   `name` varchar(128) NOT NULL DEFAULT '',
   `assembly` varchar(100) NOT NULL DEFAULT '',
-  `genebuild` varchar(100) NOT NULL DEFAULT '',
+  `genebuild` varchar(255) NOT NULL DEFAULT '',
   `has_karyotype` tinyint(1) NOT NULL DEFAULT '0',
   `is_good_for_alignment` tinyint(1) NOT NULL DEFAULT '0',
   `genome_component` varchar(5) DEFAULT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=59 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=60 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/modules/t/test-genome-DBs/test_master/compara/meta.txt
+++ b/modules/t/test-genome-DBs/test_master/compara/meta.txt
@@ -115,3 +115,4 @@
 150	\N	patch	patch_103_104_b.sql|dnafrag_alt_region
 151	\N	patch	patch_103_104_c.sql|fix_int_types
 153	\N	patch	patch_104_105_a.sql|schema_version
+154	\N	patch	patch_104_105_b.sql|genebuild_varchar255

--- a/modules/t/test-genome-DBs/test_master/compara/table.sql
+++ b/modules/t/test-genome-DBs/test_master/compara/table.sql
@@ -288,7 +288,7 @@ CREATE TABLE `genome_db` (
   `taxon_id` int(10) unsigned DEFAULT NULL,
   `name` varchar(128) NOT NULL DEFAULT '',
   `assembly` varchar(100) NOT NULL DEFAULT '',
-  `genebuild` varchar(100) NOT NULL DEFAULT '',
+  `genebuild` varchar(255) NOT NULL DEFAULT '',
   `has_karyotype` tinyint(1) NOT NULL DEFAULT '0',
   `is_good_for_alignment` tinyint(1) NOT NULL DEFAULT '0',
   `genome_component` varchar(5) DEFAULT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=154 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=155 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/modules/t/test-genome-DBs/update_homologies_test/compara/meta.txt
+++ b/modules/t/test-genome-DBs/update_homologies_test/compara/meta.txt
@@ -17,3 +17,4 @@
 20	\N	patch	patch_103_104_b.sql|dnafrag_alt_region
 21	\N	patch	patch_103_104_c.sql|fix_int_types
 23	\N	patch	patch_104_105_a.sql|schema_version
+24	\N	patch	patch_104_105_b.sql|genebuild_varchar255

--- a/modules/t/test-genome-DBs/update_homologies_test/compara/table.sql
+++ b/modules/t/test-genome-DBs/update_homologies_test/compara/table.sql
@@ -288,7 +288,7 @@ CREATE TABLE `genome_db` (
   `taxon_id` int(10) unsigned DEFAULT NULL,
   `name` varchar(128) NOT NULL DEFAULT '',
   `assembly` varchar(100) NOT NULL DEFAULT '',
-  `genebuild` varchar(100) NOT NULL DEFAULT '',
+  `genebuild` varchar(255) NOT NULL DEFAULT '',
   `has_karyotype` tinyint(1) NOT NULL DEFAULT '0',
   `is_good_for_alignment` tinyint(1) NOT NULL DEFAULT '0',
   `genome_component` varchar(5) DEFAULT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=24 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=25 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/sql/patch_104_105_b.sql
+++ b/sql/patch_104_105_b.sql
@@ -1,0 +1,27 @@
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_104_105_b.sql
+#
+# Title: Widen genebuild field in genome_db.
+#
+# Description:
+#   Widen genebuild field in genome_db to match an update done in core databases.
+
+ALTER TABLE genome_db MODIFY COLUMN genebuild varchar(255);
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_104_105_b.sql|genebuild_varchar255');

--- a/sql/patch_104_105_b.sql
+++ b/sql/patch_104_105_b.sql
@@ -20,7 +20,7 @@
 # Description:
 #   Widen genebuild field in genome_db to match an update done in core databases.
 
-ALTER TABLE genome_db MODIFY COLUMN genebuild varchar(255);
+ALTER TABLE genome_db MODIFY COLUMN genebuild varchar(255) DEFAULT '' NOT NULL;
 
 # Patch identifier
 INSERT INTO meta (species_id, meta_key, meta_value)

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -169,7 +169,7 @@ CREATE TABLE genome_db (
   taxon_id                    INT unsigned DEFAULT NULL, # KF taxon.taxon_id
   name                        varchar(128) DEFAULT '' NOT NULL,
   assembly                    varchar(100) DEFAULT '' NOT NULL,
-  genebuild                   varchar(100) DEFAULT '' NOT NULL,
+  genebuild                   varchar(255) DEFAULT '' NOT NULL,
   has_karyotype			tinyint(1) NOT NULL DEFAULT 0,
   is_good_for_alignment       TINYINT(1) NOT NULL DEFAULT 0,
   genome_component            varchar(5) DEFAULT NULL,
@@ -2282,3 +2282,6 @@ INSERT INTO meta (species_id, meta_key, meta_value) VALUES (NULL, 'schema_type',
 # Patch identifier
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_104_105_a.sql|schema_version');
+
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_104_105_b.sql|genebuild_varchar255');


### PR DESCRIPTION
## Description

Widen `genebuild` field in `genome_db` to match an update done in `core` databases.

**Related JIRA tickets:**
- ENSCOMPARASW-4676

## Overview of changes

#### Change 1
- Made `patch_104_105_b.sql`

#### Change 2
- Edited `table.sql`: `genebuild` field in `genome_db` table, added patch identifier
 
## Testing
`cp7-w ivana_copy_plants_protein_trees_104 < /hps/software/users/ensembl/repositories/compara/ivana/e105/ensembl-compara/sql/patch_104_105_b.sql`

`cp7-w ivana_copy_vertebrates_ncrna_trees_104 < /hps/software/users/ensembl/repositories/compara/ivana/e105/ensembl-compara/sql/patch_104_105_b.sql`

Now in both dbs, in table `genome_db` I see ``` `genebuild` varchar(255) NOT NULL DEFAULT '',```, and in `meta` table there is a patch `patch_104_105_b.sql|genebuild_varchar255`.