### PR TITLE
Update GERP pipeline JSON field names

### DIFF
--- a/src/python/lib/ensembl/compara/hal/maf_to_fasta.py
+++ b/src/python/lib/ensembl/compara/hal/maf_to_fasta.py
@@ -128,7 +128,7 @@ def convert_maf_to_fasta(maf_file: PathLike, output_dir: PathLike,
                     maf_src = rec.id
 
                     try:
-                        genome_name, dnafrag_name = maf_src_map.setdefault(maf_src, maf_src.split('.'))
+                        genome_name, region_name = maf_src_map.setdefault(maf_src, maf_src.split('.'))
                     except ValueError as exc:
                         if not genomes_file:
                             raise ValueError(
@@ -138,35 +138,35 @@ def convert_maf_to_fasta(maf_file: PathLike, output_dir: PathLike,
                         match = maf_src_regex.match(maf_src)
                         try:
                             genome_name = match['genome']  # type: ignore
-                            dnafrag_name = match['seqid']  # type: ignore
+                            region_name = match['seqid']  # type: ignore
                         except TypeError as exc_err:
                             raise ValueError(
                                 "MAF src regex failed to parse MAF src field: '{maf_src}'") from exc_err
-                        maf_src_map[maf_src] = [genome_name, dnafrag_name]
+                        maf_src_map[maf_src] = [genome_name, region_name]
 
                     maf_start = rec.annotations['start']
                     maf_size = rec.annotations['size']
                     maf_end = maf_start + maf_size
-                    dnafrag_strand = rec.annotations['strand']
+                    region_strand = rec.annotations['strand']
 
-                    if dnafrag_strand == 1:
-                        dnafrag_start = maf_start + 1
-                        dnafrag_end = maf_end
+                    if region_strand == 1:
+                        region_start = maf_start + 1
+                        region_end = maf_end
                     else:
                         maf_src_size = rec.annotations['srcSize']
-                        dnafrag_start = maf_src_size - maf_end + 1
-                        dnafrag_end = maf_src_size - maf_start
+                        region_start = maf_src_size - maf_end + 1
+                        region_end = maf_src_size - maf_start
 
-                    fasta_id = f'{genome_name}:{dnafrag_name}:{dnafrag_start}:{dnafrag_end}'
+                    fasta_id = f'{genome_name}:{region_name}:{region_start}:{region_end}'
                     fasta_rec = SeqRecord(rec.seq, id=fasta_id, name='', description='')
                     SeqIO.write([fasta_rec], out_f, 'fasta')
 
                     ga_recs.append({
-                        'genome_name': genome_name,
-                        'dnafrag_name': dnafrag_name,
-                        'dnafrag_start': dnafrag_start,
-                        'dnafrag_end': dnafrag_end,
-                        'dnafrag_strand': dnafrag_strand
+                        'assembly_name': genome_name,
+                        'region_name': region_name,
+                        'region_start': region_start,
+                        'region_end': region_end,
+                        'region_strand': region_strand
                     })
 
             output_data = {'aligned_seq': ga_recs}

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -55,12 +55,11 @@ def add_ce_to_json(ce_file: str, json_file: str) -> None:
             constrained_elem = {
                 "start": int(ce[0]),
                 "end": int(ce[1]),
-                "length": int(ce[2]),
                 "score": float(ce[3]),
                 "p-val": float(ce[4])
             }
             constrained_elems.append(constrained_elem)
-    align_set["constrained_elems"] = constrained_elems
+    align_set["constrained_element"] = constrained_elems
 
     with open(json_file, "w") as json_file_obj:
         json.dump(align_set, json_file_obj)

--- a/src/python/scripts/run_gerp.py
+++ b/src/python/scripts/run_gerp.py
@@ -59,7 +59,7 @@ def add_ce_to_json(ce_file: str, json_file: str) -> None:
                 "p-val": float(ce[4])
             }
             constrained_elems.append(constrained_elem)
-    align_set["constrained_element"] = constrained_elems
+    align_set["constrained_elements"] = constrained_elems
 
     with open(json_file, "w") as json_file_obj:
         json.dump(align_set, json_file_obj)

--- a/src/python/tests/flatfiles/hal_alignment/gabs/0.json
+++ b/src/python/tests/flatfiles/hal_alignment/gabs/0.json
@@ -1,25 +1,25 @@
 {
     "aligned_seq": [
         {
-            "genome_name": "genomeA.1",
-            "dnafrag_name": "chr1",
-            "dnafrag_start": 1,
-            "dnafrag_end": 4,
-            "dnafrag_strand": 1
+            "assembly_name": "genomeA.1",
+            "region_name": "chr1",
+            "region_start": 1,
+            "region_end": 4,
+            "region_strand": 1
         },
         {
-            "genome_name": "genomeB.1",
-            "dnafrag_name": "chr1",
-            "dnafrag_start": 1,
-            "dnafrag_end": 3,
-            "dnafrag_strand": 1
+            "assembly_name": "genomeB.1",
+            "region_name": "chr1",
+            "region_start": 1,
+            "region_end": 3,
+            "region_strand": 1
         },
         {
-            "genome_name": "genomeC",
-            "dnafrag_name": "chr1",
-            "dnafrag_start": 1,
-            "dnafrag_end": 2,
-            "dnafrag_strand": 1
+            "assembly_name": "genomeC",
+            "region_name": "chr1",
+            "region_start": 1,
+            "region_end": 2,
+            "region_strand": 1
         }
     ]
 }

--- a/src/python/tests/flatfiles/hal_alignment/gabs/1.json
+++ b/src/python/tests/flatfiles/hal_alignment/gabs/1.json
@@ -1,25 +1,25 @@
 {
     "aligned_seq": [
         {
-            "genome_name": "genomeA.1",
-            "dnafrag_name": "chr1",
-            "dnafrag_start": 6,
-            "dnafrag_end": 9,
-            "dnafrag_strand": 1
+            "assembly_name": "genomeA.1",
+            "region_name": "chr1",
+            "region_start": 6,
+            "region_end": 9,
+            "region_strand": 1
         },
         {
-            "genome_name": "genomeB.1",
-            "dnafrag_name": "chr1",
-            "dnafrag_start": 6,
-            "dnafrag_end": 9,
-            "dnafrag_strand": 1
+            "assembly_name": "genomeB.1",
+            "region_name": "chr1",
+            "region_start": 6,
+            "region_end": 9,
+            "region_strand": 1
         },
         {
-            "genome_name": "genomeC",
-            "dnafrag_name": "chr1",
-            "dnafrag_start": 6,
-            "dnafrag_end": 9,
-            "dnafrag_strand": -1
+            "assembly_name": "genomeC",
+            "region_name": "chr1",
+            "region_start": 6,
+            "region_end": 9,
+            "region_strand": -1
         }
     ]
 }


### PR DESCRIPTION
## Description

Updates JSON field names.

**Related JIRA tickets:**
- ENSCOMPARASW-5440

## Overview of changes

Alignment metadata keys are updated as follows:

- `genome_name` -> `assembly_name`
- `dnafrag_name` -> `region_name`
- `dnafrag_start` -> `region_start`
- `dnafrag_end` -> `region_end`
- `dnafrag_strand` -> `region_strand`

In addition, the main constrained element key is changed
from `constrained_elems` to `constrained_element`, and
the constrained element `length` field is removed.

## Testing

Unit tests have been updated and pass successfully.