### PR TITLE
Perl script to dump canonical peptides from a core db

### DIFF
--- a/scripts/dumps/dump_gene_set_from_core.pl
+++ b/scripts/dumps/dump_gene_set_from_core.pl
@@ -22,6 +22,9 @@ dump_gene_set_from_core.pl
 
 This script dumps the canonical peptide of all protein coding genes from a core database.
 
+It can be quite memory intensive, and typically requires a gigabyte
+or more of memory to dump a complete gene set.
+
 =head1 SYNOPSIS
 
     perl dump_gene_set_from_core.pl --core-db <COREDB> --host <HOST> --port <PORT> --outfile <OUTFILE>
@@ -98,11 +101,16 @@ my $seq_out = Bio::SeqIO->new( -file => ">$gene_set_dump_file", -format => 'Fast
 
 print "Found ", scalar(@$genes), " genes.\n";
 
+my $num_genes_done = 0;
 foreach my $gene (@$genes) {
     my $can_transcript = $gene->canonical_transcript();
 
     if ( $can_transcript->translation() ) {
         my $pep = $can_transcript->translate();
         $seq_out->write_seq($pep);
+        
+        $num_genes_done++;
     }
 }
+
+print "Processed ", $num_genes_done, " genes.\n";


### PR DESCRIPTION
## Description

Perl script to dump the canonical peptide of all protein coding genes from a core db

**Related JIRA tickets:**
- ENSCOMPARASW-4635

## Overview of changes
New script written from scratch.

## Testing
`ibsub -m 8gb /hps/software/users/ensembl/repositories/compara/ivana/rel_dev/ensembl-compara/scripts/dumps/dump_gene_set_from_core.pl -core-db ivana_copy_full_mus_musculus_cbaj_core_105_1 -host mysql-ens-compara-prod-10 -port 4648 -outfile $HPS_HOME/mouse_test.fasta`
reported that it found 20 252 protein-coding genes. `mouse_test.fasta` contains 20 213 sequences. The numbers correspond to those when querying the corresponding core db:
```
SELECT COUNT(gene_id) FROM gene WHERE biotype="protein_coding";

SELECT COUNT(DISTINCT(gene_id)) FROM gene LEFT JOIN transcript USING(gene_id)
	WHERE gene.biotype="protein_coding" AND canonical_translation_id IS NOT NULL;
```

Each header-AA sequence look like:
```
>MGP_CBAJ_P0041833
MGSEVWVGTWRPHRPRGPIAALYRGPGPKYKLPTNTGYKLHDPSRPRAPAFSFGSRPPLR
HATCGPGPSYLVPARMTVRGTVGSPAFSIYGRLSHTAPVLTPGPGRYYPERARNVTYPSA
PRHTIAPRNWGILAKQETPGPGSYTVPSLLGSRVISKVSAPTYSIYSRSPVGSCFEDLSK
TPGPCAYHVVNPMIYKTRAPQFTMLGRTLPPRENTKKPGPASYSVDKVVWSRGSRGRG
```

## Notes
Making a PR on behalf of @dthybert. I will be addressing the reviews.
