### PR TITLE
Include protists specific pipeconfigs

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/DumpAllForRelease_conf.pm
@@ -1,0 +1,55 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Protists::DumpAllForRelease_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Protists::DumpAllForRelease_conf -host mysql-ens-compara-prod-X -port XXXX
+
+=head1 DESCRIPTION
+
+Specialized version of the DumpAllForRelease pipeline for the Protists
+division. Please, refer to the parent class for further information.
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Protists::DumpAllForRelease_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::DumpAllForRelease_conf');
+
+
+sub default_options {
+    my ($self) = @_;
+
+    return {
+        %{ $self->SUPER::default_options },    # inherit the generic ones
+
+        'dump_dir'         => $self->o('dump_root') . '/release-' . $self->o('eg_release'),
+
+        'division'         => 'protists',
+
+        'prev_rel_ftp_root' => $self->o('ftp_root') . '/release-' . $self->o('prev_eg_release') . '/' . $self->o('division'),
+    };
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/Lastz_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/Lastz_conf.pm
@@ -1,0 +1,78 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Protists::Lastz_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Protists::Lastz_conf -host mysql-ens-compara-prod-X -port XXXX \
+        -mlss_id_list "[9515,9516,9517]"
+
+=head1 DESCRIPTION
+
+This is a Protists configuration file for LastZ pipeline. Please, refer to the
+parent class for further information.
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Protists::Lastz_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::Lastz_conf');
+
+
+sub default_options {
+my ($self) = @_;
+    return {
+        %{$self->SUPER::default_options},   # inherit the generic ones
+        'division'  => 'protists',
+        # healthcheck
+        'do_compare_to_previous_db' => 0,
+        # Net
+        'bidirectional' => 1,
+    };
+}
+
+
+sub tweak_analyses {
+    my $self = shift;
+    my $analyses_by_name = shift;
+
+    ## Extend this section to redefine the resource names of some analysis
+    my %overriden_rc_names = (
+        'alignment_nets'            => '2Gb_job',
+        'create_alignment_nets_jobs'=> '2Gb_job',
+        'create_alignment_chains_jobs'  => '4Gb_job',
+        'create_filter_duplicates_jobs'     => '2Gb_job',
+        'create_pair_aligner_jobs'  => '2Gb_job',
+        'populate_new_database' => '8Gb_job',
+        'parse_pair_aligner_conf' => '4Gb_job',
+        $self->o('pair_aligner_logic_name') => '4Gb_job',
+        $self->o('pair_aligner_logic_name')."_himem1" => '8Gb_job',
+    );
+
+    foreach my $logic_name (keys %overriden_rc_names) {
+        $analyses_by_name->{$logic_name}->{'-rc_name'} = $overriden_rc_names{$logic_name};
+    }
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/LoadMembers_conf.pm
@@ -1,0 +1,61 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Protists::LoadMembers_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Protists::LoadMembers_conf \
+    -host mysql-ens-compara-prod-X -port XXXX
+
+=head1 DESCRIPTION
+
+Specialized version of the LoadMembers pipeline for Protists. Please, refer
+to the parent class for further information.
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Protists::LoadMembers_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::LoadMembers_conf');
+
+
+sub default_options {
+    my ($self) = @_;
+
+    return {
+        %{$self->SUPER::default_options},   # inherit the generic ones
+
+        'division'  => 'protists',
+
+        # Names of species we do not want to reuse this time
+        # 'do_not_reuse_list' => [ 'bigelowiella_natans', 'emiliania_huxleyi' ],
+        'do_not_reuse_list' => [],
+
+        # "Member" parameters:
+        'store_ncrna'   => 0,  # Store ncRNA genes
+        'store_others'  => 0,  # Store other genes
+    };
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/MergeDBsIntoRelease_conf.pm
@@ -1,0 +1,74 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Protists::MergeDBsIntoRelease_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Protists::MergeDBsIntoRelease_conf \
+    -host mysql-ens-compara-prod-X -port XXXX
+
+=head1 DESCRIPTION
+
+A Protists specific pipeline to merge some production databases onto the release one.
+
+The default parameters work well in the context of a Compara release for Protists (with a well-configured
+Registry file). If the list of source-databases is different, have a look at the bottom of the base file
+for alternative configurations.
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Protists::MergeDBsIntoRelease_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::MergeDBsIntoRelease_conf');
+
+
+sub default_options {
+    my ($self) = @_;
+
+    return {
+        %{$self->SUPER::default_options},
+
+        'division' => 'protists',
+
+        # All the source databases
+        'src_db_aliases' => {
+            'master_db'     => 'compara_master',
+            'protein_db'    => 'compara_ptrees',
+        },
+
+        # From these databases, only copy these tables
+        'only_tables' => {
+            # Cannot be copied by populate_new_database because it does not contain the new
+            # mapping_session_ids yet
+            'master_db' => [ qw(mapping_session) ],
+        },
+
+        # These tables have a unique source. Content from other databases is ignored.
+        'exclusive_tables' => {
+            'mapping_session'         => 'master_db',
+        },
+    };
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/PostHomologyMerge_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/PostHomologyMerge_conf.pm
@@ -1,0 +1,56 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Protists::PostHomologyMerge_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Protists::PostHomologyMerge_conf \
+    -host mysql-ens-compara-prod-X -port XXXX
+
+=head1 DESCRIPTION
+
+Specific version of PostHomologyMerge for Protists.
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Protists::PostHomologyMerge_conf;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::PostHomologyMerge_conf');
+
+
+sub default_options {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::default_options},
+
+        'division'  => 'protists',
+
+        'do_member_stats_fam'   => 0,
+    };
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/PrepareMasterDatabaseForRelease_conf.pm
@@ -1,0 +1,59 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Protists::PrepareMasterDatabaseForRelease_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Protists::PrepareMasterDatabaseForRelease_conf \
+    -host mysql-ens-compara-prod-X -port XXXX
+
+=head1 DESCRIPTION
+
+Prepare Protists master database for next release. Please, refer to the parent
+class for further information.
+
+WARNING: the previous reports and backups will be removed if the pipeline is
+initialised again for the same division and release.
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Protists::PrepareMasterDatabaseForRelease_conf;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::PrepareMasterDatabaseForRelease_conf');
+
+sub default_options {
+    my ($self) = @_;
+
+    return {
+        %{$self->SUPER::default_options},   # inherit the generic ones
+
+        'division' => 'protists',
+    };
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/ProteinTrees_conf.pm
@@ -64,10 +64,10 @@ sub default_options {
         ],
 
         # Extra analyses:
-        # Compute dNdS for homologies?
-        'do_dnds'                => 1,
         # Gain/loss analysis?
         'do_cafe'                => 0,
+        # Compute dNdS for homologies?
+        'do_dnds'                => 1,
         # Do we want the Gene QC part to run?
         'do_gene_qc'             => 0,
         # Do we need a mapping between homology_ids of this database to another database?

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/ProteinTrees_conf.pm
@@ -1,0 +1,80 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Protists::ProteinTrees_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Protists::ProteinTrees_conf \
+    -host mysql-ens-compara-prod-X -port XXXX
+
+=head1 DESCRIPTION
+
+The Protists PipeConfig file for ProteinTrees pipeline automating execution of homology-specific analyses.
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Protists::ProteinTrees_conf;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Hive::Utils ('stringify');
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::ProteinTrees_conf');
+
+
+sub default_options {
+    my ($self) = @_;
+
+    return {
+        %{$self->SUPER::default_options},   # inherit the generic ones
+
+        'division'   => 'protists',
+
+        # homology_dnds parameters:
+        'taxlevels' => ['Alveolata', 'Amoebozoa', 'Choanoflagellida', 'Cryptophyta', 'Fornicata', 'Haptophyceae', 'Kinetoplastida', 'Rhizaria', 'Rhodophyta', 'Stramenopiles'],
+
+        # GOC parameters:
+        'goc_taxlevels' => [],
+
+        # HighConfidenceOrthologs parameters:
+        # In this structure, the "thresholds" are for resp. the GOC score, the WGA coverage and %identity
+        'threshold_levels' => [
+            {
+                'taxa'          => [ 'all' ],
+                'thresholds'    => [ undef, undef, 25 ],
+            },
+        ],
+
+        # Extra analyses:
+        # Compute dNdS for homologies?
+        'do_dnds'                => 1,
+        # Gain/loss analysis?
+        'do_cafe'                => 0,
+        # Do we want the Gene QC part to run?
+        'do_gene_qc'             => 0,
+        # Do we need a mapping between homology_ids of this database to another database?
+        # This parameter is automatically set to 1 when the GOC pipeline is going to run with a reuse database
+        'do_homology_id_mapping' => 0,
+
+    };
+}
+
+1;


### PR DESCRIPTION
## Description

Very basic pipeconfigs for the Protists division - necessary for ease of running production and reducing human error in command line parameters, subject to alteration during production.

**Related JIRA tickets:**
- ENSCOMPARASW-5026 :
- ENSCOMPARASW-5028

## Overview of changes
Quite generally the process has mimicked that of the Metazoa division, to include all the pipeconfigs that will be necessary for e107. Whilst for `e107` we will only run the protein trees pipeline, the WGA related configs are included here for ease in the future too. Additional parameters come from legacy EG division specifications for Protists as they would have been run by the Microbes team.

## Testing
NA

## Notes
- Certain resources are expected to be updated in the live running of production, at the moment they are not known.
- Have included dnds analysis because it is included still for `Metazoa` division and was specified in the old EG division related config.
