### PR TITLE
Embedded datachecks into the ReindexMembers pipeline.

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsReindexMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsReindexMembers_conf.pm
@@ -84,5 +84,12 @@ sub default_options {
     };
 }
 
+sub tweak_analyses {
+		my $self = shift;
+		my $analyses_by_name = shift;
+		# datacheck specific tweaks for pipelines
+		$analyses_by_name->{'datacheck_factory'}->{'-parameters'} = {'dba' => '#compara_db#'};
+		$analyses_by_name->{'store_results'}->{'-parameters'} = {'dbname' => '#db_name#'};
+ }
 
 1;


### PR DESCRIPTION
## Description

This PR embeds datachecks into the ReindexMembers pipeline. 

**Related JIRA tickets:**
- ENSCOMPARASW-5364
## Overview of changes

#### Change 1

Added the parameters and database creation commands necessary for the datacheks.

#### Change 2

Added the "fire_datachecks" dummy step which flows into "datacheck_factory" step after the mainb part of the pipelines finished.

#### Change 3

Added the necessary "tweak_analyses" steps to ReindexMemebers_conf and  Vertebrates/StrainsReindexMemebers_conf.

## Testing
The pipeline was run on murinae ncRNA trees. Some chechs fail but this is likely unrelated to the embedding.
