### PR TITLE
A function to calculate unidirectional GOC score for two genes

### DIFF
--- a/scripts/pipeline/orthology_benchmark.py
+++ b/scripts/pipeline/orthology_benchmark.py
@@ -35,6 +35,7 @@ import csv
 import datetime
 import glob
 import gzip
+import itertools
 import os
 from pathlib import Path
 import re
@@ -514,6 +515,79 @@ def get_neighbours(gene: str, df_genes: pandas.DataFrame, n: int) -> pandas.Data
     neighbourhood.drop("index", 1, inplace=True)
 
     return neighbourhood
+
+
+def calculate_goc_genes(gene1: str, gene2: str, neighbourhood1: pandas.DataFrame,
+                        neighbourhood2: pandas.DataFrame, orthologs: List[Tuple[str, str]], n: int = 2,
+                        allowed_gap: int = 1) -> float:
+    """Returns unidirectional GOC score for two genes.
+
+    Please note, the final GOC score for two genes is the maximum of the two unidirectional GOC scores, i.e.
+    max{calculate_goc_genes(gene1, gene2,...), calculate_goc_genes(gene2, gene1,...)}.
+
+    Args:
+        gene1: `gene_id` of one gene of interest.
+        gene2: `gene_id` of another gene of interest.
+        neighbourhood1: A data frame with a name of the chromosome or scaffold, `gene_id`, gene start
+            position and strand for neighbours of `gene1`.
+        neighbourhood2: A data frame with a name of the chromosome or scaffold, `gene_id`, gene start
+            position and strand for neighbours of `gene2`.
+        orthologs: Putative orthologous pairs between species containing `gene1` and `gene2`.
+        n: (Maximum) Radius of `neighbourhood1`. Effectively, `neighbourhood1` can be smaller if there are
+            fewer genes around `gene1`.
+        allowed_gap: Allowed gap between subsequent orthologous matches in `neighbourhood2`.
+
+    """
+    index1 = neighbourhood1.index[neighbourhood1["gene_id"] == gene1][0]
+    index2 = neighbourhood2.index[neighbourhood2["gene_id"] == gene2][0]
+    strand1 = neighbourhood1.iloc[index1]["strand"]
+    strand2 = neighbourhood2.iloc[index2]["strand"]
+
+    if strand1 != strand2:
+        neighbourhood2 = neighbourhood2.reindex(index=neighbourhood2.index[::-1])
+        neighbourhood2.reset_index(inplace=True)
+        neighbourhood2.drop("index", 1, inplace=True)
+        strand_mismatch = True
+    else:
+        strand_mismatch = False
+
+    shared_orthologs = 0
+    prev_match = -1
+    for i in neighbourhood1.iterrows():
+        gene_i = i[1]["gene_id"]
+
+        if gene_i == gene1:  # Skip gene1
+            continue
+
+        strand_i = i[1]["strand"]
+
+        # Check if there are orthologous matches starting from (`prev_match` + 1)th position in
+        # `neighbourhood2`
+        for index, row in itertools.islice(neighbourhood2.iterrows(), prev_match + 1, None):
+            gene_j = row["gene_id"]
+
+            if gene_j == gene2:
+                prev_match = index  # Current index
+                continue  # Skip gene2
+
+            # Check that gene_i and gene_j share directionality; if not, go to next gene in `neighbourhood2`
+            strand_j = row["strand"]
+            if (strand_mismatch and strand_i == strand_j) or (not strand_mismatch and strand_i != strand_j):
+                continue
+
+            if (gene_i, gene_j) in orthologs or (gene_j, gene_i) in orthologs:
+                # If prev_match >=0 and gap too big, i.e. abs(j-prev_match) > allowed_gap + 1:
+                #   Ignore that match
+                # Else:
+                #   shared_orthologs++
+                curr_pos_j = index
+                if prev_match < 0 or abs(curr_pos_j - prev_match) <= allowed_gap + 1:
+                    shared_orthologs += 1
+
+                prev_match = curr_pos_j
+                break  # Don't look for multiple matches
+
+    return (shared_orthologs / (2 * n)) * 100
 
 
 def calculate_goc_scores():


### PR DESCRIPTION
## Description

A function to calculate unidirectional GOC score for two genes

**Related JIRA tickets:**
- ENSCOMPARASW-5307

## Overview of changes
New function and corresponding test function.

## Testing
`pytest`
Test data in a more user friendly format: [link](https://docs.google.com/spreadsheets/d/1vYsSOwp-rZG_JqiDW_Ak819YraNXSSrsQ57gYW9-1Lk/edit?usp=sharing)
Visual representation of the test cases:
![1](https://user-images.githubusercontent.com/6717226/171031727-9e8501e8-7fc3-4e75-abca-84b36320c708.jpg)
![2](https://user-images.githubusercontent.com/6717226/171031738-f3f6e6b7-ee06-4a8d-a99c-93a1282ee5d7.jpg)
![3](https://user-images.githubusercontent.com/6717226/171031745-95ecd78d-3701-474d-9727-b8fe821c51a1.jpg)


## Notes
Updated documentation for 3 other functions as argument types were missing.


