### PR TITLE
Remove overlapping homologies once they have been imported

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/CultivarsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/CultivarsProteinTrees_conf.pm
@@ -118,7 +118,7 @@ sub tweak_analyses {
 
     # Wire up cultivar-specific analyses
     $analyses_by_name->{'remove_blacklisted_genes'}->{'-flow_into'} = ['check_strains_cluster_factory'];
-    push @{$analyses_by_name->{'hc_global_tree_set'}->{'-flow_into'}}, 'remove_overlapping_homologies';
+    push @{$analyses_by_name->{'backbone_pipeline_finished'}->{'-flow_into'}}, 'remove_overlapping_homologies';
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MergeDBsIntoRelease_conf.pm
@@ -89,7 +89,6 @@ sub default_options {
             'sequence'              => 'members_db',
             'exon_boundaries'       => 'members_db',
             'seq_member_projection_stable_id' => 'members_db',
-            'method_link_species_set_attr'    => 'protein_db',
             'seq_member_projection' => 'protein_db',
             'peptide_align_feature%' => 'protein_db',
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsNcRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsNcRNAtrees_conf.pm
@@ -15,16 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::StrainsNcRNAtrees_conf
@@ -38,15 +28,6 @@ Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::StrainsNcRNAtrees_conf
 =head1 DESCRIPTION
 
 This is the Strains/Breeds PipeConfig for the Vertebrates ncRNAtrees pipeline.
-
-=head1 AUTHORSHIP
-
-Ensembl Team. Individual contributions can be found in the GIT log.
-
-=head1 APPENDIX
-
-The rest of the documentation details each of the object methods.
-Internal methods are usually preceded with an underscore (_)
 
 =cut
 
@@ -123,7 +104,7 @@ sub tweak_analyses {
 
     # wire up strain-specific analyses
     $analyses_by_name->{'expand_clusters_with_projections'}->{'-flow_into'} = 'check_strains_cluster_factory';
-    push @{$analyses_by_name->{'hc_global_tree_set'}->{'-flow_into'}}, 'remove_overlapping_homologies';
+    push @{$analyses_by_name->{'backbone_pipeline_finished'}->{'-flow_into'}}, 'remove_overlapping_homologies';
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
@@ -124,7 +124,7 @@ sub tweak_analyses {
 
     # wire up strain-specific analyses
     $analyses_by_name->{'remove_blacklisted_genes'}->{'-flow_into'} = ['check_strains_cluster_factory'];
-    push @{$analyses_by_name->{'hc_global_tree_set'}->{'-flow_into'}}, 'remove_overlapping_homologies';
+    push @{$analyses_by_name->{'backbone_pipeline_finished'}->{'-flow_into'}}, 'remove_overlapping_homologies';
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RemoveOverlappingHomologies.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RemoveOverlappingHomologies.pm
@@ -15,36 +15,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::RemoveOverlappingHomologies
 
 =head1 DESCRIPTION
 
-When we build the mouse-strains protein-trees we end up with two database
-both having some homology MLSS (e.g. rat vs mouse).
-We decide here to remove the redundant MLSSs and their homologies from the
-dependent database.
-
-=head1 AUTHORSHIP
-
-Ensembl Team. Individual contributions can be found in the GIT log.
-
-=head1 APPENDIX
-
-The rest of the documentation details each of the object methods.
-Internal methods are usually preceded with an underscore (_)
+When we build the strains/breeds/cultivars gene trees we end up with two databases,
+both having some shared homology MLSSs (e.g. rat vs mouse). The redundant homology MLSSs
+and their corresponding tags/attributes in the strains/breeds/cultivars database have to
+be removed.
 
 =cut
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RemoveOverlappingHomologies.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RemoveOverlappingHomologies.pm
@@ -76,7 +76,7 @@ sub _remove_homologies {
     $self->compara_dba->dbc->do('DELETE homology_member FROM homology_member JOIN homology USING (homology_id) WHERE method_link_species_set_id = ?', undef, $mlss_id);
     $self->compara_dba->dbc->do('DELETE FROM homology WHERE method_link_species_set_id = ?',                                                          undef, $mlss_id);
     $self->compara_dba->dbc->do('DELETE FROM method_link_species_set_tag WHERE method_link_species_set_id = ?',                                       undef, $mlss_id);
-
+    $self->compara_dba->dbc->do('DELETE FROM method_link_species_set_attr WHERE method_link_species_set_id = ?',                                      undef, $mlss_id);
 }
 
 1;


### PR DESCRIPTION
## Description

During e106 we have found that the analysis `remove_overlapping_homologies` is applied **before** the homologies are imported, having no effect into the final content of the database (as it does not affect flat files). This makes MergeDB pipeline to fail on its first job because the MLSS-related information is still present in both databases.

## Overview of changes
- Move the analysis to the end of the strains/breeds/cultivars gene tree pipelines so it has the desired effect.
- Added `method_link_species_set_attr` table to the analysis so more useful information can be merged into the release database.

## Testing
This change was manually run for wheat cultivars e106, making MergeDB pipeline pass without issues.