### PR TITLE
applying tab as column separator

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromMetadataFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromMetadataFactory.pm
@@ -381,7 +381,7 @@ sub _parse_rr_genome_files {
         next if $_ !~ /[a-z]/;
         # the strain column can be blank, leading to mismatch of column numbers
         $_ = $_ . 'NULL' if $_ !~ /[a-z0-9]$/;
-        my $row = map_row_to_header( $_, $header );
+        my $row = map_row_to_header( $_, $header, "\t" );
         # only interested in the genome name
         push @species_names, $row->{name};
     }
@@ -406,7 +406,7 @@ sub _parse_rename_rr_files {
             next if $_ !~ /[a-z]/;
             # the strain column can be blank, leading to mismatch of column numbers
             $_ = $_ . 'NULL' if $_ !~ /[a-z0-9]$/;
-            my $row = map_row_to_header( $_, $header );
+            my $row = map_row_to_header( $_, $header, "\t" );
             # only interested in the genome name and old_name
             $renamed_genomes{$row->{name}} = $row->{old_name};
         }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromMetadataFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromMetadataFactory.pm
@@ -379,8 +379,7 @@ sub _parse_rr_genome_files {
         # header line is commented in output
         next if $_ =~ /^\#name/;
         next if $_ !~ /[a-z]/;
-        # the strain column can be blank, leading to mismatch of column numbers
-        $_ = $_ . 'NULL' if $_ !~ /[a-z0-9]$/;
+        # the strain column can be blank; therefore, applying "\t" as field separator
         my $row = map_row_to_header( $_, $header, "\t" );
         # only interested in the genome name
         push @species_names, $row->{name};
@@ -404,8 +403,7 @@ sub _parse_rename_rr_files {
             # header line is commented in output
             next if $_ =~ /^\#name/;
             next if $_ !~ /[a-z]/;
-            # the strain column can be blank, leading to mismatch of column numbers
-            $_ = $_ . 'NULL' if $_ !~ /[a-z0-9]$/;
+            # the strain column can be blank; therefore, applying "\t" as field separator
             my $row = map_row_to_header( $_, $header, "\t" );
             # only interested in the genome name and old_name
             $renamed_genomes{$row->{name}} = $row->{old_name};


### PR DESCRIPTION
Description described here #487.

Applying "\t" as field separator when calling the  `map_row_to_header` subroutine to avoid its death when dealing with spaces in the 'strain' field.

**Related JIRA tickets:**
- ENSCOMPARASW-5406

---

## PR review checklist

- [x] Is the PR against an appropriate branch?
- [x] Does the code adhere to coding guidelines?
- [x] Does the code do what it claims to do?
- [x] Is the code readable? Is it appropriately documented?
- [x] Is the logic in the correct place?
- [x] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [x] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [x] Will the new code fail gracefully?
- [x] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [x] Does it bring in an unnecessary dependency?
- [x] If you are reviewing a new analysis, is it future-proof and pluggable?
- [x] Does the PR meet agile guidelines?
