### PR TITLE
Move and clarify gene tree stats

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -118,6 +118,7 @@ sub executable_locations {
         'ancestral_stats_program'           => $self->check_exe_in_ensembl('ensembl-compara/scripts/ancestral_sequences/get_stats.pl'),
         'BuildSynteny_exe'                  => $self->check_file_in_ensembl('ensembl-compara/scripts/synteny/BuildSynteny.jar'),
         'compare_beds_exe'                  => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/compare_beds.pl'),
+        'count_genes_in_tree_exe'           => $self->check_exe_in_ensembl('ensembl-compara/scripts/production/count_genes_in_tree.pl'),
         'create_pair_aligner_page_exe'      => $self->check_exe_in_ensembl('ensembl-compara/scripts/report/create_pair_aligner_page.pl'),
         'dump_aln_program'                  => $self->check_exe_in_ensembl('ensembl-compara/scripts/dumps/DumpMultiAlign.pl'),
         'dump_features_exe'                 => $self->check_exe_in_ensembl('ensembl-compara/scripts/dumps/dump_features.pl'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -118,7 +118,7 @@ sub executable_locations {
         'ancestral_stats_program'           => $self->check_exe_in_ensembl('ensembl-compara/scripts/ancestral_sequences/get_stats.pl'),
         'BuildSynteny_exe'                  => $self->check_file_in_ensembl('ensembl-compara/scripts/synteny/BuildSynteny.jar'),
         'compare_beds_exe'                  => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/compare_beds.pl'),
-        'count_genes_in_tree_exe'           => $self->check_exe_in_ensembl('ensembl-compara/scripts/production/count_genes_in_tree.pl'),
+        'count_genes_in_tree_exe'           => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/count_genes_in_tree.pl'),
         'create_pair_aligner_page_exe'      => $self->check_exe_in_ensembl('ensembl-compara/scripts/report/create_pair_aligner_page.pl'),
         'dump_aln_program'                  => $self->check_exe_in_ensembl('ensembl-compara/scripts/dumps/DumpMultiAlign.pl'),
         'dump_features_exe'                 => $self->check_exe_in_ensembl('ensembl-compara/scripts/dumps/dump_features.pl'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -3367,6 +3367,7 @@ sub core_pipeline_analyses {
                 '1->A' => [
                     'rib_fire_dnds',
                     'rib_fire_homology_stats',
+                    'rib_fire_tree_stats',
                     'rib_fire_hmm_build',
                     'rib_fire_goc'
                 ],
@@ -3495,6 +3496,11 @@ sub core_pipeline_analyses {
                 WHEN('#do_homology_stats#' => 'homology_stats_factory'),
                 'set_default_values',
             ],
+        },
+
+        {   -logic_name => 'rib_fire_tree_stats',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => 'gene_count_factory',
         },
 
         {   -logic_name => 'rib_fire_hmm_build',
@@ -3718,6 +3724,24 @@ sub core_pipeline_analyses {
         {   -logic_name => 'rib_fire_goc',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => WHEN('#do_goc#' => 'goc_entry_point'),
+        },
+
+        {   -logic_name => 'gene_count_factory',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
+            -rc_name    => '1Gb_job',
+            -parameters => {
+                'component_genomes' => 0,
+                'fan_branch_code' => 1,
+            },
+            -flow_into  => [ 'count_genes_in_tree' ],
+        },
+
+        {   -logic_name => 'count_genes_in_tree',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::CountGenesInTree',
+            -rc_name    => '1Gb_job',
+            -parameters => {
+                'gene_count_exe' => $self->o('count_genes_in_tree_exe'),
+            },
         },
 
         {   -logic_name => 'homology_stats_factory',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -343,7 +343,7 @@ sub core_pipeline_analyses {
             {   -logic_name => 'backbone_fire_posttree',
                 -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
                 -flow_into  => {
-                    '1->A' => ['rib_fire_homology_dumps'],
+                    '1->A' => ['rib_fire_homology_dumps', 'rib_fire_tree_stats'],
                     'A->1' => ['backbone_pipeline_finished'],
                 },
             },
@@ -611,7 +611,7 @@ sub core_pipeline_analyses {
               -parameters         => {
                                       mode            => 'global_tree_set',
                                      },
-              -flow_into          => [ 'write_stn_tags',
+              -flow_into          => [
                                        # 'backbone_fire_homology_dumps',
                                         WHEN('#do_cafe# and  #binary_species_tree_input_file#', 'CAFE_species_tree'),
                                         WHEN('#do_cafe# and !#binary_species_tree_input_file#', 'make_full_species_tree'),
@@ -1293,6 +1293,32 @@ sub core_pipeline_analyses {
             -flow_into  => {
                 '1->A' => [ 'homology_dumps_mlss_id_factory', 'gene_dumps_genome_db_factory' ],
                 'A->1' => 'rib_fire_homology_processing',
+            },
+        },
+
+        {   -logic_name => 'rib_fire_tree_stats',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => {
+                '1->A' => 'gene_count_factory',
+                'A->1' => 'write_stn_tags',
+            },
+        },
+
+        {   -logic_name => 'gene_count_factory',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
+            -rc_name    => '1Gb_job',
+            -parameters => {
+                'component_genomes' => 0,
+                'fan_branch_code' => 1,
+            },
+            -flow_into  => [ 'count_genes_in_tree' ],
+        },
+
+        {   -logic_name => 'count_genes_in_tree',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::CountGenesInTree',
+            -rc_name    => '1Gb_job',
+            -parameters => {
+                'gene_count_exe' => $self->o('count_genes_in_tree_exe'),
             },
         },
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/ComputeStatistics.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/ComputeStatistics.pm
@@ -251,10 +251,20 @@ sub _get_number_of_proteins_used {
 
     # Compute the number of genes that are unassigned to a tree
     my $sql2 = q/
-        SELECT SUM(stnt.value)
-        FROM species_tree_node_tag stnt JOIN species_tree_node USING (node_id)
-        WHERE stnt.tag = 'nb_genes_unassigned'
-        AND node_id IN (SELECT node_id FROM species_tree_node WHERE genome_db_id IS NOT NULL)
+        SELECT
+            SUM(stnt.value)
+        FROM
+            species_tree_node_tag stnt
+                JOIN
+            species_tree_node USING (node_id)
+        WHERE
+            stnt.tag = 'nb_genes_unassigned'
+                AND node_id IN (SELECT
+                    node_id
+                FROM
+                    species_tree_node
+                WHERE
+                    genome_db_id IS NOT NULL)
     /;
 
     my $sth2 = $self->compara_dba->dbc->prepare( $sql2, { 'mysql_use_result' => 1 } );

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CountGenesInTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CountGenesInTree.pm
@@ -23,8 +23,7 @@ Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::CountGenesInTree
 
 =head1 DESCRIPTION
 
-Wraps count_genes_in_tree.pl script, parses its output
-and stores its results in the database.
+Wraps count_genes_in_tree.pl script.
 
 =cut
 
@@ -37,17 +36,6 @@ use JSON qw(decode_json);
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
-sub fetch_input {
-    my $self = shift @_;
-
-    my $mlss_id = $self->param_required('mlss_id');
-    my $genome_db_id = $self->param_required('genome_db_id');
-
-    my $tree_adaptor = $self->compara_dba->get_SpeciesTreeAdaptor();
-    my $species_tree = $tree_adaptor->fetch_by_method_link_species_set_id_label($mlss_id, 'default');
-    my $species_tree_node = $species_tree->root->find_leaves_by_field('genome_db_id', $genome_db_id)->[0];
-    $self->param('species_tree_node', $species_tree_node);
-}
 
 sub run {
     my $self = shift @_;
@@ -58,18 +46,7 @@ sub run {
     my $gene_count_exe = $self->param_required('gene_count_exe');
 
     my $cmd = [ $gene_count_exe, '-url', $db_url, '-mlss_id', $mlss_id, '-genome_db_id', $genome_db_id ];
-    my $output = $self->get_command_output($cmd);
-    my $gene_tree_stats = decode_json($output);
-
-    $self->param('nb_genes_in_tree', $gene_tree_stats->{'nb_genes_in_tree'});
-    $self->param('nb_genes_unassigned', $gene_tree_stats->{'nb_genes_unassigned'});
-}
-
-sub write_output {
-    my $self = shift @_;
-    my $species_tree_node = $self->param('species_tree_node');
-    $species_tree_node->store_tag('nb_genes_in_tree', $self->param('nb_genes_in_tree'));
-    $species_tree_node->store_tag('nb_genes_unassigned', $self->param('nb_genes_unassigned'));
+    Bio::EnsEMBL::Compara::Utils::RunCommand->new_and_exec($cmd, { die_on_failure => 1 });
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CountGenesInTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CountGenesInTree.pm
@@ -32,7 +32,7 @@ package Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::CountGenesInTree;
 use strict;
 use warnings;
 
-use JSON qw(decode_json);
+use Bio::EnsEMBL::Compara::Utils::RunCommand;
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CountGenesInTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CountGenesInTree.pm
@@ -1,0 +1,76 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::CountGenesInTree
+
+=head1 DESCRIPTION
+
+Wraps count_genes_in_tree.pl script, parses its output
+and stores its results in the database.
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::CountGenesInTree;
+
+use strict;
+use warnings;
+
+use JSON qw(decode_json);
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+sub fetch_input {
+    my $self = shift @_;
+
+    my $mlss_id = $self->param_required('mlss_id');
+    my $genome_db_id = $self->param_required('genome_db_id');
+
+    my $tree_adaptor = $self->compara_dba->get_SpeciesTreeAdaptor();
+    my $species_tree = $tree_adaptor->fetch_by_method_link_species_set_id_label($mlss_id, 'default');
+    my $species_tree_node = $species_tree->root->find_leaves_by_field('genome_db_id', $genome_db_id)->[0];
+    $self->param('species_tree_node', $species_tree_node);
+}
+
+sub run {
+    my $self = shift @_;
+
+    my $db_url = $self->compara_dba->url;
+    my $mlss_id = $self->param_required('mlss_id');
+    my $genome_db_id = $self->param_required('genome_db_id');
+    my $gene_count_exe = $self->param_required('gene_count_exe');
+
+    my $cmd = [ $gene_count_exe, '-url', $db_url, '-mlss_id', $mlss_id, '-genome_db_id', $genome_db_id ];
+    my $output = $self->get_command_output($cmd);
+    my $gene_tree_stats = decode_json($output);
+
+    $self->param('nb_genes_in_tree', $gene_tree_stats->{'nb_genes_in_tree'});
+    $self->param('nb_genes_unassigned', $gene_tree_stats->{'nb_genes_unassigned'});
+}
+
+sub write_output {
+    my $self = shift @_;
+    my $species_tree_node = $self->param('species_tree_node');
+    $species_tree_node->store_tag('nb_genes_in_tree', $self->param('nb_genes_in_tree'));
+    $species_tree_node->store_tag('nb_genes_unassigned', $self->param('nb_genes_unassigned'));
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/PerGenomeGroupsetQC.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/PerGenomeGroupsetQC.pm
@@ -82,7 +82,6 @@ sub fetch_input {
     my $self = shift @_;
 
     my $genome_db_id            = $self->param_required('genome_db_id');
-    my $this_genome_db          = $self->compara_dba->get_GenomeDBAdaptor->fetch_by_dbID($genome_db_id);
     my $this_species_tree       = $self->compara_dba->get_SpeciesTreeAdaptor->fetch_by_method_link_species_set_id_label($self->param_required('mlss_id'), 'default');
     my $ncbi_taxon_adaptor      = $self->compara_dba->get_NCBITaxonAdaptor;
     my $this_species_tree_node  = $this_species_tree->root->find_leaves_by_field('genome_db_id', $genome_db_id)->[0];
@@ -138,8 +137,10 @@ sub write_output {
     my $species_tree_node       = $self->param('species_tree_node');
 
     $species_tree_node->store_tag('nb_genes',               $self->param('total_num_genes'));
-    $species_tree_node->store_tag('nb_genes_in_tree',       $self->param('total_num_genes')-$self->param('total_orphans_num'));
     $species_tree_node->store_tag('nb_orphan_genes',        $self->param('total_orphans_num'));
+
+    my $nb_genes_in_unfiltered_cluster = $self->param('total_num_genes') - $self->param('total_orphans_num');
+    $species_tree_node->store_tag('nb_genes_in_unfiltered_cluster', $nb_genes_in_unfiltered_cluster);
 
     return unless $self->param('reuse_this');
 

--- a/modules/t/CountGenesInTree.t
+++ b/modules/t/CountGenesInTree.t
@@ -35,7 +35,7 @@ my $gene_count_exe = catfile(
     $ENV{ENSEMBL_ROOT_DIR},
     'ensembl-compara',
     'scripts',
-    'production',
+    'pipeline',
     'count_genes_in_tree.pl'
 );
 

--- a/modules/t/CountGenesInTree.t
+++ b/modules/t/CountGenesInTree.t
@@ -1,0 +1,60 @@
+#!/usr/bin/env perl
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Hive::Utils::Test qw(standaloneJob);
+use Bio::EnsEMBL::Test::MultiTestDB;
+use File::Spec::Functions qw(catfile);
+use Test::Most;
+
+
+BEGIN {
+    # check module can be seen and compiled
+    use_ok('Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::CountGenesInTree');
+}
+
+my $multi = Bio::EnsEMBL::Test::MultiTestDB->new( "homology" );
+my $compara_dba = $multi->get_DBAdaptor( "compara" );
+
+my $gene_count_exe = catfile(
+    $ENV{ENSEMBL_ROOT_DIR},
+    'ensembl-compara',
+    'scripts',
+    'production',
+    'count_genes_in_tree.pl'
+);
+
+my $test_genome_db_id = 135;
+my $test_nctrees_mlss_id = 40102;
+standaloneJob(
+    'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::CountGenesInTree',
+    {
+        'mlss_id'        => $test_nctrees_mlss_id,
+        'genome_db_id'   => $test_genome_db_id,
+        'compara_db'     => $compara_dba->url,
+        'gene_count_exe' => $gene_count_exe,
+    }
+);
+
+my $tree_adaptor = $compara_dba->get_SpeciesTreeAdaptor();
+my $species_tree = $tree_adaptor->fetch_by_method_link_species_set_id_label($test_nctrees_mlss_id, 'default');
+my $species_tree_node = $species_tree->root->find_leaves_by_field('genome_db_id', $test_genome_db_id)->[0];
+is( $species_tree_node->get_tagvalue('nb_genes_in_tree'), '6', 'nb_genes_in_tree correct' );
+is( $species_tree_node->get_tagvalue('nb_genes_unassigned'), '1', 'nb_genes_unassigned correct' );
+
+done_testing();

--- a/scripts/pipeline/count_genes_in_tree.pl
+++ b/scripts/pipeline/count_genes_in_tree.pl
@@ -66,7 +66,6 @@ use warnings;
 
 use DBI;
 use Getopt::Long;
-use JSON qw(encode_json);
 use Pod::Usage;
 
 use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;

--- a/scripts/production/count_genes_in_tree.pl
+++ b/scripts/production/count_genes_in_tree.pl
@@ -1,0 +1,121 @@
+#!/usr/bin/env perl
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+=head1 NAME
+
+count_genes_in_tree.pl
+
+=head1 DESCRIPTION
+
+Calculates the number of genes in the given genome that have been assigned
+to a gene tree in the gene-tree collection associated with the given MLSS.
+The number of unassigned genes is also calculated. Both values are printed
+to standard output as a JSON-encoded string.
+
+=head1 SYNOPSIS
+
+    perl $ENSEMBL_ROOT_DIR/ensembl-compara/scripts/production/count_genes_in_tree.pl \
+        --url <db_url> --genome_db_id <genome_db_id> --mlss_id <mlss_id>
+
+=head1 EXAMPLES
+
+    perl $ENSEMBL_ROOT_DIR/ensembl-compara/scripts/production/count_genes_in_tree.pl \
+        --url mysql://ensro@mysql-ens-compara-prod-0:65536/jo_default_plants_protein_trees_107 \
+        --genome_db_id 421 --mlss_id 40160
+
+=head1 OPTIONS
+
+=over
+
+=item B<[--help]>
+
+Prints help message and exits.
+
+=item B<[--url gene_tree_db_url]>
+
+Gene-tree database URL.
+
+=item B<[--genome_db_id genome_db_id]>
+
+Genome DB ID of the relevant organism.
+
+=item B<[--mlss_id mlss_id]>
+
+MLSS ID of the relevant gene tree.
+
+=back
+
+=cut
+
+
+use strict;
+use warnings;
+
+use DBI;
+use Getopt::Long;
+use JSON qw(encode_json);
+use Pod::Usage;
+
+use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
+
+
+my ( $help, $url, $genome_db_id, $mlss_id );
+GetOptions(
+    "help|?"         => \$help,
+    "url=s"          => \$url,
+    "genome_db_id=i" => \$genome_db_id,
+    "mlss_id=i"      => \$mlss_id,
+) or pod2usage(-verbose => 2);
+
+# Handle "print usage" scenarios
+pod2usage(-exitvalue => 0, -verbose => 1) if $help;
+pod2usage(-verbose => 1) if !$url or !$genome_db_id or !$mlss_id;
+
+
+my $dba = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba($url);
+
+my $gene_member_dba = $dba->get_GeneMemberAdaptor();
+my $nb_genes = scalar @{ $gene_member_dba->fetch_all_by_GenomeDB($genome_db_id) };
+my $nb_genes_in_tree = count_genes_in_tree($dba, $genome_db_id, $mlss_id);
+my $nb_genes_unassigned = $nb_genes - $nb_genes_in_tree;
+
+
+my $gene_tree_stats = {
+    'nb_genes_in_tree' => $nb_genes_in_tree,
+    'nb_genes_unassigned' => $nb_genes_unassigned
+};
+
+print encode_json($gene_tree_stats) . "\n";
+
+
+sub count_genes_in_tree {
+    my ($dba, $genome_db_id, $mlss_id) = @_;
+
+    my $sql = q/
+        SELECT COUNT(*) FROM gene_member gm
+        LEFT JOIN gene_tree_node gtn ON (gm.canonical_member_id = gtn.seq_member_id)
+        INNER JOIN gene_tree_root gtr USING (root_id)
+        WHERE gm.genome_db_id = ? AND gtr.method_link_species_set_id = ?
+        AND gtr.ref_root_id IS NULL AND gtn.seq_member_id IS NOT NULL
+    /;
+
+    my $sth = $dba->dbc->prepare($sql);
+    $sth->execute($genome_db_id, $mlss_id);
+    my $nb_genes_in_tree = $sth->fetchrow();
+    $sth->finish();
+
+    return $nb_genes_in_tree;
+}

--- a/scripts/production/gene_tree_stats.pl
+++ b/scripts/production/gene_tree_stats.pl
@@ -137,24 +137,28 @@ sub get_gene_tree_cov {
     my $sorted_nodes = shift @_;
 
     my @gene_coverage = ();
-    my @sums = (0) x 6;
-    my @tags = qw(nb_genes nb_seq nb_orphan_genes nb_genes_in_tree nb_genes_in_tree_single_species
-                  nb_genes_in_tree_multi_species);
+    my @sums = (0) x 8;
+    my @tags = qw(nb_genes nb_seq nb_orphan_genes nb_genes_in_unfiltered_cluster nb_genes_unassigned
+                  nb_genes_in_tree nb_genes_in_tree_single_species nb_genes_in_tree_multi_species);
     foreach my $node (@$sorted_nodes) {
         next unless $node->is_leaf();
         set_default_value_for_tag($node, 0, @tags);
         $sums[0] += $node->get_value_for_tag('nb_genes');
         $sums[1] += $node->get_value_for_tag('nb_seq');
         $sums[2] += $node->get_value_for_tag('nb_orphan_genes');
-        $sums[3] += $node->get_value_for_tag('nb_genes_in_tree');
-        $sums[4] += $node->get_value_for_tag('nb_genes_in_tree_single_species');
-        $sums[5] += $node->get_value_for_tag('nb_genes_in_tree_multi_species');
+        $sums[3] += $node->get_value_for_tag('nb_genes_in_unfiltered_cluster');
+        $sums[4] += $node->get_value_for_tag('nb_genes_unassigned');
+        $sums[5] += $node->get_value_for_tag('nb_genes_in_tree');
+        $sums[6] += $node->get_value_for_tag('nb_genes_in_tree_single_species');
+        $sums[7] += $node->get_value_for_tag('nb_genes_in_tree_multi_species');
         push @gene_coverage, [
             $node->taxon_id,
             $node->node_name,
             thousandify($node->get_value_for_tag('nb_genes')),
             thousandify($node->get_value_for_tag('nb_seq')),
             thousandify($node->get_value_for_tag('nb_orphan_genes')),
+            thousandify($node->get_value_for_tag('nb_genes_in_unfiltered_cluster')),
+            thousandify($node->get_value_for_tag('nb_genes_unassigned')),
             thousandify($node->get_value_for_tag('nb_genes_in_tree')),
             $node->get_value_for_tag('nb_genes') ? roundperc2($node->get_value_for_tag('nb_genes_in_tree') / $node->get_value_for_tag('nb_genes')) : 'NA',
             thousandify($node->get_value_for_tag('nb_genes_in_tree_single_species')),
@@ -172,6 +176,8 @@ sub get_gene_tree_cov {
         'Nb genes',
         'Nb sequences',
         'Nb orphaned genes',
+        'Nb genes in unfiltered clusters',
+        'Nb unassigned genes',
         'Nb genes in trees',
         '% genes in trees',
         'Nb genes in single-species trees',
@@ -187,11 +193,13 @@ sub get_gene_tree_cov {
         thousandify($sums[1]),
         thousandify($sums[2]),
         thousandify($sums[3]),
-        roundperc2($sums[3] / $sums[0]),
         thousandify($sums[4]),
-        roundperc2($sums[4] / $sums[0]),
         thousandify($sums[5]),
         roundperc2($sums[5] / $sums[0]),
+        thousandify($sums[6]),
+        roundperc2($sums[6] / $sums[0]),
+        thousandify($sums[7]),
+        roundperc2($sums[7] / $sums[0]),
     ];
 
     return \@gene_coverage_sorted;


### PR DESCRIPTION
## Description

The stats `nb_genes_in_tree` and `nb_orphan_genes` are calculated from the clusters during the `per_genome_qc` step of the gene tree pipelines. However, the number of genes may be reduced in subsequent pipeline steps (e.g. `recover_epo` and `infernal` in the ncRNA-trees pipeline), making this statistic incorrect.

The statistic calculated at this stage from the clusters should be given a more apt name, and `nb_genes_in_tree` should be calculated at a later stage of each gene tree pipeline, so that it is the actual number of genes in the given tree.

**Related JIRA tickets:**

- ENSCOMPARASW-4008
- ENSCOMPARASW-4962
- ENSCOMPARASW-4963

## Overview of changes

Rename the cluster-based `nb_genes_in_tree` during per-genome QC, and calculate a tree-based `nb_genes_in_tree` later in the pipeline.

#### Rename the cluster-based nb_genes_in_tree

In the `per_genome_qc` analysis, the name of the existing statistic `nb_genes_in_tree` is changed to `nb_genes_in_unfiltered_cluster`, so that it more accurately describes what is being calculated.

#### Calculate the tree-based nb_genes_in_tree

A new `count_genes_in_tree.pl` script, `CountGenesInTree` runnable and `count_genes_in_tree` analysis are created to calculate `nb_genes_in_tree` at a point in the protein-trees and ncRNA-trees pipelines after which there are no further changes to the number of genes in trees.

The `CountGenesInTree` runnable also records the tree-based stat `nb_genes_unassigned` (i.e. the difference between `total_num_genes` and `nb_genes_in_tree`). This is analogous to the cluster-based stat `nb_orphan_genes`, which is the difference between `total_num_genes` and `nb_genes_in_unfiltered_cluster`.

In the protein-trees pipeline, the `count_genes_in_tree` analysis is triggered from `rib_group_2`, after `backbone_fire_posttree` and before the `compute_statistics` and `generate_tree_stats_report` analyses.

In the ncRNA-trees pipeline, it is triggered from `backbone_fire_posttree`, and placed in a fan, with analyses `write_stn_tags` and `generate_tree_stats_report` placed in the corresponding funnel, so that `nb_genes_in_tree` is calculated before the production of the tree stats report.

#### Calculate stat.number_of_unassigned_proteins

In the `compute_statistics` analysis, `stat.number_of_unassigned_proteins` is calculated from `nb_genes_unassigned`.

#### Update the gene tree stats report

Two columns are added to the gene coverage table of the gene-tree stats report: "Nb genes in unfiltered clusters" and "Nb unassigned genes". These contain the values of `nb_genes_in_unfiltered_cluster` and `nb_genes_unassigned`, respectively.

#### Add unit test

A unit test has been added for the `CountGenesInTree` runnable.

#### Remove unused variable

The unused variable `$this_genome_db` is removed from the `PerGenomeGroupsetQC` runnable.

## Testing

A full test run was conducted of Pan protein-trees pipeline (`mysql://ensro@mysql-ens-compara-prod-7:4617/twalsh_rel_dev_pan_protein_trees_20220428`) and Murinae ncRNA-trees pipeline (`mysql://ensro@mysql-ens-compara-prod-10:4648/twalsh_rel_dev_murinae_ncrna_trees_20220428`) with code based on the `release/107` branch.

Each test pipeline directory contains a `shared` subdirectory in which the gene-tree stats files have been saved, which include the new nb_genes_in_unfiltered_cluster` and `nb_genes_unassigned` columns.

Each `shared` subdirectory also contains `.obs_stats.tsv` and `.exp_stats.tsv` files. The first of these contains the results of querying the `species_tree_node_attr.nb_genes_in_tree` per genome, while the second contains the results of recalculating this value for each genome.

In the protein-trees test pipeline database (`twalsh_rel_dev_pan_protein_trees_20220428`), the gene-tree root tag `stat.number_of_unassigned_proteins` has been stored successfully.

Test pipelines were also initialised on the main branch, again for Pan protein-trees pipeline (`mysql://ensro@mysql-ens-compara-prod-7:4617/twalsh_rel_dev_pan_protein_trees_20220503`) and Murinae ncRNA-trees pipeline (`mysql://ensro@mysql-ens-compara-prod-10:4648/twalsh_rel_dev_murinae_ncrna_trees_20220503`).

In addition, a unit test has been added for the `CountGenesInTree` runnable.

## Notes

See also [Compara PR 349](https://github.com/Ensembl/ensembl-compara/pull/349), which was an earlier iteration of the changes in this pull request.
