### PR TITLE
Integrate DCs into protein trees pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DatachecksForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DatachecksForRelease_conf.pm
@@ -63,6 +63,8 @@ sub default_options {
         failures_fatal         => 0,
         parallelize_datachecks => 1,
 
+        do_jira_ticket_creation => 1,
+
         meta_filters  => {},
         tag           => undef,
         timestamp     => undef,

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DataCheckFan.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DataCheckFan.pm
@@ -46,7 +46,9 @@ sub pipeline_analyses_datacheck_fan {
             -flow_into         => {
                 '1'  => [ '?accu_name=results&accu_address=[]' ],
                 '-1' => [ 'datacheck_fan_high_mem' ],
-                '2'  => [ 'jira_ticket_creation' ],
+                '2'  => [
+                    WHEN( '#do_jira_ticket_creation#' => 'jira_ticket_creation' )
+                ],
             },
         },
 
@@ -58,7 +60,9 @@ sub pipeline_analyses_datacheck_fan {
             -rc_name           => '8Gb_job',
             -flow_into         => {
                 '1' => [ '?accu_name=results&accu_address=[]' ],
-                '2' => [ 'jira_ticket_creation' ],
+                '2' => [
+                    WHEN( '#do_jira_ticket_creation#' => 'jira_ticket_creation' )
+                ],
             },
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/CultivarsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/CultivarsProteinTrees_conf.pm
@@ -116,6 +116,10 @@ sub tweak_analyses {
     $analyses_by_name->{'expand_clusters_with_projections'}->{'-rc_name'} = '500Mb_job';
     $analyses_by_name->{'split_genes'}->{'-hive_capacity'} = 300;
 
+    # datacheck specific tweaks for pipelines
+    $analyses_by_name->{'datacheck_factory'}->{'-parameters'} = {'dba' => '#compara_db#'};
+    $analyses_by_name->{'store_results'}->{'-parameters'} = {'dbname' => '#db_name#'};
+
     # Wire up cultivar-specific analyses
     $analyses_by_name->{'remove_blacklisted_genes'}->{'-flow_into'} = ['check_strains_cluster_factory'];
     push @{$analyses_by_name->{'backbone_pipeline_finished'}->{'-flow_into'}}, 'remove_overlapping_homologies';

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -47,6 +47,7 @@ use Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneMemberHomologyStats;
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpHomologiesForPosttree;
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::OrthologQMAlignment;
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::HighConfidenceOrthologs;
+use Bio::EnsEMBL::Compara::PipeConfig::Parts::DataCheckFactory;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
 
@@ -363,6 +364,14 @@ sub default_options {
 
         # Gene tree stats options
         'gene_tree_stats_shared_dir' => $self->o('gene_tree_stats_shared_basedir') . '/' . $self->o('collection') . '/' . $self->o('ensembl_release'),
+
+        # Whole db DC parameters
+        'datacheck_groups' => ['compara_gene_tree_pipelines'],
+        'db_type'          => ['compara'],
+        'output_dir_path'  => $self->o('work_dir') . '/datachecks/',
+        'overwrite_files'  => 1,
+        'failures_fatal'   => 1, # no DC failure tolerance
+        'db_name'          => $self->o('dbowner') . '_' . $self->o('pipeline_name'),
     };
 }
 
@@ -405,10 +414,11 @@ sub pipeline_checks_pre_init {
 
 sub pipeline_create_commands {
     my ($self) = @_;
+
     return [
         @{$self->SUPER::pipeline_create_commands},  # here we inherit creation of database, hive tables and compara tables
 
-        $self->pipeline_create_commands_rm_mkdir(['work_dir', 'cluster_dir', 'dump_dir', 'gene_dumps_dir', 'dump_pafs_dir', 'examl_dir', 'tmp_dir', 'fasta_dir', 'plots_dir']),
+        $self->pipeline_create_commands_rm_mkdir(['work_dir', 'cluster_dir', 'dump_dir', 'gene_dumps_dir', 'dump_pafs_dir', 'examl_dir', 'tmp_dir', 'fasta_dir', 'plots_dir', 'output_dir_path']),
         $self->pipeline_create_commands_rm_mkdir(['gene_tree_stats_shared_dir'], undef, 'do not rm'),
 
         $self->db_cmd( 'CREATE TABLE ortholog_quality (
@@ -421,6 +431,14 @@ sub pipeline_create_commands {
             exon_length              INT NOT NULL,
             intron_length            INT NOT NULL,
             INDEX (homology_id)
+        )'),
+        $self->db_cmd( 'CREATE TABLE datacheck_results (
+            submission_job_id INT,
+            dbname VARCHAR(255) NOT NULL,
+            passed INT,
+            failed INT,
+            skipped INT,
+            INDEX submission_job_id_idx (submission_job_id)
         )'),
     ];
 }
@@ -470,6 +488,8 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'wga_file'           => '#wga_files_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.wga.tsv',
         'previous_wga_file'  => defined $self->o('prev_wga_dumps_dir') ? '#prev_wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv' : undef,
         'high_conf_file'     => '#homology_dumps_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.high_conf.tsv',
+
+        'output_dir_path'    => $self->o('output_dir_path'),
 
         'clustering_mode'   => $self->o('clustering_mode'),
         'reuse_level'       => $self->o('reuse_level'),
@@ -1707,8 +1727,28 @@ sub core_pipeline_analyses {
             -flow_into  => [
                     WHEN('#do_stable_id_mapping#' => 'stable_id_mapping'),
                     WHEN('#do_treefam_xref#' => 'treefam_xref_idmap'),
+                    { 'datacheck_trees' => { 'db_type' => $self->o('db_type'), 'compara_db' => '#ref_db#', 'registry_file' => undef, 'datacheck_names' => ['CheckFlatProteinTrees'] } },
                 ],
             %hc_analysis_params,
+        },
+
+        {
+            -logic_name        => 'datacheck_trees',
+            -module            => 'Bio::EnsEMBL::Compara::RunnableDB::DataCheckFan',
+            -analysis_capacity => 100,
+            -max_retry_count   => 0,
+            -rc_name           => '500Mb_job',
+            -flow_into         => {
+                '-1' => [ 'datacheck_trees_high_mem' ],
+            },
+        },
+
+        {
+            -logic_name        => 'datacheck_trees_high_mem',
+            -module            => 'Bio::EnsEMBL::Compara::RunnableDB::DataCheckFan',
+            -analysis_capacity => 100,
+            -max_retry_count   => 0,
+            -rc_name           => '8Gb_job',
         },
 
         {   -logic_name    => 'compute_jaccard_index',
@@ -3475,7 +3515,10 @@ sub core_pipeline_analyses {
         {   -logic_name    => 'compute_statistics',
             -module        => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::ComputeStatistics',
             -rc_name       => '500Mb_job',
-            -flow_into     => 'write_stn_tags',
+            -flow_into     => {
+                '1->A'  => [ 'write_stn_tags' ],
+                'A->1'  => { 'datacheck_factory' => { 'datacheck_groups' => $self->o('datacheck_groups'), 'db_type' => $self->o('db_type'), 'compara_db' => $self->pipeline_url(), 'registry_file' => undef } },
+            },
         },
 
         {   -logic_name     => 'write_stn_tags',
@@ -3744,7 +3787,17 @@ sub core_pipeline_analyses {
             @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpHomologiesForPosttree::pipeline_analyses_split_homologies_posttree($self) },
             @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::OrthologQMAlignment::pipeline_analyses_ortholog_qm_alignment($self)  },
             @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::HighConfidenceOrthologs::pipeline_analyses_high_confidence($self) },
+            @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::DataCheckFactory::pipeline_analyses_datacheck_factory($self) },
     ];
+}
+
+sub tweak_analyses {
+    my $self = shift;
+    my $analyses_by_name = shift;
+
+    # datacheck specific tweaks for pipelines
+    $analyses_by_name->{'datacheck_factory'}->{'-parameters'} = {'dba' => '#compara_db#'};
+    $analyses_by_name->{'store_results'}->{'-parameters'} = {'dbname' => '#db_name#'};
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
@@ -122,6 +122,10 @@ sub tweak_analyses {
     $analyses_by_name->{'expand_clusters_with_projections'}->{'-rc_name'} = '500Mb_job';
     $analyses_by_name->{'split_genes'}->{'-hive_capacity'} = 300;
 
+    # datacheck specific tweaks for pipelines
+    $analyses_by_name->{'datacheck_factory'}->{'-parameters'} = {'dba' => '#compara_db#'};
+    $analyses_by_name->{'store_results'}->{'-parameters'} = {'dbname' => '#db_name#'};
+
     # wire up strain-specific analyses
     $analyses_by_name->{'remove_blacklisted_genes'}->{'-flow_into'} = ['check_strains_cluster_factory'];
     push @{$analyses_by_name->{'backbone_pipeline_finished'}->{'-flow_into'}}, 'remove_overlapping_homologies';


### PR DESCRIPTION
## Description

See https://github.com/Ensembl/ensembl-datacheck/pull/470
- [ENSCOMPARASW-3961](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-3961)

**Related JIRA tickets:**
- ENSCOMPARASW-5362
- ENSCOMPARASW-3820

## Overview of changes

#### Change 1
- Changed `jira_ticket_creation` into a conditional so that it can be switched on and off and does not need to be a "tweak" - should be cleaner to incorporate into pipelines now

#### Change 2
- Added individual datacheck analyses for the `CheckFlatProteinTrees` - so that these are globally checked before proceeding to homology analyses
- Added `Datacheck` `Parts` pipelines to end of protein trees pipelines to run new `compara_gene_tree_pipelines` `group`

## Testing

Tested initialisation and run on strains protein trees pipeline [here](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-9&port=4647&dbname=cristig_pig_breeds_vertebrates_protein_trees_107) - pan all the way to the left for the individual mid-pipeline datacheck, look for red "failed" analysis to see final DC checks working as they should
Tested on initialisation of default protein trees pipeline [here](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-9&port=4647&dbname=cristig_default_tree_test)