### PR TITLE
Fix handling of repeated member store calls

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/GeneMemberAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/GeneMemberAdaptor.pm
@@ -219,13 +219,12 @@ sub store {
     $sth->finish;
   } else {
     $sth->finish;
-    #UNIQUE(genome_db_id,stable_id) prevented insert since a gene_member was already inserted for this genome_db
+    #UNIQUE(genome_db_id,stable_id) prevented insert since this gene_member was already inserted for this genome_db
     #so get gene_member_id with select
     my $sth2 = $self->prepare("SELECT gene_member_id FROM gene_member WHERE genome_db_id = ? AND stable_id = ?");
     $sth2->execute($member->genome_db_id, $member->stable_id);
     my ($id) = $sth2->fetchrow_array();
-    warn("GeneMemberAdaptor: insert failed, but gene_member_id select failed too") unless($id);
-    throw(sprintf('%s already exists in this species (%s) ! Stable IDs must be unique within a species', $member->stable_id, $member->genome_db->name));
+    throw("GeneMemberAdaptor: insert failed, but gene_member_id select failed too") unless($id);
     $member->dbID($id);
     $sth2->finish;
   }

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/SeqMemberAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/SeqMemberAdaptor.pm
@@ -417,13 +417,12 @@ sub store {
     $sth->finish;
   } else {
     $sth->finish;
-    #UNIQUE(genome_db_id,stable_id) prevented insert since a seq_member was already inserted for this genome_db
+    #UNIQUE(genome_db_id,stable_id) prevented insert since this seq_member was already inserted for this genome_db
     #so get seq_member_id with select
     my $sth2 = $self->prepare("SELECT seq_member_id, sequence_id FROM seq_member WHERE genome_db_id = ? AND stable_id = ?");
     $sth2->execute($member->genome_db_id, $member->stable_id);
     my ($id, $sequence_id) = $sth2->fetchrow_array();
-    warn("SeqMemberAdaptor: insert failed, but seq_member_id select failed too") unless($id);
-    throw(sprintf('%s already exists in this species (%s) ! Stable IDs must be unique within a species', $member->stable_id, $member->genome_db->name));
+    throw("SeqMemberAdaptor: insert failed, but seq_member_id select failed too") unless($id);
     $member->dbID($id);
     $member->sequence_id($sequence_id) if ($sequence_id) and $member->isa('Bio::EnsEMBL::Compara::SeqMember');
     $sth2->finish;


### PR DESCRIPTION
## Description

Changes introduced in Compara PR #499 did not take account of the implicit assumption that a member being stored with a given `genome_db_id` and `stable_id` is the same as a previously stored member with the same `genome_db_id` and `stable_id`. As a consequence of this, an exception would be thrown for the common case in which repeated calls are made to a `GeneMemberAdaptor` or `SeqMemberAdaptor` `store` method for the same member.

**Related JIRA tickets:**
- ENSCOMPARASW-5750

## Overview of changes

The `GeneMemberAdaptor` and `SeqMemberAdaptor` `store` methods are changed so that they do not throw an exception when a given member (as identified by its `genome_db_id` and `stable_id`) is stored a second or subsequent time.

An exception is thrown only if, having failed to insert a `gene_member` (or `seq_member`) due to the existence of a previously inserted member, the `gene_member_id` (or `seq_member_id`) of the previously inserted member cannot be obtained from the database.

## Testing

A LoadMembers test pipeline (`mysql://ensro@mysql-ens-compara-prod-3:4523/twalsh_plants_load_members_20220905`) was run with e108 code patched with the relevant error-handling code in the `GeneMemberAdaptor` and `SeqMemberAdaptor` `store` methods. The `load_fresh_members_from_db` pipeline step (in which the member `store` methods are called) completed successfully for plant species `chlamydomonas_reinhardtii`.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
