### PR TITLE
Update mafft_update and related runnables to `fetch_by_stable_id_GenomeDB()`

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -1819,7 +1819,7 @@ sub core_pipeline_analyses {
         },
 
         {   -logic_name => 'mafft_update',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::Mafft_update',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::MafftUpdate',
             -parameters => {
                 'mafft_exe'                  => $self->o('mafft_exe'),
             },

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/CopyAlignmentsFromDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/CopyAlignmentsFromDB.pm
@@ -112,12 +112,6 @@ sub fetch_input {
         $self->param( 'reuse_gene_tree', $self->param('reuse_tree_adaptor')->fetch_by_stable_id( $self->param('stable_id') ) );
         $self->param( 'reuse_gene_tree_id', $self->param('reuse_gene_tree')->root_id );
 
-        #Newly added genes will not be added here, only genes that were removed or altered will be excluded.
-        #if ( defined( $members_2_b_updated{ $member->stable_id } ) ) {
-        #print "Removing updated gene: ".$member->stable_id."\n" if ( $self->debug );
-        #$self->param('sa')->remove_seq( $self->param('sa')->each_seq_with_id( $member->seq_member_id ) );
-        #}
-
         #Get all the cigar lines for all members in the reused tree.
         my %cigar_lines_reuse_tree;
         foreach my $member ( @{ $self->param('reuse_gene_tree')->get_all_Members } ) {
@@ -127,9 +121,12 @@ sub fetch_input {
 
         #Copying the cigar lines to the new tree excluding the members that need update:
         foreach my $current_member ( @{ $self->param('copy_gene_tree')->get_all_Members } ) {
-            if ( defined( $cigar_lines_reuse_tree{ $current_member->stable_id } ) && ( !defined( $members_2_b_added_updated{ $current_member->stable_id } ) ) ) {
+            my $stable_id = $current_member->stable_id;
+            my $gdb_id = $current_member->genome_db_id;
+            if ( defined( $cigar_lines_reuse_tree{ $stable_id } )
+                && ( !defined( $members_2_b_added_updated{ $stable_id . " " . $gdb_id } ) ) ) {
                 $current_member->cigar_line( $cigar_lines_reuse_tree{ $current_member->stable_id } );
-                print "copying_cigar:" . $current_member->stable_id . "\n" if ( $self->debug );
+                print "copying_cigar:" . $stable_id . " for gdb_id " . $gdb_id . "\n" if ( $self->debug );
             }
         }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/MafftUpdate.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/MafftUpdate.pm
@@ -19,7 +19,7 @@ limitations under the License.
 
 =head1 NAME
 
-Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::Mafft_update
+Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::MafftUpdate
 
 =head1 DESCRIPTION
 
@@ -30,7 +30,7 @@ It is used to add sequences to already existing alignments.
 
 =cut
 
-package Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::Mafft_update;
+package Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::MafftUpdate;
 
 use strict;
 use warnings;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/Mafft_update.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/Mafft_update.pm
@@ -1,4 +1,3 @@
-
 =head1 LICENSE
 
 See the NOTICE file distributed with this work for additional information
@@ -18,14 +17,6 @@ limitations under the License.
 
 =cut
 
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::Mafft_update
@@ -37,15 +28,6 @@ It fetches the genes to be added from the root_tag 'updated_genes_list'
 
 It is used to add sequences to already existing alignments.
 
-=head1 AUTHORSHIP
-
-Ensembl Team. Individual contributions can be found in the GIT log.
-
-=head1 APPENDIX
-
-The rest of the documentation details each of the object methods.
-Internal methods are usually preceded with an underscore (_)
-
 =cut
 
 package Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::Mafft_update;
@@ -54,6 +36,7 @@ use strict;
 use warnings;
 
 use Data::Dumper;
+use Array::Utils qw/ array_minus /;
 
 use Bio::EnsEMBL::Compara::MemberSet;
 
@@ -71,12 +54,17 @@ sub param_defaults {
 sub fetch_input {
     my ($self) = @_;
 
-    #Get adaptors
-    #----------------------------------------------------------------------------------------------------------------------------
-
     #get current tree adaptor
     $self->param( 'current_tree_adaptor', $self->compara_dba->get_GeneTreeAdaptor );
-    $self->param( 'current_gene_tree', $self->param('current_tree_adaptor')->fetch_by_dbID( $self->param('gene_tree_id') ) ) || $self->die_no_retry("Could not fetch current_gene_tree");
+    my $current_gene_tree = $self->param('current_tree_adaptor')->fetch_by_dbID( $self->param('gene_tree_id') );
+    $self->param(
+        'current_gene_tree', $current_gene_tree || $self->die_no_retry("Could not fetch current_gene_tree")
+    );
+    #get previous tree adaptor
+    $self->param( 'reuse_tree_adaptor', $self->param('reuse_compara_dba')->get_GeneTreeAdaptor );
+    $self->param( 'previous_gene_tree',
+        $self->param('reuse_tree_adaptor')->fetch_by_stable_id( $current_gene_tree->stable_id )
+    );
 
     my $copy_tree = $self->param('current_gene_tree')->alternative_trees->{ $self->param('input_clusterset_id') };
 	$self->param( 'copy_gene_tree', $copy_tree);
@@ -96,7 +84,7 @@ sub fetch_input {
     }
 
     $self->param( 'alignment_file', $input_aln );
-} ## end sub fetch_input
+}
 
 
 sub parse_and_store_alignment_into_proteintree {
@@ -115,36 +103,31 @@ sub get_msa_command_line {
 
     my $mafft_exe  = $self->require_executable('mafft_exe');
 
-    #This logic should be replaced by the new method for getting the alignment sequences directly from the adaptor.
-    #--------------------------------------------------------------------------------------------------------------
     my $new_seq_file = $self->worker_temp_directory . "/" . $self->param_required('gene_tree_id') . "_new_seq.fasta";
 
-    my %members_2_b_updated;
-    my %members_2_b_added;
-    if ( $self->param('current_gene_tree')->has_tag('updated_genes_list') ) {
-        %members_2_b_updated = map { $_ => 1 } split( /,/, $self->param('current_gene_tree')->get_value_for_tag('updated_genes_list') );
-    }
+    my @prev_member_list = @{$self->param('previous_gene_tree')->get_all_Members()};
+    my @curr_member_list = @{$self->param('current_gene_tree')->get_all_Members()};
+    my %prev_members = ( map { ($_->genome_db->dbID . " " . $_->stable_id) => 1 } @prev_member_list );
+    my %curr_members = ( map { ($_->genome_db->dbID . " " . $_->stable_id) => 1 } @curr_member_list );
 
-    if ( $self->param('current_gene_tree')->has_tag('added_genes_list') ) {
-        %members_2_b_added = map { $_ => 1 } split( /,/, $self->param('current_gene_tree')->get_value_for_tag('added_genes_list') );
-    }
-
-	@members_2_b_updated{keys %members_2_b_added} = values %members_2_b_added;
+    my @prev_members = keys %prev_members;
+    my @curr_members = keys %curr_members;
+    my @updated_genome_db_members = array_minus( @curr_members, @prev_members );
 
 	print "members to update:\n" if ( $self->debug );
     my @members_to_print;
     my $seq_member_adaptor = $self->compara_dba->get_SeqMemberAdaptor;
-    foreach my $updated_member_stable_id ( keys %members_2_b_updated ) {
-        my $seq_member = $seq_member_adaptor->fetch_by_stable_id($updated_member_stable_id);
-        print "$updated_member_stable_id|".$seq_member->seq_member_id."|".$seq_member->sequence_id."\n" if ( $self->debug );
+
+    foreach my $updated_genome_db_member_stable_id ( @updated_genome_db_members ) {
+        my ($genome_db_id, $stable_id) = split / /, $updated_genome_db_member_stable_id;
+        my $seq_member = $seq_member_adaptor->fetch_by_stable_id_GenomeDB($stable_id, $genome_db_id);
+        print $stable_id . "|" . $seq_member->seq_member_id . "|" . $seq_member->sequence_id . "\n" if ( $self->debug );
         push @members_to_print, $seq_member;
     }
+
     Bio::EnsEMBL::Compara::MemberSet->new(-MEMBERS => \@members_to_print)->print_sequences_to_file($new_seq_file, -FORMAT => 'fasta', -ID_TYPE => 'SEQUENCE_ID', -SEQ_TYPE => $self->param('cdna') ? 'cds' : undef);
 
-
-    #--------------------------------------------------------------------------------------------------------------
-
     return sprintf( '%s --add %s --anysymbol --thread 1 --auto %s > %s', $mafft_exe, $new_seq_file, $self->param('alignment_file'), $self->param('msa_output') );
-} ## end sub get_msa_command_line
+}
 
 1;


### PR DESCRIPTION
## Description
There are a few runnables that require an update upon deprecation of fetch_by_stable_id() from the MemberAdaptors.

**Related JIRA tickets:**
- ENSCOMPARASW-5361

## Overview of changes

#### Change 1
- Made change in `Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::FlagUpdateClusters` to store tags to include the `genome_db_id` with the `stable_id`.
- Replaced method to retrieve members from the gene tree adaptors - this was necessary to retrieve the genome_dbs to use the `fetch_by_stable_id_GenomeDB` method rather than the `fetch_by_stable_id` alone in `Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::CopyTreesFromDB` and `Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::MafftUpdate`.
- Updated `Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::CopyAlignmentsFromDB` to reflect new `gene_tree_root_tag` values to include `stable_id` and `genome_db_id`.

#### Change 2
- Hoping to rename the `update_mafft` runnable - which is only used in one place anyway.

#### Change 3
- POD cleanup
- Comment clean up and clarify/update
- Removal of redundant code comments to improve readability

## Testing
This has been tested syntactically locally and via Travis.

## Notes
This runnable is included in the protein trees config - but it was part of an unused development project to use a `topup`  clustering method (which as far as I know never worked out - but at least the logic is there). It will likely never be used as it is now when gene trees are overhauled, and could probably be removed from the protein trees pipeline - but at least it should be in working condition as a standalone.