### PR TITLE
Get gene member by stable_id and genome_db_id

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/BlastAndParsePAF.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/BlastAndParsePAF.pm
@@ -215,10 +215,14 @@ sub parse_blast_table_into_paf {
             if ($ref_dba) {
                 # If sequences are associated with a compara_references db - these are likely stable_ids and need to be converted
                 if ( $qmember_id =~ /^[A-Z]+/i ) {
-                    $qmember_id = $ref_gene_adap->fetch_by_stable_id($qmember_id)->canonical_member_id();
+                    my ($qmember, @unexpected_matches) = grep { $_->genome_db_id == $qgenome_db_id } @{$ref_gene_adap->fetch_all_by_stable_id_list([$qmember_id])};
+                    die "Multiple gene members match stable ID: $qmember_id\n" if @unexpected_matches;
+                    $qmember_id = $qmember->canonical_member_id();
                 }
                 if ( $hmember_id =~ /^[A-Z]+/i ) {
-                    $hmember_id = $ref_gene_adap->fetch_by_stable_id($hmember_id)->canonical_member_id();
+                    my ($hmember, @unexpected_matches) = grep { $_->genome_db_id == $hgenome_db_id } @{$ref_gene_adap->fetch_all_by_stable_id_list([$hmember_id])};
+                    die "Multiple gene members match stable ID: $hmember_id\n" if @unexpected_matches;
+                    $hmember_id = $hmember->canonical_member_id();
                 }
             }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/BlastAndParsePAF.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/BlastAndParsePAF.pm
@@ -213,7 +213,9 @@ sub parse_blast_table_into_paf {
                 $cigar_line = Bio::EnsEMBL::Compara::Utils::Cigars::cigar_from_two_alignment_strings($qseq, $sseq);
             }
             if ($ref_dba) {
-                # If sequences are associated with a compara_references db - these are likely stable_ids and need to be converted
+                # If sequences are associated with a compara_references db - these are likely stable_ids and need to be converted.
+                # Because there may be multiple genome_db entries for a given reference genome, there may be multiple gene members with the same
+                # stable_id, so we filter results by the relevant genome_db_id to be sure to retrieve the gene_member_id for the correct genome_db.
                 if ( $qmember_id =~ /^[A-Z]+/i ) {
                     my ($qmember, @unexpected_matches) = grep { $_->genome_db_id == $qgenome_db_id } @{$ref_gene_adap->fetch_all_by_stable_id_list([$qmember_id])};
                     die "Multiple gene members match stable ID: $qmember_id\n" if @unexpected_matches;


### PR DESCRIPTION
## Description

Because multiple Rapid-Release (RR) reference genome_dbs containing the same gene can currently coexist in the RR references database, a stable ID is not guaranteed to be unique, so Compara API method `Bio::EnsEMBL::Compara::DBSQL::GeneMember::fetch_by_stable_id` will fetch a gene for the earliest available genome_db (or strictly speaking, the first for which a query result is returned).

This PR addresses the issue through matching gene members by both stable_id and genome_db_id.

**Related JIRA tickets:**
- ENSCOMPARASW-5293

## Overview of changes
The function to parse BLAST tabular output into PeptideAlignFeature objects has been changed so that if a query or hit gene member is identified by a stable ID, the corresponding member ID is obtained by matching both the gene stable_id and genome_db_id. Assuming that gene stable IDs are unique within a genome, this should be sufficient to resolve genes to the correct gene member, and in turn to its canonical sequence member.

## Testing
This change was tested by a test run of the RR homology annotation pipeline on Athalia rosae (GCA_000344095.2). Homology members of this species in Human were resolved to gene members of the correct version of the Human reference.

Test pipeline URL: `mysql://ensro@mysql-ens-compara-prod-2:4522/twalsh_blastocyst_32_105_20220314`