### PR TITLE
Placeholders and new modules, update to configs

### DIFF
--- a/pipelines/OrthofinderOnQuery/nextflow.config
+++ b/pipelines/OrthofinderOnQuery/nextflow.config
@@ -17,10 +17,10 @@
 includeConfig "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/nextflow.config"
 
 params {
-    orthofinder_exe = '/hps/software/users/ensembl/ensw/C8-MAR21-sandybridge/linuxbrew/bin/orthofinder'
-    // ref_destination = '/storage/s3/long-term/reference_collections'
-    ref_destination = '/hps/nobackup/flicek/ensembl/compara/cristig/reference_collections'
-    // query_destination = '/storage/s3/short-term'
+    orthofinder_exe = "$LINUXBREW_HOME/bin/orthofinder"
+    ref_destination_cloud = "/storage/s3/long-term/comparator_results/"
+    ref_destination_farm = "$COMPARA_HPS/reference_collections"
+    query_destination = "/storage/s3/short-term/"
     taxon_selector_exe = "$ENSEMBL_ROOT_DIR/ensembl-compara/scripts/pipeline/appropriate_ref_collection.py"
-    ncbi_taxonomy_url = 'mysql://ensro@mysql-ens-mirror-1:4240/ncbi_taxonomy_106'
+    ncbi_taxonomy_url = "mysql://ensro@mysql-ens-mirror-1:4240/ncbi_taxonomy_106"
 }

--- a/pipelines/OrthofinderOnReferences/nextflow.config
+++ b/pipelines/OrthofinderOnReferences/nextflow.config
@@ -17,7 +17,7 @@
 includeConfig "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/nextflow.config"
 
 params {
-    dir = "$COMPARA_HPS/reference_fasta_symlinks/"
-    orthofinder_exe = "/hps/software/users/ensembl/ensw/C8-MAR21-sandybridge/linuxbrew/bin/orthofinder"
-    ref_destination = "/hps/nobackup/flicek/ensembl/compara/cristig/reference_collections"
+    dir = "/storage/s3/long-term/comparator_sets"
+    orthofinder_exe = "$LINUXBREW_HOME/bin/orthofinder"
+    ref_destination_cloud = "/storage/s3/long-term/comparator_results"
 }

--- a/pipelines/nextflow.config
+++ b/pipelines/nextflow.config
@@ -33,7 +33,6 @@ process {
     withLabel: slurm_default {
         executor = 'slurm'
         queue = '1c2m20d'
-        clusterOptions = ' --mem 2000 '
     }
     withLabel: rc_2Gb {
         clusterOptions = ' -C0 -M2000 '
@@ -54,11 +53,12 @@ process {
         clusterOptions = ' -C0 -M64000 '
     }
     withLabel: lsf_64Gb_32C {
-        clusterOptions = ' -n 32 -C0 -M64000 -R"span[hosts=1]" '
+        clusterOptions = ' -n 32 -C0 -M64000 -R"span[hosts=1] rusage[mem=64000.00:duration=168h:decay=0]" '
     }
     withLabel: slurm_64Gb_32C {
         executor = 'slurm'
         queue = '32c128m60d'
-        clusterOptions = ' -n 32 -C0 -M64000 '
+        memory = 64.GB
+        cpus = 32
     }
 }


### PR DESCRIPTION
## Description

This is an attempt to break up a PR, so it is parts of a couple of subtasks, incomplete as a ticket, but complete as a test functional increment on it's own for the modules and not yet the inclusion in the workflows. More work is in progress, but the review of this PR should make the next reviews easier to spot with changes to fit process.

**Related JIRA tickets:**
- ENSCOMPARASW-5375
- ENSCOMPARASW-4695
- ENSCOMPARASW-5414
- ENSCOMPARASW-5417

## Overview of changes

#### Change 1
- The `output_path` has been partially implemented as a parameter to specify the FTP directory in which to publish the results
- Another additional parameter is the use of `embassy` - by default this is `false` which will mean it will run only in lsf. Passing this parameter as `true` will put the modules (and the workflow not in this PR) into hybrid lsf/slurm usage.
- The reference directory parameters have been altered to fit the above, to better manage the differences between codon and embassy - at the moment set for testing/development - this may be changed for production.

#### Change 2
- An update on the shared pipelines `nextflow.config` for resources as improvements

#### Change 3
- Tweaks/improvements in the `orthoFinderFactory` and `runOrthoFinder` processes to better fit production purposes and tie in with the query-side of the project
- Addition of `stub` for testing in the reference side modules & the use of `scratch` for faster disk stuff

#### Change 4
- Inclusion of module/process to gunzip a fasta file if it is `gz` compressed, allowing flexibility to pass in either format
- This in the workflow is an optional step based on the file format detected - but will be in another PR

#### Change 5
- Improvements to `queryTaxonSelectionFactory` and `MergeRefToQuery` to work better with nextflow `publishDir` and such.

#### Change 6
- New module to trigger the running of the update orthofinder pipeline in hybrid mode - having split the workflow in two (this is not reflected in this PR, only the module existence)
- Update to module to update orthofinder results with query

### Change 7
- Inclusion of (commented out as an incomplete process) module to copy query orthofinder results to FTP

## Testing
These have been run in Codon and Embassy with and without stubs

## Notes
Emphasis on this is a partial but tested as a complete functional addition PR