### PR TITLE
fixing dump queue and path

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
@@ -150,7 +150,7 @@ sub default_options {
         'ce_readme'             => $self->check_file_in_ensembl('ensembl-compara/docs/ftp/constrained_elements.txt'),
         'bigbed_autosql'        => $self->check_file_in_ensembl('ensembl-compara/scripts/pipeline/constrainedelements_autosql.as'),
 
-        'uniprot_dir'  => '/nfs/ftp/pub/databases/ensembl/ensembl_compara/gene_trees_for_uniprot/',
+        'uniprot_dir'  => '/nfs/ftp/public/databases/ensembl/ensembl_compara/gene_trees_for_uniprot/',
         'uniprot_file' => 'GeneTree_content.#clusterset_id#.e#curr_release#.txt',
 
     };
@@ -380,6 +380,7 @@ sub pipeline_analyses {
                     'mv ensembl.#uniprot_file#* #uniprot_dir#',
                 ))
             },
+            -rc_name       => '1Gb_datamover_job',
         },
 
         {   -logic_name     => 'remove_uniprot_file',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -161,9 +161,10 @@ sub resource_classes_single_thread {
         '96Gb_job'     => {'LSF' => ['-C0 -M96000 -R"select[mem>96000] rusage[mem=96000]"', $reg_requirement],             'LOCAL' => [ '', $reg_requirement ] },
         '512Gb_job'    => {'LSF' => ['-q bigmem -C0 -M512000 -R"select[mem>512000] rusage[mem=512000]"', $reg_requirement],    'LOCAL' => [ '', $reg_requirement ] },
 
-        '250Mb_6_hour_job'  => {'LSF' => ['-C0 -W 6:00 -M250   -R"select[mem>250]   rusage[mem=250]"',      $reg_requirement], 'LOCAL' => [ '', $reg_requirement ] },
-        '500Mb_6_hour_job'  => {'LSF' => ['-C0 -W 6:00 -M500   -R"select[mem>500]   rusage[mem=500]"',      $reg_requirement], 'LOCAL' => [ '', $reg_requirement ] },
-        '2Gb_6_hour_job'    => {'LSF' => ['-C0 -W 6:00 -M2000  -R"select[mem>2000]  rusage[mem=2000]"',     $reg_requirement], 'LOCAL' => [ '', $reg_requirement ] },
+        '250Mb_6_hour_job' => {'LSF' => ['-C0 -W 6:00 -M250   -R"select[mem>250]   rusage[mem=250]"',  $reg_requirement],  'LOCAL' => [ '', $reg_requirement ] },
+        '500Mb_6_hour_job' => {'LSF' => ['-C0 -W 6:00 -M500   -R"select[mem>500]   rusage[mem=500]"',  $reg_requirement],  'LOCAL' => [ '', $reg_requirement ] },
+        '2Gb_6_hour_job'   => {'LSF' => ['-C0 -W 6:00 -M2000  -R"select[mem>2000]  rusage[mem=2000]"', $reg_requirement],  'LOCAL' => [ '', $reg_requirement ] },
+
         '1Gb_datamover_job' => {'LSF' => ['-q datamover -C0 -M1000 -R"select[mem>1000]  rusage[mem=1000]"', $reg_requirement], 'LOCAL' => [ '', $reg_requirement ] },
     };
 }

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -161,9 +161,10 @@ sub resource_classes_single_thread {
         '96Gb_job'     => {'LSF' => ['-C0 -M96000 -R"select[mem>96000] rusage[mem=96000]"', $reg_requirement],             'LOCAL' => [ '', $reg_requirement ] },
         '512Gb_job'    => {'LSF' => ['-q bigmem -C0 -M512000 -R"select[mem>512000] rusage[mem=512000]"', $reg_requirement],    'LOCAL' => [ '', $reg_requirement ] },
 
-        '250Mb_6_hour_job' => {'LSF' => ['-C0 -W 6:00 -M250   -R"select[mem>250]   rusage[mem=250]"',  $reg_requirement],  'LOCAL' => [ '', $reg_requirement ] },
-        '500Mb_6_hour_job' => {'LSF' => ['-C0 -W 6:00 -M500   -R"select[mem>500]   rusage[mem=500]"',  $reg_requirement],  'LOCAL' => [ '', $reg_requirement ] },
-        '2Gb_6_hour_job'   => {'LSF' => ['-C0 -W 6:00 -M2000  -R"select[mem>2000]  rusage[mem=2000]"', $reg_requirement],  'LOCAL' => [ '', $reg_requirement ] },
+        '250Mb_6_hour_job'  => {'LSF' => ['-C0 -W 6:00 -M250   -R"select[mem>250]   rusage[mem=250]"',      $reg_requirement], 'LOCAL' => [ '', $reg_requirement ] },
+        '500Mb_6_hour_job'  => {'LSF' => ['-C0 -W 6:00 -M500   -R"select[mem>500]   rusage[mem=500]"',      $reg_requirement], 'LOCAL' => [ '', $reg_requirement ] },
+        '2Gb_6_hour_job'    => {'LSF' => ['-C0 -W 6:00 -M2000  -R"select[mem>2000]  rusage[mem=2000]"',     $reg_requirement], 'LOCAL' => [ '', $reg_requirement ] },
+        '1Gb_datamover_job' => {'LSF' => ['-q datamover -C0 -M1000 -R"select[mem>1000]  rusage[mem=1000]"', $reg_requirement], 'LOCAL' => [ '', $reg_requirement ] },
     };
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,6 @@ warn_unused_configs = true
 max-line-length = 110
 disable = [
     "invalid-name",
-    "no-self-use",
-    "relative-import",
     "similarities",
     "too-few-public-methods",
     "too-many-arguments",


### PR DESCRIPTION
## Description

Fixing two issues:
- `move_uniprot_file` to run on datamover nodes
- adding a new resource class `1Gb_datamover_job`
- target path on codon must change from `/nfs/ftp/pub/databases` to `/nfs/ftp/public/databases`.

**Related JIRA tickets:**
- ENSCOMPARASW-5411


