### PR TITLE
Add Compara data dump-related Jira tickets

### DIFF
--- a/conf/relco/jira_recurrent_tickets.json
+++ b/conf/relco/jira_recurrent_tickets.json
@@ -57,6 +57,48 @@
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Static+documentation+update#Staticdocumentationupdate-Schemadocumentation",
             "summary": "Update Compara schema documentation in Ensembl plugins"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Updatingdatadumpregistryfiles",
+            "summary": "Update Compara data dump registry files"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Trackingdatadumpserverusage",
+            "summary": "Fungi data dump server usage"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Trackingdatadumpserverusage",
+            "summary": "Metazoa data dump server usage"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Trackingdatadumpserverusage",
+            "summary": "Pan data dump server usage"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Trackingdatadumpserverusage",
+            "summary": "Plants data dump server usage"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Trackingdatadumpserverusage",
+            "summary": "Protists data dump server usage"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Trackingdatadumpserverusage",
+            "summary": "Vertebrates data dump server usage"
          }
       ],
       "summary": "Release <version> Post-handover"


### PR DESCRIPTION
## Description

We need to update the Compara dump registry files each Ensembl release before 
the commencement of the Compara data dump, so that the information is correct 
for the current release.

We also need tickets to keep track of server usage during the data 
dumps, to avoid placing too great a burden on any one server.

## Overview of changes

Data dump-related tickets are added:
- one ticket to update Compara data dump registry files; and
- one server usage tracker ticket for each of six divisions.

## Testing

The updated `jira_recurrent_tickets.json` file was confirmed as being valid JSON.

## Notes

Draft SOPs can be found at the URLs in the ticket descriptions.