### PR TITLE
Obsolete resource class name

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/UpdateMemberNamesDescriptions.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/UpdateMemberNamesDescriptions.pm
@@ -78,7 +78,7 @@ sub pipeline_analyses_member_names_descriptions {
                 'genome_db_ids'           => [ '#genome_db_id#' ],
             },
             -flow_into => [ 'update_seq_member_display_labels' ],
-            -rc_name => '1Gb_job',
+            -rc_name => 'default',
         },
 
         {
@@ -93,7 +93,7 @@ sub pipeline_analyses_member_names_descriptions {
                 'genome_db_ids'           => [ '#genome_db_id#' ],
             },
             -flow_into => [ 'update_member_descriptions' ],
-            -rc_name => '1Gb_job',
+            -rc_name => 'default',
         },
 
         {
@@ -106,7 +106,7 @@ sub pipeline_analyses_member_names_descriptions {
                 'mode'                    => 'description',
                 'genome_db_ids'           => [ '#genome_db_id#' ],
             },
-            -rc_name => '1Gb_job',
+            -rc_name => 'default',
         },
 
     ];


### PR DESCRIPTION

If you can't do it shortly I'll reinstantiate this resource in our pipeline. Please advise.

## Description

Hi there, while moving to codon, we cleaned up our resources class names and made a more generic use of them in our pipeline. So we removed the resource name "1Gb_job! from our configurations files (because this is anyway the default resources allocation
While initialising Bio::EnsEMBL::Production::Pipeline::PipeConfig::GeneNameDescProjection_protists_conf I noticed the error. Sorry for the inconvenience. 


**Related JIRA tickets:**
ENSPROD-6869 

## Overview of changes
Set rc_name to 'default'

#### Change 1
- _detail 1.1_

#### Change 2
- _detail 2.1_

## Testing
_How was this tested? Have new unit tests been included?_

## Notes
_Optional extra information._
