### PR TITLE
Don't load genes with readthrough canonical transcripts

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers.pm
@@ -225,17 +225,15 @@ sub loadMembersFromCoreSlices {
 
     # Discard genes whose canonical transcripts are readthrough transcripts
     my $n2 = scalar(@relevant_genes);
-    my @readthrough_genes;
+    my %readthrough_genes;
     foreach my $gene (@relevant_genes){
         my $canonical_transcript = $gene->canonical_transcript();
         my @tr_attribs = @{$canonical_transcript->get_all_Attributes()};
         my @readthrough = grep {$_->value() eq 'readthrough'} @tr_attribs;
-        push @readthrough_genes, $gene if scalar(@readthrough) > 0;
+        $readthrough_genes{$gene} = undef if scalar(@readthrough) > 0;
     }
 
-    my %h;
-    @h{@readthrough_genes} = undef;
-    @relevant_genes = grep {not exists $h{$_}} @relevant_genes;
+    @relevant_genes = grep {not exists $readthrough_genes{$_}} @relevant_genes;
 
     if ($n2 != scalar(@relevant_genes)) {
         $self->warning("Discarded " . ($n2 - scalar(@relevant_genes)) . " genes because they have a readthrough canonical transcipt");

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers.pm
@@ -226,11 +226,10 @@ sub loadMembersFromCoreSlices {
     # Discard genes whose canonical transcripts are readthrough transcripts
     my $n2 = scalar(@relevant_genes);
     my @readthrough_genes;
-    my $attrib_value = 'readthrough';
     foreach my $gene (@relevant_genes){
-        my $can_transcript = $gene->canonical_transcript();
-        my @tr_attribs = @{$can_transcript->get_all_Attributes()};
-        my @readthrough = grep {$_->value() eq $attrib_value} @tr_attribs;
+        my $canonical_transcript = $gene->canonical_transcript();
+        my @tr_attribs = @{$canonical_transcript->get_all_Attributes()};
+        my @readthrough = grep {$_->value() eq 'readthrough'} @tr_attribs;
         push @readthrough_genes, $gene if scalar(@readthrough) > 0;
     }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers.pm
@@ -239,7 +239,7 @@ sub loadMembersFromCoreSlices {
     @relevant_genes = grep {not exists $h{$_}} @relevant_genes;
 
     if ($n2 != scalar(@relevant_genes)) {
-        $self->warning("Discarded ".($n2-scalar(@relevant_genes))." genes because they have a readthrough canonical transcipt");
+        $self->warning("Discarded " . ($n2 - scalar(@relevant_genes)) . " genes because they have a readthrough canonical transcipt");
     }
 
     $self->param('geneCount', $self->param('geneCount') + scalar(@relevant_genes) );


### PR DESCRIPTION
## Description

When readthrough transcripts are processed by Compara gene tree pipeline, they get misannotated as paralogs of genes from which they were formed via splicing. Furthermore, the corresponding erroneous duplication nodes in the gene tree can mess up many other orthology and paralogy relationships.

We could avoid that by filtering out genes whose canonical transcript is a readthrough transcript. It seems convenient to simply not load such genes in the `LoadMembers` pipeline. 

**Related JIRA tickets:**
- ENSCOMPARASW-4465

## Overview of changes
Added a piece of code which discards genes whose canonical transcript is a readthrough transcript.

## Testing
* Full `LoadMembers pipeline run on 106 dataset: `http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-compara-prod-1&port=4485&dbname=ivana_vertebrates_load_members_4jan_106&passwd=xxxxx

* `SELECT COUNT(*) FROM gene_member WHERE genome_db_id = 150;`
In `twalsh_vertebrates_load_members_106`: 69326
In `ivana_vertebrates_load_members_4jan_106`: 68345
Difference: 981

* Query `homo_sapiens_core_106_38` ( `attrib_type_id=554` -> canonical transcript, `attrib_type_id=218` -> readhrough)
```
mysql-ens-vertannot-staging homo_sapiens_core_106_38

SELECT COUNT(*) FROM gene g, transcript t, transcript_attrib ta WHERE g.gene_id=t.gene_id AND t.transcript_id=ta.transcript_id AND ta.attrib_type_id=554 AND t.transcript_id IN (SELECT transcript_id FROM transcript_attrib WHERE attrib_type_id=218);
+----------+
| COUNT(*) |
+----------+
|      981 |
+----------+
```

* [Didn't redo this in Jan; I did it only before I made the PR] In addition, I checked messages for the job loading human core in the pipeline db: `msg` table. Numbers in messages `"Discarded XX genes because they have a readthrough canonical transcipt"` sum up to 981.