### PR TITLE
New taxonomy return script for runnable on update

### DIFF
--- a/scripts/pipeline/get_nearest_taxonomy.py
+++ b/scripts/pipeline/get_nearest_taxonomy.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Classifies the appropriate set of comparators for a taxon by taxonomic classification
+
+Example::
+
+    $ python get_nearest_taxonomy.py --taxon_name canis_lupus_familiaris \
+        --url mysql://ensro@mysql-ens-mirror-1:4240/ncbi_taxonomy_106 \
+        --taxon_list mammalia vertebrata sauropsida hexapoda \
+
+"""
+
+import sys
+from typing import List
+
+from argparse import ArgumentParser
+
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.exc import NoResultFound
+
+from ensembl.database import DBConnection
+from ensembl.compara.utils.taxonomy import (
+    match_taxon_to_reference,
+)
+
+
+def get_nearest_taxonomy(session: Session, taxon: str, ref_taxa: List[str]) -> str:
+    """Returns an appropriate reference collection directory for query ``taxon``
+
+    Args:
+        session: sqlalchemy.orm.Session object holding database connection
+        taxon: Scientific taxon name as in ncbi_taxonomy
+        taxon_list: list of reference taxonomic classifications
+    """
+    ref_taxon = match_taxon_to_reference(session, taxon, ref_taxa)
+    return ref_taxon
+
+
+if __name__ == "__main__":
+
+    parser = ArgumentParser(
+        description="Selects appropriate reference taxonomy from `taxon_list` for a given `taxon_name`."
+    )
+    parser.add_argument(
+        "--taxon_name",
+        help="Species of interest species_genus",
+        type=str
+    )
+    parser.add_argument(
+        "--taxon_list",
+        nargs="+",
+        default=["mammalia", "vertebrata"],
+        help="List of reference taxon classifications",
+    )
+    parser.add_argument(
+        "--url",
+        help="URL of ncbi_taxonomy database",
+        type=str
+    )
+    args = parser.parse_args(sys.argv[1:])
+
+    try:
+        dbc = DBConnection(args.url)
+        with dbc.session_scope() as sesh:
+            comparator_taxonomy = get_nearest_taxonomy(
+                sesh, args.taxon_name, args.taxon_list
+            )
+            print(comparator_taxonomy)
+    except (TypeError, AttributeError, NoResultFound):
+        print("A valid --taxon_name, --taxon_list and --url are required")
+        sys.exit(1)

--- a/src/python/tests/test_get_nearest_taxonomy.py
+++ b/src/python/tests/test_get_nearest_taxonomy.py
@@ -1,0 +1,121 @@
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit testing of `get_nearest_taxonomy.py` script.
+
+Typical usage example::
+
+    $ pytest test_get_nearest_taxonomy.py
+
+"""
+
+from contextlib import nullcontext as does_not_raise
+from pathlib import Path
+import subprocess
+from subprocess import CalledProcessError
+from typing import ContextManager, List
+
+import pytest
+from pytest import raises
+
+from ensembl.database import UnitTestDB
+
+
+@pytest.mark.parametrize("db", [{"src": "ncbi_db"}], indirect=True)
+class TestGetNearestTaxonomy:
+    """Tests `get+get_nearest_taxonomy.py` script.
+
+    Attributes:
+        dbc (DBConnection): Database connection to the unit test database.
+        script: Path to `get_nearest_taxonomy.py`
+
+    """
+
+    dbc = None  # type: UnitTestDB
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, db: UnitTestDB) -> None:
+        """Loads the required fixtures and values as class attributes.
+
+        Args:
+            db: Generator of unit test database (fixture).
+        """
+        type(self).dbc = db.dbc
+        # pylint: disable=no-member
+        type(self).script = (  # type: ignore
+            Path(__file__).parents[3]
+            / "scripts"
+            / "pipeline"
+            / "get_nearest_taxonomy.py"
+        )
+
+    @pytest.mark.parametrize(
+        "params, exp_stdout, expectation",
+        [
+            (
+                [
+                    "--taxon_name",
+                    "canis_lupus_familiaris",
+                    "--taxon_list",
+                    "vertebrata",
+                    "mammalia",
+                    "sauropsida",
+                ],
+                "mammalia",
+                does_not_raise(),
+            ),
+            (
+                ["--taxon_name", "gallus_gallus", "--taxon_list", "ctenophora"],
+                "default",
+                does_not_raise(),
+            ),
+            (
+                [
+                    "--taxon_name",
+                    "potato_cake",
+                    "--taxon_list",
+                    "viridiplantae",
+                    "default",
+                ],
+                "A valid --taxon_name, --taxon_list and --url are required",
+                raises(CalledProcessError),
+            ),
+            (
+                [],
+                "A valid --taxon_name, --taxon_list and --url are required",
+                raises(CalledProcessError),
+            ),
+        ],
+    )
+    def test_appropriate_ref_collection(
+        self,
+        params: List[str],
+        exp_stdout: str,
+        expectation: ContextManager,
+    ) -> None:
+        """Tests the get_nearest_taxonomy.py script as a whole.
+
+        Args:
+            params: Necessary arguments to run the get_nearest_taxonomy.py script.
+            exp_stdout: Expected nearest taxonomic classification
+            expectation: Context manager for the expected exception, i.e. the test will only pass if that
+                exception is raised. Use :class:`~contextlib.nullcontext` if no exception is expected.
+        """
+        # pylint: disable=no-member
+        script = str(self.script)  # type: ignore
+        cmd = str(
+            "python" + " " + script + " " + " ".join(params) + " " + "--url" + " " + self.dbc.url
+        )
+        with expectation:
+            output = subprocess.check_output(cmd, shell=True).decode().strip()
+            assert output == exp_stdout


### PR DESCRIPTION
## Description

Need a simple script that returns just a taxonomy match based on library - need to integrate into a Perl runnable due to registry constraints, so standalone python script necessary

**Related JIRA tickets:**
- ENSCOMPARASW-5351

## Overview of changes
_New script with pytest_

## Testing
pytest

## Notes
This is not even a subtask of a jira ticket, it's a very small part that I am submitting to keep the PR small. The task is not complete with this. This will just be wrapped with another larger PR soon.