### PR TITLE
Fix `ImportAltAlleGroupAsHomologies` dependency on `gene_member.stabl…

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ImportAltAlleGroupAsHomologies.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ImportAltAlleGroupAsHomologies.pm
@@ -77,11 +77,15 @@ sub copy_and_fetch_gene {
     my $self = shift;
     my $gene = shift;
 
-    copy_data_with_foreign_keys_by_constraint($self->param('member_dbc'), $self->compara_dba->dbc, 'gene_member', 'stable_id', $gene->stable_id, undef, 'expand_tables');
-
     # Gene Member
-    my $gene_member = $self->param('gene_member_adaptor')->fetch_by_stable_id($gene->stable_id);
-    if ($self->debug) {print "GENE: $gene_member ", $gene_member->toString(), "\n";}
+    my $species = $gene->adaptor->db->get_MetaContainer->get_production_name();
+    my $genome_db = $self->compara_dba->get_GenomeDBAdaptor->fetch_by_name_assembly($species);
+    my $gene_member = $self->param('gene_member_adaptor')->fetch_by_stable_id_GenomeDB($gene->stable_id, $genome_db);
+    if ($self->debug) {
+        print "GENE: $gene_member ", $gene_member->toString(), "\n";
+    }
+
+    copy_data_with_foreign_keys_by_constraint($self->param('member_dbc'), $self->compara_dba->dbc, 'gene_member', 'gene_member_id', $gene_member->dbID, undef, 'expand_tables');
 
     # Transcript Member
     return $gene_member->get_canonical_SeqMember;


### PR DESCRIPTION
…e_id` to use `genome_db`

## Description

There are a few runnables that require an update upon deprecation of `fetch_by_stable_id()` from the `MemberAdaptors`.

**Related JIRA tickets:**
- ENSCOMPARASW-5361

## Overview of changes

#### Change 1
- Reworked the `copy_and_fetch_gene()` method to first retrieve the correct `gene_member` using the `genome_db` and `stable_id` - altered the copy statement to use the `gene_member.gene_member_id`.

## Testing
Travis and syntactically locally.

## Notes
There may be more examples in the code base in which data is copied using the `[gene|seq]_member.stable_id` which will need changing once the schema changes, particularly for the use of `Bio::EnsEMBL::Compara::Utils::CopyData::copy_data_with_foreign_keys_by_constraint()` method.