### PR TITLE
Add genome_db_id to member stable_id unique keys

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/SeqMemberAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/SeqMemberAdaptor.pm
@@ -417,13 +417,13 @@ sub store {
     $sth->finish;
   } else {
     $sth->finish;
-    #UNIQUE(stable_id) prevented insert since seq_member was already inserted
+    #UNIQUE(genome_db_id,stable_id) prevented insert since a seq_member was already inserted for this genome_db
     #so get seq_member_id with select
-    my $sth2 = $self->prepare("SELECT seq_member_id, sequence_id, genome_db_id FROM seq_member WHERE stable_id=?");
-    $sth2->execute($member->stable_id);
-    my($id, $sequence_id, $genome_db_id) = $sth2->fetchrow_array();
+    my $sth2 = $self->prepare("SELECT seq_member_id, sequence_id FROM seq_member WHERE genome_db_id = ? AND stable_id = ?");
+    $sth2->execute($member->genome_db_id, $member->stable_id);
+    my ($id, $sequence_id) = $sth2->fetchrow_array();
     warn("SeqMemberAdaptor: insert failed, but seq_member_id select failed too") unless($id);
-    throw(sprintf('%s already exists and belongs to a different species (%s) ! Stable IDs must be unique across the whole set of species', $member->stable_id, $self->db->get_GenomeDBAdaptor->fetch_by_dbID($genome_db_id)->name )) if $genome_db_id and $member->genome_db_id and $genome_db_id != $member->genome_db_id;
+    throw(sprintf('%s already exists in this species (%s) ! Stable IDs must be unique within a species', $member->stable_id, $member->genome_db->name));
     $member->dbID($id);
     $member->sequence_id($sequence_id) if ($sequence_id) and $member->isa('Bio::EnsEMBL::Compara::SeqMember');
     $sth2->finish;

--- a/sql/patch_108_109_c.sql
+++ b/sql/patch_108_109_c.sql
@@ -1,0 +1,33 @@
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_108_109_c.sql
+#
+# Title: Add genome_db_id to member stable_id unique keys.
+#
+# Description:
+#   To handle duplicate stable_ids between genomes, add genome_db_id
+#   to the gene_member and seq_member stable_id unique keys.
+
+ALTER TABLE gene_member
+  DROP KEY stable_id,
+  ADD UNIQUE KEY genome_db_stable_id (genome_db_id,stable_id);
+ALTER TABLE seq_member
+  DROP KEY stable_id,
+  ADD UNIQUE KEY genome_db_stable_id (genome_db_id,stable_id);
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_108_109_c.sql|stable_id_unique_per_genome');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -993,7 +993,7 @@ CREATE TABLE sequence (
 @colour   #808000
 
 @example   The following query refers to the human (ncbi_taxa_node.taxon_id = 9606 or genome_db_id = 150) gene ENSG00000176105
-      @sql                          SELECT * FROM gene_member WHERE stable_id = "ENSG00000176105";
+    @sql   SELECT * FROM gene_member WHERE genome_db_id = 150 AND stable_id = "ENSG00000176105";
 
 @column gene_member_id             Internal unique ID
 @column stable_id             EnsEMBL stable ID
@@ -1034,7 +1034,7 @@ CREATE TABLE gene_member (
   FOREIGN KEY (dnafrag_id) REFERENCES dnafrag(dnafrag_id),
 
   PRIMARY KEY (gene_member_id),
-  UNIQUE KEY (stable_id),
+  UNIQUE KEY genome_db_stable_id (genome_db_id,stable_id),
   KEY (source_name),
   KEY (canonical_member_id),
   KEY dnafrag_id_start (dnafrag_id,dnafrag_start),
@@ -1091,7 +1091,7 @@ CREATE TABLE gene_member_hom_stats (
 @colour   #808000
 
 @example   The following query refers to the human (ncbi_taxa_node.taxon_id = 9606 or genome_db_id = 150) peptide ENSP00000324740
-      @sql                          SELECT * FROM seq_member WHERE stable_id = "ENSP00000324740";
+    @sql   SELECT * FROM seq_member WHERE genome_db_id = 150 AND stable_id = "ENSP00000324740";
 
 @column seq_member_id             Internal unique ID
 @column stable_id             EnsEMBL stable ID or external ID (for Uniprot/SWISSPROT and Uniprot/SPTREMBL)
@@ -1138,7 +1138,7 @@ CREATE TABLE seq_member (
   FOREIGN KEY (dnafrag_id) REFERENCES dnafrag(dnafrag_id),
 
   PRIMARY KEY (seq_member_id),
-  UNIQUE KEY (stable_id),
+  UNIQUE KEY genome_db_stable_id (genome_db_id,stable_id),
   KEY (source_name),
   KEY (sequence_id),
   KEY (gene_member_id),
@@ -2285,4 +2285,7 @@ INSERT INTO meta (species_id, meta_key, meta_value)
 
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_108_109_b.sql|gene_member_qc_key');
+
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_108_109_c.sql|stable_id_unique_per_genome');
 

--- a/src/test_data/databases/homology/meta.txt
+++ b/src/test_data/databases/homology/meta.txt
@@ -78,3 +78,4 @@
 109	\N	patch	patch_107_108_a.sql|schema_version
 111	\N	patch	patch_108_109_a.sql|schema_version
 112	\N	patch	patch_108_109_b.sql|gene_member_qc_key
+113	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome

--- a/src/test_data/databases/homology/table.sql
+++ b/src/test_data/databases/homology/table.sql
@@ -559,7 +559,6 @@ CREATE TABLE `seq_member` (
   PRIMARY KEY (`seq_member_id`),
   UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `sequence_id` (`sequence_id`),
   KEY `gene_member_id` (`gene_member_id`),

--- a/src/test_data/databases/homology/table.sql
+++ b/src/test_data/databases/homology/table.sql
@@ -152,7 +152,7 @@ CREATE TABLE `gene_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`gene_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=113 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=114 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -557,7 +557,7 @@ CREATE TABLE `seq_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),

--- a/src/test_data/databases/mysqlimport_test/meta.txt
+++ b/src/test_data/databases/mysqlimport_test/meta.txt
@@ -17,3 +17,4 @@
 32	\N	patch	patch_107_108_a.sql|schema_version
 34	\N	patch	patch_108_109_a.sql|schema_version
 35	\N	patch	patch_108_109_b.sql|gene_member_qc_key
+36	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome

--- a/src/test_data/databases/mysqlimport_test/table.sql
+++ b/src/test_data/databases/mysqlimport_test/table.sql
@@ -152,7 +152,7 @@ CREATE TABLE `gene_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`gene_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=36 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=37 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -557,7 +557,7 @@ CREATE TABLE `seq_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),

--- a/src/test_data/databases/mysqlimport_test/table.sql
+++ b/src/test_data/databases/mysqlimport_test/table.sql
@@ -559,7 +559,6 @@ CREATE TABLE `seq_member` (
   PRIMARY KEY (`seq_member_id`),
   UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `sequence_id` (`sequence_id`),
   KEY `gene_member_id` (`gene_member_id`),

--- a/src/test_data/databases/orth_qm_goc/meta.txt
+++ b/src/test_data/databases/orth_qm_goc/meta.txt
@@ -84,3 +84,4 @@
 108	\N	patch	patch_107_108_a.sql|schema_version
 110	\N	patch	patch_108_109_a.sql|schema_version
 111	\N	patch	patch_108_109_b.sql|gene_member_qc_key
+112	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome

--- a/src/test_data/databases/orth_qm_goc/table.sql
+++ b/src/test_data/databases/orth_qm_goc/table.sql
@@ -152,7 +152,7 @@ CREATE TABLE `gene_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`gene_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=112 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=113 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -557,7 +557,7 @@ CREATE TABLE `seq_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),

--- a/src/test_data/databases/orth_qm_goc/table.sql
+++ b/src/test_data/databases/orth_qm_goc/table.sql
@@ -559,7 +559,6 @@ CREATE TABLE `seq_member` (
   PRIMARY KEY (`seq_member_id`),
   UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `sequence_id` (`sequence_id`),
   KEY `gene_member_id` (`gene_member_id`),

--- a/src/test_data/databases/orth_qm_wga/cc21_pair_species/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_pair_species/meta.txt
@@ -84,3 +84,4 @@
 160	\N	patch	patch_107_108_a.sql|schema_version
 162	\N	patch	patch_108_109_a.sql|schema_version
 163	\N	patch	patch_108_109_b.sql|gene_member_qc_key
+164	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome

--- a/src/test_data/databases/orth_qm_wga/cc21_pair_species/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_pair_species/table.sql
@@ -152,7 +152,7 @@ CREATE TABLE `gene_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`gene_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=164 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=165 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -557,7 +557,7 @@ CREATE TABLE `seq_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),

--- a/src/test_data/databases/orth_qm_wga/cc21_pair_species/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_pair_species/table.sql
@@ -559,7 +559,6 @@ CREATE TABLE `seq_member` (
   PRIMARY KEY (`seq_member_id`),
   UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `sequence_id` (`sequence_id`),
   KEY `gene_member_id` (`gene_member_id`),

--- a/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/meta.txt
@@ -84,3 +84,4 @@
 160	\N	patch	patch_107_108_a.sql|schema_version
 162	\N	patch	patch_108_109_a.sql|schema_version
 163	\N	patch	patch_108_109_b.sql|gene_member_qc_key
+164	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome

--- a/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/table.sql
@@ -152,7 +152,7 @@ CREATE TABLE `gene_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`gene_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=164 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=165 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -557,7 +557,7 @@ CREATE TABLE `seq_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),

--- a/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/table.sql
@@ -559,7 +559,6 @@ CREATE TABLE `seq_member` (
   PRIMARY KEY (`seq_member_id`),
   UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `sequence_id` (`sequence_id`),
   KEY `gene_member_id` (`gene_member_id`),

--- a/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/meta.txt
@@ -84,3 +84,4 @@
 160	\N	patch	patch_107_108_a.sql|schema_version
 162	\N	patch	patch_108_109_a.sql|schema_version
 163	\N	patch	patch_108_109_b.sql|gene_member_qc_key
+164	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome

--- a/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/table.sql
@@ -152,7 +152,7 @@ CREATE TABLE `gene_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`gene_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=164 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=165 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -557,7 +557,7 @@ CREATE TABLE `seq_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),

--- a/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/table.sql
@@ -559,7 +559,6 @@ CREATE TABLE `seq_member` (
   PRIMARY KEY (`seq_member_id`),
   UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `sequence_id` (`sequence_id`),
   KEY `gene_member_id` (`gene_member_id`),

--- a/src/test_data/databases/orth_qm_wga/cc21_select_mlss/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_select_mlss/meta.txt
@@ -84,3 +84,4 @@
 160	\N	patch	patch_107_108_a.sql|schema_version
 162	\N	patch	patch_108_109_a.sql|schema_version
 163	\N	patch	patch_108_109_b.sql|gene_member_qc_key
+164	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome

--- a/src/test_data/databases/orth_qm_wga/cc21_select_mlss/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_select_mlss/table.sql
@@ -152,7 +152,7 @@ CREATE TABLE `gene_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`gene_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=164 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=165 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -557,7 +557,7 @@ CREATE TABLE `seq_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),

--- a/src/test_data/databases/orth_qm_wga/cc21_select_mlss/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_select_mlss/table.sql
@@ -559,7 +559,6 @@ CREATE TABLE `seq_member` (
   PRIMARY KEY (`seq_member_id`),
   UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `sequence_id` (`sequence_id`),
   KEY `gene_member_id` (`gene_member_id`),

--- a/src/test_data/databases/parse_pair_aligner_conf/meta.txt
+++ b/src/test_data/databases/parse_pair_aligner_conf/meta.txt
@@ -50,3 +50,4 @@
 67	\N	patch	patch_107_108_a.sql|schema_version
 69	\N	patch	patch_108_109_a.sql|schema_version
 70	\N	patch	patch_108_109_b.sql|gene_member_qc_key
+71	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome

--- a/src/test_data/databases/parse_pair_aligner_conf/table.sql
+++ b/src/test_data/databases/parse_pair_aligner_conf/table.sql
@@ -152,7 +152,7 @@ CREATE TABLE `gene_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`gene_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=71 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=72 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -557,7 +557,7 @@ CREATE TABLE `seq_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),

--- a/src/test_data/databases/parse_pair_aligner_conf/table.sql
+++ b/src/test_data/databases/parse_pair_aligner_conf/table.sql
@@ -559,7 +559,6 @@ CREATE TABLE `seq_member` (
   PRIMARY KEY (`seq_member_id`),
   UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `sequence_id` (`sequence_id`),
   KEY `gene_member_id` (`gene_member_id`),

--- a/src/test_data/databases/test_master/meta.txt
+++ b/src/test_data/databases/test_master/meta.txt
@@ -123,3 +123,4 @@
 162	\N	patch	patch_107_108_a.sql|schema_version
 164	\N	patch	patch_108_109_a.sql|schema_version
 165	\N	patch	patch_108_109_b.sql|gene_member_qc_key
+166	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome

--- a/src/test_data/databases/test_master/table.sql
+++ b/src/test_data/databases/test_master/table.sql
@@ -152,7 +152,7 @@ CREATE TABLE `gene_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`gene_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=166 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=167 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -557,7 +557,7 @@ CREATE TABLE `seq_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),

--- a/src/test_data/databases/test_master/table.sql
+++ b/src/test_data/databases/test_master/table.sql
@@ -559,7 +559,6 @@ CREATE TABLE `seq_member` (
   PRIMARY KEY (`seq_member_id`),
   UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `sequence_id` (`sequence_id`),
   KEY `gene_member_id` (`gene_member_id`),

--- a/src/test_data/databases/update_homologies_test/meta.txt
+++ b/src/test_data/databases/update_homologies_test/meta.txt
@@ -25,3 +25,4 @@
 32	\N	patch	patch_107_108_a.sql|schema_version
 34	\N	patch	patch_108_109_a.sql|schema_version
 35	\N	patch	patch_108_109_b.sql|gene_member_qc_key
+36	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome

--- a/src/test_data/databases/update_homologies_test/table.sql
+++ b/src/test_data/databases/update_homologies_test/table.sql
@@ -152,7 +152,7 @@ CREATE TABLE `gene_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`gene_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=36 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=37 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -557,7 +557,7 @@ CREATE TABLE `seq_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),

--- a/src/test_data/databases/update_homologies_test/table.sql
+++ b/src/test_data/databases/update_homologies_test/table.sql
@@ -559,7 +559,6 @@ CREATE TABLE `seq_member` (
   PRIMARY KEY (`seq_member_id`),
   UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `sequence_id` (`sequence_id`),
   KEY `gene_member_id` (`gene_member_id`),

--- a/src/test_data/databases/update_msa_test/meta.txt
+++ b/src/test_data/databases/update_msa_test/meta.txt
@@ -13,3 +13,4 @@
 164	\N	patch	patch_107_108_a.sql|schema_version
 166	\N	patch	patch_108_109_a.sql|schema_version
 167	\N	patch	patch_108_109_b.sql|gene_member_qc_key
+168	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome

--- a/src/test_data/databases/update_msa_test/table.sql
+++ b/src/test_data/databases/update_msa_test/table.sql
@@ -152,7 +152,7 @@ CREATE TABLE `gene_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`gene_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=168 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=169 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -557,7 +557,7 @@ CREATE TABLE `seq_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),

--- a/src/test_data/databases/update_msa_test/table.sql
+++ b/src/test_data/databases/update_msa_test/table.sql
@@ -559,7 +559,6 @@ CREATE TABLE `seq_member` (
   PRIMARY KEY (`seq_member_id`),
   UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `sequence_id` (`sequence_id`),
   KEY `gene_member_id` (`gene_member_id`),

--- a/src/test_data/databases/vertebrates/meta.txt
+++ b/src/test_data/databases/vertebrates/meta.txt
@@ -123,3 +123,4 @@
 162	\N	patch	patch_107_108_a.sql|schema_version
 164	\N	patch	patch_108_109_a.sql|schema_version
 165	\N	patch	patch_108_109_b.sql|gene_member_qc_key
+166	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome

--- a/src/test_data/databases/vertebrates/table.sql
+++ b/src/test_data/databases/vertebrates/table.sql
@@ -152,7 +152,7 @@ CREATE TABLE `gene_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`gene_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `source_name` (`source_name`),
   KEY `canonical_member_id` (`canonical_member_id`),
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=166 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=167 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -557,7 +557,7 @@ CREATE TABLE `seq_member` (
   `dnafrag_strand` tinyint(4) DEFAULT NULL,
   `display_label` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
-  UNIQUE KEY `stable_id` (`stable_id`),
+  UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
   KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),

--- a/src/test_data/databases/vertebrates/table.sql
+++ b/src/test_data/databases/vertebrates/table.sql
@@ -559,7 +559,6 @@ CREATE TABLE `seq_member` (
   PRIMARY KEY (`seq_member_id`),
   UNIQUE KEY `genome_db_stable_id` (`genome_db_id`,`stable_id`),
   KEY `taxon_id` (`taxon_id`),
-  KEY `genome_db_id` (`genome_db_id`),
   KEY `source_name` (`source_name`),
   KEY `sequence_id` (`sequence_id`),
   KEY `gene_member_id` (`gene_member_id`),


### PR DESCRIPTION
## Description

During Ensembl Metazoa Compara 107 production, two Metazoa gene stable IDs — g3689 in _Lingula anatina_
and G3689 in _Crassostrea gigas_ — were found to clash in a case-insensitive way. To preserve stable ID
uniqueness, columns `gene_member_qc.gene_member_stable_id`, `seq_member.stable_id`
and `gene_member.stable_id` were altered to have binary collation.

The risk of further inter-genome stable ID clashes has motivated changes in the Compara schema, API and
other code in order to allow for duplicate stable IDs between genomes. As part of these efforts, these
code changes update the Compara SQL schema so that `gene_member.stable_id` and `seq_member.stable_id` are
unique per-genome, rather than unique across all Compara genomes as was previously the case.

**Related JIRA tickets:**
- ENSCOMPARASW-5750

## Overview of changes
The Compara SQL schema and related code are updated,
and test databases are patched.

#### Update of schema

A patch file `sql/patch_108_109_c.sql` removes the `gene_member` and `seq_member` `stable_id` unique keys,
and replaces each with a composite key of `genome_db_id` and `stable_id`.

The schema file `sql/table.sql` is updated to register this patch and to reflect its changes.

#### Update of related code

The `GeneMemberAdaptor` and `SeqMemberAdaptor` classes are updated to throw an error if a `stable_id` is duplicated within a genome, instead of across all Compara genomes as was done previously.

#### Patch of test databases

Test databases are patched with `patch_108_109_c.sql`.

## Testing

The Perl test suite passed locally after the test databases had been patched.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
