### PR TITLE
Species tree pipeline improvements

### DIFF
--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -81,6 +81,7 @@ process buscoAnnot {
     --num_threads ${params.cores} \
     --max_intron_length 100000 \
     --run_busco \
+    --genblast_timeout  32400\
     --busco_protein_file $busco_prot
     """
 }

--- a/pipelines/SpeciesTreeFromBusco/nextflow.config
+++ b/pipelines/SpeciesTreeFromBusco/nextflow.config
@@ -18,10 +18,11 @@ includeConfig "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/nextflow.config"
 
 params {
     dir = "$HPS_HOME/Workspace/busco_tree/species_fasta"
+    gzipped = "true"
     busco_proteins = "$HPS_HOME/Workspace/busco_tree/eukaryota_odb10/refseq_db.faa"
     results_dir = "$HPS_HOME/Pipelines/SpeciesTreeRes"
     cores = 32
-    min_taxa = 0.8
+    min_taxa = 0.9
 
     anno_exe = "$HOME/gt/ensembl-anno/ensembl_anno.py"
     enscode = "$HOME/gt"

--- a/pipelines/SpeciesTreeFromBusco/nextflow.config
+++ b/pipelines/SpeciesTreeFromBusco/nextflow.config
@@ -18,7 +18,6 @@ includeConfig "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/nextflow.config"
 
 params {
     dir = "$HPS_HOME/Workspace/busco_tree/species_fasta"
-    gzipped = "true"
     busco_proteins = "$HPS_HOME/Workspace/busco_tree/eukaryota_odb10/refseq_db.faa"
     results_dir = "$HPS_HOME/Pipelines/SpeciesTreeRes"
     cores = 32

--- a/pipelines/SpeciesTreeFromBusco/scripts/filter_for_longest_busco.py
+++ b/pipelines/SpeciesTreeFromBusco/scripts/filter_for_longest_busco.py
@@ -22,6 +22,7 @@ Example:
 """
 import sys
 import argparse
+import re
 from Bio import SeqIO
 
 # Parse command line arguments:
@@ -35,6 +36,14 @@ parser.add_argument(
 parser.add_argument(
     '-l', metavar='output', type=str, help="List of BUSCO genes.",
     required=True)
+parser.add_argument(
+    '-r', metavar='rep_filter', type=int,
+    help="Filter out seqeunces with repeats longer than this.",
+    required=False, default=None)
+parser.add_argument(
+    '-f', metavar='rep_out', type=str, help="Fasta of filtered out sequences.",
+    default="repetitive_busco.fas", required=False)
+
 
 if __name__ == '__main__':
     args = parser.parse_args()
@@ -53,13 +62,25 @@ if __name__ == '__main__':
         sys.exit(1)
 
     i = 0
-    for k, v in db.items():
-        v.id = f"g{i}"
-        v.description = ""
-        i += 1
+    repetitive = {}
+    for k, v in list(db.items()):
+        seq = str(v.seq)
+        if args.r is not None:
+            rg = f"([A-Za-z]+?)\\1{{{args.r},}}"
+            res = re.search(rg, seq)
+            if res:
+                repetitive[k] = v
+                del db[k]
+            else:
+                v.id = f"g{i}"
+                v.description = ""
+                i += 1
 
     with open(args.o, "w") as output_handle:
         SeqIO.write(db.values(), output_handle, "fasta")
+
+    with open(args.f, "w") as output_handle:
+        SeqIO.write(repetitive.values(), output_handle, "fasta")
 
     with open(args.l, "w") as oh:
         oh.write("Gene\tGeneId\n")

--- a/pipelines/SpeciesTreeFromBusco/scripts/filter_for_longest_busco.py
+++ b/pipelines/SpeciesTreeFromBusco/scripts/filter_for_longest_busco.py
@@ -75,6 +75,11 @@ if __name__ == '__main__':
                 v.id = f"g{i}"
                 v.description = ""
                 i += 1
+        else:
+                v.id = f"g{i}"
+                v.description = ""
+                i += 1
+
 
     with open(args.o, "w") as output_handle:
         SeqIO.write(db.values(), output_handle, "fasta")

--- a/pipelines/nextflow.config
+++ b/pipelines/nextflow.config
@@ -82,6 +82,13 @@ process {
        time = { 168.h }
        maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 10 : 1 }
     }
+    withLabel: retry_with_8gb_mem_c1 {
+       cpus = 1
+       errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
+       memory = { 8.GB * task.attempt }
+       time = { 168.h }
+       maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 10 : 1 }
+    }
     withLabel: retry_with_16gb_mem_c16 {
        cpus = 16
        errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }


### PR DESCRIPTION
## Description

**Related JIRA tickets:**
- ENSCOMPARASW-5679
- ENSCOMPARASW-5680

## Overview of changes

#### Change 1
Added the prepareGenomes process to handle gzipped input genomes.

#### Change 2
Added code to filter out highly repetitive BUSCO genes in order to speed up the GenBlast step.

#### Change 2
Tweaked process resource classes and added a new resource class to the shared nextflow config.


## Testing
The pipeline was run on a set of 17 vertebrate species.