### PR TITLE
Feature/die if db exists

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
@@ -25,7 +25,9 @@ Creates new MySQL compara database for a single genome_name
 E.g. standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::NewPerSpeciesComparaDB \
     -homology_host mysql-ens-compara-prod-2 \
     -genome_name canis_lupus_familiaris \
-    -curr_release 103
+    -curr_release 103 \
+    -schema_file $ENSEMBL_ROOT_DIR/ensembl-compara/sql/table.sql \
+    -db_cmd_path ${EHIVE_ROOT_DIR}/scripts/db_cmd.pl
 
 =cut
 

--- a/modules/Bio/EnsEMBL/Compara/Utils/Database.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Database.pm
@@ -38,6 +38,7 @@ our @EXPORT_OK;
 
 @EXPORT_OK = qw(
     table_exists
+    db_exists
 );
 %EXPORT_TAGS = (
   all     => [@EXPORT_OK]
@@ -64,5 +65,40 @@ sub table_exists {
 
     return scalar( @info );
 }
+
+=head2 db_exists
+
+    Arg[1]      :  Bio::EnsEMBL::Compara::DBSQL::DBAdaptor $compara_dba (mandatory)
+    Arg[2]      :  $dbname (mandatory)
+    Description :  Check to see if database exists
+    Returns     :  True if database exists, False otherwise
+    Exceptions  :  None.
+
+=cut
+
+sub db_exists {
+    my ($host, $dbname) = @_;
+
+    my $port    = Bio::EnsEMBL::Compara::Utils::Registry::get_port($host);
+    my $rw_user = Bio::EnsEMBL::Compara::Utils::Registry::get_rw_user($host);
+    my $rw_pwd  = Bio::EnsEMBL::Compara::Utils::Registry::get_rw_pass($host);
+
+    my $dsn = "DBI:mysql:database=;host=$host" . ";port=$port";
+    my $dbh = DBI->connect( $dsn, $rw_user, $rw_pwd ) || die "Could not connect to MySQL server";
+    my $sql = qq/
+        SELECT
+            SCHEMA_NAME
+        FROM
+            INFORMATION_SCHEMA.SCHEMATA
+        WHERE
+            SCHEMA_NAME = "$dbname"
+    /;
+    my $sth = $dbh->prepare($sql);
+    $sth->execute();
+    my @info = $sth->fetchrow_array;
+
+    return scalar( @info );
+}
+
 
 1;


### PR DESCRIPTION
## Description

> When a per species db exists on staging already, the pipeline will fail to copy the db on staging. The issue in this is that when the db is erased from staging and the pipeline is restarted the pipeline continues to fail unless it is restarted from scratch.
> 
> While the behaviour of having the pipeline failing in the first instance because the db exist is something we want to keep. We need to be able to restart the pipeline from the last analysis once the db has been erased.

**Related JIRA tickets:**
- ENSCOMPARASW-5400

## Overview of changes

#### Change 1
- Included a die statement for job to fail if the database already exists
- Removed later unnecessary check for existing tables - this is now redundant upon checking and failing on existing db - this means that the pipeline will fail at this stage and be easily restarted upon removal of existing db

#### Change 2
- New utils to make things simpler, might be useful elsewhere

## Testing
See below for StandAlone output - works as expected.

```
$ ibsub standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::NewPerSpeciesComparaDB -genome_name canis_lupus_familiaris -curr_release 101 -schema_file $ENSEMBL_ROOT_DIR/ensembl-compara/sql/table.sql -db_cmd_path ${EHIVE_ROOT_DIR}/scripts/db_cmd.pl 

Running 'Bio::EnsEMBL::Compara::RunnableDB::NewPerSpeciesComparaDB' with input_id='{"curr_release" => 101,"db_cmd_path" => "/hps/software/users/ensembl/repositories/compara/cristig/hive/master/scripts/db_cmd.pl","genome_name" => "canis_lupus_familiaris","schema_file" => "/hps/software/users/ensembl/repositories/compara/cristig/dev/ensembl-compara/sql/table.sql"}' :
Standalone worker 3702961 : specializing to Standalone_Dummy_Analysis(unstored)

$ ibsub standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::NewPerSpeciesComparaDB -genome_name canis_lupus_familiaris -curr_release 101 -schema_file ${ENSEMBL_ROOT_DIR}/ensembl-compara/sql/table.sql -db_cmd_path ${EHIVE_ROOT_DIR}/scripts/db_cmd.pl 

Running 'Bio::EnsEMBL::Compara::RunnableDB::NewPerSpeciesComparaDB' with input_id='{"curr_release" => 101,"db_cmd_path" => "/hps/software/users/ensembl/repositories/compara/cristig/hive/master/scripts/db_cmd.pl","genome_name" => "canis_lupus_familiaris","schema_file" => "/hps/software/users/ensembl/repositories/compara/cristig/dev/ensembl-compara/sql/table.sql"}' :
Standalone worker 1725903 : specializing to Standalone_Dummy_Analysis(unstored)
Standalone worker 1725903 : WORKER_ERROR : mysql://ensadmin:ensembl@mysql-ens-compara-prod-2:4522/canis_lupus_familiaris_compara_101 already exists at /hps/software/users/ensembl/repositories/compara/cristig/dev/ensembl-compara/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm line 72.

```

## Notes