### PR TITLE
Use the schema patcher script to patch the master database

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -125,6 +125,7 @@ sub executable_locations {
         'DumpGFFHomologuesForSynteny_exe'   => $self->check_exe_in_ensembl('ensembl-compara/scripts/synteny/DumpGFFHomologuesForSynteny.pl'),
         'emf2maf_program'                   => $self->check_exe_in_ensembl('ensembl-compara/scripts/dumps/emf2maf.pl'),
         'epo_stats_report_exe'              => $self->check_exe_in_ensembl('ensembl-compara/scripts/production/epo_stats.pl'),
+        'patch_db_exe'                      => $self->check_exe_in_ensembl('ensembl-compara/scripts/production/patch_database.pl'),
         'populate_new_database_exe'         => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/populate_new_database.pl'),
         'create_datacheck_tickets_exe'      => $self->check_exe_in_ensembl('ensembl-compara/scripts/jira_tickets/create_datacheck_tickets.pl'),
         'copy_ancestral_core_exe'           => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/copy_ancestral_core.pl'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
@@ -42,11 +42,11 @@ sub pipeline_analyses_prep_master_db_for_release {
     my ($self) = @_;
     return [
         {   -logic_name => 'patch_master_db',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::PrepareMaster::PatchMasterDB',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
             -parameters => {
-                'schema_file'  => $self->o('schema_file'),
-                'patch_dir'    => $self->o('patch_dir'),
-                'patch_names'  => '#patch_dir#/patch_' . $self->o('prev_release') . '_#release#_*.sql',
+                'patch_db_exe' => $self->o('patch_db_exe'),
+                'reg_conf'     => $self->o('reg_conf'),
+                'cmd'          => 'perl #patch_db_exe# --reg_conf #reg_conf# --reg_alias #master_db# --fixlast --nointeractive',
             },
             -flow_into  => ['load_ncbi_node'],
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
@@ -44,9 +44,7 @@ sub pipeline_analyses_prep_master_db_for_release {
         {   -logic_name => 'patch_master_db',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
             -parameters => {
-                'patch_db_exe' => $self->o('patch_db_exe'),
-                'reg_conf'     => $self->o('reg_conf'),
-                'cmd'          => 'perl #patch_db_exe# --reg_conf #reg_conf# --reg_alias #master_db# --fixlast --nointeractive',
+                'cmd' => [$self->o('patch_db_exe'), '--reg_conf', $self->o('reg_conf'), '--reg_alias', '#master_db#', '--fixlast', '--nointeractive'],
             },
             -flow_into  => ['load_ncbi_node'],
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
@@ -71,6 +71,7 @@ sub default_options {
         'prev_dbs'            => ['*_prev'],
         'taxonomy_db'         => 'ncbi_taxonomy',
         'incl_components'     => 1, # let's default this to 1 - will have no real effect if there are no component genomes (e.g. in vertebrates)
+        'patch_db_exe'        => $self->check_exe_in_ensembl('ensembl-compara/scripts/production/patch_database.pl'),
         'create_all_mlss_exe' => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/create_all_mlss.pl'),
         'xml_file'            => $self->check_file_in_ensembl('ensembl-compara/conf/' . $self->o('division') . '/mlss_conf.xml'),
         'report_file'         => $self->o( 'work_dir' ) . '/mlss_ids_' . $self->o('division') . '.list',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
@@ -71,7 +71,6 @@ sub default_options {
         'prev_dbs'            => ['*_prev'],
         'taxonomy_db'         => 'ncbi_taxonomy',
         'incl_components'     => 1, # let's default this to 1 - will have no real effect if there are no component genomes (e.g. in vertebrates)
-        'patch_db_exe'        => $self->check_exe_in_ensembl('ensembl-compara/scripts/production/patch_database.pl'),
         'create_all_mlss_exe' => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/create_all_mlss.pl'),
         'xml_file'            => $self->check_file_in_ensembl('ensembl-compara/conf/' . $self->o('division') . '/mlss_conf.xml'),
         'report_file'         => $self->o( 'work_dir' ) . '/mlss_ids_' . $self->o('division') . '.list',


### PR DESCRIPTION
## Description

Use `patch_database.pl` instead of the current module to patch the master database. The script calls `schema_patcher.pl` which applies only patches that have not been applied yet. This resolves the issue of re-applying the same patch and consequently failing a datacheck.

**Related JIRA tickets:**
- ENSCOMPARASW-3479

## Overview of changes
Replaced `PatchMasterDB` module with `patch_database.pl` script.

#### Change 1
- In `PrepareMasterDatabaseForRelease.pm`: 
    - Replaced the module with a command to run the perl script
    - Changed parameters accordingly

#### Change 2
- In `PrepareMasterDatabaseForRelease_conf.pm`: added path to `patch_database.pl`

## Testing
- I copied `ensembl_compara_master` to `mysql-ens-compara-prod-2:ivana_copy_verts_master` and `ensembl_compara_master_plants` to `mysql-ens-compara-prod-6:ivana_copy_plants_master`. In both copies, I removed patches `patch_104_105_a` and `patch_104_105_b` from `meta` table. I left `schema_version` to be 105.
- For both divisions, I initialised `PrepareMasterDatabaseForRelease_conf` and ran first 2 analyses (I set Analysis capacity to 0 for the 3rd analysis). (`mysql://ensadmin:xxxxx@mysql-ens-compara-prod-3:4523/ivana_prep_vertebrates_master_for_rel_106`, `mysql://ensadmin:xxxxx@mysql-ens-compara-prod-3:4523/ivana_prep_plants_master_for_rel_106`; 106 because I branched from `master`)
- After the jobs completed, I can see in `meta` table for both divisions: `patch_104_105_a`, `patch_104_105_b`, `patch_105_106_a` and `schema_version` 106.
- Finally, I reran this particular analysis for both divisions and the patches were not re-applied (i.e. no changes in `meta` table).