### PR TITLE
Script for concatenating constrained elements

### DIFF
--- a/src/python/lib/ensembl/compara/utils/cigar.py
+++ b/src/python/lib/ensembl/compara/utils/cigar.py
@@ -22,33 +22,34 @@ from typing import List, Tuple, Optional
 def alignment_to_seq_region(cigar: str, start: int, end: int) -> Optional[Tuple[int,int]]:
     """Convert the coordinate of a region from the alignment level to the unaligned seq level
 
-         A region with a start and a end in a non-gaped area will return a direct coordinate mapping i.e
-         the region with a start = 3 and end = 12 in the aligned sequence below will return (3,7).
-         A region with start and end in the same gap will return an empty couple as the region does not
-         exist in this sequence a start with i.e a region with start=5 and end=8 will return ()
-         A region with a start in a gap will return the first position after the gap whether the end is in
-         a non-gaped or another gap, ie start = 6 and end = 14 will return (5,9).
-         A region with a end in a gap will return the last position before the gap whether the start is
-         in a non-gaped or a different gap. i.e start = 6 and end = 20 will return (5,9)
+         An ungapped with a start and an end in a non-gaped area will return a direct coordinate mapping i.e
+         the region with a start = 3 and an end = 12 in the aligned sequence below will return (3,7).
+         A region with start and end in the single gap opening will return an empty pair as the region
+         does not exist in this sequence, i.e a region with start=5 and end=8 will return ()
+         A region with a start in a gap opening will return the first position after the gap closes whether
+         the end is in an alternative gapped or ungapped position ie start = 6 and end = 14 will return (5,9).
+         A region with an end in a gap will return the last position before the gap whether the start is
+         in an ungapped or alternative gap position. i.e start = 6 and end = 20 will return (5,9)
 
         aligned:     1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26
                      A  A  T  C  -  -  -  -  -  A  C  T  C  T  -  -  -  -  -  -  -  -  T  C  T  C
         unaligned:   1  2  3  4                 5  6  7  8  9                          10 11 12 13
 
 
-        Params:
+        Args:
             cigar: cigar line of the aligned sequence
-            start: start of the regions in the alignment
-            end: end of the region in the alignment
+            start: start coordinate of the region in the alignment
+            end: end coordinate of the region in the alignment
         Returns:
-            start and end of the region at the unaligned sequence level, None if the region is inside a gap
+            coordinate of the unaligned region at the sequence level, empty tuple if the region is
+            inside a gap
         Raises:
             AssertionError : if start >= end
 a         """
     ## test precondition for this function
     assert start < end, f"error start: {start} is not smaller than end: {end}"
 
-    result = None
+    result = ()
     ce_seq_start = alignment_to_seq_coordinate(cigar, start)
     ce_seq_end = alignment_to_seq_coordinate(cigar, end)
 
@@ -60,7 +61,7 @@ a         """
         result = (int(ce_seq_start[1]), int(ce_seq_end[0]))
     elif len(ce_seq_start) == 2 and len(ce_seq_end) == 2:  # start and end in gapped
         if ce_seq_start[0] == ce_seq_end[0] and ce_seq_start[1] == ce_seq_end[1]:  # region inside same gap
-            result = None  # if the region is inside a gap then te region does not exist in this sequence
+            result = ()  # if the region is inside a same gap then te region does not exist in the sequence
         else:
             result = (int(ce_seq_start[1]), int(ce_seq_end[0]))
     return result

--- a/src/python/lib/ensembl/compara/utils/cigar.py
+++ b/src/python/lib/ensembl/compara/utils/cigar.py
@@ -25,7 +25,7 @@ def alignment_to_seq_region(cigar: str, start: int, end: int) -> Optional[Tuple[
          An ungapped with a start and an end in a non-gaped area will return a direct coordinate mapping i.e
          the region with a start = 3 and an end = 12 in the aligned sequence below will return (3,7).
          A region with start and end in the single gap opening will return an empty pair as the region
-         does not exist in this sequence, i.e a region with start=5 and end=8 will return ()
+         does not exist in this sequence, i.e a region with start=5 and end=8 will return None
          A region with a start in a gap opening will return the first position after the gap closes whether
          the end is in an alternative gapped or ungapped position ie start = 6 and end = 14 will return (5,9).
          A region with an end in a gap will return the last position before the gap whether the start is
@@ -49,7 +49,7 @@ a         """
     ## test precondition for this function
     assert start < end, f"error start: {start} is not smaller than end: {end}"
 
-    result = ()
+    result = None
     ce_seq_start = alignment_to_seq_coordinate(cigar, start)
     ce_seq_end = alignment_to_seq_coordinate(cigar, end)
 
@@ -61,7 +61,7 @@ a         """
         result = (int(ce_seq_start[1]), int(ce_seq_end[0]))
     elif len(ce_seq_start) == 2 and len(ce_seq_end) == 2:  # start and end in gapped
         if ce_seq_start[0] == ce_seq_end[0] and ce_seq_start[1] == ce_seq_end[1]:  # region inside same gap
-            result = ()  # if the region is inside a same gap then te region does not exist in the sequence
+            result = None  # if the region is inside a same gap then te region does not exist in the sequence
         else:
             result = (int(ce_seq_start[1]), int(ce_seq_end[0]))
     return result

--- a/src/python/lib/ensembl/compara/utils/cigar.py
+++ b/src/python/lib/ensembl/compara/utils/cigar.py
@@ -14,9 +14,56 @@
 # limitations under the License.
 """Collection of utils methods targeted to cigar line manipulation."""
 
-__all__ = ['aligned_seq_to_cigar', 'alignment_to_seq_coordinate', 'get_cigar_array']
+__all__ = ['aligned_seq_to_cigar', 'alignment_to_seq_coordinate',
+           'get_cigar_array', 'alignment_to_seq_region']
 
-from typing import List, Tuple
+from typing import List, Tuple, Optional
+
+def alignment_to_seq_region(cigar: str, start: int, end: int) -> Optional[Tuple[int,int]]:
+    """Convert the coordinate of a region from the alignment level to the unaligned seq level
+
+         A region with a start and a end in a non-gaped area will return a direct coordinate mapping i.e
+         the region with a start = 3 and end = 12 in the aligned sequence below will return (3,7).
+         A region with start and end in the same gap will return an empty couple as the region does not
+         exist in this sequence a start with i.e a region with start=5 and end=8 will return ()
+         A region with a start in a gap will return the first position after the gap whether the end is in
+         a non-gaped or another gap, ie start = 6 and end = 14 will return (5,9).
+         A region with a end in a gap will return the last position before the gap whether the start is
+         in a non-gaped or a different gap. i.e start = 6 and end = 20 will return (5,9)
+
+        aligned:     1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26
+                     A  A  T  C  -  -  -  -  -  A  C  T  C  T  -  -  -  -  -  -  -  -  T  C  T  C
+        unaligned:   1  2  3  4                 5  6  7  8  9                          10 11 12 13
+
+
+        Params:
+            cigar: cigar line of the aligned sequence
+            start: start of the regions in the alignment
+            end: end of the region in the alignment
+        Returns:
+            start and end of the region at the unaligned sequence level, None if the region is inside a gap
+        Raises:
+            AssertionError : if start >= end
+a         """
+    ## test precondition for this function
+    assert start < end, f"error start: {start} is not smaller than end: {end}"
+
+    result = None
+    ce_seq_start = alignment_to_seq_coordinate(cigar, start)
+    ce_seq_end = alignment_to_seq_coordinate(cigar, end)
+
+    if len(ce_seq_start) == 1 and len(ce_seq_end) == 1:  # two position in a non gapped area
+        result = (int(ce_seq_start[0]), int(ce_seq_end[0]))
+    elif len(ce_seq_start) == 1 and len(ce_seq_end) == 2:  # start in non gapped, end in gapped
+        result = (int(ce_seq_start[0]), int(ce_seq_end[0]))
+    elif len(ce_seq_start) == 2 and len(ce_seq_end) == 1:  # start in gapped, end in non gapped
+        result = (int(ce_seq_start[1]), int(ce_seq_end[0]))
+    elif len(ce_seq_start) == 2 and len(ce_seq_end) == 2:  # start and end in gapped
+        if ce_seq_start[0] == ce_seq_end[0] and ce_seq_start[1] == ce_seq_end[1]:  # region inside same gap
+            result = None  # if the region is inside a gap then te region does not exist in this sequence
+        else:
+            result = (int(ce_seq_start[1]), int(ce_seq_end[0]))
+    return result
 
 
 def aligned_seq_to_cigar(aligned_seq: str) -> str:

--- a/src/python/scripts/concat_constrained_elems.py
+++ b/src/python/scripts/concat_constrained_elems.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Concatenate the constrained elements from each GAB into one file for each species present in the
+alignment
+
+The coordinates of each constrained element are translated from the GAB coordinate level to the Genome
+coordinate level of each species and then they are concatenated into one file per species
+
+Typical usage example:
+
+    $ python concatenate_constrained_elements.py --json_desc gab_ce.txt --out_dir ./out/
+
+"""
+
+import argparse
+import json
+from typing import Dict
+
+from ensembl.compara.utils import alignment_to_seq_region
+
+
+def translate_ce_coordinates(json_conf: str) -> Dict:
+    """Project each constrained elements to the unaligned genomic level in each species contained in the
+    alignment
+
+    Params:
+        json_conf: file storing the list of json files to analyse
+
+    Returns:
+        a dictionary that has for key the assembly name and the value is the list of constrained elements at
+        the genomic coordinate level for this assembly a constraint element is a list of the type
+        [seq_name, start, end, score, pval, strand]
+    """
+    result = {}  # type: ignore
+    with open(json_conf, 'r') as json_file_handler:
+        align_set = json.load(json_file_handler)
+        aligned_seqs = align_set["aligned_seq"]
+        constrained_elems = align_set["constrained_elems"]
+
+        for aligned_seq in aligned_seqs:
+            cigar = aligned_seq["cigar"]
+            unaligned_seq_size = int(aligned_seq["dnafrag_end"]) - int(aligned_seq["dnafrag_start"]) + 1
+            for constrained_elem in constrained_elems:
+                # covert from align coordinate to unaligned coordinate
+
+                region = alignment_to_seq_region(cigar, int(constrained_elem["start"]),
+                                                 int(constrained_elem["end"]))
+                if not region:  # if empty tuple go to the next constrained element
+                    continue
+                ce_seq_start = region[0]
+                ce_seq_end = region[1]
+                if int(aligned_seq["dnafrag_strand"]) == -1:  # if negative strand calculate coordinates
+                                                              # based on reverse complement
+                    seq_start = unaligned_seq_size - ce_seq_end + 1
+                    ce_seq_end = unaligned_seq_size - ce_seq_start + 1
+                    ce_seq_start = seq_start
+
+                # convert to the genomic coordinate
+                ce_genomic_start = ce_seq_start + int(aligned_seq["dnafrag_start"]) - 1
+                ce_genomic_end = ce_seq_end + int(aligned_seq["dnafrag_start"]) - 1
+
+                # add constrained elements in the dictionary
+                genome_name = aligned_seq["genome_name"]
+                if genome_name not in result:
+                    result[genome_name] = []
+                result[genome_name].append([aligned_seq["dnafrag_name"], ce_genomic_start, ce_genomic_end,
+                                            constrained_elem["score"], constrained_elem["p-val"],
+                                            aligned_seq["dnafrag_strand"]])
+    return result
+
+
+def save_constrained_elements(constraint_species: dict, out_dir: str) -> None:
+    """Save in TSV  format the constraint elements for each species
+
+        The format is the following: <seq name> \t <start> \t <end> \t <score> \t <pval> \t <strand>
+        The file name will be prefixed with the name of the assembly and post-fixed with .tsv
+
+    Params:
+        constraint_species: Dictionary with key the species and value the list of constraint elements
+        out_dir: out directory where the bed files are saved
+    """
+    for sp, ces in constraint_species.items():
+        with open(f"{out_dir}/{sp}.tsv", "w") as bed_file_obj:
+            ## add sorting ces
+            for ce in ces:
+                strand = "+"
+                if ce[5] == -1:
+                    strand = "-"
+                line = f"{ce[0]}\t{ce[1]}\t{ce[2]}\t{ce[3]}\t{ce[4]}\t{strand}\n"
+                bed_file_obj.write(line)
+
+
+def main(params: argparse.Namespace) -> None:
+    """ Main function of the script
+
+    Params:
+        params argparse.Namespace parameters provided by the user.
+    """
+    # concatenate the constraints elements per species
+    with open(params.json_desc) as file_obj:
+        species = {}  # type: ignore
+        for json_file in file_obj:
+            json_file = json_file.rstrip()
+            sp_constrained = translate_ce_coordinates(json_file)
+            for sp, ces in sp_constrained.items():
+                if sp not in species:
+                    species[sp] = []
+                species[sp] = species[sp] + ces
+        save_constrained_elements(species, params.out_dir)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="Process some integers.")
+    parser.add_argument("--json_desc", type=str, required=True, help="File listign the path to all the "
+                                               "align set json file for a given alignment")
+    parser.add_argument("--out_dir", type=str, required=True, help="out directory storing all the  "
+                                               "constrained element files concatenated at the species level")
+    args = parser.parse_args()
+    main(args)

--- a/src/python/scripts/concat_constrained_elems.py
+++ b/src/python/scripts/concat_constrained_elems.py
@@ -13,8 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Concatenate the constrained elements from each GAB into one file for each species present in the
-alignment
+"""Concatenate the constrained elements from each Genomic Align Block (GAB) into one file for each species
+present in the alignment
 
 The coordinates of each constrained element are translated from the GAB coordinate level to the Genome
 coordinate level of each species and then they are concatenated into one file per species
@@ -33,16 +33,16 @@ from ensembl.compara.utils import alignment_to_seq_region
 
 
 def translate_ce_coordinates(json_conf: str) -> Dict:
-    """Project each constrained elements to the unaligned genomic level in each species contained in the
-    alignment
+    """Project each of the constrained elements to the unaligned genomic coordinates in each
+    genome/species aligned
 
-    Params:
+    Args:
         json_conf: file storing the list of json files to analyse
 
     Returns:
-        a dictionary that has for key the assembly name and the value is the list of constrained elements at
-        the genomic coordinate level for this assembly a constraint element is a list of the type
-        [seq_name, start, end, score, pval, strand]
+        A dictionary of assembly name to constrained element at the genomic coordinate level for the named
+        assembly.The constrained element is a list of the type [seq_name, start, end, score, pval, strand]
+
     """
     result = {}  # type: ignore
     with open(json_conf, 'r') as json_file_handler:
@@ -54,7 +54,7 @@ def translate_ce_coordinates(json_conf: str) -> Dict:
             cigar = aligned_seq["cigar"]
             unaligned_seq_size = int(aligned_seq["dnafrag_end"]) - int(aligned_seq["dnafrag_start"]) + 1
             for constrained_elem in constrained_elems:
-                # covert from align coordinate to unaligned coordinate
+                # convert from aligned coordinate to unaligned coordinate
 
                 region = alignment_to_seq_region(cigar, int(constrained_elem["start"]),
                                                  int(constrained_elem["end"]))
@@ -88,7 +88,7 @@ def save_constrained_elements(constraint_species: dict, out_dir: str) -> None:
         The format is the following: <seq name> \t <start> \t <end> \t <score> \t <pval> \t <strand>
         The file name will be prefixed with the name of the assembly and post-fixed with .tsv
 
-    Params:
+    Args:
         constraint_species: Dictionary with key the species and value the list of constraint elements
         out_dir: out directory where the bed files are saved
     """
@@ -106,7 +106,7 @@ def save_constrained_elements(constraint_species: dict, out_dir: str) -> None:
 def main(params: argparse.Namespace) -> None:
     """ Main function of the script
 
-    Params:
+    Args:
         params argparse.Namespace parameters provided by the user.
     """
     # concatenate the constraints elements per species
@@ -125,7 +125,7 @@ def main(params: argparse.Namespace) -> None:
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Process some integers.")
-    parser.add_argument("--json_desc", type=str, required=True, help="File listign the path to all the "
+    parser.add_argument("--json_desc", type=str, required=True, help="File listing the path to all the "
                                                "align set json file for a given alignment")
     parser.add_argument("--out_dir", type=str, required=True, help="out directory storing all the  "
                                                "constrained element files concatenated at the species level")

--- a/src/python/tests/test_cigar.py
+++ b/src/python/tests/test_cigar.py
@@ -112,7 +112,7 @@ class TestCigar:
             ("4M5D5M8D4M", 6, 12, (5,7)),  # start in gap and end not in gap
             ("4M5D5M8D4M", 4, 18, (4,9)),  # start not in gap and end  in gap
             ("4M5D5M8D4M", 5, 18, (5,9)),  # start and end in different gaps
-            ("4M5D5M8D4M", 5, 9, None),    # start and end in same gap
+            ("4M5D5M8D4M", 5, 9, ()),      # start and end in same gap
             ("4M5D5M8D4M", 4, 6, (4,4)),   # start last element of non gap and end the gap following the non
                                            # gap
             ("4M5D5M8D4M", 9, 10, (5,5))   # start  gap and end in the first element of the following non gap

--- a/src/python/tests/test_cigar.py
+++ b/src/python/tests/test_cigar.py
@@ -21,11 +21,12 @@ Typical usage example::
 """
 
 from contextlib import nullcontext as does_not_raise
-from typing import Tuple, ContextManager, List
+from typing import Tuple, ContextManager, List, Optional
 
 import pytest
 
-from ensembl.compara.utils import aligned_seq_to_cigar, alignment_to_seq_coordinate, get_cigar_array
+from ensembl.compara.utils import aligned_seq_to_cigar, alignment_to_seq_coordinate, \
+                                  get_cigar_array, alignment_to_seq_region
 
 
 class TestCigar:
@@ -98,6 +99,35 @@ class TestCigar:
                 expectation: Context manager for the expected exception, i.e. the test will only pass if that
                     exception is raised. Use :class:`~contextlib.nullcontext` if no exception is expected.
         """
-        error = "difference of coord_seq compared to the one expected with coord_align"
+        error = "difference with expected output regions"
         with expectation:
             assert alignment_to_seq_coordinate(cigar, coord_align) == coord_seq, error
+
+
+    @pytest.mark.parametrize(
+        "cigar, start, end, output",
+        [
+            ("4M5D5M8D4M", 1, 4, (1,4)),   # before first gap
+            ("4M5D5M8D4M", 3, 12,(3,7)),   # start and end not in a gap but a gap between them
+            ("4M5D5M8D4M", 6, 12, (5,7)),  # start in gap and end not in gap
+            ("4M5D5M8D4M", 4, 18, (4,9)),  # start not in gap and end  in gap
+            ("4M5D5M8D4M", 5, 18, (5,9)),  # start and end in different gaps
+            ("4M5D5M8D4M", 5, 9, None),    # start and end in same gap
+            ("4M5D5M8D4M", 4, 6, (4,4)),   # start last element of non gap and end the gap following the non
+                                           # gap
+            ("4M5D5M8D4M", 9, 10, (5,5))   # start  gap and end in the first element of the following non gap
+                                           # element
+        ],
+    )
+    def test_alignment_to_seq_region(self, cigar: str, start: int, end: int,
+                                     output: Optional[Tuple[int,int]]) -> None:
+        """Tests :func:`alignment_to_seq_region()` function.
+
+        Args:
+            cigar: cigar line.
+            start: start of the region
+            end: end of the region
+            output: tuple corresponding to the region of the sequence coordinate level
+        """
+        assert alignment_to_seq_region(cigar, start, end) == output, "cigar line returned differs " \
+                                                                     "from the one expected"

--- a/src/python/tests/test_cigar.py
+++ b/src/python/tests/test_cigar.py
@@ -112,7 +112,7 @@ class TestCigar:
             ("4M5D5M8D4M", 6, 12, (5,7)),  # start in gap and end not in gap
             ("4M5D5M8D4M", 4, 18, (4,9)),  # start not in gap and end  in gap
             ("4M5D5M8D4M", 5, 18, (5,9)),  # start and end in different gaps
-            ("4M5D5M8D4M", 5, 9, ()),      # start and end in same gap
+            ("4M5D5M8D4M", 5, 9, None),      # start and end in same gap
             ("4M5D5M8D4M", 4, 6, (4,4)),   # start last element of non gap and end the gap following the non
                                            # gap
             ("4M5D5M8D4M", 9, 10, (5,5))   # start  gap and end in the first element of the following non gap


### PR DESCRIPTION
## Description

Development of the runnable that concatenates the constrained element for the GERP pipeline.

**Related JIRA tickets:**
- ENSCOMPARASW-5354

## Overview of changes
The development involved the creation of a script that gets all the conserved element defined at the alignment coordinate system level and translate their coordinate to the sequence level of each species assemblies involved in the alignment. To do so the cigar.py library module has been extended with a function that translates the coordinate of a region from the alignment coordinate system to the sequence coordinate system using the cigar line of the aligned sequence.

#### Change 1
- cigar.py: addition of a function that translates a region from the alignment coordinate system to the sequence coordinate system.  This function takes into account whether the start/end of the region is in a gap to better translate the coordinate system (see comment in the function)

#### Change 2
- concat_constrained_elems.py . This script get as entry a list of json file containing the constrained element for each GAB and concatenate then into a bed file for each species. 

## Testing
- the cigar.py extention has been tested with a unitary test in the test_cigar,py (the test module has been extended to test the new function)
- the script has been tested using as a set of artificial json files with a set of constrained elements and a set of sequences. The test cases included cases where no file is present, a set of json files with not all species represented in all json.


