### PR TITLE
Change gene_member_qc schema to use gene_member_id

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/GeneMemberAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/GeneMemberAdaptor.pm
@@ -15,17 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::DBSQL::GeneMemberAdaptor
@@ -39,15 +28,6 @@ Most of the methods are shared with the SeqMemberAdaptor.
 
   Bio::EnsEMBL::Compara::DBSQL::GeneMemberAdaptor
   +- Bio::EnsEMBL::Compara::DBSQL::MemberAdaptor
-
-=head1 AUTHORSHIP
-
-Ensembl Team. Individual contributions can be found in the GIT log.
-
-=head1 APPENDIX
-
-The rest of the documentation details each of the object methods.
-Internal methods are usually preceded with an underscore (_)
 
 =cut
 
@@ -261,7 +241,7 @@ sub delete {
     foreach my $seq_member (@{$gene_member->get_all_SeqMembers}) {
         $seq_member->adaptor->delete($seq_member);
     }
-    $self->dbc->do('DELETE FROM gene_member_qc          WHERE gene_member_stable_id = ?', undef, $gene_member->stable_id);
+    $self->dbc->do('DELETE FROM gene_member_qc          WHERE gene_member_id = ?', undef, $gene_member->dbID);
     $self->dbc->do('DELETE FROM member_xref             WHERE gene_member_id = ?', undef, $gene_member->dbID);
     $self->dbc->do('DELETE FROM gene_member_hom_stats   WHERE gene_member_id = ?', undef, $gene_member->dbID);
     $self->dbc->do('DELETE FROM gene_member             WHERE gene_member_id = ?', undef, $gene_member->dbID);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneSetQC/CompareToCloseSpecies.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneSetQC/CompareToCloseSpecies.pm
@@ -15,17 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::GeneSetQC::CompareToCloseSpecies
@@ -42,15 +31,6 @@ the reference species.
 
 standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::GeneSetQC::CompareToCloseSpecies \
  -compara_db mysql://server/mm14_protein_trees_82
-
-=head1 AUTHORSHIP
-
-Ensembl Team. Individual contributions can be found in the GIT log.
-
-=head1 APPENDIX
-
-The rest of the documentation details each of the object methods.
-Internal methods are usually preceded with an underscore (_)
 
 =cut
 
@@ -163,8 +143,12 @@ sub analyze_number_copies {
         join(',', grep {$_} (map {$strs{$_}} @other_gdb_ids)) || 'NULL',
     );
 
-    printf("BRANCH_LENGTH\t%s\t%f\t%s\t%f\n", $sample_gene{$genome_db_id}->stable_id, $sample_gene{$genome_db_id}->distance_to_parent, $sample_gene{$ref_gdb_id}->stable_id, $sample_gene{$ref_gdb_id}->distance_to_parent) if $counts{$ref_gdb_id} == 1 and $counts{$genome_db_id} == 1;
-
+    if (($counts{$ref_gdb_id} == 1) and ($counts{$genome_db_id} == 1)) {
+        printf("BRANCH_LENGTH\t%d\t%s\t%f\t%d\t%s\t%f\n",
+            $genome_db_id, $sample_gene{$genome_db_id}->stable_id, $sample_gene{$genome_db_id}->distance_to_parent,
+            $ref_gdb_id, $sample_gene{$ref_gdb_id}->stable_id, $sample_gene{$ref_gdb_id}->distance_to_parent
+        );
+    }
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneSetQC/GetSplitGenes.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneSetQC/GetSplitGenes.pm
@@ -15,17 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::GeneSetQC::GetSplitGenes
@@ -71,7 +60,7 @@ sub fetch_input {
     my $genome_db_id = $self->param_required('genome_db_id');
   
     # Fetch the split genes
-    my $split_genes = $self->compara_dba->dbc->db_handle->selectall_arrayref('SELECT seq_member_id, gm.stable_id FROM split_genes sg JOIN seq_member sm USING (seq_member_id) JOIN gene_member gm USING (gene_member_id) WHERE sm.genome_db_id = ?', undef, $genome_db_id);
+    my $split_genes = $self->compara_dba->dbc->db_handle->selectall_arrayref('SELECT seq_member_id, gene_member_id FROM split_genes JOIN seq_member USING (seq_member_id) WHERE genome_db_id = ?', undef, $genome_db_id);
     $self->param('split_genes_hash', $split_genes);
     print Dumper($split_genes) if ($self->debug >3);
 #    die;
@@ -84,7 +73,7 @@ sub run {
   
   for my $smid (@sg_keys) {
     print " $smid->[0]    %%%%%%%%%% $smid->[1]   %%%%%%%%%%%%%%%%%%%%%%%%%%%%\n" if ($self->debug >3);
-    $self->dataflow_output_id( {'genome_db_id' => $self->param_required('genome_db_id'), 'seq_member_id' => $smid->[0], 'gene_member_stable_id' => $smid->[1], 'status' => 'split-gene' }, 2 );
+    $self->dataflow_output_id( {'genome_db_id' => $self->param_required('genome_db_id'), 'seq_member_id' => $smid->[0], 'gene_member_id' => $smid->[1], 'status' => 'split-gene' }, 2 );
     $count +=1;
 #    if ($count == 10){
  #     last;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ReindexMembers/DeleteOldMember.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ReindexMembers/DeleteOldMember.pm
@@ -70,7 +70,7 @@ sub run {
             $dbc->do('DELETE m FROM gene_align_member m JOIN gene_tree_root r USING(gene_align_id)
                       WHERE r.tree_type = "supertree" AND m.seq_member_id = ?;', undef, $self->param('seq_member_id'));
 
-            $dbc->do('DELETE FROM gene_member_qc                  WHERE gene_member_stable_id = ?', undef, $self->param('gene_member_stable_id'));
+            $dbc->do('DELETE FROM gene_member_qc                  WHERE gene_member_id = ?',        undef, $self->param('gene_member_id'));
             $dbc->do('DELETE FROM member_xref                     WHERE gene_member_id = ?',        undef, $self->param('gene_member_id'));
             $dbc->do('DELETE FROM gene_member_hom_stats           WHERE gene_member_id = ?',        undef, $self->param('gene_member_id'));
             $dbc->do('DELETE FROM seq_member_projection_stable_id WHERE target_seq_member_id = ?',  undef, $self->param('seq_member_id'));

--- a/sql/patch_108_109_b.sql
+++ b/sql/patch_108_109_b.sql
@@ -1,0 +1,36 @@
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_108_109_b.sql
+#
+# Title: Change the gene_member_qc key to gene_member_id.
+#
+# Description:
+#   To allow for duplicate stable IDs between genomes, replace the
+#   gene_member_stable_id column of gene_member_qc with gene_member_id.
+
+SET session sql_mode='TRADITIONAL';
+
+ALTER TABLE gene_member_qc
+  DROP FOREIGN KEY gene_member_stable_id,
+  DROP KEY gene_member_stable_id,
+  DROP COLUMN gene_member_stable_id,
+  ADD COLUMN gene_member_id INT unsigned NOT NULL FIRST,
+  ADD KEY (gene_member_id),
+  ADD FOREIGN KEY (gene_member_id) REFERENCES gene_member(gene_member_id);
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_108_109_b.sql|gene_member_qc_key');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1783,7 +1783,7 @@ CREATE TABLE gene_tree_node_attr (
 */
 
 CREATE TABLE gene_member_qc (
-  gene_member_stable_id       varchar(128) BINARY NOT NULL,
+  gene_member_id              INT unsigned NOT NULL,
   genome_db_id                INT unsigned NOT NULL,
   seq_member_id               INT unsigned,
   n_species                   INT,
@@ -1791,11 +1791,11 @@ CREATE TABLE gene_member_qc (
   avg_cov                     FLOAT,
   status                      varchar(50) NOT NULL,
 
-  FOREIGN KEY (gene_member_stable_id) REFERENCES gene_member(stable_id),
+  FOREIGN KEY (gene_member_id) REFERENCES gene_member(gene_member_id),
   FOREIGN KEY (seq_member_id) REFERENCES seq_member(seq_member_id),
   FOREIGN KEY (genome_db_id) REFERENCES genome_db(genome_db_id),
 
-  KEY (gene_member_stable_id)
+  KEY (gene_member_id)
 
 ) COLLATE=latin1_swedish_ci ENGINE=MyISAM;
 
@@ -2282,3 +2282,7 @@ INSERT INTO meta (species_id, meta_key, meta_value) VALUES (NULL, 'schema_type',
 # Patch identifier
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_108_109_a.sql|schema_version');
+
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_108_109_b.sql|gene_member_qc_key');
+

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1773,7 +1773,7 @@ CREATE TABLE gene_tree_node_attr (
 @desc  This table contains gene quality information from the geneset_QC pipeline
 @colour   #FFCC66
 
-@column gene_member_stable_id    EnsEMBL stable ID
+@column gene_member_id           External reference to gene_member_id in the @link gene_member table.
 @column genome_db_id             Internal unique ID for this table
 @column seq_member_id            canonical seq_member_id
 @column n_species                -n_species

--- a/src/test_data/databases/homology/meta.txt
+++ b/src/test_data/databases/homology/meta.txt
@@ -77,3 +77,4 @@
 107	\N	patch	patch_106_107_b.sql|case_sensitive_stable_id
 109	\N	patch	patch_107_108_a.sql|schema_version
 111	\N	patch	patch_108_109_a.sql|schema_version
+112	\N	patch	patch_108_109_b.sql|gene_member_qc_key

--- a/src/test_data/databases/homology/table.sql
+++ b/src/test_data/databases/homology/table.sql
@@ -175,7 +175,7 @@ CREATE TABLE `gene_member_hom_stats` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_member_qc` (
-  `gene_member_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `gene_member_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   `seq_member_id` int(10) unsigned DEFAULT NULL,
   `n_species` int(11) DEFAULT NULL,
@@ -183,8 +183,8 @@ CREATE TABLE `gene_member_qc` (
   `avg_cov` float DEFAULT NULL,
   `status` varchar(50) NOT NULL,
   KEY `genome_db_id` (`genome_db_id`),
-  KEY `gene_member_stable_id` (`gene_member_stable_id`),
-  KEY `seq_member_id` (`seq_member_id`)
+  KEY `seq_member_id` (`seq_member_id`),
+  KEY `gene_member_id` (`gene_member_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_node` (
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=112 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=113 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/src/test_data/databases/mysqlimport_test/meta.txt
+++ b/src/test_data/databases/mysqlimport_test/meta.txt
@@ -16,3 +16,4 @@
 30	\N	patch	patch_106_107_b.sql|case_sensitive_stable_id
 32	\N	patch	patch_107_108_a.sql|schema_version
 34	\N	patch	patch_108_109_a.sql|schema_version
+35	\N	patch	patch_108_109_b.sql|gene_member_qc_key

--- a/src/test_data/databases/mysqlimport_test/table.sql
+++ b/src/test_data/databases/mysqlimport_test/table.sql
@@ -175,7 +175,7 @@ CREATE TABLE `gene_member_hom_stats` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_member_qc` (
-  `gene_member_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `gene_member_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   `seq_member_id` int(10) unsigned DEFAULT NULL,
   `n_species` int(11) DEFAULT NULL,
@@ -183,8 +183,8 @@ CREATE TABLE `gene_member_qc` (
   `avg_cov` float DEFAULT NULL,
   `status` varchar(50) NOT NULL,
   KEY `genome_db_id` (`genome_db_id`),
-  KEY `gene_member_stable_id` (`gene_member_stable_id`),
-  KEY `seq_member_id` (`seq_member_id`)
+  KEY `seq_member_id` (`seq_member_id`),
+  KEY `gene_member_id` (`gene_member_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_node` (
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=35 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=36 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/src/test_data/databases/orth_qm_goc/meta.txt
+++ b/src/test_data/databases/orth_qm_goc/meta.txt
@@ -83,3 +83,4 @@
 106	\N	patch	patch_106_107_b.sql|case_sensitive_stable_id
 108	\N	patch	patch_107_108_a.sql|schema_version
 110	\N	patch	patch_108_109_a.sql|schema_version
+111	\N	patch	patch_108_109_b.sql|gene_member_qc_key

--- a/src/test_data/databases/orth_qm_goc/table.sql
+++ b/src/test_data/databases/orth_qm_goc/table.sql
@@ -175,7 +175,7 @@ CREATE TABLE `gene_member_hom_stats` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_member_qc` (
-  `gene_member_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `gene_member_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   `seq_member_id` int(10) unsigned DEFAULT NULL,
   `n_species` int(11) DEFAULT NULL,
@@ -183,8 +183,8 @@ CREATE TABLE `gene_member_qc` (
   `avg_cov` float DEFAULT NULL,
   `status` varchar(50) NOT NULL,
   KEY `genome_db_id` (`genome_db_id`),
-  KEY `gene_member_stable_id` (`gene_member_stable_id`),
-  KEY `seq_member_id` (`seq_member_id`)
+  KEY `seq_member_id` (`seq_member_id`),
+  KEY `gene_member_id` (`gene_member_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_node` (
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=111 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=112 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/src/test_data/databases/orth_qm_wga/cc21_pair_species/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_pair_species/meta.txt
@@ -83,3 +83,4 @@
 158	\N	patch	patch_106_107_b.sql|case_sensitive_stable_id
 160	\N	patch	patch_107_108_a.sql|schema_version
 162	\N	patch	patch_108_109_a.sql|schema_version
+163	\N	patch	patch_108_109_b.sql|gene_member_qc_key

--- a/src/test_data/databases/orth_qm_wga/cc21_pair_species/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_pair_species/table.sql
@@ -175,7 +175,7 @@ CREATE TABLE `gene_member_hom_stats` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_member_qc` (
-  `gene_member_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `gene_member_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   `seq_member_id` int(10) unsigned DEFAULT NULL,
   `n_species` int(11) DEFAULT NULL,
@@ -183,8 +183,8 @@ CREATE TABLE `gene_member_qc` (
   `avg_cov` float DEFAULT NULL,
   `status` varchar(50) NOT NULL,
   KEY `genome_db_id` (`genome_db_id`),
-  KEY `gene_member_stable_id` (`gene_member_stable_id`),
-  KEY `seq_member_id` (`seq_member_id`)
+  KEY `seq_member_id` (`seq_member_id`),
+  KEY `gene_member_id` (`gene_member_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_node` (
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=163 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=164 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/meta.txt
@@ -83,3 +83,4 @@
 158	\N	patch	patch_106_107_b.sql|case_sensitive_stable_id
 160	\N	patch	patch_107_108_a.sql|schema_version
 162	\N	patch	patch_108_109_a.sql|schema_version
+163	\N	patch	patch_108_109_b.sql|gene_member_qc_key

--- a/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/table.sql
@@ -175,7 +175,7 @@ CREATE TABLE `gene_member_hom_stats` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_member_qc` (
-  `gene_member_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `gene_member_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   `seq_member_id` int(10) unsigned DEFAULT NULL,
   `n_species` int(11) DEFAULT NULL,
@@ -183,8 +183,8 @@ CREATE TABLE `gene_member_qc` (
   `avg_cov` float DEFAULT NULL,
   `status` varchar(50) NOT NULL,
   KEY `genome_db_id` (`genome_db_id`),
-  KEY `gene_member_stable_id` (`gene_member_stable_id`),
-  KEY `seq_member_id` (`seq_member_id`)
+  KEY `seq_member_id` (`seq_member_id`),
+  KEY `gene_member_id` (`gene_member_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_node` (
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=163 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=164 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/meta.txt
@@ -83,3 +83,4 @@
 158	\N	patch	patch_106_107_b.sql|case_sensitive_stable_id
 160	\N	patch	patch_107_108_a.sql|schema_version
 162	\N	patch	patch_108_109_a.sql|schema_version
+163	\N	patch	patch_108_109_b.sql|gene_member_qc_key

--- a/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/table.sql
@@ -175,7 +175,7 @@ CREATE TABLE `gene_member_hom_stats` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_member_qc` (
-  `gene_member_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `gene_member_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   `seq_member_id` int(10) unsigned DEFAULT NULL,
   `n_species` int(11) DEFAULT NULL,
@@ -183,8 +183,8 @@ CREATE TABLE `gene_member_qc` (
   `avg_cov` float DEFAULT NULL,
   `status` varchar(50) NOT NULL,
   KEY `genome_db_id` (`genome_db_id`),
-  KEY `gene_member_stable_id` (`gene_member_stable_id`),
-  KEY `seq_member_id` (`seq_member_id`)
+  KEY `seq_member_id` (`seq_member_id`),
+  KEY `gene_member_id` (`gene_member_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_node` (
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=163 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=164 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/src/test_data/databases/orth_qm_wga/cc21_select_mlss/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_select_mlss/meta.txt
@@ -83,3 +83,4 @@
 158	\N	patch	patch_106_107_b.sql|case_sensitive_stable_id
 160	\N	patch	patch_107_108_a.sql|schema_version
 162	\N	patch	patch_108_109_a.sql|schema_version
+163	\N	patch	patch_108_109_b.sql|gene_member_qc_key

--- a/src/test_data/databases/orth_qm_wga/cc21_select_mlss/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_select_mlss/table.sql
@@ -175,7 +175,7 @@ CREATE TABLE `gene_member_hom_stats` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_member_qc` (
-  `gene_member_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `gene_member_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   `seq_member_id` int(10) unsigned DEFAULT NULL,
   `n_species` int(11) DEFAULT NULL,
@@ -183,8 +183,8 @@ CREATE TABLE `gene_member_qc` (
   `avg_cov` float DEFAULT NULL,
   `status` varchar(50) NOT NULL,
   KEY `genome_db_id` (`genome_db_id`),
-  KEY `gene_member_stable_id` (`gene_member_stable_id`),
-  KEY `seq_member_id` (`seq_member_id`)
+  KEY `seq_member_id` (`seq_member_id`),
+  KEY `gene_member_id` (`gene_member_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_node` (
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=163 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=164 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/src/test_data/databases/parse_pair_aligner_conf/meta.txt
+++ b/src/test_data/databases/parse_pair_aligner_conf/meta.txt
@@ -49,3 +49,4 @@
 65	\N	patch	patch_106_107_b.sql|case_sensitive_stable_id
 67	\N	patch	patch_107_108_a.sql|schema_version
 69	\N	patch	patch_108_109_a.sql|schema_version
+70	\N	patch	patch_108_109_b.sql|gene_member_qc_key

--- a/src/test_data/databases/parse_pair_aligner_conf/table.sql
+++ b/src/test_data/databases/parse_pair_aligner_conf/table.sql
@@ -175,7 +175,7 @@ CREATE TABLE `gene_member_hom_stats` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_member_qc` (
-  `gene_member_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `gene_member_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   `seq_member_id` int(10) unsigned DEFAULT NULL,
   `n_species` int(11) DEFAULT NULL,
@@ -183,8 +183,8 @@ CREATE TABLE `gene_member_qc` (
   `avg_cov` float DEFAULT NULL,
   `status` varchar(50) NOT NULL,
   KEY `genome_db_id` (`genome_db_id`),
-  KEY `gene_member_stable_id` (`gene_member_stable_id`),
-  KEY `seq_member_id` (`seq_member_id`)
+  KEY `seq_member_id` (`seq_member_id`),
+  KEY `gene_member_id` (`gene_member_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_node` (
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=70 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=71 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/src/test_data/databases/test_master/meta.txt
+++ b/src/test_data/databases/test_master/meta.txt
@@ -122,3 +122,4 @@
 160	\N	patch	patch_106_107_b.sql|case_sensitive_stable_id
 162	\N	patch	patch_107_108_a.sql|schema_version
 164	\N	patch	patch_108_109_a.sql|schema_version
+165	\N	patch	patch_108_109_b.sql|gene_member_qc_key

--- a/src/test_data/databases/test_master/table.sql
+++ b/src/test_data/databases/test_master/table.sql
@@ -175,7 +175,7 @@ CREATE TABLE `gene_member_hom_stats` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_member_qc` (
-  `gene_member_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `gene_member_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   `seq_member_id` int(10) unsigned DEFAULT NULL,
   `n_species` int(11) DEFAULT NULL,
@@ -183,8 +183,8 @@ CREATE TABLE `gene_member_qc` (
   `avg_cov` float DEFAULT NULL,
   `status` varchar(50) NOT NULL,
   KEY `genome_db_id` (`genome_db_id`),
-  KEY `gene_member_stable_id` (`gene_member_stable_id`),
-  KEY `seq_member_id` (`seq_member_id`)
+  KEY `seq_member_id` (`seq_member_id`),
+  KEY `gene_member_id` (`gene_member_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_node` (
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=165 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=166 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/src/test_data/databases/update_homologies_test/meta.txt
+++ b/src/test_data/databases/update_homologies_test/meta.txt
@@ -24,3 +24,4 @@
 30	\N	patch	patch_106_107_b.sql|case_sensitive_stable_id
 32	\N	patch	patch_107_108_a.sql|schema_version
 34	\N	patch	patch_108_109_a.sql|schema_version
+35	\N	patch	patch_108_109_b.sql|gene_member_qc_key

--- a/src/test_data/databases/update_homologies_test/table.sql
+++ b/src/test_data/databases/update_homologies_test/table.sql
@@ -175,7 +175,7 @@ CREATE TABLE `gene_member_hom_stats` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_member_qc` (
-  `gene_member_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `gene_member_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   `seq_member_id` int(10) unsigned DEFAULT NULL,
   `n_species` int(11) DEFAULT NULL,
@@ -183,8 +183,8 @@ CREATE TABLE `gene_member_qc` (
   `avg_cov` float DEFAULT NULL,
   `status` varchar(50) NOT NULL,
   KEY `genome_db_id` (`genome_db_id`),
-  KEY `gene_member_stable_id` (`gene_member_stable_id`),
-  KEY `seq_member_id` (`seq_member_id`)
+  KEY `seq_member_id` (`seq_member_id`),
+  KEY `gene_member_id` (`gene_member_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_node` (
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=35 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=36 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/src/test_data/databases/update_msa_test/meta.txt
+++ b/src/test_data/databases/update_msa_test/meta.txt
@@ -12,3 +12,4 @@
 162	\N	patch	patch_106_107_b.sql|case_sensitive_stable_id
 164	\N	patch	patch_107_108_a.sql|schema_version
 166	\N	patch	patch_108_109_a.sql|schema_version
+167	\N	patch	patch_108_109_b.sql|gene_member_qc_key

--- a/src/test_data/databases/update_msa_test/table.sql
+++ b/src/test_data/databases/update_msa_test/table.sql
@@ -175,7 +175,7 @@ CREATE TABLE `gene_member_hom_stats` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_member_qc` (
-  `gene_member_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `gene_member_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   `seq_member_id` int(10) unsigned DEFAULT NULL,
   `n_species` int(11) DEFAULT NULL,
@@ -183,8 +183,8 @@ CREATE TABLE `gene_member_qc` (
   `avg_cov` float DEFAULT NULL,
   `status` varchar(50) NOT NULL,
   KEY `genome_db_id` (`genome_db_id`),
-  KEY `gene_member_stable_id` (`gene_member_stable_id`),
-  KEY `seq_member_id` (`seq_member_id`)
+  KEY `seq_member_id` (`seq_member_id`),
+  KEY `gene_member_id` (`gene_member_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_node` (
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=167 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=168 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/src/test_data/databases/vertebrates/meta.txt
+++ b/src/test_data/databases/vertebrates/meta.txt
@@ -122,3 +122,4 @@
 160	\N	patch	patch_106_107_b.sql|case_sensitive_stable_id
 162	\N	patch	patch_107_108_a.sql|schema_version
 164	\N	patch	patch_108_109_a.sql|schema_version
+165	\N	patch	patch_108_109_b.sql|gene_member_qc_key

--- a/src/test_data/databases/vertebrates/table.sql
+++ b/src/test_data/databases/vertebrates/table.sql
@@ -175,7 +175,7 @@ CREATE TABLE `gene_member_hom_stats` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_member_qc` (
-  `gene_member_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `gene_member_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   `seq_member_id` int(10) unsigned DEFAULT NULL,
   `n_species` int(11) DEFAULT NULL,
@@ -183,8 +183,8 @@ CREATE TABLE `gene_member_qc` (
   `avg_cov` float DEFAULT NULL,
   `status` varchar(50) NOT NULL,
   KEY `genome_db_id` (`genome_db_id`),
-  KEY `gene_member_stable_id` (`gene_member_stable_id`),
-  KEY `seq_member_id` (`seq_member_id`)
+  KEY `seq_member_id` (`seq_member_id`),
+  KEY `gene_member_id` (`gene_member_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_tree_node` (
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=165 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=166 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/travisci/sql-unittest/latest_schema_patch.t
+++ b/travisci/sql-unittest/latest_schema_patch.t
@@ -25,7 +25,7 @@ use Bio::EnsEMBL::ApiVersion;
 use Bio::EnsEMBL::Compara::Utils::Test;
 
 
-## Check that the schemas test databases are fully compliant with the SQL standard
+## Check that the schema patches correctly and fully patch the schema
 
 my $compara_dir = Bio::EnsEMBL::Compara::Utils::Test::get_repository_root();
 my $multitestdb = Bio::EnsEMBL::Compara::Utils::Test::create_multitestdb();
@@ -35,9 +35,13 @@ my $current_db_name = $multitestdb->create_db_name('current_schema');
 my $current_statements = Bio::EnsEMBL::Compara::Utils::Test::read_sqls("${compara_dir}/sql/table.sql");
 my $current_db = Bio::EnsEMBL::Compara::Utils::Test::load_statements($multitestdb, $current_db_name, $current_statements, 'Can load the current Compara schema');
 my $current_schema = Bio::EnsEMBL::Compara::Utils::Test::get_schema_from_database($current_db, $current_db_name);
+
+my @row = $current_db->selectrow_array('SELECT meta_value FROM meta WHERE meta_key = "schema_version"');
+die('Failed to obtain current Compara schema version') if scalar(@row) == 0;
+my $curr_release = $row[0];
+
 Bio::EnsEMBL::Compara::Utils::Test::drop_database($multitestdb, $current_db_name);
 
-my $curr_release = software_version();
 my $prev_release = $curr_release -1;
 
 


### PR DESCRIPTION
## Description

During Ensembl Metazoa Compara 107 production, two Metazoa gene stable IDs — g3689 in _Lingula anatina_
and G3689 in _Crassostrea gigas_ — were found to clash in a case-insensitive way. To preserve stable ID
uniqueness, columns `gene_member_qc.gene_member_stable_id`, `seq_member.stable_id`
and `gene_member.stable_id` were altered to have binary collation.

The risk of further inter-genome stable ID clashes has motivated changes in the Compara schema, API and
other code in order to allow for duplicate stable IDs between genomes. As part of these efforts, these
code changes update the Compara SQL schema to replace the column `gene_member_qc.gene_member_stable_id`
with `gene_member_qc.gene_member_id`.

**Related JIRA tickets:**
- ENSCOMPARASW-5365

## Overview of changes

The Compara SQL schema and related code are updated, test databases
are patched, and some POD documentation is cleaned up.

#### Update of schema

A patch file `sql/patch_108_109_b.sql` replaces the column `gene_member_qc.gene_member_stable_id` with `gene_member_qc.gene_member_id`.

The schema file `sql/table.sql` is updated to register this patch and to reflect its changes.

#### Update of related code

The `GeneMemberAdaptor` class and `ReindexMembers::DeleteOldMember` runnable are updated to delete `gene_member_qc` rows based on their `gene_member_id` instead of their `gene_member_stable_id`.

Gene-member QC runnables are updated to access `gene_member_qc` rows using `gene_member_id` instead of `gene_member_stable_id`.

#### Patch of test databases

Test databases are patched with `patch_108_109_b.sql`.

#### Cleanup of POD

POD is cleaned up to remove unused `APPENDIX`, `AUTHORSHIP`
and `CONTACT` sections, and to drop any redundant `=cut` commands.

## Testing

A test pipeline (`mysql://ensro@mysql-ens-compara-prod-3:4523/twalsh_rel_dev_pan_protein_trees_20220812`)
based on the `release/108` branch was run to confirm that the `gene_member_qc` table could be populated
with gene-member QC stats, and that those stats could then be used to calculate corresponding species-tree
attributes.
