### PR TITLE
fixing pylint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,6 @@ warn_unused_configs = true
 max-line-length = 110
 disable = [
     "invalid-name",
-    "no-self-use",
-    "relative-import",
     "similarities",
     "too-few-public-methods",
     "too-many-arguments",


### PR DESCRIPTION
## Description

fixing the following error
```
************* Module pyproject.toml
pyproject.toml:1:0: W0012: Unknown option value for '--disable', expected a valid pylint message and got 'no-self-use' (unknown-option-value)
pyproject.toml:1:0: W0012: Unknown option value for '--disable', expected a valid pylint message and got 'relative-import' (unknown-option-value)
```