### PR TITLE
ExaML and FastTree issues in WheatCultivarsProteinTrees

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/WheatCultivarsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/WheatCultivarsProteinTrees_conf.pm
@@ -77,7 +77,7 @@ sub tweak_analyses {
     $analyses_by_name->{'fasttree'}->{'-parameters'}->{'cmd'} = '#fasttree_exe# -nosupport -pseudo -quiet -nopr -wag #alignment_file# > #output_file#';
 
     # Flow "examl_32_cores" #-2 to "fasttree"
-    $analyses_by_name->{'examl_32_cores'}->{'-flow_into'}{-2} = [ 'fasttree' ];
+    $analyses_by_name->{'examl_32_cores'}->{'-flow_into'}->{-2} = [ 'fasttree' ];
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/WheatCultivarsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/WheatCultivarsProteinTrees_conf.pm
@@ -70,4 +70,15 @@ sub default_options {
 }
 
 
+sub tweak_analyses {
+    my $self = shift;
+    my $analyses_by_name = shift;
+
+    $analyses_by_name->{'fasttree'}->{'-parameters'}->{'cmd'} = '#fasttree_exe# -nosupport -pseudo -quiet -nopr -wag #alignment_file# > #output_file#';
+
+    # Flow "examl_32_cores" #-2 to "fasttree"
+    $analyses_by_name->{'examl_32_cores'}->{'-flow_into'}{-2} = [ 'fasttree' ];
+}
+
+
 1;


### PR DESCRIPTION
## Description

Two issues were encountered while running protein trees pipeline for wheat cultivars on `release/106` code:

1. FastTree produced trees with negative branch lengths for all 7 cases on which it was run
2. Long-running ExaML jobs using 64 cores

For a detailed description, please see the ticket

**Related JIRA tickets:**
- ENSCOMPARASW-4969

## Overview of changes
#### Change 1
- Run FastTree without `-noml` option to avoid negative branch lengths.

#### Change 2
- Set the `#-2` flow from `examl_32_cores` to `fasttree` (instead of `examl_64_cores`).

## Testing
Initialised pipelines:
- Current: http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-compara-prod-1&port=4485&dbname=ivana_wheat_current&passwd=xxxxx
- New: http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-compara-prod-1&port=4485&dbname=ivana_wheat_new&passwd=xxxxx
- Since the branch number is hidden in the visualisation of the new pipeline, I checked in the db:
`SELECT * FROM dataflow_rule WHERE from_analysis_id = 149;`
and got `branch_code` `-1` and `-2`.