### PR TITLE
fixing allowed species list

### DIFF
--- a/conf/metazoa/allowed_species.json
+++ b/conf/metazoa/allowed_species.json
@@ -65,7 +65,7 @@
     "danaus_plexippus",
     "daphnia_magna",
     "daphnia_pulex",
-    "dendroctonus_ponderosae",
+    "dendroctonus_ponderosae_gca000355655v1",
     "dermacentor_silvarum_gca013339745v1",
     "dermatophagoides_pteronyssinus_gca001901225v2",
     "diabrotica_virgifera_gca003013835v2",


### PR DESCRIPTION
substituting old dendroctonus_ponderosae with dendroctonus_ponderosae_gca000355655v1

## Description

Found 2 cores with the same assembly accession (GCA_000355655.1) passed  through the DC (handed over).
To assist production and compara production we're deleting the old one and using a new one for the compara runs.

As discussed with the production and compara teams.