### PR TITLE
upgrating numpyt to 1.21 due to Buffer Overflow in NumPy

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -16,8 +16,6 @@ jobs=1
 # --disable=W"
 disable=
   invalid-name,
-  no-self-use,
-  relative-import,
   similarities,
   too-many-statements,
   too-many-arguments,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ biopython>=1.76,<=1.78
 ete3>=3.1.1,<=3.1.2
 lxml==4.6.5
 mysqlclient>=1.4.6,<=2.0.3
-numpy>=1.16.5,<=1.19.5
+numpy>=1.21
 pandas>=0.24.2,<=1.2.1
 pybedtools==0.8.2
 pytest>=5.2.1,<=5.3.1


### PR DESCRIPTION
## Description

updating `numpy` to at least version `1.21` due to  Buffer Overflow in NumPy
