### PR TITLE
A function to read in OrthoFinder paralogs for a species

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
@@ -270,7 +270,7 @@ sub group_hash_by {
 sub check_column_integrity {
     my ($file, $delimiter) = @_;
 
-    my $awk_opts = $delimiter ? "-F$delimiter" : "";
+    my $awk_opts = $delimiter ? "-F'$delimiter'" : "";
 
     my $run_awk = Bio::EnsEMBL::Compara::Utils::RunCommand->new_and_exec(
         "awk $awk_opts '{print NF}' $file | sort | uniq -c",

--- a/modules/t/homology_flatfiles/ortho.test.tsv
+++ b/modules/t/homology_flatfiles/ortho.test.tsv
@@ -1,4 +1,4 @@
-homology_id	homology_type	gene_tree_node_id	gene_tree_root_id	species_tree_node_id	gene_member_id	seq_member_id	stable_id	genome_db_id  species	perc_id	homology_gene_member_id	homology_seq_member_id	homology_stable_id	homology_genome_db_id homology_species	homology_perc_id
+homology_id	homology_type	gene_tree_node_id	gene_tree_root_id	species_tree_node_id	gene_member_id	seq_member_id	stable_id	genome_db_id	species	perc_id	homology_gene_member_id	homology_seq_member_id	homology_stable_id	homology_genome_db_id	homology_species	homology_perc_id
 2089891	ortholog_one2one	4084544	4084544	40133000	1317571	1776012	ENSMEUP00000010101	111	anolis_carolinensis	25.2	902949217	904807664	C43H8.2.2	142	gallus_gallus	25.7143
 2094923	ortholog_one2one	4084040	4084040	40133001	1327596	1786077	ENSMEUP00000001319	111	anolis_carolinensis	36.9627	903101985	905107315	K02B2.3.1	142	gallus_gallus	38.7387
 4385940	ortholog_one2one	7018131	482468	40133001	1312823	1771145	ENSMEUP00000010655	111	anolis_carolinensis	29.9435	903091057	905089591	K08D12.3a.1	142	gallus_gallus	35.0993

--- a/modules/t/homology_flatfiles/prep_orth.hom_map.tsv
+++ b/modules/t/homology_flatfiles/prep_orth.hom_map.tsv
@@ -1,3 +1,3 @@
-curr_release_homology_id    prev_release_homology_id
+curr_release_homology_id	prev_release_homology_id
 102	2
 103	3

--- a/scripts/pipeline/orthology_benchmark.py
+++ b/scripts/pipeline/orthology_benchmark.py
@@ -357,6 +357,7 @@ def extract_paralogs(res_dir: str, species_key: str) -> List[Tuple[str, str]]:
 
     predictions_file = os.path.join(res_dir, "Gene_Duplication_Events", "Duplications.tsv")
 
+    gene_pattern = re.compile(f'{re.escape(species_key)}_(?P<gene_id>.+)')
     with open(predictions_file) as file_handle:
         reader = csv.DictReader(file_handle, delimiter="\t")
         for row in reader:
@@ -364,7 +365,6 @@ def extract_paralogs(res_dir: str, species_key: str) -> List[Tuple[str, str]]:
             genes1 = row["Genes 1"].split(", ")
             genes2 = row["Genes 2"].split(", ")
 
-            gene_pattern = re.compile(f'{re.escape(species_key)}_(?P<gene_id>.+)')
             if species == species_key:
                 for gene1 in genes1:
                     gene1_match = gene_pattern.fullmatch(gene1)

--- a/scripts/pipeline/orthology_benchmark.py
+++ b/scripts/pipeline/orthology_benchmark.py
@@ -341,6 +341,39 @@ def extract_orthologs(res_dir: str, species_key1: str, species_key2: str) -> Lis
     return orthologs
 
 
+def extract_paralogs(res_dir: str, species_key: str) -> List[Tuple[str, str]]:
+    """Reads in putative paralogs inferred by OrthoFinder.
+
+    Args:
+        res_dir: Path to the directory with OrthoFinder results.
+        species_key: OrthoFinder identificator of the species of interest.
+
+    Returns:
+        A list of putative paralogous pairs for a specified species identificator used in the
+        OrthoFinder analysis.
+
+    """
+    paralogs = []
+
+    predictions_file = os.path.join(res_dir, "Gene_Duplication_Events", "Duplications.tsv")
+
+    with open(predictions_file) as file_handle:
+        reader = csv.DictReader(file_handle, delimiter="\t")
+        for row in reader:
+            species = row["Species Tree Node"]
+            genes1 = row["Genes 1"].split(", ")
+            genes2 = row["Genes 2"].split(", ")
+
+            if species == species_key:
+                for gene1 in genes1:
+                    for gene2 in genes2:
+                        paralogs.append(
+                            (gene1.split(f"{species_key}_")[1], gene2.split(f"{species_key}_")[1])
+                        )
+
+    return paralogs
+
+
 def calculate_goc_scores():
     """Docstring"""
 

--- a/scripts/pipeline/orthology_benchmark.py
+++ b/scripts/pipeline/orthology_benchmark.py
@@ -368,12 +368,10 @@ def extract_paralogs(res_dir: str, species_key: str) -> List[Tuple[str, str]]:
             if species == species_key:
                 for gene1 in genes1:
                     gene1_match = gene_pattern.fullmatch(gene1)
-                    if gene1_match:
-                        gene1_bare_id = gene1_match["gene_id"]
+                    gene1_bare_id = gene1_match["gene_id"]  # type: ignore
                     for gene2 in genes2:
                         gene2_match = gene_pattern.fullmatch(gene2)
-                        if gene2_match:
-                            gene2_bare_id = gene2_match["gene_id"]
+                        gene2_bare_id = gene2_match["gene_id"]  # type: ignore
                         paralogs.append((gene1_bare_id, gene2_bare_id))
 
     return paralogs

--- a/scripts/pipeline/orthology_benchmark.py
+++ b/scripts/pipeline/orthology_benchmark.py
@@ -364,12 +364,17 @@ def extract_paralogs(res_dir: str, species_key: str) -> List[Tuple[str, str]]:
             genes1 = row["Genes 1"].split(", ")
             genes2 = row["Genes 2"].split(", ")
 
+            gene_pattern = re.compile(f'{re.escape(species_key)}_(?P<gene_id>.+)')
             if species == species_key:
                 for gene1 in genes1:
+                    gene1_match = gene_pattern.fullmatch(gene1)
+                    if gene1_match:
+                        gene1_bare_id = gene1_match["gene_id"]
                     for gene2 in genes2:
-                        paralogs.append(
-                            (gene1.split(f"{species_key}_")[1], gene2.split(f"{species_key}_")[1])
-                        )
+                        gene2_match = gene_pattern.fullmatch(gene2)
+                        if gene2_match:
+                            gene2_bare_id = gene2_match["gene_id"]
+                        paralogs.append((gene1_bare_id, gene2_bare_id))
 
     return paralogs
 

--- a/src/python/tests/flatfiles/orth_benchmark/OrthoFinder/Results_Mar03/Gene_Duplication_Events/Duplications.tsv
+++ b/src/python/tests/flatfiles/orth_benchmark/OrthoFinder/Results_Mar03/Gene_Duplication_Events/Duplications.tsv
@@ -1,0 +1,3 @@
+Orthogroup	Species Tree Node	Gene Tree Node	Support	Type	Genes 1	Genes 2
+OG0000873	homo_sapiens_core_106_38	n0	1.0	Terminal	homo_sapiens_core_106_38_ENSG00000163565	homo_sapiens_core_106_38_ENSG00000163568
+OG0000790	gallus_gallus_core_106_6	n1	1.0	Terminal	gallus_gallus_core_106_6_ENSGALG00000015336	gallus_gallus_core_106_6_ENSGALG00000004096

--- a/src/python/tests/test_orthology_benchmark.py
+++ b/src/python/tests/test_orthology_benchmark.py
@@ -312,3 +312,14 @@ def test_extract_orthologs() -> None:
     assert orthology_benchmark.extract_orthologs(
         orthofinder_res, "gallus_gallus_core_106_6", "homo_sapiens_core_106_38"
     ) == [("ENSGALG00000030005", "ENSG00000147255")]
+
+
+def test_extract_paralogs() -> None:
+    """Tests :func:`orthology_benchmark.extract_paralogs()` function.
+    """
+    # pylint: disable-next=no-member
+    test_files_dir = pytest.files_dir / "orth_benchmark" # type: ignore[attr-defined]
+    orthofinder_res = test_files_dir  / "OrthoFinder" / "Results_Mar03"
+    assert orthology_benchmark.extract_paralogs(
+        orthofinder_res, "homo_sapiens_core_106_38"
+    ) == [("ENSG00000163565", "ENSG00000163568")]

--- a/travisci/all-housekeeping/tsv.t
+++ b/travisci/all-housekeeping/tsv.t
@@ -37,7 +37,7 @@ my @all_files = Bio::EnsEMBL::Compara::Utils::Test::find_all_files();
 
 foreach my $f (@all_files) {
     if ($f =~ /\.tsv$/) {
-        is_valid_tsv($f);
+        is_valid_tsv($f, '\t');
     } elsif ($f =~ /\.matrix$/) {
         is_valid_tsv($f, ' ');
     }


### PR DESCRIPTION
## Description

In order to calculate GOC scores, it's necessary to have OrthoFinder pairwise paralogs for a species so tandem repeats can be discarded. This function parses OrthoFinder output and returns a list of paralogs for a specified species.

**Related JIRA tickets:**
- ENSCOMPARASW-5308

## Overview of changes
- A new function and corresponding `pytest`.

## Testing
- Corresponding `pytest`
- I also tested the function in the Python interpreter on an existing OrthoFinder output that I have:
```
res_dir = "/hps/nobackup/flicek/ensembl/compara/ivana/test_gtfs_orthofinder/OrthoFinder/Results_Jan17"
species_key = "ivana_gallus_gallus_core_106_6"
paralogs = extract_paralogs(res_dir, species_key)
```
Looks ok.

## Notes
Almost copy-paste of https://github.com/Ensembl/ensembl-compara/pull/405 so it should be easy to review 😉 