### PR TITLE
replace agrschema with agrparse and add constraint elements in the json files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -140,7 +140,7 @@ jobs:
       script: ./travisci/perl-linter_harness.sh
 
     - language: python
-      python: 3.7
+      python: 3.7.9
       name: "Python unit tests on the minimum version"
       install:
         - pip install -r requirements.txt -r requirements-test.txt

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -28,11 +28,10 @@ path where they can be found::
     $ python run_gerp.py --msa_file alignment.mfa --tree_file tree.nw --gerp_exe_dir path/to/gerp/
 
 """
-import os
-import subprocess
 import argparse
 import json
-
+import os
+import subprocess
 
 def add_ce_to_json(ce_file: str, json_file: str) -> None:
     """Enrich the json file with the constrained elements.
@@ -42,31 +41,32 @@ def add_ce_to_json(ce_file: str, json_file: str) -> None:
         json_file: json file with genome coordinate level.
 
     """
-    with open(json_file, 'r') as json_file_handler:
-        align_set = json.load(json_file_handler)
+    with open(json_file, 'r') as json_file_obj:
+        align_set = json.load(json_file_obj)
 
-    with open(ce_file) as ce_file_handler:
-        constrained_elements = [ce.split() for ce in ce_file_handler if ce.rstrip() != ""]
-
-    # enrich json file with constrained elements info
     constrained_elems = []
-    for ce in constrained_elements:
-        constrained_elem = {
-            "start": int(ce[0]),
-            "end": int(ce[1]),
-            "length": int(ce[2]),
-            "score": float(ce[3]),
-            "p-val": float(ce[4])
-        }
-        constrained_elems.append(constrained_elem)
-    align_set["constraint_elems"] = constrained_elems
+    with open(ce_file) as ce_file_obj:
+        # enrich json file with constrained elements info
+        for cons_elem in ce_file_obj:
+            if cons_elem.rstrip() == "":
+                continue
+            ce = cons_elem.split()
+            constrained_elem = {
+                "start": int(ce[0]),
+                "end": int(ce[1]),
+                "length": int(ce[2]),
+                "score": float(ce[3]),
+                "p-val": float(ce[4])
+            }
+            constrained_elems.append(constrained_elem)
+    align_set["constrained_elems"] = constrained_elems
 
-    with open(json_file, 'w') as json_file_handler:
-        json.dump(align_set, json_file_handler)
+    with open(json_file, 'w') as json_file_obj:
+        json.dump(align_set, json_file_obj)
 
 
 def main(param: argparse.Namespace) -> None:
-    ''' Main function of the run_gerp.py script
+    """ Main function of the run_gerp.py script
 
     This function is running gerpcol that define a gerpscore for every column of the genomic alignment bloc
     and gerpelem that identify constrained elements across the alignment bloc
@@ -74,9 +74,7 @@ def main(param: argparse.Namespace) -> None:
     Args:
         param: argparse.Namespace storing all the script parameters
 
-    Returns:
-        None
-    '''
+    """
 
     cmd = ["gerpcol", "-t", param.tree_file, "-f", param.msa_file]
     cmd[0] = os.path.join(param.gerp_exe_dir, cmd[0])
@@ -88,7 +86,7 @@ def main(param: argparse.Namespace) -> None:
     cmd += ["-d", str(param.depth_threshold)]
     subprocess.run(cmd, check=True)
 
-    add_ce_to_json(f"{param.msa_file}.rates.elems", param.msa_file.replace(".fa", ".json"))
+    add_ce_to_json(f"{param.msa_file}.rates.elems", f"{os.path.splitext(param.msa_file)[0]}.json")
 
 
 if __name__ == "__main__":

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -35,12 +35,15 @@ import json
 
 
 def add_ce_to_json(ce_file: str, json_file: str) -> None:
-    '''Enrich the json file with the constraint elements
+    """Enrich the json file with the constraint elements
 
-    :param ce_file: file containing the constraint elements
-    :param json_file: json file with genome coordinate elevel
-    :return: None
-    '''
+    Args:
+        ce_file: file containing the constraint elements.
+        json_file: json file with genome coordinate level.
+
+    Returns:
+        None
+    """
     with open(json_file, 'r') as json_file_handler:
         align_set = json.load(json_file_handler)
 
@@ -69,8 +72,11 @@ def main(param: argparse.Namespace) -> None:
     This function is running gerpcol that define a gerpscore for every column of the genomic alignment bloc
     and gerpelem that identify constraint elements across the alignment bloc
 
-    :param param: argparse.Namespace storing all the script parameters
-    :return: None
+    Args:
+        param: argparse.Namespace storing all the script parameters
+
+    Returns:
+        None
     '''
 
     cmd = ["gerpcol", "-t", param.tree_file, "-f", param.msa_file]
@@ -88,7 +94,7 @@ def main(param: argparse.Namespace) -> None:
 
 if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser(description='Process some integers.')
+    parser = argparse.ArgumentParser(description='Calculate GERP score and identify constraint elements.')
     parser.add_argument('--msa_file', type=str, required=True, help='MSA file (MFA format) (REQUIRED)')
     parser.add_argument('--tree_file', type=str, required=True, help='Tree file (Newick format). Must '
                                                 'include every species in the MSA. (REQUIRED)')

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -97,10 +97,10 @@ if __name__ == "__main__":
                                                 "include every species in the MSA. (REQUIRED)")
     parser.add_argument("--depth_threshold", default=0.5, type=float, help="Constrained elements depth "
                                                 "threshold for shallow columns, in substitutions per site. "
-                                                "By default, 0.5.")
+                                                "The default is 0.5.")
     parser.add_argument("--gerp_exe_dir", default="", type=str,
-                        help="Path where 'gerpcol' and 'gerpelem' binaries can be found."
-                             " By default, these are assumed to be accessible from the $PATH.")
+                        help="Path where 'gerpcol' and 'gerpelem' executable binaries can be found."
+                             " The default is $PATH.")
 
     args = parser.parse_args()
     main(args)

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -35,7 +35,7 @@ import json
 
 
 def add_ce_to_json(ce_file: str, json_file: str) -> None:
-    """Enrich the json file with the constrained elements
+    """Enrich the json file with the constrained elements.
 
     Args:
         ce_file: file containing the constrained elements.

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -22,7 +22,7 @@ Typical usage example::
 
     $ python run_gerp.py --msa_file alignment.mfa --tree_file tree.nw
 
-If ``gerpcol`` and/or ``gerpelem`` are not accesible from ``$PATH``, you will need to provide the
+If ``gerpcol`` and/or ``gerpelem`` are not accessible from ``$PATH``, you will need to provide the
 path where they can be found::
 
     $ python run_gerp.py --msa_file alignment.mfa --tree_file tree.nw --gerp_exe_dir path/to/gerp/
@@ -37,7 +37,7 @@ def add_ce_to_json(ce_file: str, json_file: str) -> None:
     """Enrich the json file with the constrained elements.
 
     Args:
-        ce_file: file containing the constrained elements (csv format).
+        ce_file: file containing the constrained elements (space-delimited format).
         json_file: json file with genome coordinate level.
 
     """

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -42,7 +42,7 @@ def add_ce_to_json(ce_file: str, json_file: str) -> None:
         json_file: json file with genome coordinate level.
 
     """
-    with open(json_file, 'r') as json_file_obj:
+    with open(json_file, "r") as json_file_obj:
         align_set = json.load(json_file_obj)
 
     constrained_elems = []

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -41,8 +41,6 @@ def add_ce_to_json(ce_file: str, json_file: str) -> None:
         ce_file: file containing the constrained elements.
         json_file: json file with genome coordinate level.
 
-    Returns:
-        None
     """
     with open(json_file, 'r') as json_file_handler:
         align_set = json.load(json_file_handler)

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -67,7 +67,7 @@ def add_ce_to_json(ce_file: str, json_file: str) -> None:
 
 
 def main(param: argparse.Namespace) -> None:
-    """ Main function of the run_gerp.py script
+    """Main function of the run_gerp.py script
 
     This function runs gerpcol to define a GERP score for every column of the genomic alignment block
     and gerpelem to identify constrained elements across the genomic alignment block.

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -98,8 +98,9 @@ if __name__ == "__main__":
     parser.add_argument("--depth_threshold", default=0.5, type=float, help="Constrained elements depth "
                                                 "threshold for shallow columns, in substitutions per site. "
                                                 "By default, 0.5.")
-    parser.add_argument("--gerp_exe_dir", default="", type=str, help="Path where 'gerpcol' and 'gerpelem' "
-                                                "binaries can be found. By default, resort to $PATH.")
+    parser.add_argument("--gerp_exe_dir", default="", type=str,
+                        help="Path where 'gerpcol' and 'gerpelem' binaries can be found."
+                             " By default, these are assumed to be accessible from the $PATH.")
 
     args = parser.parse_args()
     main(args)

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -51,12 +51,13 @@ def add_ce_to_json(ce_file: str, json_file: str) -> None:
     # enrich json file with constrained elements info
     constrained_elems = []
     for ce in constrained_elements:
-        constrained_elem = {}
-        constrained_elem["start"] = ce[0]
-        constrained_elem["end"] = ce[1]
-        constrained_elem["length"] = ce[2]
-        constrained_elem["score"] = ce[3]
-        constrained_elem["p-val"] = ce[4]
+        constrained_elem = {
+            "start": int(ce[0]),
+            "end": int(ce[1]),
+            "length": int(ce[2]),
+            "score": float(ce[3]),
+            "p-val": float(ce[4])
+        }
         constrained_elems.append(constrained_elem)
     align_set["constraint_elems"] = constrained_elems
 

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -37,7 +37,7 @@ def add_ce_to_json(ce_file: str, json_file: str) -> None:
     """Enrich the json file with the constrained elements.
 
     Args:
-        ce_file: file containing the constrained elements.
+        ce_file: file containing the constrained elements (csv format).
         json_file: json file with genome coordinate level.
 
     """
@@ -68,8 +68,8 @@ def add_ce_to_json(ce_file: str, json_file: str) -> None:
 def main(param: argparse.Namespace) -> None:
     """ Main function of the run_gerp.py script
 
-    This function is running gerpcol that define a gerpscore for every column of the genomic alignment bloc
-    and gerpelem that identify constrained elements across the alignment bloc
+    This function runs gerpcol to define a GERP score for every column of the genomic alignment block
+    and gerpelem to identify constrained elements across the genomic alignment block.
 
     Args:
         param: argparse.Namespace storing all the script parameters
@@ -91,15 +91,15 @@ def main(param: argparse.Namespace) -> None:
 
 if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser(description='Calculate GERP score and identify constraint elements.')
-    parser.add_argument('--msa_file', type=str, required=True, help='MSA file (MFA format) (REQUIRED)')
-    parser.add_argument('--tree_file', type=str, required=True, help='Tree file (Newick format). Must '
-                                                'include every species in the MSA. (REQUIRED)')
-    parser.add_argument('--depth_threshold', default=0.5, type=float, help='Constrained elements depth '
-                                                'threshold for shallow columns, in substitutions per site. '
-                                                'By default, 0.5.')
-    parser.add_argument('--gerp_exe_dir', default="", type=str, help='Path where "gerpcol" and "gerpelem" '
-                                                'binaries can be found. By default, resort to $PATH.')
+    parser = argparse.ArgumentParser(description="Calculate GERP score and identify constrained elements.")
+    parser.add_argument("--msa_file", type=str, required=True, help="MSA file (MFA format) (REQUIRED)")
+    parser.add_argument("--tree_file", type=str, required=True, help="Tree file (Newick format). Must "
+                                                "include every species in the MSA. (REQUIRED)")
+    parser.add_argument("--depth_threshold", default=0.5, type=float, help="Constrained elements depth "
+                                                "threshold for shallow columns, in substitutions per site. "
+                                                "By default, 0.5.")
+    parser.add_argument("--gerp_exe_dir", default="", type=str, help="Path where 'gerpcol' and 'gerpelem' "
+                                                "binaries can be found. By default, resort to $PATH.")
 
     args = parser.parse_args()
     main(args)

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -28,45 +28,75 @@ path where they can be found::
     $ python run_gerp.py --msa_file alignment.mfa --tree_file tree.nw --gerp_exe_dir path/to/gerp/
 
 """
-
 import os
 import subprocess
-
-import argschema
-
-
-class InputSchema(argschema.ArgSchema):
-    """Calculates the Genomic Evolutionary Rate Profiling (GERP) of a multiple sequence alignment (MSA)."""
-
-    msa_file = argschema.fields.InputFile(
-        required=True, description="MSA file (MFA format)"
-    )
-    tree_file = argschema.fields.InputFile(
-        required=True, description="Tree file (Newick format). Must include every species in the MSA."
-    )
-    depth_threshold = argschema.fields.Float(
-        required=False,
-        description="Constrained elements' depth threshold for shallow columns, in substitutions "
-                    "per site. By default, 0.5."
-    )
-    gerp_exe_dir = argschema.fields.InputDir(
-        required=False,
-        description="Path where 'gerpcol' and 'gerpelem' binaries can be found. By default, resort to $PATH."
-    )
+import argparse
+import json
 
 
-if __name__ == "__main__":
-    mod = argschema.ArgSchemaParser(schema_type=InputSchema)
+def add_ce_to_json(ce_file: str, json_file: str) -> None:
+    '''Enrich the json file with the constraint elements
 
-    cmd = ["gerpcol", "-t", mod.args["tree_file"], "-f", mod.args["msa_file"]]
-    if "gerp_exe_dir" in mod.args:
-        cmd[0] = os.path.join(mod.args['gerp_exe_dir'], cmd[0])
+    :param ce_file: file containing the constraint elements
+    :param json_file: json file with genome coordinate elevel
+    :return: None
+    '''
+    with open(json_file, 'r') as json_file_handler:
+        align_set = json.load(json_file_handler)
+
+    with open(ce_file) as ce_file_handler:
+        constraint_elements = [ce.split() for ce in ce_file_handler if ce.rstrip() != ""]
+
+    # enrich json file with constraint elements info
+    constraint_elems = []
+    for ce in constraint_elements:
+        constraint_elem = {}
+        constraint_elem["start"] = int(ce[0])
+        constraint_elem["end"] = int(ce[1])
+        constraint_elem["length"] = int(ce[2])
+        constraint_elem["score"] = ce[3]
+        constraint_elem["p-val"] = ce[4]
+        constraint_elems.append(constraint_elem)
+    align_set["constraint_elems"] = constraint_elems
+
+    with open(json_file, 'w') as json_file_handler:
+        json.dump(align_set, json_file_handler)
+
+
+def main(param: argparse.Namespace) -> None:
+    ''' Main function of the run_gerp.py script
+
+    This function is running gerpcol that define a gerpscore for every column of the genomic alignment bloc
+    and gerpelem that identify constraint elements across the alignment bloc
+
+    :param param: argparse.Namespace storing all the script parameters
+    :return: None
+    '''
+
+    cmd = ["gerpcol", "-t", param.tree_file, "-f", param.msa_file]
+    cmd[0] = os.path.join(param.gerp_exe_dir, cmd[0])
     subprocess.run(cmd, check=True)
 
     # By default, gerpcol's ouput filename has the MSA filename plus ".rates" suffix
-    cmd = ["gerpelem", "-f", f"{mod.args['msa_file']}.rates"]
-    if "gerp_exe_dir" in mod.args:
-        cmd[0] = os.path.join(mod.args['gerp_exe_dir'], cmd[0])
-    if "depth_threshold" in mod.args:
-        cmd += ["-d", str(mod.args["depth_threshold"])]
+    cmd = ["gerpelem", "-f", f"{param.msa_file}.rates"]
+    cmd[0] = os.path.join(param.gerp_exe_dir, cmd[0])
+    cmd += ["-d", str(param.depth_threshold)]
     subprocess.run(cmd, check=True)
+
+    add_ce_to_json(f"{param.msa_file}.rates.elems", param.msa_file.replace(".fa", ".json"))
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Process some integers.')
+    parser.add_argument('--msa_file', type=str, required=True, help='MSA file (MFA format) (REQUIRED)')
+    parser.add_argument('--tree_file', type=str, required=True, help='Tree file (Newick format). Must '
+                                                'include every species in the MSA. (REQUIRED)')
+    parser.add_argument('--depth_threshold', default=0.5, type=float, help='Constrained elements depth '
+                                                'threshold for shallow columns, in substitutions per site. '
+                                                'By default, 0.5.')
+    parser.add_argument('--gerp_exe_dir', default="", type=str, help='Path where "gerpcol" and "gerpelem" '
+                                                'binaries can be found. By default, resort to $PATH.')
+
+    args = parser.parse_args()
+    main(args)

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -33,6 +33,7 @@ import json
 import os
 import subprocess
 
+
 def add_ce_to_json(ce_file: str, json_file: str) -> None:
     """Enrich the json file with the constrained elements.
 

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -62,7 +62,7 @@ def add_ce_to_json(ce_file: str, json_file: str) -> None:
             constrained_elems.append(constrained_elem)
     align_set["constrained_elems"] = constrained_elems
 
-    with open(json_file, 'w') as json_file_obj:
+    with open(json_file, "w") as json_file_obj:
         json.dump(align_set, json_file_obj)
 
 

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -35,10 +35,10 @@ import json
 
 
 def add_ce_to_json(ce_file: str, json_file: str) -> None:
-    """Enrich the json file with the constraint elements
+    """Enrich the json file with the constrained elements
 
     Args:
-        ce_file: file containing the constraint elements.
+        ce_file: file containing the constrained elements.
         json_file: json file with genome coordinate level.
 
     Returns:
@@ -48,19 +48,19 @@ def add_ce_to_json(ce_file: str, json_file: str) -> None:
         align_set = json.load(json_file_handler)
 
     with open(ce_file) as ce_file_handler:
-        constraint_elements = [ce.split() for ce in ce_file_handler if ce.rstrip() != ""]
+        constrained_elements = [ce.split() for ce in ce_file_handler if ce.rstrip() != ""]
 
-    # enrich json file with constraint elements info
-    constraint_elems = []
-    for ce in constraint_elements:
-        constraint_elem = {}
-        constraint_elem["start"] = int(ce[0])
-        constraint_elem["end"] = int(ce[1])
-        constraint_elem["length"] = int(ce[2])
-        constraint_elem["score"] = ce[3]
-        constraint_elem["p-val"] = ce[4]
-        constraint_elems.append(constraint_elem)
-    align_set["constraint_elems"] = constraint_elems
+    # enrich json file with constrained elements info
+    constrained_elems = []
+    for ce in constrained_elements:
+        constrained_elem = {}
+        constrained_elem["start"] = ce[0]
+        constrained_elem["end"] = ce[1]
+        constrained_elem["length"] = ce[2]
+        constrained_elem["score"] = ce[3]
+        constrained_elem["p-val"] = ce[4]
+        constrained_elems.append(constrained_elem)
+    align_set["constraint_elems"] = constrained_elems
 
     with open(json_file, 'w') as json_file_handler:
         json.dump(align_set, json_file_handler)
@@ -70,7 +70,7 @@ def main(param: argparse.Namespace) -> None:
     ''' Main function of the run_gerp.py script
 
     This function is running gerpcol that define a gerpscore for every column of the genomic alignment bloc
-    and gerpelem that identify constraint elements across the alignment bloc
+    and gerpelem that identify constrained elements across the alignment bloc
 
     Args:
         param: argparse.Namespace storing all the script parameters

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -73,7 +73,7 @@ def dir_cmp(request: FixtureRequest, tmp_dir: PathLike) -> DirCmp:
     ref_src = ref if ref.is_absolute() else pytest.files_dir / ref  # type: ignore[attr-defined,operator]
     ref_tmp = Path(tmp_dir) / str(ref).replace(os.path.sep, '_')
     target = Path(request.param['target'])  # type: ignore[attr-defined]
-    target_src = target if target.is_absolute() else pytest.files_dir / target  # type: ignore[attr-defined]
+    target_src = target if target.is_absolute() else pytest.files_dir / target  # type: ignore[attr-defined,operator]
     target_tmp = Path(tmp_dir) / str(target).replace(os.path.sep, '_')
     # Copy directory trees (if they have not been copied already) ignoring file metadata
     if not ref_tmp.exists():

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -70,7 +70,7 @@ def dir_cmp(request: FixtureRequest, tmp_dir: PathLike) -> DirCmp:
     """
     # Get the source and temporary absolute paths for reference and target root directories
     ref = Path(request.param['ref'])  # type: ignore[attr-defined]
-    ref_src = ref if ref.is_absolute() else pytest.files_dir / ref  # type: ignore[attr-defined]
+    ref_src = ref if ref.is_absolute() else pytest.files_dir / ref  # type: ignore[attr-defined,operator]
     ref_tmp = Path(tmp_dir) / str(ref).replace(os.path.sep, '_')
     target = Path(request.param['target'])  # type: ignore[attr-defined]
     target_src = target if target.is_absolute() else pytest.files_dir / target  # type: ignore[attr-defined]

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -73,7 +73,7 @@ def dir_cmp(request: FixtureRequest, tmp_dir: PathLike) -> DirCmp:
     ref_src = ref if ref.is_absolute() else pytest.files_dir / ref  # type: ignore[attr-defined,operator]
     ref_tmp = Path(tmp_dir) / str(ref).replace(os.path.sep, '_')
     target = Path(request.param['target'])  # type: ignore[attr-defined]
-    target_src = target if target.is_absolute() else pytest.files_dir / target  # type: ignore[attr-defined,operator]
+    target_src = target if target.is_absolute() else pytest.files_dir / target  # type: ignore[operator]
     target_tmp = Path(tmp_dir) / str(target).replace(os.path.sep, '_')
     # Copy directory trees (if they have not been copied already) ignoring file metadata
     if not ref_tmp.exists():

--- a/src/python/tests/test_hal_gene_liftover.py
+++ b/src/python/tests/test_hal_gene_liftover.py
@@ -88,7 +88,7 @@ class TestHalGeneLiftover:
     def setup(self) -> None:
         """Loads necessary fixtures and values as class attributes."""
         # pylint: disable-next=no-member
-        type(self).ref_file_dir = pytest.files_dir / 'hal_alignment'  # type: ignore[attr-defined]
+        type(self).ref_file_dir = pytest.files_dir / 'hal_alignment' # type: ignore[attr-defined,operator]
 
     @pytest.mark.parametrize(
         "region, exp_output, expectation",


### PR DESCRIPTION
src/python/scripts/run_gerp.py

## Description
The constraint elements identified by gerpelem have coordinates based on the genomic alignment bloc. To simplified the coordinate transformation required in the next step of the pipeline (concatenation of constraint element for each species) we want to have these constraint elements into the json file describing the start and end of the genomic alignment bloc for each species. the goal of this developemnt is to add a new attribute constraint elements in the json file which will contained the constraints elements.

**Related JIRA tickets:**
- ENSCOMPARASW-5353

## Overview of changes
We had two different changes in this developemnt. First one is switching argument passing system from argschema to argpars. This was not in the jira ticket by argshema was not adapted int this script as discussed with some team members. The second change aims to add the constraint element into the json file

#### Change 1
-  switching argshema to argparse and wrapping the main code of the script into a main fucntion that get as a parameter the argparse.Namespace

#### Change 2
- creation of a function which aim to add the conserved element of a genomic alignment bloc to its corresponding json file and in a attribut called : constraint_elems

## Testing
I tested by using a constraint element file with one and two and 0 constraint elements.
pass pylint with a score of 100%

## Notes
_Optional extra information._
