### PR TITLE
Copy resolved symbolic links in ref_dirs to cloud bucket

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -62,11 +62,10 @@ sub default_options {
         'pipeline_name' => 'update_references_' . $self->o('rel_with_suffix'),
         'backups_dir'   => $self->o('pipeline_dir') . '/reference_db_backups/',
 
-        # shared location to symlink to fastas for orthofinder
+        # shared locations to symlink and copy fastas for orthofinder
         'shared_fasta_dir' => $self->o('shared_hps_dir') . '/reference_fasta_symlinks/',
-
-        # orthofinder executable
-        # 'orthofinder_exe' => $self->o('orthofinder_exe'),
+        'ssh_ip_loc' => '45.88.81.155',
+        'ref_bucket' => '/bucket1/',
 
         # update from metadata options
         'list_genomes_script'    => $self->check_exe_in_ensembl('ensembl-metadata/misc_scripts/get_list_genomes_for_division.pl'),
@@ -363,7 +362,8 @@ sub core_pipeline_analyses {
             -flow_into  => {
                 '1->A'  => { 'datacheck_factory' => { 'datacheck_groups' => $self->o('datacheck_groups'), 'db_type' => $self->o('db_type'), 'compara_db' => '#ref_db#', 'registry_file' => undef, 'datacheck_types' => $self->o('dc_type') }},
                 'A->1'  => [ 'backup_ref_db_again' ],
-                1       => [ 'fasta_dumps_per_collection_factory' ],
+                'B->1'  => [ 'copy_to_bucket' ],
+                '1->B'  => [ 'fasta_dumps_per_collection_factory' ],
 
             },
             -rc_name    => '2Gb_job',
@@ -386,6 +386,16 @@ sub core_pipeline_analyses {
             -language   => 'python3',
             -parameters => {
                 'symlink_fasta_exe' => $self->o('symlink_fasta_exe'),
+            },
+        },
+
+        {   -logic_name => 'copy_to_bucket',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -parameters => {
+                'ssh_ip_loc' => $self->o('ssh_ip_loc'),
+                'ref_bucket' => $self->o('ref_bucket'),
+                'symlink_dir' => $self->o('shared_fasta_dir'),
+                'cmd'         => 'cd #symlink_dir#; tar cfhp - * | ssh ${USER}@#ssh_ip_loc# \'(cd #ref_bucket#; tar xfp - )\'',
             },
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -392,8 +392,8 @@ sub core_pipeline_analyses {
         {   -logic_name => 'copy_to_bucket',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
             -parameters => {
-                'ssh_ip_loc' => $self->o('ssh_ip_loc'),
-                'ref_bucket' => $self->o('ref_bucket'),
+                'ssh_ip_loc'  => $self->o('ssh_ip_loc'),
+                'ref_bucket'  => $self->o('ref_bucket'),
                 'symlink_dir' => $self->o('shared_fasta_dir'),
                 'cmd'         => 'cd #symlink_dir#; tar cfhp - * | ssh ${USER}@#ssh_ip_loc# \'(cd #ref_bucket#; tar xfp - )\'',
             },


### PR DESCRIPTION
## Description

Transfer the collections to the cloud buckets

**Related JIRA tickets:**
- ENSCOMPARASW-5052

## Overview of changes
New analysis in the pipe config - simply a hive `SystemCmd`, nothing big.

## Testing
[Here is a pipeline.](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-3&port=4523&dbname=cristig_update_references_105)

## Notes
The bucket is a temporary solution until we have real S3 cloud buckets - @thiagogenez is working on it.
Directories `test1` and `test2` were the output of the tested pipeline, can be found in `45.88.81.155:/bucket1/` if further evidence is required.