### PR TITLE
Revert binary fix in member stable_id columns

### DIFF
--- a/sql/patch_108_109_d.sql
+++ b/sql/patch_108_109_d.sql
@@ -1,0 +1,30 @@
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_108_109_d.sql
+#
+# Title: Revert stable_id collation to be case insensitive.
+#
+# Description:
+#   With the schema updated so that stable_ids are required to be unique per genome,
+#   the workaround of using binary collation for stable_ids is not longer needed.
+#   Reverting this binary fix reverts stable_id collation to be case insensitive.
+
+ALTER TABLE gene_member MODIFY stable_id VARCHAR(128) NOT NULL;
+ALTER TABLE seq_member MODIFY stable_id VARCHAR(128) NOT NULL;
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_108_109_d.sql|case_insensitive_stable_id');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1015,7 +1015,7 @@ CREATE TABLE sequence (
 
 CREATE TABLE gene_member (
   gene_member_id              INT unsigned NOT NULL AUTO_INCREMENT, # unique internal id
-  stable_id                   varchar(128) BINARY NOT NULL, # e.g. ENSP000001234 or P31946
+  stable_id                   varchar(128) NOT NULL, # e.g. ENSP000001234 or P31946
   version                     INT UNSIGNED DEFAULT 0,
   source_name                 ENUM('ENSEMBLGENE', 'EXTERNALGENE') NOT NULL,
   taxon_id                    INT unsigned NOT NULL, # FK taxon.taxon_id
@@ -1115,7 +1115,7 @@ CREATE TABLE gene_member_hom_stats (
 
 CREATE TABLE seq_member (
   seq_member_id               INT unsigned NOT NULL AUTO_INCREMENT, # unique internal id
-  stable_id                   varchar(128) BINARY NOT NULL, # e.g. ENSP000001234 or P31946
+  stable_id                   varchar(128) NOT NULL, # e.g. ENSP000001234 or P31946
   version                     INT UNSIGNED DEFAULT 0,
   source_name                 ENUM('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   taxon_id                    INT unsigned NOT NULL, # FK taxon.taxon_id
@@ -2289,3 +2289,5 @@ INSERT INTO meta (species_id, meta_key, meta_value)
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_108_109_c.sql|stable_id_unique_per_genome');
 
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_108_109_d.sql|case_insensitive_stable_id');

--- a/src/test_data/databases/homology/meta.txt
+++ b/src/test_data/databases/homology/meta.txt
@@ -79,3 +79,4 @@
 111	\N	patch	patch_108_109_a.sql|schema_version
 112	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 113	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
+114	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id

--- a/src/test_data/databases/homology/table.sql
+++ b/src/test_data/databases/homology/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=114 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=115 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/mysqlimport_test/meta.txt
+++ b/src/test_data/databases/mysqlimport_test/meta.txt
@@ -18,3 +18,4 @@
 34	\N	patch	patch_108_109_a.sql|schema_version
 35	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 36	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
+37	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id

--- a/src/test_data/databases/mysqlimport_test/table.sql
+++ b/src/test_data/databases/mysqlimport_test/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=37 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=38 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/orth_qm_goc/meta.txt
+++ b/src/test_data/databases/orth_qm_goc/meta.txt
@@ -85,3 +85,4 @@
 110	\N	patch	patch_108_109_a.sql|schema_version
 111	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 112	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
+113	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id

--- a/src/test_data/databases/orth_qm_goc/table.sql
+++ b/src/test_data/databases/orth_qm_goc/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=113 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=114 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/orth_qm_wga/cc21_pair_species/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_pair_species/meta.txt
@@ -85,3 +85,4 @@
 162	\N	patch	patch_108_109_a.sql|schema_version
 163	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 164	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
+165	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id

--- a/src/test_data/databases/orth_qm_wga/cc21_pair_species/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_pair_species/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=165 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=166 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/meta.txt
@@ -85,3 +85,4 @@
 162	\N	patch	patch_108_109_a.sql|schema_version
 163	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 164	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
+165	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id

--- a/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=165 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=166 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/meta.txt
@@ -85,3 +85,4 @@
 162	\N	patch	patch_108_109_a.sql|schema_version
 163	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 164	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
+165	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id

--- a/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=165 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=166 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/orth_qm_wga/cc21_select_mlss/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_select_mlss/meta.txt
@@ -85,3 +85,4 @@
 162	\N	patch	patch_108_109_a.sql|schema_version
 163	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 164	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
+165	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id

--- a/src/test_data/databases/orth_qm_wga/cc21_select_mlss/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_select_mlss/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=165 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=166 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/parse_pair_aligner_conf/meta.txt
+++ b/src/test_data/databases/parse_pair_aligner_conf/meta.txt
@@ -51,3 +51,4 @@
 69	\N	patch	patch_108_109_a.sql|schema_version
 70	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 71	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
+72	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id

--- a/src/test_data/databases/parse_pair_aligner_conf/table.sql
+++ b/src/test_data/databases/parse_pair_aligner_conf/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=72 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=73 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/test_master/meta.txt
+++ b/src/test_data/databases/test_master/meta.txt
@@ -124,3 +124,4 @@
 164	\N	patch	patch_108_109_a.sql|schema_version
 165	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 166	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
+167	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id

--- a/src/test_data/databases/test_master/table.sql
+++ b/src/test_data/databases/test_master/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=167 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=168 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/update_homologies_test/meta.txt
+++ b/src/test_data/databases/update_homologies_test/meta.txt
@@ -26,3 +26,4 @@
 34	\N	patch	patch_108_109_a.sql|schema_version
 35	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 36	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
+37	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id

--- a/src/test_data/databases/update_homologies_test/table.sql
+++ b/src/test_data/databases/update_homologies_test/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=37 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=38 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/update_msa_test/meta.txt
+++ b/src/test_data/databases/update_msa_test/meta.txt
@@ -14,3 +14,4 @@
 166	\N	patch	patch_108_109_a.sql|schema_version
 167	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 168	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
+169	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id

--- a/src/test_data/databases/update_msa_test/table.sql
+++ b/src/test_data/databases/update_msa_test/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=169 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=170 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/vertebrates/meta.txt
+++ b/src/test_data/databases/vertebrates/meta.txt
@@ -124,3 +124,4 @@
 164	\N	patch	patch_108_109_a.sql|schema_version
 165	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 166	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
+167	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id

--- a/src/test_data/databases/vertebrates/table.sql
+++ b/src/test_data/databases/vertebrates/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=167 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=168 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `stable_id` varchar(128) NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,


### PR DESCRIPTION
## Description

During Ensembl Metazoa Compara 107 production, two Metazoa gene stable IDs — g3689 in _Lingula anatina_
and G3689 in _Crassostrea gigas_ — were found to clash in a case-insensitive way. To preserve stable ID
uniqueness, columns `gene_member_qc.gene_member_stable_id`, `seq_member.stable_id`
and `gene_member.stable_id` were altered to have binary collation.

The risk of further inter-genome stable ID clashes has motivated changes in the Compara schema, API and
other code in order to allow for duplicate stable IDs between genomes. As part of these efforts, the
columns `gene_member.stable_id` and `seq_member.stable_id` are being reverted to non-binary collation.

**Related JIRA tickets:**
- ENSCOMPARASW-5751

## Overview of changes
The Compara SQL schema is updated and test databases are patched.

#### Update of schema

A patch file `sql/patch_108_109_d.sql` reverts changes made in the patch `patch_106_107_b.sql`,
so that `gene_member` and `seq_member` `stable_id` columns again use non-binary collation.

The schema file `sql/table.sql` is updated to register this patch and to reflect its changes.

#### Patch of test databases

Test databases are patched with `patch_108_109_d.sql`.

## Testing

The Perl test suite passed locally after the test databases had been patched.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
