### PR TITLE
Solve bugfix in update_master_db.pl

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
@@ -188,7 +188,7 @@ sub pipeline_analyses_prep_master_db_for_release {
             -parameters => {
                 'update_metadata_script' => $self->o('update_metadata_script'),
                 'reg_conf'               => $self->o('reg_conf'),
-                'cmd' => 'perl #update_metadata_script# --reg_conf #reg_conf# --compara #master_db# --division #division# --nocheck_species_missing_from_compara'
+                'cmd'                    => 'perl #update_metadata_script# --reg_conf #reg_conf# --compara #master_db#',
             },
             -flow_into  => [ 'update_collection' ],
         },


### PR DESCRIPTION
## Description

Avoid using vertannot as reference for the species that should be in compara master. Instead, use the list of current genomes in the database and just confirm they have a matching core db in the registry and the meta-data matches.

**Related JIRA tickets:**
- ENSCOMPARASW-4906

## Overview of changes
- The previous behaviour of this script was working as expected before freezing the list of species and when we were in charge of copying the species to vertannot. Since these two things have changed, relying on the information in the registry can end on releasing species that shouldn't. Thus, the script now uses the current species in compara master to check everything is correct.
- With this change, the `$division` information is no longer required.
- Reverted usage of `--check_species_missing_from_compara` flag, as we are the only ones using this script and we were using it with the `no` prefix.

## Testing
The script has been tested for plants e106, where vertannot has `theobroma_cacao_criollo` and it was being re-released before this update.

## Notes
- Updated POD (because why not!)