### PR TITLE
Add new references division and its JIRA tickets JSON file

### DIFF
--- a/conf/references/jira_recurrent_tickets.json
+++ b/conf/references/jira_recurrent_tickets.json
@@ -18,7 +18,7 @@
       "subtasks": [{
             "assignee": "<RelCo>",
             "component": "Production tasks",
-            "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Update+Compara+References+for+Rapid+Release\n*GitHub*: [<Division>/PrepareMasterDatabaseForRelease_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/<Division>/PrepareMasterDatabaseForRelease_conf.pm]\n{code}ibsub init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::UpdateReferenceDatabase_conf --host mysql-ens-compara-prod-X -port XXXX -email ensembl-production@ebi.ac.uk{code}",
+            "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Update+Compara+References+for+Rapid+Release\n*GitHub*: [<Division>/PrepareMasterDatabaseForRelease_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/<Division>/PrepareMasterDatabaseForRelease_conf.pm]\n{code}ibsub init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::UpdateReferenceDatabase_conf --host mysql-ens-compara-prod-X -port XXXX -email=ensembl-production@ebi.ac.uk{code}",
             "summary": "Update the references database"
          }
       ],

--- a/conf/references/jira_recurrent_tickets.json
+++ b/conf/references/jira_recurrent_tickets.json
@@ -1,0 +1,28 @@
+[
+    {
+      "assignee": "<RelCo>",
+      "component": "Relco tasks",
+      "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Relco+setup#Relcosetup-Rapidrelease",
+      "subtasks": [{
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Relco+setup#Relcosetup-Setuptheenvironment",
+            "summary": "Setup the rapid release environment"
+         }
+      ],
+      "summary": "References Release <version> Relco setup"
+   },
+   {
+      "assignee": "<RelCo>",
+      "component": "Relco tasks",
+      "subtasks": [{
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
+            "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Update+Compara+References+for+Rapid+Release\n*GitHub*: [<Division>/PrepareMasterDatabaseForRelease_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/<Division>/PrepareMasterDatabaseForRelease_conf.pm]\n{code}ibsub init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::UpdateReferenceDatabase_conf --host mysql-ens-compara-prod-X -port XXXX -email ensembl-production@ebi.ac.uk{code}",
+            "summary": "Update the references database"
+         }
+      ],
+      "labels": ["Production_anchor"],
+      "summary": "References Release <version> Production pipelines"
+   }
+]


### PR DESCRIPTION
## Description

Added new references division linked to the rapid release. In this case, we are only interested in the JIRA tickets JSON file as the rest of the configuration/files are located in another branch. This is just to ease the ticket creation from the RR RelCo.

**Related JIRA tickets:**
- ENSCOMPARASW-4743

## Overview of changes
New `references` folder inside `conf` with its corresponding `jira_recurrent_tickets.json` file.

## Testing
I have run the following command and the output was as expected:
```
perl ${ENSEMBL_ROOT_DIR}/ensembl-compara/scripts/jira_tickets/create_compara_release_JIRA_tickets.pl -division vertebrates -release 106 -dry_run -tickets /hps/software/users/ensembl/repositories/compara/jalvarez/master/ensembl-compara/conf/references/jira_recurrent_tickets.json 
```

## Notes
As you can noticed, I have had to put `division` as `vertebrates` in the testing command because the JIRA's division field doesn't support `references` as a value. I have ask @dthybert to request for this field to be updated. I'm also happy to rename the division `rapid` if we want to look a little bit forward into the future.
