### PR TITLE
Update tests with fetch_by_stable_id()

### DIFF
--- a/modules/t/geneTreeAdaptor.t
+++ b/modules/t/geneTreeAdaptor.t
@@ -29,7 +29,8 @@ my $multi = Bio::EnsEMBL::Test::MultiTestDB->new( "homology" );
 my $compara_dba = $multi->get_DBAdaptor( "compara" );
 
 my $gene_tree_adaptor = $compara_dba->get_GeneTreeAdaptor();
-my $gene_member = $compara_dba->get_GeneMemberAdaptor->fetch_by_stable_id("ENSTSYG00000021671");
+my $gdb = $compara_dba->get_GenomeDBAdaptor->fetch_by_name_assembly("tarsius_syrichta");
+my $gene_member = $compara_dba->get_GeneMemberAdaptor->fetch_by_stable_id_GenomeDB("ENSTSYG00000021671", $gdb);
 my $gene_tree_other = $gene_tree_adaptor->fetch_default_for_Member($gene_member, "other");
 my $gene_tree_default = $gene_tree_adaptor->fetch_default_for_Member($gene_member, "default");
 
@@ -40,7 +41,7 @@ subtest "Test Bio::EnsEMBL::Compara::DBSQL::GeneTreeAdaptor delete_tree method",
     is($default_before, 1, "Num default trees");
     is($other_before, 1, "Num other trees");
     $gene_tree_adaptor->delete_tree($gene_tree_default);
-    $gene_member = $compara_dba->get_GeneMemberAdaptor->fetch_by_stable_id("ENSTSYG00000021671");
+    $gene_member = $compara_dba->get_GeneMemberAdaptor->fetch_by_stable_id_GenomeDB("ENSTSYG00000021671", $gdb);
     my $default_after = $gene_member->has_GeneTree("default");
     my $other_after = $gene_member->has_GeneTree("other");
     is($default_after, 0, "Num default tree after delete");

--- a/modules/t/homologyAdaptor.t
+++ b/modules/t/homologyAdaptor.t
@@ -59,7 +59,7 @@ subtest "Test fetch methods", sub {
 
     ok(1);
 
-    my $member = $ma->fetch_by_stable_id($member_stable_id);
+    my $member = $ma->fetch_by_stable_id_GenomeDB($member_stable_id, $hs_gdb);
 
     ok($member);
 


### PR DESCRIPTION
## Description

There are a few scripts that require an update upon deprecation of `fetch_by_stable_id()` from the `MemberAdaptors`.

**Related JIRA tickets:**
- ENSCOMPARASW-5361

## Overview of changes
- Swap `fetch_by_stable_id()` with `fetch_by_stable_id_GenomeDB()` in tests

## Testing
They are the tests... Travis and a local run I guess :shrug: 
