### PR TITLE
pyling and mypy travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,6 +166,7 @@ jobs:
       python: 3.9
       name: "Python linter"
       install:
+        - pip freeze | grep -v -f requirements.txt - | grep -v '^#' | xargs pip uninstall -y
         - pip install pylint mypy
         - pip install -r requirements.txt
         - pip install .

--- a/travisci/python-linter_harness.sh
+++ b/travisci/python-linter_harness.sh
@@ -20,7 +20,8 @@ PYTHON_SOURCE_LOCATIONS=('scripts' 'src/python')
 # Setup the environment variables
 # shellcheck disable=SC2155
 export PYTHONPATH=$PYTHONPATH:$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
-export MYPYPATH=$MYPYPATH:$PWD/src/python/lib
+# more info: https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules
+export MYPYPATH=$MYPYPATH:src/python/lib
 
 PYLINT_OUTPUT_FILE=$(mktemp)
 PYLINT_ERRORS=$(mktemp)


### PR DESCRIPTION
## Description

- Travis loads `python3.9.13` with old installed packages, such as `dataclasses ==0.6` applicable only for `python 3.6 and 3.7`. Therefore, removing unnecessary pip-installed packages with `pip freeze | grep -v -f requirements.txt - | grep -v '^#' | xargs pip uninstall -y` before triggering `travisci/python-linter_harness.sh`
- Solving the issue`/home/travis/Ensembl/ensembl-compara is in the MYPYPATH. Please remove it.` by setting `MYPYPATH` with relative `src` path.  More details, click [here](https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules)
