### PR TITLE
Set 'default' collection for each non-vertebrate protein tree

### DIFF
--- a/conf/metazoa/mlss_conf.xml
+++ b/conf/metazoa/mlss_conf.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <compara_db division="metazoa">
 
+  <!-- Collections are species-sets that are needed to define several mlsss -->
+  <collections>
+
+    <!-- All metazoa -->
+    <collection name="default">
+      <taxonomic_group taxon_name="Eukaryota"/>
+    </collection>
+
+  </collections>
+
   <pairwise_alignments>
 
     <!-- bees and stuff (A.mel, A.cep, B.imp, B.ter, N.vit) -->
@@ -54,7 +64,7 @@
   </pairwise_alignments>
 
   <gene_trees>
-    <protein_trees collection="metazoa"/>
+    <protein_trees collection="default"/>
   </gene_trees>
 
 </compara_db>

--- a/conf/pan/mlss_conf.xml
+++ b/conf/pan/mlss_conf.xml
@@ -1,8 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <compara_db division="pan">
 
+  <!-- Collections are species-sets that are needed to define several mlsss -->
+  <collections>
+
+    <!-- All representative genomes from all significant clades aka "pan-taxonomic" -->
+    <collection name="default">
+      <taxonomic_group taxon_name="Eukaryota"/>
+      <taxonomic_group taxon_name="Prokaryota"/>
+      <taxonomic_group taxon_name="Archaea"/>
+    </collection>
+
+  </collections>
+
   <gene_trees>
-    <protein_trees collection="pan"/>
+    <protein_trees collection="default"/>
   </gene_trees>
 
 </compara_db>

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
@@ -46,7 +46,6 @@ sub default_options {
         %{$self->SUPER::default_options},   # inherit the generic ones
 
         'division'   => 'metazoa',
-        'collection' => $self->o('division'),
 
         # homology_dnds parameters:
         'taxlevels' => ['Drosophila' ,'Hymenoptera', 'Nematoda'],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/ProteinTrees_conf.pm
@@ -47,7 +47,6 @@ sub default_options {
         %{$self->SUPER::default_options},   # inherit the generic ones
 
     'division'   => 'pan',
-    'collection' => $self->o('division'),
 
     # threshold used by per_genome_qc in order to check if the amount of orphan genes are acceptable
     # values were infered by checking previous releases, values that are out of these ranges may be caused by assembly and/or gene annotation problems.

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
@@ -46,7 +46,6 @@ sub default_options {
         %{$self->SUPER::default_options},   # inherit the generic ones
 
     'division'   => 'plants',
-    'collection' => $self->o('division'),
 
     # clustering parameters:
         # affects 'hcluster_dump_input_per_genome'


### PR DESCRIPTION
## Description

Change all divisions' default collection to `default` in order to make it easier for us (no renaming back and forth for reruns of parts of the gene trees pipelines) and for web (to access the data via the default API configuration).

**Related JIRA tickets:**
- ENSCOMPARASW-4706

## Overview of changes
Created `default` collection for metazoa and pan (was already done for plants), and changed the protein trees collection from `<division>` to `default` (set in the base [`ProteinTrees_conf`](https://github.com/Ensembl/ensembl-compara/blob/6daeeac20e895de36293316a6dd84a91fc19edcf/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm#L72) pipeconfig).

## Testing
Not tested as the changes are similar to those in the recent plants e106 PR.

## Notes
No further changes are required as the pipeline already handles everything as `default` and then renames the gene trees `clusterset_id` at the end. Even the email analysis has `default` hardcoded, so everything should be fine.