### PR TITLE
making delimiter flexible into map_row_to_header

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
@@ -59,7 +59,7 @@ our @EXPORT_OK;
 
     To avoid hard-coding array indexes, map the values in each row based on the
     header line. This way, it doesn't matter if we add extra fields to the input
-    file. This subroutine uses `\s+` as default separator between fields. This 
+    file. This subroutine uses `\s+` as default separator between fields. This
     behaviour can be changed using the `delimiter_pattern` parameter. Tab value
     `\t` has been tested
 

--- a/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
@@ -65,7 +65,7 @@ our @EXPORT_OK;
 
 sub map_row_to_header {
     my ($line, $header, $delimiter_pattern) = @_;
-    $delimiter_pattern //= "\\s+";
+    $delimiter_pattern //= '\s+';
     
     chomp $line;
     chomp $header;

--- a/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
@@ -74,7 +74,7 @@ sub map_row_to_header {
     if ( ref $header eq 'ARRAY' ) {
         @head_cols = @$header;
     } else {
-        @head_cols = split(/$delimiter_pattern/, $header);
+        @head_cols = split(/$delimiter_pattern/, $header, -1);
     }
     
     die "Number of columns in header (", (scalar @head_cols),") do not match row (", (scalar @cols),")" unless scalar @cols == scalar @head_cols;

--- a/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
@@ -64,19 +64,20 @@ our @EXPORT_OK;
 =cut
 
 sub map_row_to_header {
-    my ($line, $header) = @_;
+    my ($line, $header, $delimiter_pattern) = @_;
+    $delimiter_pattern //= "\\s+";
     
     chomp $line;
     chomp $header;
-    my @cols      = split(/\s+/, $line);
+    my @cols      = split(/$delimiter_pattern/, $line);
     my @head_cols;
     if ( ref $header eq 'ARRAY' ) {
         @head_cols = @$header;
     } else {
-        @head_cols = split(/\s+/, $header);
+        @head_cols = split(/$delimiter_pattern/, $header);
     }
     
-    die "Number of columns in header do not match row" unless scalar @cols == scalar @head_cols;
+    die "Number of columns in header (", (scalar @head_cols),") do not match row (", (scalar @cols),")" unless scalar @cols == scalar @head_cols;
     
     my $row;
     for ( my $i = 0; $i < scalar @cols; $i++ ) {
@@ -84,6 +85,7 @@ sub map_row_to_header {
     }
     return $row;
 }
+
 
 =head2 parse_flatfile_into_hash
 

--- a/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
@@ -59,7 +59,9 @@ our @EXPORT_OK;
 
     To avoid hard-coding array indexes, map the values in each row based on the
     header line. This way, it doesn't matter if we add extra fields to the input
-    file
+    file. This subroutine uses `\s+` as default separator between fields. This 
+    behaviour can be changed using the `delimiter_pattern` parameter. Tab value
+    `\t` has been tested
 
 =cut
 

--- a/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/FlatFile.pm
@@ -69,7 +69,7 @@ sub map_row_to_header {
     
     chomp $line;
     chomp $header;
-    my @cols      = split(/$delimiter_pattern/, $line);
+    my @cols      = split(/$delimiter_pattern/, $line, -1);
     my @head_cols;
     if ( ref $header eq 'ARRAY' ) {
         @head_cols = @$header;
@@ -85,7 +85,6 @@ sub map_row_to_header {
     }
     return $row;
 }
-
 
 =head2 parse_flatfile_into_hash
 

--- a/modules/t/Utils/FlatFile.t
+++ b/modules/t/Utils/FlatFile.t
@@ -25,7 +25,7 @@ use Bio::EnsEMBL::Compara::Utils::FlatFile;
 
 subtest 'map_row_to_header' => sub {
     my $line_1 = "a\tb\tc\td";
-    my $line_2 = "a;b;c;d";
+    my $line_2 = "a b  c   d";
     my @header1 = (1, 2, 3, 4);
     my @header2 = (1, 2);
 
@@ -35,66 +35,57 @@ subtest 'map_row_to_header' => sub {
     );
 
     is_deeply( 
-        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t3\t4"), 
-        { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
-    );
-    
-    is_deeply( 
         Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header1, "\t"), 
         { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
     );
 
     is_deeply( 
-        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header1, '\t'), 
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t3\t4"), 
         { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
     );
 
     is_deeply( 
-        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t3\t4", "\t"), 
-        { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header("a\tb\tc\t", "1\t2\t3\t4"), 
+        { 1 => 'a', 2 => 'b', 3 => 'c', 4 => '' }
     );
-
-    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header2) } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
-    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2")  } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
-    # to test LIMIT = -1 of split function: https://perldoc.perl.org/functions/split
-    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t")  } qr/Number of columns in header \(3\) do not match row \(4\)/, "Header doesn't match";
-
-    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header2, "\t") } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
-    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2", "\t") } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
-    # to test LIMIT = -1 of split function: https://perldoc.perl.org/functions/split
-    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t", "\t") } qr/Number of columns in header \(3\) do not match row \(4\)/, "Header doesn't match";
-
-    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header2, '\t') } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
-    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2", '\t') } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
-    # to test LIMIT = -1 of split function: https://perldoc.perl.org/functions/split
-    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t", '\t') } qr/Number of columns in header \(3\) do not match row \(4\)/, "Header doesn't match";
-
     
     is_deeply( 
-        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, \@header1, ";"), 
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header("a\t\tc\td", "1\t2\t3\t4", "\t"), 
+        { 1 => 'a', 2 => '', 3 => 'c', 4 => 'd' }
+    );
+
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header2) }        qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header2, "\t") }  qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header("a\t\tc\td", "1\t2\t3\t4") } qr/Number of columns in header \(4\) do not match row \(3\)/, "Header doesn't match";
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header2, '\t') }  qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2", "\t") }     qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2") }           qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
+
+    # to test LIMIT = -1 of split function: https://perldoc.perl.org/functions/split
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t") }         qr/Number of columns in header \(3\) do not match row \(4\)/, "Header doesn't match";
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t", "\t") }   qr/Number of columns in header \(3\) do not match row \(4\)/, "Header doesn't match";
+    
+    is_deeply( 
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, \@header1), 
         { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
     );
 
     is_deeply( 
-        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, "1;2;3;4", ";"), 
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header("a b c d", \@header1), 
         { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
     );
 
     is_deeply( 
-        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, \@header1, ';'), 
-        { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header("a b c d ", "1 2 3 4 "), 
+        { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd', '' => ''}
     );
 
     is_deeply( 
-        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, "1;2;3;4", ';'), 
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, "1 2 3 4"), 
         { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
     );
 
-    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, \@header1) } qr/Number of columns in header \(4\) do not match row \(1\)/, "Header doesn't match";
-    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, \@header2) } qr/Number of columns in header \(2\) do not match row \(1\)/, "Header doesn't match";
-
-
-
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header("a b c d ", \@header1) }   qr/Number of columns in header \(4\) do not match row \(5\)/, "Header doesn't match";
 };
 
 subtest 'group_array_of_hashes_by' => sub {

--- a/modules/t/Utils/FlatFile.t
+++ b/modules/t/Utils/FlatFile.t
@@ -24,15 +24,53 @@ use Test::Exception;
 use Bio::EnsEMBL::Compara::Utils::FlatFile;
 
 subtest 'map_row_to_header' => sub {
-    my $line = "a\tb\tc\td";
+    my $line_1 = "a\tb\tc\td";
+    my $line_2 = "a;b;c;d";
     my @header1 = (1, 2, 3, 4);
     my @header2 = (1, 2);
 
     is_deeply( 
-        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line, \@header1), 
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header1), 
         { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
     );
-    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line, \@header2) } qr/Number of columns in header do not match row/, "Header doesn't match";
+
+    is_deeply( 
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t3\t4"), 
+        { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
+    );
+    
+    is_deeply( 
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header1, "\t"), 
+        { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
+    );
+
+    is_deeply( 
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t3\t4", "\t"), 
+        { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
+    );
+
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header2) } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t")  } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header2, "\t") } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t", "\t") } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
+
+
+    
+    is_deeply( 
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, \@header1, ";"), 
+        { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
+    );
+
+    is_deeply( 
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, "1;2;3;4", ";"), 
+        { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
+    );
+
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, \@header1) } qr/Number of columns in header \(4\) do not match row \(1\)/, "Header doesn't match";
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, \@header2) } qr/Number of columns in header \(2\) do not match row \(1\)/, "Header doesn't match";
+
+
+
 };
 
 subtest 'group_array_of_hashes_by' => sub {

--- a/modules/t/Utils/FlatFile.t
+++ b/modules/t/Utils/FlatFile.t
@@ -30,27 +30,26 @@ subtest 'map_row_to_header' => sub {
     my @header2 = (1, 2);
 
     is_deeply( 
-        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header1), 
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header1),
         { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
     );
 
-    is_deeply( 
-        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header1, "\t"), 
+    is_deeply(
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header1, "\t"),
         { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
     );
 
-    is_deeply( 
-        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t3\t4"), 
+    is_deeply(
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t3\t4"),
         { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
     );
 
-    is_deeply( 
-        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header("a\tb\tc\t", "1\t2\t3\t4"), 
+    is_deeply(
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header("a\tb\tc\t", "1\t2\t3\t4"),
         { 1 => 'a', 2 => 'b', 3 => 'c', 4 => '' }
     );
-    
-    is_deeply( 
-        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header("a\t\tc\td", "1\t2\t3\t4", "\t"), 
+    is_deeply(
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header("a\t\tc\td", "1\t2\t3\t4", "\t"),
         { 1 => 'a', 2 => '', 3 => 'c', 4 => 'd' }
     );
 
@@ -64,24 +63,23 @@ subtest 'map_row_to_header' => sub {
     # to test LIMIT = -1 of split function: https://perldoc.perl.org/functions/split
     throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t") }         qr/Number of columns in header \(3\) do not match row \(4\)/, "Header doesn't match";
     throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t", "\t") }   qr/Number of columns in header \(3\) do not match row \(4\)/, "Header doesn't match";
-    
-    is_deeply( 
-        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, \@header1), 
+    is_deeply(
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, \@header1),
         { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
     );
 
-    is_deeply( 
-        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header("a b c d", \@header1), 
+    is_deeply(
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header("a b c d", \@header1),
         { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
     );
 
-    is_deeply( 
-        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header("a b c d ", "1 2 3 4 "), 
+    is_deeply(
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header("a b c d ", "1 2 3 4 "),
         { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd', '' => ''}
     );
 
-    is_deeply( 
-        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, "1 2 3 4"), 
+    is_deeply(
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, "1 2 3 4"),
         { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
     );
 

--- a/modules/t/Utils/FlatFile.t
+++ b/modules/t/Utils/FlatFile.t
@@ -45,15 +45,29 @@ subtest 'map_row_to_header' => sub {
     );
 
     is_deeply( 
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header1, '\t'), 
+        { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
+    );
+
+    is_deeply( 
         Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t3\t4", "\t"), 
         { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
     );
 
     throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header2) } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
-    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t")  } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
-    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header2, "\t") } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
-    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t", "\t") } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2")  } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
+    # to test LIMIT = -1 of split function: https://perldoc.perl.org/functions/split
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t")  } qr/Number of columns in header \(3\) do not match row \(4\)/, "Header doesn't match";
 
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header2, "\t") } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2", "\t") } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
+    # to test LIMIT = -1 of split function: https://perldoc.perl.org/functions/split
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t", "\t") } qr/Number of columns in header \(3\) do not match row \(4\)/, "Header doesn't match";
+
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, \@header2, '\t') } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2", '\t') } qr/Number of columns in header \(2\) do not match row \(4\)/, "Header doesn't match";
+    # to test LIMIT = -1 of split function: https://perldoc.perl.org/functions/split
+    throws_ok { Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_1, "1\t2\t", '\t') } qr/Number of columns in header \(3\) do not match row \(4\)/, "Header doesn't match";
 
     
     is_deeply( 
@@ -63,6 +77,16 @@ subtest 'map_row_to_header' => sub {
 
     is_deeply( 
         Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, "1;2;3;4", ";"), 
+        { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
+    );
+
+    is_deeply( 
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, \@header1, ';'), 
+        { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
+    );
+
+    is_deeply( 
+        Bio::EnsEMBL::Compara::Utils::FlatFile::map_row_to_header($line_2, "1;2;3;4", ';'), 
         { 1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd' }
     );
 


### PR DESCRIPTION
## Description

A row containing a space as the content of some field may cause an incorrect split action. As a consequence, the number of tokens (words) in a row may not match the number of tokens (words) in the header, and therefore the function `map_row_to_header` dies.

**Related JIRA tickets:**
- ENSCOMPARASW-5406

## Overview of changes
A new non-mandatory argument (called `delimiter_pattern`) has been added to the `map_row_to_header` subroutine. Its default value has been set to `\\s` because it is already in use.

#### Change 1

The addition of a non-mandatory argument with a default value set to `\s+` if nothing is passed.

```Perl
$delimiter_pattern //= '\s+';
```

#### Change 2
The 'LIMIT' parameter of the Perl 'split' function has been set to a negative value (`-1`) to avoid the removal of empty trailing fields. As things are currently implemented, an empty 'strain' field is removed by 'split', which calls for very special handling ([here](https://github.com/Ensembl/ensembl-compara/blob/feature/homology_annotation/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromMetadataFactory.pm#L383) and [here](https://github.com/Ensembl/ensembl-compara/blob/c1e262ff33b70780a592d567d00af416c1e3bbfd/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromMetadataFactory.pm#L408)) to ensure that the 'strain' field is not an empty string. 

Therefore, setting the 'LIMIT' to a negative value would leave such empty fields intact and would remove the need for special (hacky-ish?) handling. 

#### Change 3
Improve the error message in the case the function dies due to the different numbers of tokens in the given line and header. The proposal message is to include the number of tokens found in the given parameters. 


```Perl
die "Number of columns in header (", (scalar @head_cols),") do not match row (", (scalar @cols),")" unless scalar @cols == scalar @head_cols;
```

## Testing
Yes, new test have been included.

## Notes
_Optional extra information._

---

## PR review checklist

- [x] Is the PR against an appropriate branch?
- [x] Does the code adhere to coding guidelines?
- [x] Does the code do what it claims to do?
- [x] Is the code readable? Is it appropriately documented?
- [x] Is the logic in the correct place?
- [x] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [x] Will the new code fail gracefully?
- [x] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [x] Does it bring in an unnecessary dependency?
- [x] If you are reviewing a new analysis, is it future-proof and pluggable?
- [x] Does the PR meet agile guidelines?
