### PR TITLE
Add references database patch analysis

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -127,6 +127,7 @@ sub executable_locations {
         'DumpGFFHomologuesForSynteny_exe'   => $self->check_exe_in_ensembl('ensembl-compara/scripts/synteny/DumpGFFHomologuesForSynteny.pl'),
         'emf2maf_program'                   => $self->check_exe_in_ensembl('ensembl-compara/scripts/dumps/emf2maf.pl'),
         'epo_stats_report_exe'              => $self->check_exe_in_ensembl('ensembl-compara/scripts/production/epo_stats.pl'),
+        'patch_db_exe'                      => $self->check_exe_in_ensembl('ensembl-compara/scripts/production/patch_database.pl'),
         'populate_new_database_exe'         => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/populate_new_database.pl'),
         'populate_per_genome_database_exe'  => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/populate_per_genome_database.pl'),
         'create_datacheck_tickets_exe'      => $self->check_exe_in_ensembl('ensembl-compara/scripts/jira_tickets/create_datacheck_tickets.pl'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -23,6 +23,10 @@ Bio::EnsEMBL::Compara::PipeConfig::UpdateReferenceDatabase_conf
 
     PipeConfig to update the reference database.
 
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::UpdateReferenceDatabase_conf -host mysql-ens-compara-prod-X -port XXXX
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::UpdateReferenceDatabase_conf;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -182,8 +182,16 @@ sub core_pipeline_analyses {
                 'src_db_conn' => '#ref_db#',
                 'output_file' => '#backups_dir#/compara_references.pre#release#.sql'
             },
-            -flow_into => [ 'load_ncbi_node' ],
+            -flow_into => [ 'patch_references_db' ],
             -rc_name   => '1Gb_job'
+        },
+
+        {   -logic_name => 'patch_references_db',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -parameters => {
+                'cmd' => [$self->o('patch_db_exe'), '--reg_conf', $self->o('reg_conf'), '--reg_alias', '#ref_db#', '--fixlast', '--nointeractive'],
+            },
+            -flow_into  => ['load_ncbi_node'],
         },
 
         {   -logic_name => 'load_ncbi_node',


### PR DESCRIPTION
## Description

Whilst setting up the new rapid release SOP, I have noticed this analysis was not present in `UpdateReferencesDatabase` pipeline. I have added it for convenience, copying the same code as in `PrepareMasterDBForRelease`.

**Related JIRA tickets:**
- ENSCOMPARASW-4744

## Overview of changes
- Added `patch_references_db` to `UpdateReferencesDatabase` in the same fashion as `patch_master_db` in `PrepareMasterDBForRelease`.

## Testing
Once followed the required setup SOP, the init command has produced the pipeline [jalvarez_update_references_105](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-10&port=4648&dbname=jalvarez_update_references_105) correctly.

## Notes
- A new tag (`rapid_release-v1.3`) will need to be added after this PR is merged.