### PR TITLE
Ensure write_stn_tags runs before rename_labels

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -362,8 +362,16 @@ sub core_pipeline_analyses {
             {   -logic_name => 'backbone_fire_posttree',
                 -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
                 -flow_into  => {
-                    '1->A' => ['rib_fire_homology_dumps', 'rib_fire_tree_stats'],
+                    '1->A' => ['rib_fire_posttree_processing'],
                     'A->1' => ['backbone_pipeline_finished'],
+                },
+            },
+
+            {   -logic_name => 'rib_fire_posttree_processing',
+                -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+                -flow_into  => {
+                    '1->A' => [ 'rib_fire_tree_stats' ],
+                    'A->1' => [ 'rib_fire_homology_dumps' ],
                 },
             },
 


### PR DESCRIPTION
## Description

Compara [pull request 424](https://github.com/Ensembl/ensembl-compara/pull/424) addressed the issue of inaccurate gene-tree stats, but introduced a subtle bug in the ncRNA-trees pipeline, such that summary stats calculated in the `write_stn_tags` analysis are inaccurate if that analysis is run after `rename_labels`. This PR addresses the issue by rewiring the ncRNA-trees pipeline to ensure that `write_stn_tags` always runs before `rename_labels`.

**Related JIRA tickets:**
- ENSCOMPARASW-5423

## Overview of changes

A new dummy analysis (`rib_fire_posttree_processing`) is added to the ncRNA-trees pipeline,
and the analyses `rib_fire_tree_stats` and `rib_fire_homology_dumps` are placed in a fan and funnel, respectively.

## Testing

A pipeline to test the changes in this draft pull request is underway and can be viewed [here](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-7&port=4617&dbname=twalsh_rel_dev_murinae_ncrna_trees_20220510).

---

With the test pipeline run completed, this is being changed from a draft to final pull request.

As expected based on the pipeline structure, `write_stn_tags` ran before `rename_labels`. The issue with calculation of `root_nb_trees` has been fixed.  Gene-tree stats attributes and tags are accurate.