### PR TITLE
allow drop dbs if exists under --force option

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
@@ -73,8 +73,8 @@ sub write_output {
     my $db_cmd_path = $self->param_required( 'db_cmd_path' );
 
     # force db drop if requested
-    my $cmd = "";
-    my $sql = ""; 
+    my $cmd;
+    my $sql; 
     my $force = $self->param('force');
     if ( db_exists( $host, $new_db_name ) && $force ){
         $sql = "DROP DATABASE IF EXISTS $new_db_name";

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
@@ -83,7 +83,7 @@ sub write_output {
     }
 
     # Preferred behaviour is to die if the database already exists
-    die $new_db . " already exists. You can use the --force option equal to 1 to drop the mentioned db" if db_exists( $host, $new_db_name );
+    die $new_db . " already exists. You can use the -force option equal to 1 to drop the mentioned db" if db_exists( $host, $new_db_name );
 
     $sql = "CREATE DATABASE IF NOT EXISTS $new_db_name";
     $cmd = "$db_cmd_path -url $server_uri -sql '$sql'";

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
@@ -75,7 +75,7 @@ sub write_output {
     # force db drop if requested
     my $cmd = "";
     my $sql = ""; 
-    my $force = $self->param('force')
+    my $force = $self->param('force');
     if ( db_exists( $host, $new_db_name ) && $force ){
         $sql = "DROP DATABASE IF EXISTS $new_db_name";
         $cmd = "$db_cmd_path -url $server_uri -sql '$sql'";

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm
@@ -73,22 +73,24 @@ sub write_output {
     my $db_cmd_path = $self->param_required( 'db_cmd_path' );
 
     # force db drop if requested
+    my $cmd = "";
+    my $sql = ""; 
     my $force = $self->param('force')
     if ( db_exists( $host, $new_db_name ) && $force ){
-        my $sql = "DROP DATABASE IF EXISTS $new_db_name";
-        my $cmd = "$db_cmd_path -url $server_uri -sql '$sql'";
+        $sql = "DROP DATABASE IF EXISTS $new_db_name";
+        $cmd = "$db_cmd_path -url $server_uri -sql '$sql'";
         $self->run_command( $cmd, { die_on_failure => 1 } );
     }
 
     # Preferred behaviour is to die if the database already exists
-    die $new_db . " already exists. You can use the --force option to drop the mentioned db" if db_exists( $host, $new_db_name );
+    die $new_db . " already exists. You can use the --force option equal to 1 to drop the mentioned db" if db_exists( $host, $new_db_name );
 
-    my $sql = "CREATE DATABASE IF NOT EXISTS $new_db_name";
-    my $cmd = "$db_cmd_path -url $server_uri -sql '$sql'";
+    $sql = "CREATE DATABASE IF NOT EXISTS $new_db_name";
+    $cmd = "$db_cmd_path -url $server_uri -sql '$sql'";
     $self->run_command( $cmd, { die_on_failure => 1 } );
 
     my $dba = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba( $new_db );
-    my $cmd = "$db_cmd_path -url $new_db < $schema_file";
+    $cmd = "$db_cmd_path -url $new_db < $schema_file";
     $self->run_command( $cmd, { die_on_failure => 1 } );
 
     $self->dataflow_output_id( { 'per_species_db' => $new_db }, 2 );


### PR DESCRIPTION
## Description

The homology annotation pipeline dies if species db exists. A manual db removal is expected by the user before restarting the pipeline. This behaviour has been included in the #430 for ticket [ENSCOMPARASW-5400](|https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-5400). 

**Related JIRA tickets:**
- ENSCOMPARASW-5400

## Overview of changes

This ticket aims to add `--force` option to allow automatic db drops and ease the user side.

#### Change 1
- Inclusion of a conditional to drop tables
- Inclusion of `force` with a default value of `0` as the default parameter.

#### Change 2
- Removal of unused array `@cmd`

## Testing
- creating a dummy db: 
```bash
/hps/software/users/ensembl/repositories/ensrapid/ensembl-hive/scripts/db_cmd.pl -url mysql://ensadmin:ensembl@mysql-ens-compara-prod-3:4523 -sql "CREATE DATABASE IF NOT EXISTS thiagogenez_dummy_compara_107"
```
- running `standaloneJob` without `-force`:
```bash
ibsub standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::NewPerSpeciesComparaDB -genome_name thiagogenez_dummy -curr_release 107 -homology_host mysql-ens-compara-prod-3 -schema_file $ENSEMBL_ROOT_DIR/ensembl-compara/sql/table.sql -db_cmd_path ${EHIVE_ROOT_DIR}/scripts/db_cmd.pl

bsub -q standard -M250 -R"select[mem>250] rusage[mem=250]" -n 1  -env all -Is standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::NewPerSpeciesComparaDB -genome_name thiagogenez_dummy -curr_release 107 -homology_host mysql-ens-compara-prod-3 -schema_file /hps/software/users/ensembl/repositories/compara/thiagogenez/rapid/ensembl-compara/sql/table.sql -db_cmd_path /hps/software/users/ensembl/repositories/compara/thiagogenez/hive/main/scripts/db_cmd.pl
Job <2983660> is submitted to queue <standard>.
<<Waiting for dispatch ...>>
<<Starting on hl-codon-17-02>>

Running 'Bio::EnsEMBL::Compara::RunnableDB::NewPerSpeciesComparaDB' with input_id='{"curr_release" => 107,"db_cmd_path" => "/hps/software/users/ensembl/repositories/compara/thiagogenez/hive/main/scripts/db_cmd.pl","genome_name" => "thiagogenez_dummy","homology_host" => "mysql-ens-compara-prod-3","schema_file" => "/hps/software/users/ensembl/repositories/compara/thiagogenez/rapid/ensembl-compara/sql/table.sql"}' :
Standalone worker 1464743 : specializing to Standalone_Dummy_Analysis(unstored)
Standalone worker 1464743 : WORKER_ERROR : mysql://ensadmin:ensembl@mysql-ens-compara-prod-3:4523/thiagogenez_dummy_compara_107 already exists. You can use the --force option equal to 1 to drop the mentioned db at /homes/thiagogenez/tmp/ensembl-compara/modules/Bio/EnsEMBL/Compara/RunnableDB/NewPerSpeciesComparaDB.pm line 86.
```

- running `standaloneJob` with `-force 1`:
```bash
ibsub standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::NewPerSpeciesComparaDB -genome_name thiagogenez_dummy -curr_release 107 -homology_host mysql-ens-compara-prod-3 -schema_file $ENSEMBL_ROOT_DIR/ensembl-compara/sql/table.sql -db_cmd_path ${EHIVE_ROOT_DIR}/scripts/db_cmd.pl -force 1
bsub -q standard -M250 -R"select[mem>250] rusage[mem=250]" -n 1  -env all -Is standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::NewPerSpeciesComparaDB -genome_name thiagogenez_dummy -curr_release 107 -homology_host mysql-ens-compara-prod-3 -schema_file /hps/software/users/ensembl/repositories/compara/thiagogenez/rapid/ensembl-compara/sql/table.sql -db_cmd_path /hps/software/users/ensembl/repositories/compara/thiagogenez/hive/main/scripts/db_cmd.pl -force 1
Job <2983840> is submitted to queue <standard>.
<<Waiting for dispatch ...>>
<<Starting on hl-codon-107-04>>

Running 'Bio::EnsEMBL::Compara::RunnableDB::NewPerSpeciesComparaDB' with input_id='{"curr_release" => 107,"db_cmd_path" => "/hps/software/users/ensembl/repositories/compara/thiagogenez/hive/main/scripts/db_cmd.pl","force" => 1,"genome_name" => "thiagogenez_dummy","homology_host" => "mysql-ens-compara-prod-3","schema_file" => "/hps/software/users/ensembl/repositories/compara/thiagogenez/rapid/ensembl-compara/sql/table.sql"}' :
Standalone worker 2427861 : specializing to Standalone_Dummy_Analysis(unstored)
```
---

## PR review checklist

- [x] Is the PR against an appropriate branch?
- [x] Does the code adhere to coding guidelines?
- [x] Does the code do what it claims to do?
- [x] Is the code readable? Is it appropriately documented?
- [x] Is the logic in the correct place?
- [x] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [x] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [x] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [x] If you are reviewing a new analysis, is it future-proof and pluggable?
- [x] Does the PR meet agile guidelines?
