### PR TITLE
Update embassy configuration in references

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -74,6 +74,11 @@ sub shared_default_options {
         'pipeline_dir'          => $self->o('hps_dir') . '/' . $self->o('dbowner') . '/' . $self->o('pipeline_name'),
         'shared_hps_dir'        => $self->o('hps_dir') . '/shared',
 
+        # Embassy IP for rapid release project
+        'embassy_ip_rr' => '45.88.81.155',
+        # S3 buckets on Embassy cloud
+        'embassy_ref_bucket' => '/storage/s3/long-term/',
+
         # Where to find the linuxbrew installation
         'linuxbrew_home'        => $ENV{'LINUXBREW_HOME'} || $self->o('linuxbrew_home'),
         'compara_software_home' => $self->o('warehouse_dir') . '/software/',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -64,8 +64,8 @@ sub default_options {
 
         # shared locations to symlink and copy fastas for orthofinder
         'shared_fasta_dir' => $self->o('shared_hps_dir') . '/reference_fasta_symlinks/',
-        'ssh_ip_loc' => '45.88.81.155',
-        'ref_bucket' => '/bucket1/',
+        'ssh_ip_loc' => $self->o('embassy_ip_rr'),
+        'ref_bucket' => $self->o('embassy_ref_bucket'),
 
         # update from metadata options
         'list_genomes_script'    => $self->check_exe_in_ensembl('ensembl-metadata/misc_scripts/get_list_genomes_for_division.pl'),


### PR DESCRIPTION
## Description

Just needed to update the bucket path from `bucket_1` to the actual long term bucket.

**Related JIRA tickets:**
- ENSCOMPARASW-5295

## Overview of changes
- Moved specific parameters to `ENV.pm`.
- Replaced fake bucket with real bucket.

## Testing
See analysis `copy_to_bucket` in [guihive pipeline](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-10&port=4648&dbname=cristig_update_references_105) to see changes of IP etc.

## Notes
