### PR TITLE
Choose fasta header ID type [gene/protein]

### DIFF
--- a/scripts/dumps/dump_gene_set_from_core.pl
+++ b/scripts/dumps/dump_gene_set_from_core.pl
@@ -91,12 +91,8 @@ GetOptions(
 );
 
 pod2usage(1) if $help;
-unless ($dbname and $host and $port and $gene_set_dump_file and $id_type) {
+unless ($dbname and $host and $port and $gene_set_dump_file and grep( /^$id_type$/, qw(gene protein))) {
     pod2usage(1);
-}
-
-if ( $id_type !~ /^(?:gene|protein)$/ ) {
-    die "ERROR: '--id_type' has to be either 'gene' or 'protein'\n";
 }
 
 my $dba = Bio::EnsEMBL::DBSQL::DBAdaptor->new(

--- a/scripts/dumps/dump_gene_set_from_core.pl
+++ b/scripts/dumps/dump_gene_set_from_core.pl
@@ -59,7 +59,7 @@ File where the dumped sequence will be stored (in fasta format).
 =item B<-id_type> <id_type>
 
 Type of stable ID in the fasta file header.
-Either "gene" or "protein".
+Either "gene" or "protein". If not specified, "protein".
 
 =item B<-h[elp]>
 
@@ -81,6 +81,7 @@ use Pod::Usage;
 
 my ($dbname, $host, $port, $gene_set_dump_file, $help);
 my $id_type = "protein";
+
 GetOptions(
     'core-db|core_db=s' => \$dbname,
     'host=s'            => \$host,
@@ -91,7 +92,7 @@ GetOptions(
 );
 
 pod2usage(1) if $help;
-unless ($dbname and $host and $port and $gene_set_dump_file and grep( /^$id_type$/, qw(gene protein))) {
+unless ($dbname and $host and $port and $gene_set_dump_file and $id_type =~ /^(?:gene|protein)$/) {
     pod2usage(1);
 }
 

--- a/scripts/dumps/dump_gene_set_from_core.pl
+++ b/scripts/dumps/dump_gene_set_from_core.pl
@@ -79,8 +79,8 @@ use Bio::SeqIO;
 use Getopt::Long;
 use Pod::Usage;
 
-my ($dbname, $host, $port, $gene_set_dump_file, $id_type, $help);
-
+my ($dbname, $host, $port, $gene_set_dump_file, $help);
+my $id_type = "protein";
 GetOptions(
     'core-db|core_db=s' => \$dbname,
     'host=s'            => \$host,

--- a/scripts/dumps/dump_gene_set_from_core.pl
+++ b/scripts/dumps/dump_gene_set_from_core.pl
@@ -95,7 +95,7 @@ unless ($dbname and $host and $port and $gene_set_dump_file and $id_type) {
     pod2usage(1);
 }
 
-if ( $id_type !~ /gene|protein/ ) {
+if ( $id_type !~ /^(?:gene|protein)$/ ) {
     die "ERROR: '--id_type' has to be either 'gene' or 'protein'\n";
 }
 


### PR DESCRIPTION
## Description

`dump_gene_set_from_core.pl ` dumps peptide sequences of canonical transcripts from a core db into a fasta file. In its current form, protein `stable_id` is used in the fasta header. Yet, some applications require or would benefit from having gene `stable_id` in the header.

**Related JIRA tickets:**
- ENSCOMPARASW-5032

## Overview of changes
Extended functionality of the script by adding an option to choose which type of stable id should be written in the header - gene or protein.

## Testing
Dump prior to any code changes: `/hps/nobackup/flicek/ensembl/compara/ivana/citest_gallus_gallus_core_99_6.fasta` 

Running modified script
```
ibsub -m 2Gb /hps/software/users/ensembl/repositories/compara/ivana/rel_dev/ensembl-compara/scripts/dumps/dump_gene_set_from_core.pl -core-db citest_gallus_gallus_core_99_6 -host mysql-ens-compara-prod-10 -port 4648 -outfile $HPS_HOME/gallus_protein_default.fasta

ibsub -m 2Gb /hps/software/users/ensembl/repositories/compara/ivana/rel_dev/ensembl-compara/scripts/dumps/dump_gene_set_from_core.pl -core-db citest_gallus_gallus_core_99_6 -host mysql-ens-compara-prod-10 -port 4648 -outfile $HPS_HOME/gallus_protein.fasta -id_type protein

ibsub -m 2Gb /hps/software/users/ensembl/repositories/compara/ivana/rel_dev/ensembl-compara/scripts/dumps/dump_gene_set_from_core.pl -core-db citest_gallus_gallus_core_99_6 -host mysql-ens-compara-prod-10 -port 4648 -outfile $HPS_HOME/gallus_gene.fasta -id_type gene
```
produced:
-  **[PROTEIN DEFAULT]**  `/hps/nobackup/flicek/ensembl/compara/ivana/gallus_protein_default.fasta` -> Identical to `citest_gallus_gallus_core_99_6.fasta` -> Correct.
-  **[PROTEIN]** `/hps/nobackup/flicek/ensembl/compara/ivana/gallus_protein.fasta` -> Identical to `citest_gallus_gallus_core_99_6.fasta` -> Correct.
- **[GENE]** `/hps/nobackup/flicek/ensembl/compara/ivana/gallus_gene.fasta` -> Differs from `citest_gallus_gallus_core_99_6.fasta` only in IDs. Examples of new IDs: `ENSGALG00000015701`,  `ENSGALG00000028290`,... -> Looks ok.

Running:
```
ibsub -m 2Gb /hps/software/users/ensembl/repositories/compara/ivana/rel_dev/ensembl-compara/scripts/dumps/dump_gene_set_from_core.pl -core-db citest_gallus_gallus_core_99_6 -host mysql-ens-compara-prod-10 -port 4648 -outfile $HPS_HOME/gallus_protein.fasta -id_type gallus
```
Shows POD usage message. -> Correct.
