### PR TITLE
Add LastZ batching option exclude_mlss_ids_file

### DIFF
--- a/scripts/production/batch_lastz.pl
+++ b/scripts/production/batch_lastz.pl
@@ -73,7 +73,12 @@ my $dba = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba( $maste
 print STDERR "Fetching current $method_link MethodLinkSpeciesSets from the database..\n";
 my $mlss_adaptor = $dba->get_MethodLinkSpeciesSetAdaptor();
 my $all_lastz_mlsses = $mlss_adaptor->fetch_all_by_method_link_type($method_link);
-my %mlss_ids_to_include = map {$_ => 1} split(/[\s,]+/, $include_mlss_ids);
+
+my %mlss_ids_to_include;
+if (defined $include_mlss_ids) {
+    %mlss_ids_to_include = map {$_ => 1} split(/[\s,]+/, $include_mlss_ids);
+}
+
 my (@current_lastz_mlsses, %genome_dbs);
 foreach my $this_mlss ( @$all_lastz_mlsses ) {
     if ((($this_mlss->first_release || 0) == $release)

--- a/scripts/production/batch_lastz.pl
+++ b/scripts/production/batch_lastz.pl
@@ -419,12 +419,15 @@ Usage: batch_lastz.pl --master_db <master url or alias> --release <release numbe
 
 Options:
 	master_db         : url or registry alias of master db containing the method_link MLSSes (required)
-	release           : current release version (required)
+	release           : current release version (required). The standard criteria for choosing which
+	                    LASTZ MLSSes to batch are that the 'first_release' attribute of the MLSS matches
+	                    the current release, or that a 'rerun_in_XXX' MLSS tag is defined for the MLSS,
+	                    (where 'XXX' is the current release).
 	reg_conf          : registry config file (required if using alias for master)
 	max_jobs          : maximum number of jobs allowed per-database (default: 6,000,000)
-	include_mlss_ids  : list of comma separated MLSS IDs to add
-	exclude_mlss_ids  : list of MLSS IDs to ignore (if they've already been run).
-	                    list should be comma separated values.
+	include_mlss_ids  : comma-separated list of MLSS IDs to batch IN ADDITION to those selected
+	                    by the standard criteria
+	exclude_mlss_ids  : comma-separated list of MLSS IDs to ignore (e.g. if they've already been run).
 	method_link       : method used to select MLSSes (default: LASTZ_NET)
 	start_index       : number to assign to the first batch (default: 1)
 	jira_off|jira-off : do not submit JIRA tickets to the JIRA server (default: tickets are submitted)


### PR DESCRIPTION
## Description

The LastZ batching script has an `--exclude_mlss_ids` option to allow the user to specify on the command line those LastZ MLSSes that should be excluded from the batching process. However, for large numbers of MLSSes, this option can be cumbersome to use. This PR addresses the issue by adding an `--exclude_mlss_ids_file` option, which can be used to specify a text file that contains the MLSS IDs to be excluded, one per line.

## Overview of changes

#### Addition of exclude_mlss_ids_file option
- An `--exclude_mlss_ids_file` option is added to the script `batch_lastz.pl` so that MLSSes to be excluded from the batching process can be specified using a text file.

#### Expansion of help text and minor bugfix
- The `batch_lastz.pl` help text is expanded to clarify how the list of MLSSes to be batched is determined.
- The variable `$include_mlss_ids` is only processed if it has been specified by the user.

## Testing
This script was tested live in production when creating the first batch set of the Ensembl Protists 109 LastZ alignments.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
