### PR TITLE
Add ability to exclude species from GenomeDBFactory by name

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/UpdateMemberNamesDescriptions.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/UpdateMemberNamesDescriptions.pm
@@ -61,6 +61,9 @@ sub pipeline_analyses_member_names_descriptions {
         {
             -logic_name => 'species_update_factory',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
+            -parameters => {
+                'exclude_species'  => $self->o('exclude_species'),
+            }
             -flow_into => {
                 2   => [ 'update_member_display_labels' ],
             },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMemberNamesDescriptions_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMemberNamesDescriptions_conf.pm
@@ -53,6 +53,7 @@ sub default_options {
 
         #Pipeline capacities:
         'update_capacity'                           => '5',
+        #Outgroup species to exclude from GenomeDBFactory
         'exclude_species'  => [],
 
     };
@@ -80,5 +81,4 @@ sub pipeline_analyses {
 }
 
 1;
-
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMemberNamesDescriptions_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMemberNamesDescriptions_conf.pm
@@ -53,6 +53,7 @@ sub default_options {
 
         #Pipeline capacities:
         'update_capacity'                           => '5',
+        'exclude_species'  => [],
 
     };
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomeDBFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomeDBFactory.pm
@@ -127,7 +127,7 @@ sub fetch_input {
     # filter out exclude_species
     my %exclude_species_map;
     my $excluded_species = $self->param('exclude_species');
-    if ( ref $_exclude_species eq 'ARRAY' ) {
+    if ( ref $excluded_species eq 'ARRAY' ) {
         @exclude_species_map{ @$excluded_species } = ();
     } else {
         @exclude_species_map{ split(/,/, $excluded_species) } = ();

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomeDBFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomeDBFactory.pm
@@ -61,7 +61,7 @@ sub param_defaults {
         'component_genomes' => 1,
         'normal_genomes'    => 1,
         'ancestral_genomes' => 0,
-        # list of genome db names to exlcude
+        # list of genome db names to exclude
         'exclude_species' => [],
 
         # List of GenomeDB attribute names that will be added to the output_ids

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomeDBFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomeDBFactory.pm
@@ -61,6 +61,8 @@ sub param_defaults {
         'component_genomes' => 1,
         'normal_genomes'    => 1,
         'ancestral_genomes' => 0,
+        # list of genome db names to exlcude
+        'exclude_species' => [],
 
         # List of GenomeDB attribute names that will be added to the output_ids
         'extra_parameters'  => [],
@@ -120,6 +122,21 @@ sub fetch_input {
     $genome_dbs = [grep {not $_->is_polyploid} @$genome_dbs] if not $self->param('polyploid_genomes');
     $genome_dbs = [grep {not $_->genome_component} @$genome_dbs] if not $self->param('component_genomes');
     $genome_dbs = [grep {($_->name eq 'ancestral_sequences') or $_->is_polyploid or $_->genome_component} @$genome_dbs] if not $self->param('normal_genomes');
+
+
+    # filter out exclude_species
+    my %exclude_species;
+    my $_exclude_species = $self->param('exclude_species');
+    if ( ref $_exclude_species eq 'ARRAY' ) {
+        @exclude_species{ @$_exclude_species } = ();
+    } else {
+        @exclude_species{ split(/\s+/, $_exclude_species) } = ();
+    }
+    my @_gdbs = ();
+    foreach my $gdb ( @{ $genome_dbs } ){
+        push(@_gdbs, $gdb) unless exists $exclude_species{$gdb->name};
+    }
+    $genome_dbs = \@_gdbs;
 
     if ($self->param('genome_db_data_source')) {
         my $genomedb_dba = $self->get_cached_compara_dba('genome_db_data_source');

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomeDBFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomeDBFactory.pm
@@ -125,18 +125,18 @@ sub fetch_input {
 
 
     # filter out exclude_species
-    my %exclude_species;
-    my $_exclude_species = $self->param('exclude_species');
+    my %exclude_species_map;
+    my $excluded_species = $self->param('exclude_species');
     if ( ref $_exclude_species eq 'ARRAY' ) {
-        @exclude_species{ @$_exclude_species } = ();
+        @exclude_species_map{ @$excluded_species } = ();
     } else {
-        @exclude_species{ split(/\s+/, $_exclude_species) } = ();
+        @exclude_species_map{ split(/,/, $excluded_species) } = ();
     }
-    my @_gdbs = ();
+    my @gdbs = ();
     foreach my $gdb ( @{ $genome_dbs } ){
-        push(@_gdbs, $gdb) unless exists $exclude_species{$gdb->name};
+        push(@gdbs, $gdb) unless exists $excluded_species_map{$gdb->name};
     }
-    $genome_dbs = \@_gdbs;
+    $genome_dbs = \@gdbs;
 
     if ($self->param('genome_db_data_source')) {
         my $genomedb_dba = $self->get_cached_compara_dba('genome_db_data_source');

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomeDBFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomeDBFactory.pm
@@ -134,7 +134,7 @@ sub fetch_input {
     }
     my @gdbs = ();
     foreach my $gdb ( @{ $genome_dbs } ){
-        push(@gdbs, $gdb) unless exists $excluded_species_map{$gdb->name};
+        push(@gdbs, $gdb) unless exists $exclude_species_map{$gdb->name};
     }
     $genome_dbs = \@gdbs;
 


### PR DESCRIPTION
## Description

GenomeDBFactory returns an array of genome dbs, which can be filtered by broad categories (i.e. polyploids). Production requested the ability to filter specific species. This functionality is added by these changes. `exclude_species` may be supplied as an array or a space-separated string.

**Related JIRA tickets:**
- ENSCOMPARASW-4673
- ENSPROD-6669

## Overview of changes
Add `exclude_species` parameter to relevant config files and code for filtering based on it within `GenomeDBFactory.pm`

#### Change 1
- `exclude_species` added to `PipeConfig/Parts/UpdateMemberNamesDescriptions.pm` and `PipeConfig/UpdateMemberNamesDescriptions_conf.pm` and defaults to an empty array 

#### Change 2
- Code to filter genome dbs using the supplied `exclude_species` array added to `GenomeDBFactory.pm`  

## Testing
`LoadMembers` plants pipeline run with and without `exclude_species` array and reduction in genome dbs passed from `load_genomedb_factory` to `load_genomedb`

