### PR TITLE
Remove previously removed code dependency

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Families/LoadUniProtEntries.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Families/LoadUniProtEntries.pm
@@ -17,9 +17,6 @@ limitations under the License.
 
 =cut
 
-
-=pod 
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::Families::LoadUniProtEntries
@@ -83,22 +80,6 @@ sub run {
         return;
     }
 
-    my $ids         = $self->param('ids');
-
-    my @not_yet_stored_ids = ();
-  
-    foreach my $id (@$ids) {
-        my $stable_id = ($id =~ /^(\S+)\.\d+$/) ? $1 : $id;     # drop the version number if it's there
-        my $seq_member = $self->compara_dba()->get_SeqMemberAdaptor->fetch_by_stable_id($stable_id);
-        my $seq_member_id;
-
-        if($seq_member and $seq_member_id = $seq_member->seq_member_id) {
-            print "Member '$stable_id' already stored (seq_member_id=$seq_member_id), skipping\n";
-        } else {    # skip the ones that have been already stored
-            push @not_yet_stored_ids, $id;
-        }
-    }
-    $self->param('member_ids', $self->fetch_and_store_a_chunk($source_name, join(' ',@not_yet_stored_ids), scalar @not_yet_stored_ids) );
 }
 
 


### PR DESCRIPTION
## Description
There are a few runnables that require an update upon deprecation of `fetch_by_stable_id()` from the `MemberAdaptors`.

**Related JIRA tickets:**
- ENSCOMPARASW-5361

## Overview of changes

#### Change 1
- Code removal. The chunk of code removed is not in use - aside from the discontinuation of `families` in compara. The piece of code removed requires a parameter that is dataflowed from https://github.com/Ensembl/ensembl-compara/blob/49ea58101d80708e6fdfeb04897a99b841f8dcb0/modules/Bio/EnsEMBL/Compara/RunnableDB/Families/LoadUniProtIndex.pm, the last time this runnable was seen was in commit https://github.com/Ensembl/ensembl-compara/commit/49ea58101d80708e6fdfeb04897a99b841f8dcb0#diff-b9f8e664a256240d95c9e7e5f30cb40767f4428d00bff0c9c3a084d764db0b12 :point_left: this runnable has not been in existence for around 11 years. I think it is safe to remove.

## Testing
N/A - purely investigation and Travis

## Notes
See Change 1.