### PR TITLE
New GERP script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ensembl-py@git+https://github.com/Ensembl/ensembl-py.git@main#egg=ensembl-py
 ensembl-prodinf-tools@git+https://github.com/Ensembl/ensembl-prodinf-tools.git@main#egg=ensembl-prodinf-tools
+argschema>=3.0.1
 biopython>=1.76
 ete3>=3.1.1
 lxml==4.6.3

--- a/setup.py
+++ b/setup.py
@@ -55,5 +55,8 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
         "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+    scripts=[
+        'src/python/scripts/run_gerp.py'
     ]
 )

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Calculates the Genomic Evolutionary Rate Profiling (GERP) of a multiple sequence alignment.
+
+GERP will produce two files, one with the conservation scores (suffixed with ".rates") and another with
+the constrained elements (suffixed with ".elems").
+
+Typical usage example::
+
+    $ python run_gerp.py --msa_file alignment.mfa --tree_file tree.nw
+
+If ``gerpcol`` and/or ``gerpelem`` are not accesible from ``$PATH``, you will need to provide the
+path where they can be found::
+
+    $ python run_gerp.py --msa_file alignment.mfa --tree_file tree.nw --gerp_exe_dir path/to/gerp/
+
+"""
+
+import subprocess
+
+import argschema
+
+
+class InputSchema(argschema.ArgSchema):
+    """Calculates the Genomic Evolutionary Rate Profiling (GERP) of a multiple sequence alignment (MSA)."""
+
+    msa_file = argschema.fields.InputFile(
+        required=True, description="MSA file (MFA format)"
+    )
+    tree_file = argschema.fields.InputFile(
+        required=True, description="Tree file (Newick format). Must include every species in the MSA."
+    )
+    depth_threshold = argschema.fields.Float(
+        required=False,
+        description="Constrained elements' depth threshold for shallow columns, in substitutions "
+                    "per site. By default, 0.5."
+    )
+    gerp_exe_dir = argschema.fields.InputDir(
+        required=False,
+        description="Path where 'gerpcol' and 'gerpelem' binaries can be found. By default, resort to $PATH."
+    )
+
+
+if __name__ == "__main__":
+    mod = argschema.ArgSchemaParser(schema_type=InputSchema)
+
+    cmd = ["gerpcol", "-t", mod.args["tree_file"], "-f", mod.args["msa_file"]]
+    if "gerp_exe_dir" in mod.args:
+        cmd[0] = f"{mod.args['gerp_exe_dir']}/{cmd[0]}"
+    subprocess.run(cmd, check=True)
+
+    # By default, gerpcol's ouput filename has the MSA filename plus ".rates" suffix
+    cmd = ["gerpelem", "-f", f"{mod.args['msa_file']}.rates"]
+    if "gerp_exe_dir" in mod.args:
+        cmd[0] = f"{mod.args['gerp_exe_dir']}/{cmd[0]}"
+    if "depth_threshold" in mod.args:
+        cmd += ["-d", str(mod.args["depth_threshold"])]
+    subprocess.run(cmd, check=True)

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -29,6 +29,7 @@ path where they can be found::
 
 """
 
+import os
 import subprocess
 
 import argschema
@@ -59,13 +60,13 @@ if __name__ == "__main__":
 
     cmd = ["gerpcol", "-t", mod.args["tree_file"], "-f", mod.args["msa_file"]]
     if "gerp_exe_dir" in mod.args:
-        cmd[0] = f"{mod.args['gerp_exe_dir']}/{cmd[0]}"
+        cmd[0] = os.path.join(mod.args['gerp_exe_dir'], cmd[0])
     subprocess.run(cmd, check=True)
 
     # By default, gerpcol's ouput filename has the MSA filename plus ".rates" suffix
     cmd = ["gerpelem", "-f", f"{mod.args['msa_file']}.rates"]
     if "gerp_exe_dir" in mod.args:
-        cmd[0] = f"{mod.args['gerp_exe_dir']}/{cmd[0]}"
+        cmd[0] = os.path.join(mod.args['gerp_exe_dir'], cmd[0])
     if "depth_threshold" in mod.args:
         cmd += ["-d", str(mod.args["depth_threshold"])]
     subprocess.run(cmd, check=True)


### PR DESCRIPTION
## Description

New GERP script that calculates both conservation scores and constrained elements from a given MSA (in MFA format) and species tree (in NEWICK format).

**Related JIRA tickets:**
- ENSCOMPARASW-5021

## Overview of changes
- New GERP script that mimics the `run()` code in [`Gerp.pm`](https://github.com/Ensembl/ensembl-compara/blob/main/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomicAlignBlock/Gerp.pm)
- Added the script as part of the installation process so it will be available by just typing `run_gerp.py`

## Testing
I have created a mock MFA and NEWICK files (see `/hps/nobackup/flicek/ensembl/compara/jalvarez/cactus_test_files`) and the script has run successfully, creating the expected output files.

## Notes
- I have taken advantage of `ArgSchema` to avoid having to check if in the input files/directory exist (it is done internally).