### PR TITLE
Add CIGAR to maf_to_fasta.py JSON output

### DIFF
--- a/src/python/lib/ensembl/compara/hal/maf_to_fasta.py
+++ b/src/python/lib/ensembl/compara/hal/maf_to_fasta.py
@@ -39,6 +39,7 @@ from Bio import SeqIO
 from Bio.SeqRecord import SeqRecord
 
 from ensembl.compara.filesys import PathLike
+from ensembl.compara.utils.cigar import aligned_seq_to_cigar
 
 
 def compile_maf_src_regex(genome_names: Iterable[str]) -> Pattern[str]:
@@ -166,7 +167,8 @@ def convert_maf_to_fasta(maf_file: PathLike, output_dir: PathLike,
                         'region_name': region_name,
                         'region_start': region_start,
                         'region_end': region_end,
-                        'region_strand': region_strand
+                        'region_strand': region_strand,
+                        'cigar': aligned_seq_to_cigar(rec.seq)
                     })
 
             output_data = {'aligned_seq': ga_recs}

--- a/src/test_data/flatfiles/hal_alignment/gabs/0.json
+++ b/src/test_data/flatfiles/hal_alignment/gabs/0.json
@@ -5,21 +5,24 @@
             "region_name": "chr1",
             "region_start": 1,
             "region_end": 4,
-            "region_strand": 1
+            "region_strand": 1,
+            "cigar": "4M"
         },
         {
             "assembly_name": "genomeB.1",
             "region_name": "chr1",
             "region_start": 1,
             "region_end": 3,
-            "region_strand": 1
+            "region_strand": 1,
+            "cigar": "MD2M"
         },
         {
             "assembly_name": "genomeC",
             "region_name": "chr1",
             "region_start": 1,
             "region_end": 2,
-            "region_strand": 1
+            "region_strand": 1,
+            "cigar": "M2DM"
         }
     ]
 }

--- a/src/test_data/flatfiles/hal_alignment/gabs/1.json
+++ b/src/test_data/flatfiles/hal_alignment/gabs/1.json
@@ -5,21 +5,24 @@
             "region_name": "chr1",
             "region_start": 6,
             "region_end": 9,
-            "region_strand": 1
+            "region_strand": 1,
+            "cigar": "4M"
         },
         {
             "assembly_name": "genomeB.1",
             "region_name": "chr1",
             "region_start": 6,
             "region_end": 9,
-            "region_strand": 1
+            "region_strand": 1,
+            "cigar": "4M"
         },
         {
             "assembly_name": "genomeC",
             "region_name": "chr1",
             "region_start": 6,
             "region_end": 9,
-            "region_strand": -1
+            "region_strand": -1,
+            "cigar": "4M"
         }
     ]
 }


### PR DESCRIPTION
## Description

The CIGAR of each aligned sequence needs to be available when processing GERP output.

**Related JIRA tickets:**
- ENSCOMPARASW-5671

## Overview of changes
While converting the alignment from MAF to FASTA format, the CIGAR string of each aligned sequence is calculated and output — along with other metadata — to the output JSON file.

## Testing
The updated code was tested with a small example dataset. Relevant unit tests were updated and passed.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
