### PR TITLE
Record queries to references per release text files

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -91,7 +91,8 @@ sub shared_default_options {
         'genome_dumps_dir'      => $self->o('shared_hps_dir') . '/genome_dumps/'.$self->o('division').'/',
         'ref_member_dumps_dir'  => $self->o('shared_hps_dir') . '/reference_dumps/',
         'sketch_dir'            => $self->o('shared_hps_dir') . '/species_tree/' . $self->o('division') . '_sketches/',
-
+        # Record of the species that have been run with each reference in RR
+        'rr_species_set_record' => $self->o('shared_hps_dir') . '/species_set_record/' . Bio::EnsEMBL::ApiVersion::software_version() . '/',
         # HMM library
         'hmm_library_version'   => '2',
         'hmm_library_basedir'   => $self->o('shared_hps_dir') . '/treefam_hmms/2019-01-02',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
@@ -77,6 +77,8 @@ sub default_options {
         'ref_dump_dir' => $self->o('ref_member_dumps_dir'),
         # Directory for diamond and fasta files for query genome
         'members_dumps_dir' => $self->o('dump_path'),
+        # Directory for species set record of references to query
+        'species_set_record' => $self->o('rr_species_set_record'),
         # Compara schema file path
         'schema_file' => $self->o('schema_file_sql'),
         # Path to db_cmd.pl script
@@ -162,6 +164,7 @@ sub pipeline_create_commands {
         @{$self->SUPER::pipeline_create_commands},  # Here we inherit creation of database, hive tables and compara tables
 
         $self->pipeline_create_commands_rm_mkdir(['work_dir', 'output_dir_path']), # Here we create directories
+        $self->pipeline_create_commands_rm_mkdir(['species_set_record'], undef, 1),
         $self->db_cmd($results_table_sql),
 
     ];

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PerSpeciesCopyFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PerSpeciesCopyFactory.pm
@@ -73,7 +73,18 @@ sub pipeline_analyses_create_and_copy_per_species_db {
                 'skip_dna'   => $self->o('skip_dna'),
             },
             -hive_capacity => 1,
+            -flow_into => {
+                1 => { 'record_species_set' => INPUT_PLUS() },
+            }
         },
+
+        {   -logic_name => 'record_species_set',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::RecordSpeciesSet',
+            -parameters => {
+                'species_set_record' => $self->o('species_set_record'),
+            },
+            -hive_capacity => 1,
+        }
 
     ];
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/RecordSpeciesSet.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/RecordSpeciesSet.pm
@@ -1,0 +1,67 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::RecordSpeciesSet
+
+=head1 DESCRIPTION
+
+Records the query species run for each reference in database species_set
+E.g. standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::RecordSpeciesSet \
+    -compara_db $(mysql-ens-compara-prod-2 details url cristig_blastocyst_106) \
+    -genome_name canis_lupus_familiaris \
+    -species_set_record /hps/nobackup/flicek/ensembl/compara/shared/species_set_record/106/
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::RecordSpeciesSet;
+
+use warnings;
+use strict;
+use Bio::EnsEMBL::Registry;
+use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
+use Data::Dumper;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+sub fetch_input {
+    my $self = shift;
+
+    my @genome_db = @{$self->compara_dba->get_GenomeDBAdaptor->fetch_all_by_name($self->param('genome_name'))};
+    my @species_sets = @{$self->compara_dba->get_SpeciesSetAdaptor->fetch_all_by_GenomeDB($genome_db[0])};
+    my @genome_list;
+    foreach my $ss ( @species_sets ) {
+        my @genomes = map { $_->name } @{ $ss->genome_dbs() };
+        push @genome_list, @genomes;
+    }
+    $self->param('ref_genomes', \@genome_list);
+}
+
+sub write_output {
+    my $self = shift;
+    my $base_dir = $self->param('species_set_record');
+    my @ref_genomes = @{$self->param('ref_genomes')};
+    my $query = $self->param('genome_name');
+    foreach my $ref ( @ref_genomes ) {
+        next if $ref eq $query;
+        my $cmd = "echo '$query' >> $base_dir" . "/$ref.txt";
+        $self->run_command($cmd);
+    }
+}
+
+1;


### PR DESCRIPTION
## Description

Production team needs to know when a species needs to be re-run. The aim of this PR is to address the need when a reference genome is either updated or retired. In this PR the query half is executed to provide a list of query species for each reference genome. See figure.

**Related JIRA tickets:**
- ENSCOMPARASW-5089
- ENSCOMPARASW-5004

## Overview of changes

#### Change 1
- New runnable in Perl - required because of incorporation with Perl API and Compara Schema

## Testing
- Run in two pipelines for two species to ensure it works as one would hope.
- [Test 1](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-9&port=4647&dbname=cristig_blastocyst_1_105)
- [Test 2](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-9&port=4647&dbname=cristig_blastocyst_105)
- File output here:
```
/hps/nobackup/flicek/ensembl/compara/shared/species_set_record/105/
```

## Notes
The reference side (not yet written) will parse the genome specific text file output (by release and genome) upon update or retiring of a reference - concatenate the necessary files, uniquely sort them and pass a list of query species that need to be re-run via email to the production team.

![species_update_method drawio (3)](https://user-images.githubusercontent.com/29229640/162186430-3588e2ec-c318-4bf6-a212-6220fa7284a5.png)


