### PR TITLE
Move and clarify gene tree stats

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -3322,6 +3322,7 @@ sub core_pipeline_analyses {
                 '1->A' => [
                     'rib_fire_dnds',
                     'rib_fire_homology_stats',
+                    'rib_fire_tree_stats',
                     'rib_fire_hmm_build',
                     'rib_fire_goc'
                 ],
@@ -3450,6 +3451,11 @@ sub core_pipeline_analyses {
                 WHEN('#do_homology_stats#' => 'homology_stats_factory'),
                 'set_default_values',
             ],
+        },
+
+        {   -logic_name => 'rib_fire_tree_stats',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => 'gene_count_factory',
         },
 
         {   -logic_name => 'rib_fire_hmm_build',
@@ -3669,6 +3675,21 @@ sub core_pipeline_analyses {
         {   -logic_name => 'rib_fire_goc',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => WHEN('#do_goc#' => 'goc_entry_point'),
+        },
+
+        {   -logic_name => 'gene_count_factory',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
+            -rc_name    => '1Gb_job',
+            -parameters => {
+                'compara_db'      => '#master_db#',
+                'fan_branch_code' => 1,
+            },
+            -flow_into  => [ 'count_genes_in_tree' ],
+        },
+
+        {   -logic_name => 'count_genes_in_tree',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::CountGenesInTree',
+            -rc_name    => '1Gb_job',
         },
 
         {   -logic_name => 'homology_stats_factory',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -339,7 +339,7 @@ sub core_pipeline_analyses {
             {   -logic_name => 'backbone_fire_posttree',
                 -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
                 -flow_into  => {
-                    '1->A' => ['rib_fire_homology_dumps'],
+                    '1->A' => ['rib_fire_homology_dumps', 'rib_fire_tree_stats'],
                     'A->1' => ['backbone_pipeline_finished'],
                 },
             },
@@ -607,7 +607,7 @@ sub core_pipeline_analyses {
               -parameters         => {
                                       mode            => 'global_tree_set',
                                      },
-              -flow_into          => [ 'write_stn_tags',
+              -flow_into          => [
                                        # 'backbone_fire_homology_dumps',
                                         WHEN('#do_cafe# and  #binary_species_tree_input_file#', 'CAFE_species_tree'),
                                         WHEN('#do_cafe# and !#binary_species_tree_input_file#', 'make_full_species_tree'),
@@ -1272,6 +1272,29 @@ sub core_pipeline_analyses {
                 '1->A' => [ 'homology_dumps_mlss_id_factory', 'gene_dumps_genome_db_factory' ],
                 'A->1' => 'rib_fire_homology_processing',
             },
+        },
+
+        {   -logic_name => 'rib_fire_tree_stats',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => {
+                '1->A' => 'gene_count_factory',
+                'A->1' => 'write_stn_tags',
+            },
+        },
+
+        {   -logic_name => 'gene_count_factory',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
+            -rc_name    => '1Gb_job',
+            -parameters => {
+                'compara_db'      => '#master_db#',
+                'fan_branch_code' => 1,
+            },
+            -flow_into  => [ 'count_genes_in_tree' ],
+        },
+
+        {   -logic_name => 'count_genes_in_tree',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::CountGenesInTree',
+            -rc_name    => '1Gb_job',
         },
 
         {   -logic_name => 'rib_fire_homology_processing',

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CountGenesInTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CountGenesInTree.pm
@@ -1,0 +1,103 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <https://lists.ensembl.org/mailman/listinfo/dev>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <https://www.ensembl.org/Help/Contact>.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::CountNumGenesInTrees
+
+=head1 AUTHORSHIP
+
+Ensembl Team. Individual contributions can be found in the GIT log.
+
+=head1 APPENDIX
+
+The rest of the documentation details each of the object methods.
+Internal methods are usually preceded with an underscore (_)
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::CountGenesInTree;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub fetch_input {
+    my $self = shift @_;
+
+    my $mlss_id = $self->param_required('mlss_id');
+    my $genome_db_id = $self->param_required('genome_db_id');
+
+    my $tree_adaptor = $self->compara_dba->get_SpeciesTreeAdaptor;
+    my $species_tree = $tree_adaptor->fetch_by_method_link_species_set_id_label($mlss_id, 'default');
+    my $species_tree_node = $species_tree->root->find_leaves_by_field('genome_db_id', $genome_db_id)->[0];
+    $self->param('species_tree_node', $species_tree_node);
+
+    my $gene_member_adaptor = $self->compara_dba->get_GeneMemberAdaptor;
+    my $total_num_genes = scalar @{ $gene_member_adaptor->fetch_all_by_GenomeDB($genome_db_id) };
+    $self->param('total_num_genes', $total_num_genes);
+
+    my $total_num_unassigned = $self->count_gdb_unassigned_genes($genome_db_id);
+    $self->param('total_num_unassigned', $total_num_unassigned);
+}
+
+
+sub run {
+    my ($self) = @_;
+    $self->param('nb_genes_in_tree', $self->param('total_num_genes') - $self->param('total_num_unassigned'));
+}
+
+
+sub write_output {
+    my $self = shift @_;
+    my $species_tree_node = $self->param('species_tree_node');
+    $species_tree_node->store_tag('nb_genes_in_tree', $self->param('nb_genes_in_tree'));
+    $species_tree_node->store_tag('nb_genes_unassigned', $self->param('total_num_unassigned'));
+}
+
+
+sub count_gdb_unassigned_genes {
+    my ($self, $genome_db_id) = @_;
+
+    my $sql = q/
+        SELECT COUNT(*) FROM gene_member mg
+        LEFT JOIN gene_tree_node gtn ON (mg.canonical_member_id = gtn.seq_member_id)
+        WHERE gtn.seq_member_id IS NULL AND mg.genome_db_id = ?
+    /;
+
+    my $sth = $self->compara_dba->dbc->prepare($sql);
+    $sth->execute($genome_db_id);
+    my $total_num_unassigned = $sth->fetchrow();
+    $sth->finish();
+
+    return $total_num_unassigned;
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CountGenesInTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CountGenesInTree.pm
@@ -17,26 +17,9 @@ limitations under the License.
 
 =cut
 
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <https://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <https://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::CountNumGenesInTrees
-
-=head1 AUTHORSHIP
-
-Ensembl Team. Individual contributions can be found in the GIT log.
-
-=head1 APPENDIX
-
-The rest of the documentation details each of the object methods.
-Internal methods are usually preceded with an underscore (_)
 
 =cut
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/HTMLReport.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/HTMLReport.pm
@@ -33,11 +33,14 @@ my $txt = <<EOF;
 <h1>Statistics on #collection# #method_name#</h1>
 
 <ul>
-<li>Gene coverage: Number of genes and members in total, included in trees (either species-specific, or encompassing other species), and orphaned (not in any tree)</li>
+<li>Gene coverage: Number of genes and members in total, included in trees (either species-specific, or
+  encompassing other species), orphaned (not in any unfiltered cluster), and unassigned (not in any tree)</h3>
 <li>Tree size: Sizes of trees (genes, and distinct species), grouped according to the root ancestral species</li>
 <li>Predicted gene events: For each ancestral species, number of speciation and duplication nodes (inc. dubious ones), with the average duplication score</li>
 </ul>
-<br/><h3>Number of genes and members in total, included in trees (either species-specific, or encompassing other species), and orphaned (not in any tree)</h3>
+<br/>
+<h3>Number of genes and members in total, included in trees (either species-specific, or
+    encompassing other species), orphaned (not in any unfiltered cluster), and unassigned (not in any tree)</h3>
 #html_array1#
 
 <br/><h3>Sizes of trees (genes, and distinct species), grouped according to the root ancestral species</h3>
@@ -75,13 +78,15 @@ sub fetch_input {
 
     {
         my @data1 = ();
-        my @sums = (0) x 6;
+        my @sums = (0) x 8;
         push @data1, [
             'Taxon ID',
             'Taxon name',
             'Nb genes',
             'Nb sequences',
             'Nb orphaned genes',
+            'Nb genes in unfiltered clusters',
+            'Nb unassigned genes',
             'Nb genes in trees',
             '% genes in trees',
             'Nb genes in single-species trees',
@@ -95,15 +100,19 @@ sub fetch_input {
             $sums[0] += $species->get_value_for_tag('nb_genes');
             $sums[1] += $species->get_value_for_tag('nb_seq');
             $sums[2] += $species->get_value_for_tag('nb_orphan_genes');
-            $sums[3] += $species->get_value_for_tag('nb_genes_in_tree');
-            $sums[4] += $species->get_value_for_tag('nb_genes_in_tree_single_species');
-            $sums[5] += $species->get_value_for_tag('nb_genes_in_tree_multi_species');
+            $sums[3] += $species->get_value_for_tag('nb_genes_in_unfiltered_cluster');
+            $sums[4] += $species->get_value_for_tag('nb_genes_unassigned');
+            $sums[5] += $species->get_value_for_tag('nb_genes_in_tree');
+            $sums[6] += $species->get_value_for_tag('nb_genes_in_tree_single_species');
+            $sums[7] += $species->get_value_for_tag('nb_genes_in_tree_multi_species');
             push @data1, [
                 $species->taxon_id,
                 $species->node_name,
                 thousandify($species->get_value_for_tag('nb_genes')),
                 thousandify($species->get_value_for_tag('nb_seq')),
                 thousandify($species->get_value_for_tag('nb_orphan_genes')),
+                thousandify($species->get_value_for_tag('nb_genes_in_unfiltered_cluster')),
+                thousandify($species->get_value_for_tag('nb_genes_unassigned')),
                 thousandify($species->get_value_for_tag('nb_genes_in_tree')),
                 $species->get_value_for_tag('nb_genes') ? roundperc2($species->get_value_for_tag('nb_genes_in_tree') / $species->get_value_for_tag('nb_genes')) : 'NA',
                 thousandify($species->get_value_for_tag('nb_genes_in_tree_single_species')),
@@ -119,11 +128,13 @@ sub fetch_input {
             thousandify($sums[1]),
             thousandify($sums[2]),
             thousandify($sums[3]),
-            roundperc2($sums[3] / $sums[0]),
             thousandify($sums[4]),
-            roundperc2($sums[4] / $sums[0]),
             thousandify($sums[5]),
             roundperc2($sums[5] / $sums[0]),
+            thousandify($sums[6]),
+            roundperc2($sums[6] / $sums[0]),
+            thousandify($sums[7]),
+            roundperc2($sums[7] / $sums[0]),
         ];
         $self->param('html_array1', array_arrays_to_html_table(@data1));
     }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/PerGenomeGroupsetQC.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/PerGenomeGroupsetQC.pm
@@ -137,8 +137,10 @@ sub write_output {
     my $species_tree_node       = $self->param('species_tree_node');
 
     $species_tree_node->store_tag('nb_genes',               $self->param('total_num_genes'));
-    $species_tree_node->store_tag('nb_genes_in_unfiltered_cluster', $self->param('total_num_genes')-$self->param('total_orphans_num'));
     $species_tree_node->store_tag('nb_orphan_genes',        $self->param('total_orphans_num'));
+
+    my $nb_genes_in_unfiltered_cluster = $self->param('total_num_genes') - $self->param('total_orphans_num');
+    $species_tree_node->store_tag('nb_genes_in_unfiltered_cluster', $nb_genes_in_unfiltered_cluster);
 
     return unless $self->param('reuse_this');
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/PerGenomeGroupsetQC.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/PerGenomeGroupsetQC.pm
@@ -82,7 +82,6 @@ sub fetch_input {
     my $self = shift @_;
 
     my $genome_db_id            = $self->param_required('genome_db_id');
-    my $this_genome_db          = $self->compara_dba->get_GenomeDBAdaptor->fetch_by_dbID($genome_db_id);
     my $this_species_tree       = $self->compara_dba->get_SpeciesTreeAdaptor->fetch_by_method_link_species_set_id_label($self->param_required('mlss_id'), 'default');
     my $ncbi_taxon_adaptor      = $self->compara_dba->get_NCBITaxonAdaptor;
     my $this_species_tree_node  = $this_species_tree->root->find_leaves_by_field('genome_db_id', $genome_db_id)->[0];
@@ -138,7 +137,7 @@ sub write_output {
     my $species_tree_node       = $self->param('species_tree_node');
 
     $species_tree_node->store_tag('nb_genes',               $self->param('total_num_genes'));
-    $species_tree_node->store_tag('nb_genes_in_tree',       $self->param('total_num_genes')-$self->param('total_orphans_num'));
+    $species_tree_node->store_tag('nb_genes_in_unfiltered_cluster', $self->param('total_num_genes')-$self->param('total_orphans_num'));
     $species_tree_node->store_tag('nb_orphan_genes',        $self->param('total_orphans_num'));
 
     return unless $self->param('reuse_this');


### PR DESCRIPTION
## Description

The stat `nb_genes_in_tree` is calculated from the clusters during the `per_genome_qc` step of the gene tree pipelines.
However, the number of genes may be reduced in subsequent pipeline steps (e.g. `recover_epo` and `infernal` in the
ncRNA-trees pipeline), making this statistic incorrect.

The statistic calculated at this stage from the clusters should be given a more apt name, and `nb_genes_in_tree` should be calculated at a later stage of each gene tree pipeline, so that it is the actual number of genes in the given tree.

**Related JIRA tickets:**
- ENSCOMPARASW-4008

## Overview of changes

Rename the cluster-based `nb_genes_in_tree` during per-genome QC, calculate a tree-based `nb_genes_in_tree` later in the pipeline.

#### Rename the cluster-based nb_genes_in_tree

In the `per_genome_qc` analysis, the name of the existing statistic `nb_genes_in_tree` is changed to `nb_genes_in_unfiltered_cluster`, so that it more accurately describes what is being calculated.

#### Calculate the tree-based nb_genes_in_tree

A new `count_genes_in_tree` analysis and `CountGenesInTree` runnable are created to calculate `nb_genes_in_tree` at a point in the protein-trees and ncRNA-trees pipelines after which there are no further changes to the number of genes in trees. 

The `CountGenesInTree` runnable also records the tree-based stat `nb_genes_unassigned` (i.e. the difference between `total_num_genes` and `nb_genes_in_tree`). This is analogous to the cluster-based stat `nb_orphan_genes`, which is the difference between `total_num_genes` and `nb_genes_in_unfiltered_cluster`.

In the protein-trees pipeline, the `count_genes_in_tree` analysis is triggered from `rib_group_2`, after `backbone_fire_posttree` and before the `compute_statistics` and `email_tree_stats_report` analyses.

In the ncRNA-trees pipeline, it is triggered from `backbone_fire_posttree`, and placed in a fan, with analyses `write_stn_tags` and `email_tree_stats_report` placed in the corresponding funnel, so that `nb_genes_in_tree` is calculated before the production of the tree stats report.

#### Calculate stat.number_of_unassigned_proteins

In the `compute_statistics` analysis, `stat.number_of_unassigned_proteins` is calculated from `nb_genes_unassigned`.

#### Update the tree stats HTML report

Two columns are added to the gene coverage table of the tree stats HTML report: "Nb genes in unfiltered clusters" and "Nb unassigned genes". These contain the values of `nb_genes_in_unfiltered_cluster` and `nb_genes_unassigned`, respectively.

#### Remove unused variable

The unused variable `this_genome_db` is removed from the `PerGenomeGroupsetQC` runnable.

## Testing
A full test run was conducted of Metazoa protein-trees and Murinae ncRNA-trees pipelines.
