### PR TITLE
Deprecate `MemberAdaptor::fetch_by_stable_id()`

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -21,7 +21,6 @@ _All files (e.g. scripts) under these directories will be deleted_
 
 # Deprecated methods scheduled for deletion
 
-* `DBSQL::'*MemberAdaptor::fetch_by_stable_id()` in Ensembl 109
 * `AlignedMember::get_cigar_breakout()` in Ensembl 102
 * `AlignedMember::get_cigar_array()` in Ensembl 102
 
@@ -31,6 +30,10 @@ _All files (e.g. scripts) under these directories will be deleted_
 * `GenomicAlignTree::get_all_GenomicAligns()`
 
 # Methods removed in previous versions of Ensembl
+
+## Ensembl 109
+
+* `DBSQL::'*MemberAdaptor::fetch_by_stable_id()`
 
 ## Ensembl 100
 

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/MemberAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/MemberAdaptor.pm
@@ -76,33 +76,6 @@ use base qw(Bio::EnsEMBL::Compara::DBSQL::BaseAdaptor);
 #
 #####################
 
-sub fetch_by_stable_id { ## DEPRECATED
-    my ($self, $stable_id) = @_;
-
-    deprecate(
-        "MemberAdaptor::fetch_by_stable_id() is to be deprecated and will be removed in e109. Use fetch_all_by_stable_id_GenomeDB instead."
-    );
-
-    throw("MemberAdaptor::fetch_by_stable_id() must have an stable_id") unless $stable_id;
-
-    my $constraint = 'm.stable_id = ?';
-    $self->bind_param_generic_fetch($stable_id, SQL_VARCHAR);
-    my $m = $self->generic_fetch_one($constraint);
-    return $m if $m;
-
-    my $vindex = rindex($stable_id, '.');
-    return undef if $vindex <= 0;  # bail out if there is no dot, or if the string starts with a dot (since that would make the stable_id part empty)
-    my $version = substr($stable_id,$vindex+1);
-    if (looks_like_number($version)) {  # to avoid DBI complains
-        $constraint = 'm.stable_id = ? AND m.version = ?';
-        $self->bind_param_generic_fetch(substr($stable_id,0,$vindex), SQL_VARCHAR);
-        $self->bind_param_generic_fetch($version, SQL_INTEGER);
-        return $self->generic_fetch_one($constraint);
-    } else {
-        return undef;
-    }
-}
-
 =head2 fetch_by_stable_id_GenomeDB
   Arg [1]       : string $stable_id
   Arg [2]       : integer $genome_db_id or Bio::EnsEMBL::Compara::GenomeDB object

--- a/travisci/perl-external_unittest_harness.sh
+++ b/travisci/perl-external_unittest_harness.sh
@@ -23,7 +23,7 @@ ENSEMBL_PERL5OPT='-MDevel::Cover=+ignore,bioperl,+ignore,ensembl,+ignore,ensembl
 ENSEMBL_TESTER="$PWD/ensembl-test/scripts/runtests.pl"
 ENSEMBL_TESTER_OPTIONS=()
 CORE_SCRIPTS=("$PWD/ensembl/modules/t/compara.t")
-REST_SCRIPTS=("$PWD/ensembl-rest/t/genomic_alignment.t" "$PWD/ensembl-rest/t/info.t" "$PWD/ensembl-rest/t/taxonomy.t" "$PWD/ensembl-rest/t/homology.t" "$PWD/ensembl-rest/t/gene_tree.t" "$PWD/ensembl-rest/t/cafe_tree.t" "$PWD/ensembl-rest/t/family.t")
+REST_SCRIPTS=("$PWD/ensembl-rest/t/genomic_alignment.t" "$PWD/ensembl-rest/t/info.t" "$PWD/ensembl-rest/t/taxonomy.t" "$PWD/ensembl-rest/t/homology.t" "$PWD/ensembl-rest/t/gene_tree.t" "$PWD/ensembl-rest/t/cafe_tree.t")
 
 if [ "$COVERAGE" = 'true' ]; then
   EFFECTIVE_PERL5OPT="$ENSEMBL_PERL5OPT"


### PR DESCRIPTION
## Description

`MemberAdaptor::fetch_by_stable_id()` requires deprecation due to the fact that `$gene->stable_id` does not need to be unique across Ensembl - but it does need to be unique within a genome. This is the way.

**Related JIRA tickets:**
- ENSCOMPARASW-5361

## Overview of changes

#### Change 1
- Update `DEPRECATED.md`

#### Change 2
- Remove the method from `DBSQL::MemberAdaptor`

## Testing

All tests on Travis pass :crossed_fingers: (once the below is addressed)

## Notes

This commit/PR cannot be merged until the following PRs have been approved and merged:

- https://github.com/Ensembl/ensembl-compara/pull/451
- https://github.com/Ensembl/ensembl-compara/pull/452
- https://github.com/Ensembl/ensembl-compara/pull/454
- https://github.com/Ensembl/ensembl-compara/pull/453
- https://github.com/Ensembl/ensembl-compara/pull/458
- https://github.com/Ensembl/ensembl-compara/pull/459
- https://github.com/Ensembl/ensembl-compara/pull/460
- https://github.com/Ensembl/ensembl-compara/pull/461
- https://github.com/Ensembl/ensembl-compara/pull/462
- https://github.com/Ensembl/ensembl-compara/pull/463
- https://github.com/Ensembl/ensembl-compara/pull/464
- https://github.com/Ensembl/ensembl-compara/pull/468
- https://github.com/Ensembl/ensembl-rest/pull/542
- https://github.com/Ensembl/ensembl/pull/621