### PR TITLE
Runnable to parse queries per reference on reference update :up:

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ParseQueryToUpdateList.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ParseQueryToUpdateList.pm
@@ -58,7 +58,7 @@ sub write_output {
         $self->run_command($cmd);
     }
     my @query_list = sort ( uniq( @queries ) );
-    $self->_spurt( $out_file, join( "\n", @query_list ) );
+    $self->_spurt( $out_file, join( "\n", @query_list, 1 ) );
     $self->dataflow_output_id( { 'queries_to_update' => \@query_list }, 1);
 
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ParseQueryToUpdateList.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ParseQueryToUpdateList.pm
@@ -1,0 +1,65 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::ParseQueryToUpdateList
+
+=head1 DESCRIPTION
+
+Runnable to parse the record of query genomes to each reference genome
+that has been updated during the reference update in rapid release
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::ParseQueryToUpdateList;
+
+use warnings;
+use strict;
+use List::MoreUtils qw/ uniq /;
+use File::Copy qw/ move /;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+sub param_defaults {
+    return {
+        'queries_to_update_file'  => 'queries_to_update.txt',
+    };
+}
+
+sub write_output {
+    my $self = shift;
+
+    # Updated reference genome production name
+    my $genome     = $self->param_required("species_name");
+    my $record_dir = $self->param_required("species_set_record");
+    my @records    = glob "${record_dir}/*/${genome}.txt";
+    my $out_file   = $self->param("queries_to_update_file");
+    my @queries;
+
+    foreach my $file ( @records ) {
+        my $contents = $self->_slurp( $file );
+        push @queries, ( split( /\n/, $contents ) );
+        my $cmd = "mv $file $file" . ".used";
+        $self->run_command($cmd);
+    }
+    my @query_list = sort ( uniq( @queries ) );
+    $self->_spurt( $out_file, join( "\n", @query_list ) );
+
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ParseQueryToUpdateList.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ParseQueryToUpdateList.pm
@@ -31,7 +31,6 @@ package Bio::EnsEMBL::Compara::RunnableDB::ParseQueryToUpdateList;
 use warnings;
 use strict;
 use List::MoreUtils qw/ uniq /;
-use File::Copy qw/ move /;
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ParseQueryToUpdateList.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ParseQueryToUpdateList.pm
@@ -54,11 +54,12 @@ sub write_output {
     foreach my $file ( @records ) {
         my $contents = $self->_slurp( $file );
         push @queries, ( split( /\n/, $contents ) );
-        my $cmd = "mv $file $file" . ".used";
+        my $cmd = "mv --force $file $file" . ".used";
         $self->run_command($cmd);
     }
     my @query_list = sort ( uniq( @queries ) );
     $self->_spurt( $out_file, join( "\n", @query_list ) );
+    $self->dataflow_output_id( { 'queries_to_update' => \@query_list }, 1);
 
 }
 

--- a/modules/t/homology_annotation_dirs/species_set_record/test/homo_sapiens.txt
+++ b/modules/t/homology_annotation_dirs/species_set_record/test/homo_sapiens.txt
@@ -1,0 +1,1 @@
+accipiter_gentilis

--- a/modules/t/homology_annotation_dirs/species_set_record/test2/canis_lupus_familiaris.txt
+++ b/modules/t/homology_annotation_dirs/species_set_record/test2/canis_lupus_familiaris.txt
@@ -1,0 +1,1 @@
+gallus_gallus

--- a/modules/t/homology_annotation_dirs/species_set_record/test2/homo_sapiens.txt
+++ b/modules/t/homology_annotation_dirs/species_set_record/test2/homo_sapiens.txt
@@ -1,0 +1,1 @@
+oncorhynchus_nerka

--- a/modules/t/parseQueryToUpdateList.t
+++ b/modules/t/parseQueryToUpdateList.t
@@ -1,0 +1,60 @@
+#!/usr/bin/env perl
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Hive::Utils::Test qw(standaloneJob);
+
+use Cwd 'abs_path';
+use Test::Most;
+
+BEGIN {
+    use_ok('Bio::EnsEMBL::Compara::RunnableDB::ParseQueryToUpdateList');
+}
+
+my $test_path = abs_path($0);
+my $test_dir = $test_path;
+$test_dir =~ s!parseQueryToUpdateList\.t!homology_annotation_dirs/species_set_record/!;
+
+my $exp_dataflow = {
+    queries_to_update => [
+        "accipiter_gentilis",
+        "oncorhynchus_nerka",
+    ],
+};
+
+standaloneJob(
+    'Bio::EnsEMBL::Compara::RunnableDB::ParseQueryToUpdateList',
+    {
+        'species_name'        => "homo_sapiens",
+        'species_set_record'  => $test_dir,
+    },
+    [
+        [
+            'DATAFLOW',
+            $exp_dataflow,
+            1
+        ],
+    ]
+);
+
+ok(-e "queries_to_update.txt", "Record file exists");
+ok(-e $test_dir . "test/homo_sapiens.txt.used", "Used file moved");
+ok(-e $test_dir . "test2/homo_sapiens.txt.used", "Used file moved");
+ok(-e $test_dir . "test2/canis_lupus_familiaris.txt", "Unused file not moved");
+
+done_testing();


### PR DESCRIPTION
## Description

From the list updated references, what are the expected query/rapid release species in which homologies need to be recomputed.

**Related JIRA tickets:**
- ENSCOMPARASW-5350

## Overview of changes

- New runnable to simply parse from https://github.com/Ensembl/ensembl-compara/pull/412
- New perl tests and files

## Testing
New tests.

```
standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::ParseQueryToUpdateList -species_name homo_sapiens -species_set_record /hps/nobackup/flicek/ensembl/compara/shared/species_set_record/
```
## Notes

~~Test coming soon...~~