### PR TITLE
Creation of cigar manipulating functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -140,7 +140,7 @@ jobs:
       script: ./travisci/perl-linter_harness.sh
 
     - language: python
-      python: 3.7
+      python: 3.7.9
       name: "Python unit tests on the minimum version"
       install:
         - pip install -r requirements.txt -r requirements-test.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -169,4 +169,6 @@ jobs:
         - pip install pylint mypy
         - pip install -r requirements.txt
         - pip install .
+        - pylint --version
+        - mypy --version
       script: ./travisci/python-linter_harness.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ source = ["src/python/lib"]
 [tool.mypy]
 ignore_missing_imports = true
 warn_unused_configs = true
+show_error_codes = true
 
 [tool.pylint.messages_control]
 max-line-length = 110

--- a/src/python/lib/ensembl/compara/utils/__init__.py
+++ b/src/python/lib/ensembl/compara/utils/__init__.py
@@ -15,3 +15,4 @@
 """Utils module."""
 
 from .tools import *
+from .cigar import *

--- a/src/python/lib/ensembl/compara/utils/cigar.py
+++ b/src/python/lib/ensembl/compara/utils/cigar.py
@@ -73,14 +73,14 @@ def aligned_seq_to_cigar(aligned_seq:str) -> str:
     return cigar
 
 
-def get_cigar_array(cigar:str) -> List[Tuple]:
+def get_cigar_array(cigar:str) -> List[Tuple[int, str]]:
     """Return an array of the cigar line, e.g.: [(34, 'M'), (12, 'D'), ( 5, 'M') ...]
 
     Params:
         cigar: cigar line of the aligned sequence (str)
 
     Returns:
-        cigar array (list<tuple>)
+        cigar array (List[Tuple[int, str]])
     Raises:
         ValueError :  if cigar line incorrect
     """

--- a/src/python/lib/ensembl/compara/utils/cigar.py
+++ b/src/python/lib/ensembl/compara/utils/cigar.py
@@ -1,0 +1,145 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Collection of utils methods targeted to cigar line manipulation.
+
+Typical usage examples::
+
+
+"""
+
+__all__ = ['aligned_seq_to_cigar', 'alignment_to_seq_coordinate', 'get_cigar_array']
+
+from typing import List
+
+def aligned_seq_to_cigar(aligned_seq:str) -> str:
+    """ Convert an aligned_seq to its cigar line
+
+    Params:
+        aligned_seq: the aligned sequence (str)
+
+    Returns:
+         cigar line (str)
+    """
+    cigar = ""
+    matches = 0
+    gaps = 0
+    for nt in aligned_seq:
+        if nt == "-" and matches == 0:
+            gaps = gaps + 1
+        elif nt == "-" and matches == 1:
+            cigar = f"{cigar}M"
+            matches = 0
+            gaps = gaps + 1
+        elif nt == "-" and matches > 1: # matches > 1
+            cigar = f"{cigar}M{matches}"
+            matches = 0
+            gaps = gaps + 1
+        elif nt != "-" and gaps == 0:
+            matches = matches + 1
+        elif nt != "-" and gaps == 1:
+            cigar = f"{cigar}D"
+            gaps = 0
+            matches = matches + 1
+        elif nt != "-" and gaps > 1:
+            cigar = f"{cigar}D{gaps}"
+            gaps = 0
+            matches = matches + 1
+
+    ## process the remaining gap/matched after the loop
+    if gaps != 0 and gaps == 1:
+        cigar = f"{cigar}D"
+    elif gaps != 0 and gaps > 1:
+        cigar = f"{cigar}D{gaps}"
+    elif matches != 0 and matches == 1:
+        cigar = f"{cigar}M"
+    elif matches != 0 and matches > 1:
+        cigar = f"{cigar}M{matches}"
+
+    return cigar
+
+
+def get_cigar_array(cigar:str) -> List:
+    """Return an array of the cigar line, e.g.: [('M', 34), ('D', 12), ('M', 5) ...]
+
+    Params:
+        cigar: cigar line of the aligned sequence (str)
+
+    Returns:
+        cigar array (list<tuple>)
+    """
+    number = ""
+    result = []
+    symbol = ""
+    for c in cigar:
+        if not c.isdigit():
+            if symbol == "" and number == "":
+                symbol = c
+            elif symbol != "" and number == "": # new symbol precede by a different symbol then leght is 1
+                result.append((symbol, 1))
+                symbol = c
+            elif symbol != "" and number != "":
+                result.append((symbol, int(number)))
+                number = ""
+                symbol = c
+        else:  # in this case chr.isdigit():
+            number = number + c
+    if number != "":
+        result.append((symbol, int(number)))
+    return result
+
+
+def alignment_to_seq_coordinate(cigar: str, coord: int) -> int:
+    '''Covert coordinate from the alignment level to sequence level
+
+    Params:
+        cigar: cigar line of the aligned sequence (str)
+        coord: coordinate at the alignment level (int)
+
+    Returns:
+        coordinate at the unaligned sequence level (int)
+
+    Raises:
+        ValueError :  if coord is  <= 0 and if coord > alignment length
+    '''
+
+    if coord < 1:
+        raise ValueError(f"coord need to be > 0 : current value {coord}")
+
+    cigar_array =  get_cigar_array(cigar)
+    seq_level_coord = coord
+    align_index = 0
+    for cigar_elem in cigar_array:
+        align_index = align_index + cigar_elem[1]
+        if cigar_elem[0] == "M":
+            if coord <= align_index:
+                # in this case coord is included in the M cigar_elem
+                # so seq_level_coord  has been trim from all the gap and has now the correct coordinate
+                break
+        elif cigar_elem[0] == "D":
+            if coord <= align_index:
+                # in this case coord is included in the D cigar_elem
+                # so we need to trim only a few gaps from seq_level_coord  to have the correct coordinate
+                start_gap = align_index - cigar_elem[1]
+                gap_to_remove = coord - start_gap
+                seq_level_coord = seq_level_coord - gap_to_remove
+                break
+            seq_level_coord = seq_level_coord - cigar_elem[1]
+        else:
+            raise ValueError("no valid cigar line")
+
+    if coord > align_index:
+        raise ValueError(f"{coord} is larger than the maximum size of the alignment {align_index}")
+
+    return seq_level_coord

--- a/src/python/lib/ensembl/compara/utils/cigar.py
+++ b/src/python/lib/ensembl/compara/utils/cigar.py
@@ -81,6 +81,8 @@ def get_cigar_array(cigar:str) -> List[Tuple]:
 
     Returns:
         cigar array (list<tuple>)
+    Raises:
+        ValueError :  if cigar line incorrect
     """
     number = ""
     result = []
@@ -93,12 +95,12 @@ def get_cigar_array(cigar:str) -> List[Tuple]:
             result.append((int(number), c))
             number = ""
         else:
-            print("issue")
+            raise ValueError(f"issue with cigar line {cigar}")
     return result
 
 
 def alignment_to_seq_coordinate(cigar: str, coord: int) -> List[int]:
-    '''Covert coordinate from the alignment level to sequence level
+    """Covert coordinate from the alignment level to sequence level
 
     This function will convert a position at the coordinate level to the sequence level. To be able to
     deal with gasp and give the maximum information the function is return a list of position. If the
@@ -122,7 +124,7 @@ def alignment_to_seq_coordinate(cigar: str, coord: int) -> List[int]:
 
     Raises:
         ValueError :  if coord is  <= 0 and if coord > alignment length
-    '''
+    """
 
     if coord < 1:
         raise ValueError(f"coord need to be > 0 : current value {coord}")

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -70,10 +70,10 @@ def dir_cmp(request: FixtureRequest, tmp_dir: PathLike) -> DirCmp:
     """
     # Get the source and temporary absolute paths for reference and target root directories
     ref = Path(request.param['ref'])  # type: ignore[attr-defined]
-    ref_src = ref if ref.is_absolute() else pytest.files_dir / ref  # type: ignore[attr-defined]
+    ref_src = ref if ref.is_absolute() else pytest.files_dir / ref  # type: ignore
     ref_tmp = Path(tmp_dir) / str(ref).replace(os.path.sep, '_')
     target = Path(request.param['target'])  # type: ignore[attr-defined]
-    target_src = target if target.is_absolute() else pytest.files_dir / target  # type: ignore[attr-defined]
+    target_src = target if target.is_absolute() else pytest.files_dir / target  # type: ignore
     target_tmp = Path(tmp_dir) / str(target).replace(os.path.sep, '_')
     # Copy directory trees (if they have not been copied already) ignoring file metadata
     if not ref_tmp.exists():

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -70,10 +70,10 @@ def dir_cmp(request: FixtureRequest, tmp_dir: PathLike) -> DirCmp:
     """
     # Get the source and temporary absolute paths for reference and target root directories
     ref = Path(request.param['ref'])  # type: ignore[attr-defined]
-    ref_src = ref if ref.is_absolute() else pytest.files_dir / ref  # type: ignore
+    ref_src = ref if ref.is_absolute() else pytest.files_dir / ref  # type: ignore[attr-defined,operator]
     ref_tmp = Path(tmp_dir) / str(ref).replace(os.path.sep, '_')
     target = Path(request.param['target'])  # type: ignore[attr-defined]
-    target_src = target if target.is_absolute() else pytest.files_dir / target  # type: ignore
+    target_src = target if target.is_absolute() else pytest.files_dir / target  # type: ignore[attr-defined,operator]
     target_tmp = Path(tmp_dir) / str(target).replace(os.path.sep, '_')
     # Copy directory trees (if they have not been copied already) ignoring file metadata
     if not ref_tmp.exists():

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -73,7 +73,7 @@ def dir_cmp(request: FixtureRequest, tmp_dir: PathLike) -> DirCmp:
     ref_src = ref if ref.is_absolute() else pytest.files_dir / ref  # type: ignore[attr-defined,operator]
     ref_tmp = Path(tmp_dir) / str(ref).replace(os.path.sep, '_')
     target = Path(request.param['target'])  # type: ignore[attr-defined]
-    target_src = target if target.is_absolute() else pytest.files_dir / target  # type: ignore[attr-defined,operator]
+    target_src = target if target.is_absolute() else pytest.files_dir / target  # type: ignore[operator]
     target_tmp = Path(tmp_dir) / str(target).replace(os.path.sep, '_')
     # Copy directory trees (if they have not been copied already) ignoring file metadata
     if not ref_tmp.exists():

--- a/src/python/tests/test_cigar.py
+++ b/src/python/tests/test_cigar.py
@@ -12,14 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit testing of :mod:`utils` module.
+"""Unit testing of :mod:`cigar` module.
 
 The unit testing is divided into one test class per submodule/class found in this module, and one test method
 per public function/class method.
 
 Typical usage example::
 
-    $ pytest test_utils.py
+    $ pytest test_cigar.py
 
 """
 
@@ -32,19 +32,19 @@ from ensembl.compara.utils import aligned_seq_to_cigar, get_cigar_array, alignme
 
 
 class TestCigar:
-    """Tests :mod:`tools` submodule."""
+    """Tests :mod:`cigar` submodule."""
 
     @pytest.mark.parametrize(
         "aligned_seq, cigar",
         [
-            ("ATGCATTGAT---ATTTA--AT", "M10D3M5D2M2"),
-            ("A-T-GCA--T-TGAT---ATTTA--AT", "MDMDM3D2MDM4D3M5D2M2"),
-            ("ATGCATTGATATTTAAT", "M17"),
-            ("-----------------", "D17"),
-            ("-ATGCATTGATATTTAAT", "DM17"),
-            ("ATGCATTGATATTTAAT-", "M17D"),
-            ("--ATGCATTGATATTTAAT", "D2M17"),
-            ("ATGCATTGATATTTAAT--", "M17D2")
+            ("ATGCATTGAT---ATTTA--AT", "10M3D5M2D2M"),
+            ("A-T-GCA--T-TGAT---ATTTA--AT", "MDMD3M2DMD4M3D5M2D2M"),
+            ("ATGCATTGATATTTAAT", "17M"),
+            ("-----------------", "17D"),
+            ("-ATGCATTGATATTTAAT", "D17M"),
+            ("ATGCATTGATATTTAAT-", "17MD"),
+            ("--ATGCATTGATATTTAAT", "2D17M"),
+            ("ATGCATTGATATTTAAT--", "17M2D")
         ],
     )
     def test_aligned_seq_to_cigar(self, aligned_seq: str, cigar: str) -> None:
@@ -60,10 +60,10 @@ class TestCigar:
     @pytest.mark.parametrize(
         "cigar, cigar_array",
         [
-            ("M10D3M5D2M2", [("M", 10), ("D", 3), ("M", 5), ("D", 2), ("M", 2)]),
-            ("MDMDM3D2", [("M", 1), ("D", 1), ("M", 1), ("D", 1), ("M", 3), ("D", 2)]),
-            ("M17",[("M", 17)]),
-            ("D17",[("D", 17)])
+            ("10M3D5M2D2M", [(10, "M"), (3, "D"), (5, "M"), (2, "D"), (2, "M")]),
+            ("MDMD3M2D", [(1, "M"), (1, "D"), (1, "M"), (1, "D"), (3, "M"), (2, "D")]),
+            ("17M", [(17, "M")]),
+            ("17D", [(17, "D")])
         ],
     )
     def test_get_cigar_array(self, cigar: str, cigar_array: List[Tuple]) -> None:
@@ -79,18 +79,17 @@ class TestCigar:
     @pytest.mark.parametrize(
         "cigar, coord_align, coord_seq, expectation",
         [
-            ("M10D3M5D2M2", 21, 16, does_not_raise()),
-            ("M10D3M5D2M2", 12, 10, does_not_raise()),
-            ("M10D3M5D2M2", 13, 10, does_not_raise()),
-            ("M10D3M5D2M2", 11, 10, does_not_raise()),
-            ("M10D3M5D2M2", 19, 15, does_not_raise()),
-            ("M10D3M5D2M2", 20, 15, does_not_raise()),
-            ("M10D3M5D2M2", 20, 15, does_not_raise()),
-            ("D17",15, 0, does_not_raise()),
-            ("M17", 15, 15, does_not_raise()),
-            ("M10D3M5D2M2", 30, None, pytest.raises(ValueError)),
-            ("M10D3M5D2M2", 0, None, pytest.raises(ValueError)),
-            ("M10D3M5D2M2", -4, None, pytest.raises(ValueError))
+            ("10M3D5M2D2M", 21, [16], does_not_raise()),
+            ("10M3D5M2D2M", 12, [10, 11], does_not_raise()),
+            ("10M3D5M2D2M", 13, [10, 11], does_not_raise()),
+            ("10M3D5M2D2M", 11, [10, 11], does_not_raise()),
+            ("10M3D5M2D2M", 19, [15, 16], does_not_raise()),
+            ("10M3D5M2D2M", 20, [15, 16], does_not_raise()),
+            ("17D",15, [0, 1], does_not_raise()),
+            ("17M", 15, [15], does_not_raise()),
+            ("10M3D5M2D2M", 30, None, pytest.raises(ValueError)),
+            ("10M3D5M2D2M", 0, None, pytest.raises(ValueError)),
+            ("10M3D5M2D2M", -4, None, pytest.raises(ValueError))
         ],
     )
     def test_alignment_to_seq_coordinate(self, cigar: str, coord_align: int,
@@ -100,7 +99,9 @@ class TestCigar:
             Args:
                 cigar: cigar line (str).
                 coord_align: Coordinate at the alignment level (int)
-                coord_seq:
+                coord_seq: expected coordinat at the sequence level
+                expectation: Context manager for the expected exception, i.e. the test will only pass if that
+                    exception is raised. Use :class:`~contextlib.nullcontext` if no exception is expected.
         """
         error = "difference of coord_seq compared tot he one expected with  coord_align"
         with expectation:

--- a/src/python/tests/test_cigar.py
+++ b/src/python/tests/test_cigar.py
@@ -1,0 +1,107 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit testing of :mod:`utils` module.
+
+The unit testing is divided into one test class per submodule/class found in this module, and one test method
+per public function/class method.
+
+Typical usage example::
+
+    $ pytest test_utils.py
+
+"""
+
+from typing import Tuple, ContextManager, List
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from ensembl.compara.utils import aligned_seq_to_cigar, get_cigar_array, alignment_to_seq_coordinate
+
+
+class TestCigar:
+    """Tests :mod:`tools` submodule."""
+
+    @pytest.mark.parametrize(
+        "aligned_seq, cigar",
+        [
+            ("ATGCATTGAT---ATTTA--AT", "M10D3M5D2M2"),
+            ("A-T-GCA--T-TGAT---ATTTA--AT", "MDMDM3D2MDM4D3M5D2M2"),
+            ("ATGCATTGATATTTAAT", "M17"),
+            ("-----------------", "D17"),
+            ("-ATGCATTGATATTTAAT", "DM17"),
+            ("ATGCATTGATATTTAAT-", "M17D"),
+            ("--ATGCATTGATATTTAAT", "D2M17"),
+            ("ATGCATTGATATTTAAT--", "M17D2")
+        ],
+    )
+    def test_aligned_seq_to_cigar(self, aligned_seq: str, cigar: str) -> None:
+        """Tests :meth:`cigar.aligned_seq_to_cigar()` method.
+
+        Args:
+            aligned_seq: aligned sequence (str).
+            cigar: Expected cigar line (str).
+
+        """
+        assert aligned_seq_to_cigar(aligned_seq) == cigar, "cigar line returned differs from the one expected"
+
+    @pytest.mark.parametrize(
+        "cigar, cigar_array",
+        [
+            ("M10D3M5D2M2", [("M", 10), ("D", 3), ("M", 5), ("D", 2), ("M", 2)]),
+            ("MDMDM3D2", [("M", 1), ("D", 1), ("M", 1), ("D", 1), ("M", 3), ("D", 2)]),
+            ("M17",[("M", 17)]),
+            ("D17",[("D", 17)])
+        ],
+    )
+    def test_get_cigar_array(self, cigar: str, cigar_array: List[Tuple]) -> None:
+        """Tests :meth:`cigar.aligned_seq_to_cigar()` method.
+
+            Args:
+                cigar: cigar line (str).
+                cigar_array: Expected cigar array (List[Tuple])
+        """
+        assert get_cigar_array(cigar) == cigar_array, "cigar line returned differs from the one expected"
+
+
+    @pytest.mark.parametrize(
+        "cigar, coord_align, coord_seq, expectation",
+        [
+            ("M10D3M5D2M2", 21, 16, does_not_raise()),
+            ("M10D3M5D2M2", 12, 10, does_not_raise()),
+            ("M10D3M5D2M2", 13, 10, does_not_raise()),
+            ("M10D3M5D2M2", 11, 10, does_not_raise()),
+            ("M10D3M5D2M2", 19, 15, does_not_raise()),
+            ("M10D3M5D2M2", 20, 15, does_not_raise()),
+            ("M10D3M5D2M2", 20, 15, does_not_raise()),
+            ("D17",15, 0, does_not_raise()),
+            ("M17", 15, 15, does_not_raise()),
+            ("M10D3M5D2M2", 30, None, pytest.raises(ValueError)),
+            ("M10D3M5D2M2", 0, None, pytest.raises(ValueError)),
+            ("M10D3M5D2M2", -4, None, pytest.raises(ValueError))
+        ],
+    )
+    def test_alignment_to_seq_coordinate(self, cigar: str, coord_align: int,
+                                         coord_seq: int, expectation: ContextManager) -> None:
+        """Tests :meth:`cigar.alignment_to_seq_coordinate()` method.
+
+            Args:
+                cigar: cigar line (str).
+                coord_align: Coordinate at the alignment level (int)
+                coord_seq:
+        """
+        error = "difference of coord_seq compared tot he one expected with  coord_align"
+        with expectation:
+            assert alignment_to_seq_coordinate(cigar, coord_align) == coord_seq, error

--- a/src/python/tests/test_hal_gene_liftover.py
+++ b/src/python/tests/test_hal_gene_liftover.py
@@ -88,7 +88,7 @@ class TestHalGeneLiftover:
     def setup(self) -> None:
         """Loads necessary fixtures and values as class attributes."""
         # pylint: disable-next=no-member
-        type(self).ref_file_dir = pytest.files_dir / 'hal_alignment'  # type: ignore
+        type(self).ref_file_dir = pytest.files_dir / 'hal_alignment' # type: ignore[attr-defined,operator]
 
     @pytest.mark.parametrize(
         "region, exp_output, expectation",

--- a/src/python/tests/test_hal_gene_liftover.py
+++ b/src/python/tests/test_hal_gene_liftover.py
@@ -88,7 +88,7 @@ class TestHalGeneLiftover:
     def setup(self) -> None:
         """Loads necessary fixtures and values as class attributes."""
         # pylint: disable-next=no-member
-        type(self).ref_file_dir = pytest.files_dir / 'hal_alignment'  # type: ignore[attr-defined]
+        type(self).ref_file_dir = pytest.files_dir / 'hal_alignment'  # type: ignore
 
     @pytest.mark.parametrize(
         "region, exp_output, expectation",

--- a/travisci/python-linter_harness.sh
+++ b/travisci/python-linter_harness.sh
@@ -24,8 +24,8 @@ export MYPYPATH=$MYPYPATH:$PWD/src/python/lib
 
 
 # Check mypy and pyling versions 
-echo "$(pylint --version)"
-echo "$(mypy --version)"
+pylint --version
+mypy --version
 
 
 PYLINT_OUTPUT_FILE=$(mktemp)

--- a/travisci/python-linter_harness.sh
+++ b/travisci/python-linter_harness.sh
@@ -24,8 +24,9 @@ export MYPYPATH=$MYPYPATH:$PWD/src/python/lib
 
 
 # Check mypy and pyling versions 
-pylint --version
-mypy --version 
+echo "$(pylint --version)"
+echo "$(mypy --version)"
+
 
 PYLINT_OUTPUT_FILE=$(mktemp)
 PYLINT_ERRORS=$(mktemp)
@@ -43,5 +44,7 @@ rt2=$?
 if [[ ($rt1 -eq 0) && ($rt2 -eq 0) ]]; then
   exit 0
 else
+  echo "pylint exitcode=$rt1"
+  echo "mypy exitcode=$rt2"
   exit 255
 fi

--- a/travisci/python-linter_harness.sh
+++ b/travisci/python-linter_harness.sh
@@ -22,6 +22,11 @@ PYTHON_SOURCE_LOCATIONS=('scripts' 'src/python')
 export PYTHONPATH=$PYTHONPATH:$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
 export MYPYPATH=$MYPYPATH:$PWD/src/python/lib
 
+
+# Check mypy and pyling versions 
+pylint --version
+mypy --version 
+
 PYLINT_OUTPUT_FILE=$(mktemp)
 PYLINT_ERRORS=$(mktemp)
 # CITest project is on hold and it needs to be updated before resuming its linter checker


### PR DESCRIPTION
## Description

Creating a function that produce a cigar line from an aligned seq and that has as a reference the unaligned sequence. And create a function that covert a coordinate at the level of the aligned seq to a coordinate at the level of the unaligned seq.

**Related JIRA tickets:**
- ENSCOMPARASW-5358
- ENSCOMPARASW-5359


## Overview of changes
Added two new files cigar.py and test_cigar.py and modified __init__.py to include the cigar.py module

#### Change 1
- aligned_seq_to_cigar function. This function will create a cigar line from an aligned sequence and use the unaligned seq as a reference. For this reason the cigar line will be composed only with M (for matches) and D (for deletion)

#### Change 2
- alignment_to_seq_coordinate. This function  translate a coordinate at the alignment level to a coordinate at the unaligned sequence level.  It will first get a cigar array by calling get_cigar_array() and analyse the cigar array to translate the coordinate. If a aligned coordinate fall into a gap it will retune the position upstream the gap as unaligned coordinate.

#### Change 3
- get_cigar_array(). This function transform a cigar line into an array 

## Testing
To test this modul I have created anew unitary test module test_citest.py.

## Notes
_Optional extra information._
