### PR TITLE
Move data to principals in plants protein data merge

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeDBsIntoRelease_conf.pm
@@ -278,6 +278,7 @@ sub pipeline_analyses {
             -parameters => {
                 'component_genomes' => 0,
                 'normal_genomes'    => 0,
+                'compara_db'        => '#curr_rel_db#',
             },
             -flow_into => {
                 2 => [ 'component_genome_dbs_move_back_factory' ],
@@ -286,6 +287,9 @@ sub pipeline_analyses {
 
         {   -logic_name => 'component_genome_dbs_move_back_factory',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::ComponentGenomeDBFactory',
+            -parameters => {
+                'compara_db' => '#curr_rel_db#',
+            },
             -flow_into => {
                 2 => {
                     'move_back_component_genes' => { 'source_gdb_id' => '#component_genome_db_id#', 'target_gdb_id' => '#principal_genome_db_id#'},
@@ -295,6 +299,9 @@ sub pipeline_analyses {
 
         {   -logic_name => 'move_back_component_genes',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::MoveComponentGenes',
+            -parameters => {
+                'compara_db' => '#curr_rel_db#',
+            },
             -hive_capacity => 3,
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/MergeDBsIntoRelease_conf.pm
@@ -87,8 +87,8 @@ sub default_options {
         # In these databases, ignore these tables
         'ignored_tables' => {
             # 'db_alias'     => Arrayref of table names
-            'protein_db'     => [qw(ortholog_quality id_generator id_assignments)],
-            'wheat_prot_db'  => [qw(ortholog_quality id_generator id_assignments)],
+            'protein_db'     => [qw(ortholog_quality id_generator id_assignments datacheck_results)],
+            'wheat_prot_db'  => [qw(ortholog_quality id_generator id_assignments datacheck_results)],
         },
     };
 }

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/MergeDBsIntoRelease_conf.pm
@@ -55,7 +55,8 @@ sub default_options {
     return {
         %{$self->SUPER::default_options},
         'division' => 'plants',
-        
+        'move_components' => 1,
+
         # All the source databases
         'src_db_aliases' => {
             'master_db'     => 'compara_master',


### PR DESCRIPTION
## Description

We don't want the data merged from the member loading pipeline on the components.

**Related JIRA tickets:**
- ENSCOMPARASW-5408

## Overview of changes

#### Change 1
- Include new flag to `move_components` for plants

#### Change 2
- Include runnables from the protein trees pipeline to move the data from the components back to the principal genome in polyploids

## Testing
Guihive [here](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-5&port=4615&dbname=cristig_plants_dbmerge_108)

## Notes
NA