### PR TITLE
RemoveBlockListedGenes to use fetch_by_stable_id_GenomeDB()

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateHmmProfiles_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateHmmProfiles_conf.pm
@@ -101,7 +101,7 @@ sub default_options {
         'clustering_max_gene_halfcount' => 750,
         # File with gene / peptide names that must be excluded from the
         # clusters (e.g. know to disturb the trees)
-        'gene_blacklist_file'           => '/dev/null',
+        'gene_blocklist_file'           => '/dev/null',
 
     # tree building parameters:
         'use_quick_tree_break'      => 1,
@@ -910,7 +910,7 @@ sub core_pipeline_analyses {
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into => {
                 '1->A' => [ 'load_PANTHER' ],
-                'A->1' => [ 'remove_blacklisted_genes' ],
+                'A->1' => [ 'remove_blocklisted_genes' ],
             },
         },
 
@@ -972,10 +972,10 @@ sub core_pipeline_analyses {
         },
 
 
-        {   -logic_name         => 'remove_blacklisted_genes',
-            -module             => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::RemoveBlacklistedGenes',
+        {   -logic_name         => 'remove_blocklisted_genes',
+            -module             => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::RemoveBlocklistedGenes',
             -parameters         => {
-                blacklist_file      => $self->o('gene_blacklist_file'),
+                'blocklist_file' => $self->o('gene_blocklist_file'),
             },
             -flow_into          => [ 'clusterset_backup' ],
             -rc_name => '500Mb_job',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
@@ -57,7 +57,7 @@ sub default_options {
             'saccharomyces_cerevisiae' => 2,
         },
         # File with gene / peptide names that must be excluded from the clusters (e.g. know to disturb the trees)
-        'gene_blacklist_file'          => $self->o('warehouse_dir') . '/proteintree_blacklist.e82.txt',
+        'gene_blocklist_file'          => $self->o('warehouse_dir') . '/template_blocklist.txt',
 
     # species tree reconciliation
         # you can define your own species_tree for 'treebest'. It can contain multifurcations

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -118,7 +118,7 @@ sub default_options {
         # (half of the previously used 'clutering_max_gene_count=1500) affects 'hcluster_run'
         'clustering_max_gene_halfcount' => 750,
         # File with gene / peptide names that must be excluded from the clusters (e.g. know to disturb the trees)
-        'gene_blacklist_file'           => '/dev/null',
+        'gene_blocklist_file'           => '/dev/null',
 
     # tree building parameters:
         'use_raxml'                 => 0,
@@ -1575,19 +1575,19 @@ sub core_pipeline_analyses {
             -parameters => {
                 'tags_to_copy'              => [ 'division' ],
             },
-            -flow_into  => [ 'remove_blacklisted_genes' ],
+            -flow_into  => [ 'remove_blocklisted_genes' ],
             -rc_name => '4Gb_job',
         },
 
         {   -logic_name         => 'expand_clusters_with_projections',
             -module             => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::ExpandClustersWithProjections',
-            -flow_into          => [ 'remove_blacklisted_genes' ],
+            -flow_into          => [ 'remove_blocklisted_genes' ],
         },
 
-        {   -logic_name         => 'remove_blacklisted_genes',
-            -module             => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::RemoveBlacklistedGenes',
+        {   -logic_name         => 'remove_blocklisted_genes',
+            -module             => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::RemoveBlocklistedGenes',
             -parameters         => {
-                blacklist_file      => $self->o('gene_blacklist_file'),
+                'blocklist_file' => $self->o('gene_blocklist_file'),
             },
             -flow_into          => [ 'hc_clusters' ],
             -rc_name => '500Mb_job',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ProteinTrees_conf.pm
@@ -51,7 +51,7 @@ sub default_options {
         # affects 'hcluster_dump_input_per_genome'
         'outgroups'                     => { 'saccharomyces_cerevisiae' => 2 },
         # File with gene / peptide names that must be excluded from the clusters (e.g. know to disturb the trees)
-        'gene_blacklist_file'           => $self->o('warehouse_dir') . '/proteintree_blacklist.e82.txt',
+        'gene_blocklist_file'           => $self->o('warehouse_dir') . '/template_blocklist.txt',
 
     # species tree reconciliation
         # you can define your own species_tree for 'notung' or 'CAFE'. It *has* to be binary

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RemoveBlacklistedGenes.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RemoveBlacklistedGenes.pm
@@ -17,31 +17,17 @@ limitations under the License.
 
 =cut
 
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RemoveBlacklistedGenes
 
 =head1 DESCRIPTION
 
-Removes from the (flat) clusters the genes listed in a file
-
-=head1 AUTHORSHIP
-
-Ensembl Team. Individual contributions can be found in the GIT log.
-
-=head1 APPENDIX
-
-The rest of the documentation details each of the object methods.
-Internal methods are usually preceded with an underscore (_)
+Removes the stable_id corresponding to a genome_db from a flat gene tree/cluster.
+    The blocklist_file should follow the format:
+<stable_id> <genome_db_id>
+ENSTNIG00000004376 65
+ENSTNIG00000004377 65
 
 =cut
 
@@ -59,44 +45,47 @@ use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 sub fetch_input {
     my $self = shift @_;
 
-    my $blacklist_genes         = slurp_to_array($self->param_required('blacklist_file'), 1);
+    my $blocklist_genes_genomes = slurp_to_array($self->param_required('blocklist_file'), 1);
 
-    # remove members related to blacklisted genes
+    # remove members related to blocklisted genes
     my $gene_member_adaptor     = $self->compara_dba->get_GeneMemberAdaptor;
     my $seq_member_adaptor      = $self->compara_dba->get_SeqMemberAdaptor;
     my $gene_tree_node_adaptor  = $self->compara_dba->get_GeneTreeNodeAdaptor;
 
-    my @blacklist_seq_members;
-    foreach my $gene_name (@$blacklist_genes) {
-        my $member = $gene_member_adaptor->fetch_by_stable_id($gene_name) || $seq_member_adaptor->fetch_by_stable_id($gene_name);
-        unless ( $member ){
-            $self->warning( "Cannot find '$gene_name' in the database\n" );
+    my @blocklist_seq_members;
+    foreach my $stable_id_genome_db_id ( @$blocklist_genes_genomes ) {
+        my ($stable_id, $genome_db_id) = split / /, $stable_id_genome_db_id;
+        my $member = $gene_member_adaptor->fetch_by_stable_id_GenomeDB($stable_id, $genome_db_id) ||
+            $seq_member_adaptor->fetch_by_stable_id_GenomeDB($stable_id, $genome_db_id) ||
+            undef;
+        if (! defined $member) {
+            $self->warning( "Cannot find '$stable_id' for '$genome_db_id' in the database\n" );
             next;
         }
 
         my $aligned_member = $gene_tree_node_adaptor->fetch_default_AlignedMember_for_Member($member);
         unless ( $aligned_member ) {
-            $self->warning( "Cannot find alignment for '$gene_name' in the database\n" );
+            $self->warning( "Cannot find alignment for '$stable_id' for '$genome_db_id' in the database\n" );
             next;
         }
-        push @blacklist_seq_members, $aligned_member;
+        push @blocklist_seq_members, $aligned_member;
     }
 
-    $self->param('blacklist_seq_members', \@blacklist_seq_members);
+    $self->param('blocklist_seq_members', \@blocklist_seq_members);
 }
 
 sub write_output {
     my $self = shift @_;
 
-    my $blacklist_seq_members   = $self->param('blacklist_seq_members');
+    my $blocklist_seq_members   = $self->param('blocklist_seq_members');
     my $gene_tree_node_adaptor  = $self->compara_dba->get_GeneTreeNodeAdaptor;
     my $gene_tree_adaptor       = $self->compara_dba->get_GeneTreeAdaptor;
 
-    print Dumper $blacklist_seq_members if $self->debug;
+    print Dumper $blocklist_seq_members if $self->debug;
 
     $self->call_within_transaction( sub {
         # NOTE: Here we assume that the default tree is flat !
-        foreach my $m (@$blacklist_seq_members) {
+        foreach my $m (@$blocklist_seq_members) {
             if (!$m->tree){
                 next;
             }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RemoveBlocklistedGenes.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RemoveBlocklistedGenes.pm
@@ -19,7 +19,7 @@ limitations under the License.
 
 =head1 NAME
 
-Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RemoveBlacklistedGenes
+Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RemoveBlocklistedGenes
 
 =head1 DESCRIPTION
 
@@ -31,7 +31,7 @@ ENSTNIG00000004377 65
 
 =cut
 
-package Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::RemoveBlacklistedGenes;
+package Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::RemoveBlocklistedGenes;
 
 use strict;
 use warnings;


### PR DESCRIPTION
## Description

There are a few runnables that require an update upon deprecation of `fetch_by_stable_id()` from the `MemberAdaptors`.

**Related JIRA tickets:**
- ENSCOMPARASW-5361

## Overview of changes

#### Change 1
- The initial input for list of genes to avoid was expected only to be a list of `stable_ids` - a new template has been provided in `${COMPARA_WAREHOUSE}` with fake genes and the ancestral `genome_db_id` - so there will be no detrimental effect when run with it - this has been included in the relevant protein tree pipelines. The previous list that was used and stored in the warehouse is redundant, none of the genes exist anymore, and never will.
- The POD has been changed to reflect this.

#### Change 2
- Logic was simply altered to fit this new list that includes a `genome_db_id` also.
- Some renaming while I was here seemed necessary for Equality/Equity, Inclusivity and Diversity at a bare minimum.

## Testing
Tested as a `standaloneJob`:
```
standaloneJob.pl --url mysql://xxxx:xxxx@mysql-ens-compara-prod-7:4617/cristig_default_plants_protein_trees_108 --job_id 17627 --blocklist_file /nfs/production/flicek/ensembl/compara/warehouse/template_blacklist.txt -compara_db mysql://xxxx:xxxx@mysql-ens-compara-prod-7:4617/cristig_default_plants_protein_trees_108
bsub -q standard -M500 -R"select[mem>500] rusage[mem=500]" -n 1  -env all -Is standaloneJob.pl --url mysql://xxxx:xxxx@mysql-ens-compara-prod-7:4617/cristig_default_plants_protein_trees_108 --job_id 17627 --blocklist_file /nfs/production/flicek/ensembl/compara/warehouse/template_blacklist.txt -compara_db mysql://xxxx:xxxx@mysql-ens-compara-prod-7:4617/cristig_default_plants_protein_trees_108
Job <6516044> is submitted to queue <standard>.
<<Waiting for dispatch ...>>
<<Starting on hl-codon-33-02>>

Taken parameters from job_id 17627 (status DONE) @ 'mysql://xxxx:${_EHIVE_HIDDEN_PASS}@mysql-ens-compara-prod-7:4617/cristig_default_plants_protein_trees_108'
Will now disconnect from it. Be aware that the original Job will NOT be updated with the outcome of this standalone. Use runWorker.pl if you want to register your run.

Running 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::RemoveBlacklistedGenes' with input_id='{"all_blast_params" => [[0,35,"-seg no -max_hsps 1 -use_sw_tback -num_threads 1 -matrix PAM30 -word_size 2","1e-4"],[35,50,"-seg no -max_hsps 1 -use_sw_tback -num_threads 1 -matrix PAM70 -word_size 2","1e-6"],[50,100,"-seg no -max_hsps 1 -use_sw_tback -num_threads 1 -matrix BLOSUM80 -word_size 2","1e-8"],[100,10000000,"-seg no -max_hsps 1 -use_sw_tback -num_threads 1 -matrix BLOSUM62 -word_size 3","1e-10"]],"alt_aln_dbs" => ["compara_curr"],"are_all_species_reused" => 0,"binary_species_tree_input_file" => undef,"blacklist_file" => "/nfs/production/flicek/ensembl/compara/warehouse/proteintree_blacklist.e82.txt","blocklist_file" => "/nfs/production/flicek/ensembl/compara/warehouse/template_blacklist.txt","cluster_dir" => "/hps/nobackup/flicek/ensembl/compara/cristig/default_plants_protein_trees_108/cluster","clustering_mode" => "hybrid","compara_db" => "mysql://xxxx:xxxx\@mysql-ens-compara-prod-7:4617/cristig_default_plants_protein_trees_108","dbID_range_index" => undef,"dna_alns_complete" => 1,"do_cafe" => 1,"do_gene_qc" => 1,"do_goc" => 1,"do_hmm_export" => 0,"do_homology_id_mapping" => 1,"do_homology_stats" => 1,"do_jaccard_index" => 1,"do_stable_id_mapping" => 1,"do_treefam_xref" => 1,"dump_dir" => "/hps/nobackup/flicek/ensembl/compara/cristig/default_plants_protein_trees_108/dumps","dump_pafs_dir" => "/hps/nobackup/flicek/ensembl/compara/cristig/default_plants_protein_trees_108/dumps/pafs","ensembl_release" => 108,"examl_dir" => "/hps/nobackup/flicek/ensembl/compara/cristig/default_plants_protein_trees_108/examl","fasta_dir" => "/hps/nobackup/flicek/ensembl/compara/cristig/default_plants_protein_trees_108/blast_db","gene_dumps_dir" => "/hps/nobackup/flicek/ensembl/compara/cristig/default_plants_protein_trees_108/dumps/genes","gene_tree_stats_shared_dir" => "/hps/nobackup/flicek/ensembl/compara/shared/gene_tree_stats/plants/default/108","goc_file" => "#goc_files_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.goc.tsv","goc_files_dir" => "/hps/nobackup/flicek/ensembl/compara/cristig/default_plants_protein_trees_108/dumps/homology_dumps/","hashed_mlss_id" => "#expr(dir_revhash(#mlss_id#))expr#","high_conf_file" => "#homology_dumps_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.high_conf.tsv","high_confidence_capacity" => 500,"hmm_library_basedir" => "/hps/nobackup/flicek/ensembl/compara/shared/treefam_hmms/2019-01-02","hmm_library_version" => 2,"homology_dumps_dir" => "/hps/nobackup/flicek/ensembl/compara/cristig/default_plants_protein_trees_108/dumps/homology_dumps/","homology_dumps_shared_dir" => "/hps/nobackup/flicek/ensembl/compara/shared/homology_dumps/plants/default/108","import_homologies_capacity" => 20,"mapped_gene_ratio_per_taxon" => {2759 => "0.5",3041 => "0.65",3193 => "0.7",33090 => "0.65"},"mapping_db" => "compara_prev","master_db" => "compara_master","member_db" => "compara_members","member_type" => "protein","mlss_id" => 40153,"ncbi_db" => "compara_master","nonreuse_ss_csv" => "-1,2105,2143,2116,2250,2106,2169,2118,2249,2251,2039,2137,2144,2141,2168,2170,2136,1962,2145,2142,2165,2117,2104,2103,2134,2102,2135","nonreuse_ss_id" => 10000002,"orth_batch_size" => 10,"orth_wga_complete" => 0,"orthotree_dir" => "/hps/nobackup/flicek/ensembl/compara/cristig/default_plants_protein_trees_108/dumps/orthotree/","output_dir_path" => "/hps/nobackup/flicek/ensembl/compara/cristig/default_plants_protein_trees_108/datachecks/","pipeline_dir" => "/hps/nobackup/flicek/ensembl/compara/cristig/default_plants_protein_trees_108","plots_dir" => "/hps/nobackup/flicek/ensembl/compara/cristig/default_plants_protein_trees_108/plots","prev_homology_dumps_dir" => "/hps/nobackup/flicek/ensembl/compara/shared/homology_dumps/plants/default/107","prev_wga_dumps_dir" => "/hps/nobackup/flicek/ensembl/compara/shared/homology_dumps/plants/default/107","previous_wga_file" => "#prev_wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv","range_label" => "protein","reg_conf" => "/hps/software/users/ensembl/repositories/compara/cristig/e108/ensembl-compara/conf/plants/production_reg_conf.pl","reuse_db" => "compara_prev","reuse_level" => "members","reuse_ss_csv" => "-1,2199,2176,2174,2034,2071,2206,2177,2007,2131,2037,2132,2152,2173,27,2193,2198,2179,2172,2120,2108,2107,2096,2076,2115,2191,2147,2067,2097,2077,2140,2162,1553,2171,2161,2154,2121,2189,2178,2009,2075,2133,2035,2246,2074,2123,1560,1572,1554,2197,2150,2139,2006,2245,2167,2130,2157,2138,2119,2192,2113,2153,2038,2109,2122,1601,2010,2151,2148,2091,2098,2090,2111,2127,2242,2196,2124,2078,2004,1558,2247,2194,2190,2201,1582,2100,2175,1505,2188,2163,2062,2248,2110,2114,2200,2195,1557,2244,2243,1985,2101,2099","reuse_ss_id" => 10000001,"species_count" => 122,"threshold_levels" => [{"taxa" => ["all"],"thresholds" => [50,50,25]}],"use_notung" => 0,"use_quick_tree_break" => 1,"use_raxml" => 0,"use_treerecs" => 0,"wga_dumps_dir" => "/hps/nobackup/flicek/ensembl/compara/cristig/default_plants_protein_trees_108/dumps/homology_dumps/","wga_file" => "#wga_files_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.wga.tsv","wga_files_dir" => "/hps/nobackup/flicek/ensembl/compara/cristig/default_plants_protein_trees_108/dumps/homology_dumps/"}' :
Standalone worker 3385176 : specializing to Standalone_Dummy_Analysis(unstored)
Standalone worker 3385176 : INFO : Cannot find 'ENSANSC00000000001' for '63' in the database
Standalone worker 3385176 : INFO : Cannot find 'ENSANSC00000000002' for '63' in the database
```

## Notes
We don't currently have any blocklisted genes.