### PR TITLE
Adjust and add parameters for compatibility

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -50,6 +50,9 @@ sub shared_default_options {
         # we sometimes initialise pipelines with a shared user
         'dbowner'               => $ENV{'EHIVE_USER'} || $ENV{'SUDO_USER'} || whoami() || $self->o('dbowner'),
 
+        # $ENSEMBL_ROOT_DIR is also loaded into ensembl_cvs_root_dir
+        'ensembl_root_dir'      => $self->o('ensembl_cvs_root_dir'),
+
         # Since we run the same pipeline for multiple divisions, include the division name in the pipeline name
         'pipeline_name'         => $self->o('division').'_'.$self->default_pipeline_name().'_'.$self->o('rel_with_suffix'),
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
@@ -22,10 +22,10 @@ Bio::EnsEMBL::Compara::PipeConfig::HomologyAnnotation_conf
 =head1 SYNOPSIS
 
     init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::HomologyAnnotation_conf -host mysql-ens-compara-prod-X -port XXXX \
-        --species_list <species_1,species_2,...,species_n>
+        --species species_1 --species species_2 --species species_n
 
     init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::HomologyAnnotation_conf -host mysql-ens-compara-prod-X -port XXXX \
-        --species_list_file <path/to/one_species_per_line_file.txt>
+        --species_list path/to/one_species_per_line_file.txt
 
 =head1 DESCRIPTION
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
@@ -59,9 +59,13 @@ sub default_options {
         'pipeline_name'     => 'blastocyst_' . $self->o('rel_with_suffix'),
 
         # Mandatory species input, one or the other only
-        'species_list_file' => undef,
-        'species_list'      => [ ],
-        'division'          => 'homology_annotation',
+        'species_list'  => undef,
+        'species'       => [ ],
+        'division'      => 'homology_annotation',
+        # Mandatory server host for species homology databases
+        'homology_host' => 'mysql-ens-sta-5',
+        # registry_file compatibility so can be overridden if necessary
+        'registry_file' => $self->o('reg_conf'),
 
         # Directories to write to
         'work_dir'     => $self->o('pipeline_dir'),
@@ -203,9 +207,9 @@ sub core_pipeline_analyses {
             -module          => 'Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::SpeciesFactory',
             -max_retry_count => 1,
             -input_ids       => [{
-                'registry_file'      => $self->o('reg_conf'),
-                'species_list'       => $self->o('species_list'),
-                'species_list_file'  => $self->o('species_list_file'),
+                'registry_file'      => $self->o('registry_file'),
+                'species_list'       => $self->o('species'),
+                'species_list_file'  => $self->o('species_list'),
             },],
             -flow_into       => {
                 8 => [ 'backbone_fire_db_prepare' ],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
@@ -57,6 +57,9 @@ sub default_options {
         %{$self->SUPER::default_options},   # Inherit the generic ones
 
         'pipeline_name'     => 'blastocyst_' . $self->o('rel_with_suffix'),
+        # Back compatibility for production team's use of '--pass' instead of '--password'
+        'pass'     => undef,
+        'password' => $self->o('pass') ? $self->o('pass') : $self->o('password'),
 
         # Mandatory species input, one or the other only
         'species_list'  => undef,

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PerSpeciesCopyFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PerSpeciesCopyFactory.pm
@@ -57,6 +57,7 @@ sub pipeline_analyses_create_and_copy_per_species_db {
                 'curr_release' => $self->o('ensembl_release'),
                 'db_cmd_path'  => $self->o('db_cmd_path'),
                 'schema_file'  => $self->o('schema_file'),
+                'homology_host' => $self->o('homology_host'),
             },
             -flow_into => {
                 '2->A'  => { 'copy_per_species_db'  => INPUT_PLUS() },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -50,6 +50,10 @@ sub default_options {
         'ref_db'       => 'compara_references',
         'taxonomy_db'  => 'ncbi_taxonomy',
 
+        # Back compatibility for production team's use of '--pass' instead of '--password'
+        'pass'     => undef,
+        'password' => $self->o('pass') ? $self->o('pass') : $self->o('password'),
+
         # how many parts should per-genome files be split into?
         'num_fasta_parts'  => 100,
         # at which id should genome_db start?


### PR DESCRIPTION

## Description

In the testing phase of the homology annotation handover to production for rapid release a few very small bugs/parameter preferences were reported. This PR addresses those as reported in below tickets.

**Related JIRA tickets:**
- ENSCOMPARASW-4689
- ENSCOMPARASW-4674

## Overview of changes

#### Change 1
- Include homology_host as default parameter

#### Change 2
- Change parameter names to "species" to meet SpeciesFactory inputs

#### Change 3 
- Include option to input "registry" to override "reg_conf" for SpeciesFactory

## Testing
Via running entire pipeline through cleanly with new changes.

## Notes

> To be tested by Production's rapid release relco when ENSCOMPARASW-4688 completed by @JAlvarezJarreta 
