### PR TITLE
Function to read in info from GTF file required for GOC score calculation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 ensembl-prodinf-tools@git+https://github.com/Ensembl/ensembl-prodinf-tools.git@main#egg=ensembl-prodinf-tools
 biopython>=1.76
 ete3>=3.1.1
+gtfparse==1.2.1
 pandas>=0.24.2
 pybedtools==0.8.2
 sqlalchemy>=1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ ete3>=3.1.1
 gtfparse==1.2.1
 pandas>=0.24.2
 pybedtools==0.8.2
-sqlalchemy>=1.4.0
 pytest>=7.1.2
+sqlalchemy>=1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ gtfparse==1.2.1
 pandas>=0.24.2
 pybedtools==0.8.2
 sqlalchemy>=1.4.0
+pytest>=7.1.2

--- a/scripts/pipeline/orthology_benchmark.py
+++ b/scripts/pipeline/orthology_benchmark.py
@@ -403,9 +403,9 @@ def read_in_gtf(species_name: str, gtf_dir: str) -> pandas.DataFrame:
 
     df = gtfparse.read_gtf(gtf_file)
     df_genes = df[df["feature"] == "gene"][["seqname", "gene_id", "start", "strand"]]
-    df_genes = df_genes.sort_values(["seqname", "start"])
-    df_genes = df_genes.reset_index()
-    df_genes = df_genes.drop("index", 1)
+    df_genes.sort_values(["seqname", "start"], inplace=True)
+    df_genes.reset_index(inplace=True)
+    df_genes.drop("index", 1, inplace=True)
 
     return df_genes
 

--- a/scripts/pipeline/orthology_benchmark.py
+++ b/scripts/pipeline/orthology_benchmark.py
@@ -394,7 +394,6 @@ def read_in_gtf(species_name: str, gtf_dir: str) -> Union[pandas.DataFrame, type
         UserWarning: If the GTF file was not found.
 
     """
-    gtf_file = None
     gtf_file_pattern = f"{species_name.capitalize()}.*.gtf"
 
     try:

--- a/src/python/tests/test_mlss_conf_parser.py
+++ b/src/python/tests/test_mlss_conf_parser.py
@@ -59,6 +59,6 @@ def test_get_species_set_by_name(mlss_conf_file: str, species_set_name: str, exp
 
     """
     # pylint: disable-next=no-member
-    mlss_conf_path = pytest.files_dir / 'config' / mlss_conf_file  # type: ignore[attr-defined]
+    mlss_conf_path = pytest.files_dir / 'config' / mlss_conf_file  # type: ignore[attr-defined, operator]
     with expectation:
         assert get_species_set_by_name(mlss_conf_path, species_set_name) == exp_output

--- a/src/python/tests/test_orthology_benchmark.py
+++ b/src/python/tests/test_orthology_benchmark.py
@@ -129,7 +129,7 @@ class TestDumpGenomes:
 
             out_files = tmp_dir / species_set_name
             # pylint: disable-next=no-member
-            exp_out = pytest.files_dir / "orth_benchmark"  # type: ignore[attr-defined]
+            exp_out = pytest.files_dir / "orth_benchmark"  # type: ignore[attr-defined, operator]
             for db_name, unittest_db in self.core_dbs.items():
                 assert file_cmp(out_files / f"{unittest_db.dbc.db_name}.fasta", exp_out / f"{db_name}.fasta")
 
@@ -266,7 +266,7 @@ def test_get_gtf_file(core_name: str, tmp_dir: Path, expectation: ContextManager
 
     """
     # pylint: disable-next=no-member
-    test_source_dir = pytest.files_dir / "orth_benchmark"  # type: ignore[attr-defined]
+    test_source_dir = pytest.files_dir / "orth_benchmark"  # type: ignore[attr-defined, operator]
     with expectation:
         orthology_benchmark.get_gtf_file(core_name, test_source_dir, tmp_dir)
 
@@ -308,7 +308,7 @@ def test_extract_orthologs() -> None:
     """Tests :func:`orthology_benchmark.extract_orthologs()` function.
     """
     # pylint: disable-next=no-member
-    test_files_dir = pytest.files_dir / "orth_benchmark" # type: ignore[attr-defined]
+    test_files_dir = pytest.files_dir / "orth_benchmark" # type: ignore[attr-defined, operator]
     orthofinder_res = test_files_dir  / "OrthoFinder" / "Results_Mar03"
     assert orthology_benchmark.extract_orthologs(
         orthofinder_res, "gallus_gallus_core_106_6", "homo_sapiens_core_106_38"
@@ -319,7 +319,7 @@ def test_extract_paralogs() -> None:
     """Tests :func:`orthology_benchmark.extract_paralogs()` function.
     """
     # pylint: disable-next=no-member
-    test_files_dir = pytest.files_dir / "orth_benchmark" # type: ignore[attr-defined]
+    test_files_dir = pytest.files_dir / "orth_benchmark" # type: ignore[attr-defined, operator]
     orthofinder_res = test_files_dir  / "OrthoFinder" / "Results_Mar03"
     assert orthology_benchmark.extract_paralogs(
         orthofinder_res, "homo_sapiens_core_106_38"
@@ -348,7 +348,7 @@ def test_read_in_gtf(species_name, exp_data, expectation) -> None:
 
     """
     # pylint: disable-next=no-member
-    test_source_dir = pytest.files_dir / "orth_benchmark"  # type: ignore[attr-defined]
+    test_source_dir = pytest.files_dir / "orth_benchmark"  # type: ignore[attr-defined, operator]
     test_gtf_dir = test_source_dir / "release-51" / "metazoa" / "gtf" / "anopheles_albimanus"
 
     with expectation:

--- a/src/python/tests/test_orthology_benchmark.py
+++ b/src/python/tests/test_orthology_benchmark.py
@@ -293,7 +293,7 @@ def test_prepare_gtf_files(core_names: str, tmp_dir: Path, expectation: ContextM
 
     """
     # pylint: disable-next=no-member
-    test_source_dir = pytest.files_dir / "orth_benchmark"  # type: ignore[attr-defined]
+    test_source_dir = pytest.files_dir / "orth_benchmark"  # type: ignore[attr-defined, operator]
     with expectation:
         orthology_benchmark.prepare_gtf_files(core_names, test_source_dir, tmp_dir)
 

--- a/src/python/tests/test_orthology_benchmark.py
+++ b/src/python/tests/test_orthology_benchmark.py
@@ -330,10 +330,11 @@ def test_extract_paralogs() -> None:
     "species_name, exp_data, expectation",
     [
         ("anopheles_albimanus",
-         [["2R", "AALB007248", 16547908, 16549308, "+"], ["2R", "AALB008253", 30120952, 30126022, "-"],
-          ["2R", "AALB014269", 44548737, 44555057, "+"], ["3L", "AALB004554", 11249104, 11253606, "-"]],
+         [["2R", "AALB007248", 16547908, "+"], ["2R", "AALB008253", 30120952, "-"],
+          ["2R", "AALB014269", 44548737, "+"], ["3L", "AALB004554", 11249104, "-"]],
          does_not_raise()),
-        ("ensembl_compara", None, warns(UserWarning, match=r"GTF file for 'ensembl_compara' not found."))
+        ("ensembl_compara", None, raises(FileNotFoundError,
+                                         match=r"GTF file for 'ensembl_compara' not found."))
     ]
 )
 def test_read_in_gtf(species_name, exp_data, expectation) -> None:
@@ -352,6 +353,5 @@ def test_read_in_gtf(species_name, exp_data, expectation) -> None:
 
     with expectation:
         out_df = orthology_benchmark.read_in_gtf(species_name, test_gtf_dir)
-        if out_df is not None:
-            exp_df = pandas.DataFrame(exp_data, columns=["seqname", "gene_id", "start", "end", "strand"])
-            pandas.testing.assert_frame_equal(out_df, exp_df)
+        exp_df = pandas.DataFrame(exp_data, columns=["seqname", "gene_id", "start", "strand"])
+        pandas.testing.assert_frame_equal(out_df, exp_df)

--- a/src/python/tests/test_orthology_benchmark.py
+++ b/src/python/tests/test_orthology_benchmark.py
@@ -33,7 +33,7 @@ import pandas
 import sqlalchemy
 
 import pytest
-from pytest import FixtureRequest, raises, warns
+from pytest import FixtureRequest, raises, warns  # type: ignore
 
 from ensembl.compara.filesys import file_cmp
 


### PR DESCRIPTION
## Description

Reading in gene location and strand for all genes in a GTF file - necessary for GOC score calculation.

**Related JIRA tickets:**
- ENSCOMPARASW-5306

## Overview of changes
New function and corresponding `pytest`.
Parsing is done using `gtfparse` library -> added to `requirements.txt`

## Testing
- `pytest`

## Notes
In `requirements.txt`: Shall I keep `gtfparse==1.2.1` or perhaps put `gtfparse>=1.2.1`? Do we have any guidelines on this?

Side note: Genebuild's python gtf adaptor is in development. They use perl solution at the moment.