### PR TITLE
On new References Species Set compute queries to re-run :bangbang:

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/MoreAppropriateCollectionToQuery.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/MoreAppropriateCollectionToQuery.pm
@@ -1,0 +1,115 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::MoreAppropriateCollectionToQuery
+
+=head1 DESCRIPTION
+
+Runnable to parse the record of query genomes to check and pass on
+for potential update with new taxonomic based reference comparison
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::MoreAppropriateCollectionToQuery;
+
+use warnings;
+use strict;
+use List::MoreUtils qw/ uniq /;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+sub param_defaults {
+    return {
+        'queries_to_update_file'  => 'queries_to_update.txt',
+    };
+}
+
+sub fetch_input {
+    my $self = shift;
+
+    my $record_dir  = $self->param_required("species_set_record");
+    my $ignore_file = $self->param("queries_to_update_file");
+    my @records     = glob "${record_dir}/*/*.txt";
+    my @queries;
+    my @ignore_list;
+
+    if ( $self->param("queries_to_update_file") ) {
+        @ignore_list = split( /\n/, $self->_slurp( $self->param("queries_to_update_file") ) );
+    }
+
+    foreach my $file ( @records ) {
+        my $contents = $self->_slurp( $file );
+        push @queries, ( split( /\n/, $contents ) );
+    }
+
+    my @query_list = uniq( @queries );
+    my %all_queries;
+    @all_queries{ @ignore_list } = ();
+    my @reduced_queries = ( grep ! exists $all_queries{$_}, @query_list );
+
+    my $ss_adap = $self->compara_dba->get_SpeciesSetAdaptor;
+    my $collections = $ss_adap->fetch_all_current_collections;
+
+    my @collection_names = map { $_->name() } @{ $collections };
+    my @taxons = grep { $_ !~ /shared|default|references/ } @collection_names;
+    s/^collection-//g for @taxons;
+
+    my @new_taxa = map { $_->is_current ? $_->name() : () } @{ $collections };
+    my @new_collection_taxons = grep { $_ !~ /shared|default|references/ } @new_taxa;
+    s/^collection-//g for @new_collection_taxons;
+
+    $self->param('check_for_update_queries', \@reduced_queries);
+    $self->param('taxon_list', \@taxons);
+    $self->param('new_taxons', \@new_collection_taxons);
+}
+
+sub run {
+    my $self = shift;
+
+    my @update_list;
+    my @reduced_queries          = @{ $self->param('check_for_update_queries') };
+    my $get_nearest_taxonomy_exe =  $self->param_required("get_nearest_taxonomy_exe");
+    unless ($self->compara_dba->dbc->isa('Bio::EnsEMBL::Hive::DBSQL::DBConnection')) {
+        bless $self->compara_dba->dbc, 'Bio::EnsEMBL::Hive::DBSQL::DBConnection';
+    }
+    my $url        = $self->compara_dba->dbc->url();
+    my $taxon_list = join( " ", @{ $self->param("taxon_list") } );
+    $taxon_list =~ s/\n//g;
+
+    foreach my $query ( @reduced_queries ) {
+        my $cmd = "python $get_nearest_taxonomy_exe --taxon_name $query --url $url --taxon_list " .
+            join( " ", @{ $self->param("taxon_list") } );
+        my $appropriate_taxon = $self->get_command_output($cmd, { die_on_failure => 1 });
+        push @update_list, $query if ( grep( $appropriate_taxon, @{ $self->param('new_taxons') } ) );
+    }
+
+    $self->param('update_species', \@update_list);
+}
+
+sub write_output {
+    my $self = shift;
+
+    my $queries_to_update = $self->param('update_species');
+    my $out_file          = $self->param("queries_to_update_file");
+    $self->_spurt( $out_file, "\n" . join( "\n", @{ $queries_to_update } ), 1 );
+    $self->dataflow_output_id( { 'queries_to_update' => $queries_to_update }, 1);
+
+}
+
+1;

--- a/scripts/pipeline/get_nearest_taxonomy.py
+++ b/scripts/pipeline/get_nearest_taxonomy.py
@@ -43,6 +43,9 @@ def get_nearest_taxonomy(session: Session, taxon: str, ref_taxa: List[str]) -> s
         taxon: Scientific taxon name as in ncbi_taxonomy
         taxon_list: list of reference taxonomic classifications
     """
+    gca = '_gca'
+    if taxon is not None:
+        taxon = taxon = taxon.split(gca, 1)[0]
     ref_taxon = match_taxon_to_reference(session, taxon, ref_taxa)
     return ref_taxon
 


### PR DESCRIPTION
## Description

From the list updated/new reference comparator sets, what are the expected query/rapid release species in which homologies need to be recomputed.

**Related JIRA tickets:**
- ENSCOMPARASW-5351

## Overview of changes

#### Change 1
- Quick fix for the python script to remove gca from taxon name

#### Change 2
- New eHive runnable - because heavily tied to registry and database, so very necessary. Has capabilities to be run in `NextFlow` however using `standAloneJob.pl` and it doesn't really matter too much because this is a stop-gap solution until a better `meta`/ API with adaptors method can be written (this would be a heavy piece of development).

## Testing
```
$ standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::MoreAppropriateCollectionToQuery -species_set_record /hps/nobackup/flicek/ensembl/compara/shared/species_set_record/ -release 106  -compara_db "mysql://XXXX:XXXX@mysql-ens-compara-prod-2:XXXX/ensembl_compara_references" -get_nearest_taxonomy_exe /hps/software/users/ensembl/repositories/compara/cristig/dev/ensembl-compara/scripts/pipeline/get_nearest_taxonomy.py -release 106 -debug 9 

Running 'Bio::EnsEMBL::Compara::RunnableDB::MoreAppropriateCollectionToQuery' with input_id='{"compara_db" => "mysql://XXXX:XXXX\@mysql-ens-compara-prod-2:XXXX/ensembl_compara_references","get_nearest_taxonomy_exe" => "/hps/software/users/ensembl/repositories/compara/cristig/dev/ensembl-compara/scripts/pipeline/get_nearest_taxonomy.py","release" => 106,"species_set_record" => "/hps/nobackup/flicek/ensembl/compara/shared/species_set_record/"}' :
Standalone worker 3115762 : specializing to Standalone_Dummy_Analysis(unstored)
Standalone worker 3115762 : -> COMPILATION
Standalone worker 3115762 : -> READY
Standalone worker 3115762 : -> FETCH_INPUT
Standalone worker 3115762 : -> RUN
COMMAND: python /hps/software/users/ensembl/repositories/compara/cristig/dev/ensembl-compara/scripts/pipeline/get_nearest_taxonomy.py --taxon_name jaculus_jaculus_gca020740685v1 --url mysql://XXXX:XXXX@mysql-ens-compara-prod-2:XXXX/ensembl_compara_references --taxon_list hexapoda mammalia vertebrata actinopterygii sauropsida
SUCCESS !
STANDARD OUTPUT: mammalia

STANDARD ERROR : 

COMMAND: python /hps/software/users/ensembl/repositories/compara/cristig/dev/ensembl-compara/scripts/pipeline/get_nearest_taxonomy.py --taxon_name canis_lupus_familiaris --url mysql://XXXX:XXXX@mysql-ens-compara-prod-2:XXXX/ensembl_compara_references --taxon_list hexapoda mammalia vertebrata actinopterygii sauropsida
SUCCESS !
STANDARD OUTPUT: mammalia

STANDARD ERROR : 

Standalone worker 3115762 : -> WRITE_OUTPUT
Standalone worker 3115762 : Dataflow on branch #1 of {"queries_to_update" => ["jaculus_jaculus_gca020740685v1","canis_lupus_familiaris"]}
```
## Notes

---

## PR review checklist

- [X] Is the PR against an appropriate branch?
- [X] Does the code adhere to coding guidelines?
- [X] Does the code do what it claims to do?
- [x] Is the code readable? Is it appropriately documented?
- [X] Is the logic in the correct place?
- [x] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [x] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [X] Will the new code fail gracefully?
- [X] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [X] Does it bring in an unnecessary dependency?
- [X] If you are reviewing a new analysis, is it future-proof and pluggable?
- [X] Does the PR meet agile guidelines?
