### PR TITLE
Improve the species_set_header names creation

### DIFF
--- a/scripts/pipeline/create_mlss.pl
+++ b/scripts/pipeline/create_mlss.pl
@@ -458,6 +458,9 @@ sub create_mlss {
         foreach my $gdb (@{$all_genome_dbs}) {
           my $species_name = $gdb->name;
           $species_name =~ s/\b(\w)/\U$1/g;
+          my @species_name_split = split('_', $species_name);
+          my @first_two_species_name_split = @species_name_split[0, 1];
+          $species_name = join('_',@first_two_species_name_split);
           $species_name =~ s/(\S)\S+\_/$1\./;
           $species_name = substr($species_name, 0, 5);
           push @individual_names, $species_name;


### PR DESCRIPTION
## Description

This fix is about this issue explained here (https://genomes-ebi.slack.com/archives/C0HTNH2GG/p1659706069100799). WBPS is using a different format of species.production_name than ensembl (<genus>_<species>_<bioproject> instead of <genus>_<species>) and for this reason, the species_set_header names created by this script are not very meaningful for WBPS (all look very identical). With this fix both nomenclatures are being supported and the names created are more descriptive.

## Overview of changes
Changed the way the species name is being handled to create the species_set header names.

## PR review checklist

- [x] Is the PR against an appropriate branch?
- [x] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [x] Is the code readable? Is it appropriately documented?
- [x] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [x] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [x] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [x] Does it bring in an unnecessary dependency?
- [x] If you are reviewing a new analysis, is it future-proof and pluggable?
- [x] Does the PR meet agile guidelines?
