### PR TITLE
Reinstate Human vs Chicken alignment and synteny

### DIFF
--- a/conf/vertebrates/mlss_conf.xml
+++ b/conf/vertebrates/mlss_conf.xml
@@ -111,6 +111,9 @@
     <one_vs_all method="LASTZ_NET" ref_genome="ciona_intestinalis" against="Ciona" ref_amongst="Cyclostomata"/>
     <one_vs_all method="LASTZ_NET" ref_genome="petromyzon_marinus" against="Cyclostomata" ref_amongst="Ciona"/>
 
+    <!-- Chicken vs Human LastZ (on Human) -->
+    <pairwise_alignment method="LASTZ_NET" ref_genome="homo_sapiens" target_genome="gallus_gallus"/>
+
   </pairwise_alignments>
 
   <multiple_alignments>


### PR DESCRIPTION
## Description

The Human vs Chicken alignment and corresponding synteny were retired after release 106.
These are to be reinstated in release 109.

**Related JIRA tickets:**
- ENSCOMPARASW-5737

## Overview of changes

A single Human vs Chicken pairwise alignment has been added. As in the previous
iteration of this alignment, Human has been configured as the reference genome.

## Testing
The updated Vertebrates `mlss_conf.xml` file was validated against the
relevant RelaxNG schema document using the following Python snippet:
```python
from lxml import etree

with open("scripts/pipeline/compara_db_config.rng") as schema_file_obj:
    schema_doc = etree.parse(schema_file_obj)
schema = etree.RelaxNG(schema_doc)

with open("conf/vertebrates/mlss_conf.xml") as mlss_conf_file_obj:
    mlss_conf_doc = etree.parse(mlss_conf_file_obj)
schema.validate(mlss_conf_doc)
```
Validation was successful.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
