### PR TITLE
Fixing the issue with the first analysis in the Merging pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MergeDBsIntoRelease_conf.pm
@@ -97,12 +97,12 @@ sub default_options {
         # In these databases, ignore these tables
         'ignored_tables' => {
             # Mapping 'db_alias' => Arrayref of table names
-            'ncrna_db'       => [qw(ortholog_quality id_generator id_assignments)],
-            'protein_db'     => [qw(ortholog_quality id_generator id_assignments)],
-            'mouse_prot_db'  => [qw(ortholog_quality id_generator id_assignments)],
-            'mouse_ncrna_db' => [qw(ortholog_quality id_generator id_assignments)],
-            'pig_prot_db'    => [qw(ortholog_quality id_generator id_assignments)],
-            'pig_ncrna_db'   => [qw(ortholog_quality id_generator id_assignments)],
+            'ncrna_db'       => [qw(ortholog_quality id_generator id_assignments datacheck_results)],
+            'protein_db'     => [qw(ortholog_quality id_generator id_assignments datacheck_results)],
+            'mouse_prot_db'  => [qw(ortholog_quality id_generator id_assignments datacheck_results)],
+            'mouse_ncrna_db' => [qw(ortholog_quality id_generator id_assignments datacheck_results)],
+            'pig_prot_db'    => [qw(ortholog_quality id_generator id_assignments datacheck_results)],
+            'pig_ncrna_db'   => [qw(ortholog_quality id_generator id_assignments datacheck_results)],
             'projection_db'  => [qw(id_generator id_assignments)],
         },
    };


### PR DESCRIPTION
## Description

DCs have been added to the trees pipelines recently and the corresponding pipeline dbs now have a `datacheck_results` table. The release database doesn't have that table and the first analysis in the Merging pipeline fails. Since the release db is not expected to have `datacheck_results`, I thought we could ignore that table in the trees pipelines.

## Testing
This wasn't tested (because the Merging pipeline had already been initialised) so I thought I'd open a PR for another pair of eyes to confirm the fix.

## Notes
This release I bypassed the problem by including `datacheck_results` in [this line](https://github.com/Ensembl/ensembl-compara/blob/release/108/modules/Bio/EnsEMBL/Compara/RunnableDB/DBMergeCheck.pm#L95). 
