### PR TITLE
Bugfix/supertree nodes

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/GeneTreeNode.pm
+++ b/modules/Bio/EnsEMBL/Compara/GeneTreeNode.pm
@@ -313,7 +313,6 @@ sub is_leaf {
     if ( $self->is_supertree and $child_count == 1 ) {
         my $child = $self->children->[0];
         return 1 if ($child->node_id != $child->root->node_id);
-        return 0;
     }
     return 0;
 }
@@ -323,9 +322,7 @@ sub is_leaf {
   Example     : print "I'm a supertree" if $node->is_supertree();
   Description : Detects and reports if a node is a supertree.
   Returntype  : Boolean
-  Exceptions  :
-  Caller      : general
-  Status      : stable
+  Exceptions  : None
 
 =cut
 
@@ -335,7 +332,6 @@ sub is_supertree {
         if ($self->tree->tree_type eq 'supertree') {
             return 1;
         }
-        return 0;
     }
     return 0;
 }

--- a/modules/Bio/EnsEMBL/Compara/GeneTreeNode.pm
+++ b/modules/Bio/EnsEMBL/Compara/GeneTreeNode.pm
@@ -82,6 +82,7 @@ use List::Util qw(min);
 
 use Bio::EnsEMBL::Utils::Argument;
 use Bio::EnsEMBL::Utils::Exception;
+use Bio::EnsEMBL::Utils::Scalar qw/check_ref_can/;
 
 use Bio::EnsEMBL::Compara::AlignedMemberSet;
 
@@ -306,17 +307,37 @@ sub root {
 =cut
 
 sub is_leaf {
-  my $self = shift;
-
+    my $self = shift;
     my $child_count = $self->get_child_count;
-    if ( $child_count == 0 ) {
-        return 1;
-    } elsif ( $child_count == 1 && $self->tree->tree_type eq 'supertree' ) {
+    return 1 if ($child_count == 0);
+    if ( $self->is_supertree and $child_count == 1 ) {
         my $child = $self->children->[0];
-        return ($child->node_id == $child->root->node_id);
-    } else {
+        return 1 if ($child->node_id != $child->root->node_id);
         return 0;
     }
+    return 0;
+}
+
+=head2 is_supertree
+
+  Example     : print "I'm a supertree" if $node->is_supertree();
+  Description : Detects and reports if a node is a supertree.
+  Returntype  : Boolean
+  Exceptions  :
+  Caller      : general
+  Status      : stable
+
+=cut
+
+sub is_supertree {
+    my $self = shift;
+    if (check_ref_can($self->tree, 'tree_type')) {
+        if ($self->tree->tree_type eq 'supertree') {
+            return 1;
+        }
+        return 0;
+    }
+    return 0;
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/QuickTreeBreak.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/QuickTreeBreak.pm
@@ -347,9 +347,7 @@ sub rec_update_tags {
 
 
 sub generate_subtrees {
-    my $self                    = shift @_;
-    my $newtree                 = shift @_;
-    my $attach_node             = shift @_;
+    my ($self, $newtree, $attach_node) = @_;
 
     my $supertree = $attach_node->tree;
     my $members = $attach_node->get_all_leaves;
@@ -369,10 +367,10 @@ sub generate_subtrees {
                 $max_subtree = $child;
             }
         }
-        # Broke down to half, happy with it
-        print STDERR "QuickTreeBreak iterate -- $max_num_leaves (goal: $half_count)\n"; # if ($self->debug);
+        # Broke down to half or to the specified treebreak_gene_count, happy with it
+        print STDERR "QuickTreeBreak iterate -- $max_num_leaves (goal: $half_count)\n";
         die "Tree is empty - cannot break" if $max_num_leaves == 0;
-        if ($max_num_leaves <= $half_count) {
+        if (($max_num_leaves <= $half_count) or ($max_num_leaves <= ($self->param('treebreak_gene_count')))) {
             $keep_breaking = 0;
         }
     }
@@ -407,6 +405,9 @@ sub generate_subtrees {
             else {
                 $cluster2->add_Member($leaf);
             }
+        }
+        else {
+            $self->die_with_log("Not all leaves in this array of members are seq_members");
         }
     }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/SqlHealthChecks.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/SqlHealthChecks.pm
@@ -408,6 +408,11 @@ our $config = {
                 description => 'The "gene_count" tags must sum-up to the super-tree\'s',
                 query => 'SELECT COUNT(*), gtra1.gene_count, SUM(gtra2.gene_count) FROM (gene_tree_node gtn1 JOIN gene_tree_root_attr gtra1 USING (root_id))  JOIN gene_tree_node gtn2 ON gtn2.parent_id = gtn1.node_id AND gtn2.root_id != gtn1.root_id JOIN gene_tree_root_attr gtra2 ON gtra2.root_id=gtn2.root_id WHERE gtn1.root_id = #gene_tree_id# HAVING gtra1.gene_count != SUM(gtra2.gene_count)',
             },
+            {
+                description => 'The super-tree must have subtree children',
+                query => 'SELECT gtn1.root_id FROM (gene_tree_node gtn1 JOIN gene_tree_node gtn2 ON gtn1.parent_id = gtn2.node_id WHERE gtn1.root_id != gtn2.root_id AND gtn2.root_id = #gene_tree_id#',
+                expected_size => '> 0',
+            },
         ],
     },
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/SqlHealthChecks.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/SqlHealthChecks.pm
@@ -410,7 +410,7 @@ our $config = {
             },
             {
                 description => 'The super-tree must have subtree children',
-                query => 'SELECT gtn1.root_id FROM (gene_tree_node gtn1 JOIN gene_tree_node gtn2 ON gtn1.parent_id = gtn2.node_id WHERE gtn1.root_id != gtn2.root_id AND gtn2.root_id = #gene_tree_id#',
+                query => 'SELECT gtn1.root_id FROM (gene_tree_node gtn1 JOIN gene_tree_root_attr USING (root_id)) JOIN gene_tree_node gtn2 ON gtn1.parent_id = gtn2.node_id WHERE gtn1.root_id != gtn2.root_id AND gtn2.root_id = #gene_tree_id#',
                 expected_size => '> 0',
             },
         ],


### PR DESCRIPTION
## Description

In e105 an issue in the way the `is_leaf` method which was moved to `GeneTreeNode.pm` from `NestedSet.pm`. It was correct to move the method, but the method was rewritten in such a way that supertree leaf nodes (which are not `seq_members`) were undetected as leaf nodes and later disconnected in the `QuickTreeBreak.pm` analyses. In investigating the problem, it was further seen that some subtrees were being unnecessarily broken too far if they were already made up of 400 members, but were not less than half the initial cluster being broken. Finally, this could have been avoided with more tests.

**Related JIRA tickets:**
- ENSCOMPARASW-4658
- ENSCOMPARASW-4666
- ENSCOMPARASW-4659

## Overview of changes

#### Change 1
- Rewrite of `is_leaf` method in `GeneTreeNode` and inclusion of `is_supertree` method to simplify code. The code has been re-written in this way to preserve a necessary order of edge cases whilst meeting all the known edge cases that were there previously

#### Change 2
- The `generate_subtrees` method which was over-breaking some subtrees now stops when the gene number parameter has been reached also
- A message will now be logged to flag when/if a leaf node that is passed through to form new clusters and is not a `seq_member` - although with Change 1 this should not occur 

#### Change 3
- A new test was included in `GeneTrees::SqlHealthChecks.pm` for the supertrees to ensure that subtrees were linked, `QuickTreeBreak` should fail if there are no subtrees linked. This is with the assumption that a supertree will always have subtrees, otherwise it cannot be a supertree.

## Testing
This has been tested live during production e105 for vertebrates ncrna and protein trees with extensive datachecks run on the resulting gene trees to ensure there are no longer any "flat" protein trees (unstructured clusters of homologous genes with no relationships except to a subtree `root_id`)

## Notes
Initially these `is_leaf` related changes were made in the `QuickTreeBreak` runnable as edgecases, but after further investigation and some discussion, it was realised that the code in `is_leaf` as it was would break anything that called upon supertrees. The disconnection of the subtrees from supertrees have been picked up for `e103` and `e104` by outreach.
