### PR TITLE
Compara is taking back Flatfile Dumps for a release or few

### DIFF
--- a/conf/fungi/jira_recurrent_tickets.json
+++ b/conf/fungi/jira_recurrent_tickets.json
@@ -171,5 +171,24 @@
          }
       ],
       "summary": "<Division> Release <version> Final checks before public release"
+   },
+   {
+      "assignee": "<RelCo>",
+      "component": "Relco tasks",
+      "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps",
+      "subtasks": [{
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Databaseupdate",
+            "summary": "Incremental copy back release database"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Runningthepipeline",
+            "summary": "Data dump"
+         }
+      ],
+      "summary": "<Division> Release <version> FTP Dumps"
    }
 ]

--- a/conf/metazoa/jira_recurrent_tickets.json
+++ b/conf/metazoa/jira_recurrent_tickets.json
@@ -178,5 +178,24 @@
          }
       ],
       "summary": "<Division> Release <version> Final checks before public release"
+   },
+   {
+      "assignee": "<RelCo>",
+      "component": "Relco tasks",
+      "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps",
+      "subtasks": [{
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Databaseupdate",
+            "summary": "Incremental copy back release database"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Runningthepipeline",
+            "summary": "Data dump"
+         }
+      ],
+      "summary": "<Division> Release <version> FTP Dumps"
    }
 ]

--- a/conf/pan/jira_recurrent_tickets.json
+++ b/conf/pan/jira_recurrent_tickets.json
@@ -121,9 +121,28 @@
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Test+the+test+sites#Testthetestsites-RESTserver",
-            "summary": "test the REST server"
+            "summary": "Test the REST server"
          }
       ],
       "summary": "<Division> Release <version> Final checks before public release"
+   },
+   {
+      "assignee": "<RelCo>",
+      "component": "Relco tasks",
+      "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps",
+      "subtasks": [{
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Databaseupdate",
+            "summary": "Incremental copy back release database"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Runningthepipeline",
+            "summary": "Data dump"
+         }
+      ],
+      "summary": "<Division> Release <version> FTP Dumps"
    }
 ]

--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -215,5 +215,24 @@
          }
       ],
       "summary": "<Division> Release <version> Final checks before public release"
+   },
+   {
+      "assignee": "<RelCo>",
+      "component": "Relco tasks",
+      "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps",
+      "subtasks": [{
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Databaseupdate",
+            "summary": "Incremental copy back release database"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Runningthepipeline",
+            "summary": "Data dump"
+         }
+      ],
+      "summary": "<Division> Release <version> FTP Dumps"
    }
 ]

--- a/conf/protists/jira_recurrent_tickets.json
+++ b/conf/protists/jira_recurrent_tickets.json
@@ -178,5 +178,24 @@
          }
       ],
       "summary": "<Division> Release <version> Final checks before public release"
+   },
+   {
+      "assignee": "<RelCo>",
+      "component": "Relco tasks",
+      "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps",
+      "subtasks": [{
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Databaseupdate",
+            "summary": "Incremental copy back release database"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Runningthepipeline",
+            "summary": "Data dump"
+         }
+      ],
+      "summary": "<Division> Release <version> FTP Dumps"
    }
 ]

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -350,7 +350,7 @@
       "subtasks": [{
             "assignee": "<RelCo>",
             "component": "Production tasks",
-            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps- Databaseupdate",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Databaseupdate",
             "summary": "Incremental copy back release database"
          },
          {

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -342,5 +342,24 @@
          }
       ],
       "summary": "<Division> Release <version> Final checks before public release"
+   },
+   {
+      "assignee": "<RelCo>",
+      "component": "Relco tasks",
+      "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps",
+      "subtasks": [{
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps- Databaseupdate",
+            "summary": "Incremental copy back release database"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Flat+file+dumps#Flatfiledumps-Runningthepipeline",
+            "summary": "Data dump"
+         }
+      ],
+      "summary": "<Division> Release <version> FTP Dumps"
    }
 ]


### PR DESCRIPTION
## Description

Compara is taking back FTP dumps.

**Related JIRA tickets:**
- ENSCOMPARASW-5413

## Overview of changes
Stuck the json blocks in for the tickets required for running dumps, split into two subtasks - the copy back of the db, and then the running of the pipeline/dumps.

## Testing
This is totally untested.

## Notes
I did change the case for one character in the pan file that was outside of the scope of the ticket. This was intentional, and I think it should be agreeable.