### PR TITLE
Reinstate binary fix in member stable_id columns

### DIFF
--- a/sql/patch_108_109_e.sql
+++ b/sql/patch_108_109_e.sql
@@ -1,0 +1,29 @@
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_108_109_e.sql
+#
+# Title: Reinstate case-sensitive stable_id collation.
+#
+# Description:
+#    Make the stable_id field case sensitive again so that, for as long as
+#    it is needed, values continue to remain UNIQUE with case differences.
+
+ALTER TABLE gene_member MODIFY stable_id VARCHAR(128) BINARY NOT NULL;
+ALTER TABLE seq_member MODIFY stable_id VARCHAR(128) BINARY NOT NULL;
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_108_109_e.sql|case_sensitive_stable_id_again');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1015,7 +1015,7 @@ CREATE TABLE sequence (
 
 CREATE TABLE gene_member (
   gene_member_id              INT unsigned NOT NULL AUTO_INCREMENT, # unique internal id
-  stable_id                   varchar(128) NOT NULL, # e.g. ENSP000001234 or P31946
+  stable_id                   varchar(128) BINARY NOT NULL, # e.g. ENSP000001234 or P31946
   version                     INT UNSIGNED DEFAULT 0,
   source_name                 ENUM('ENSEMBLGENE', 'EXTERNALGENE') NOT NULL,
   taxon_id                    INT unsigned NOT NULL, # FK taxon.taxon_id
@@ -1115,7 +1115,7 @@ CREATE TABLE gene_member_hom_stats (
 
 CREATE TABLE seq_member (
   seq_member_id               INT unsigned NOT NULL AUTO_INCREMENT, # unique internal id
-  stable_id                   varchar(128) NOT NULL, # e.g. ENSP000001234 or P31946
+  stable_id                   varchar(128) BINARY NOT NULL, # e.g. ENSP000001234 or P31946
   version                     INT UNSIGNED DEFAULT 0,
   source_name                 ENUM('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   taxon_id                    INT unsigned NOT NULL, # FK taxon.taxon_id
@@ -2291,3 +2291,6 @@ INSERT INTO meta (species_id, meta_key, meta_value)
 
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_108_109_d.sql|case_insensitive_stable_id');
+
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_108_109_e.sql|case_sensitive_stable_id_again');

--- a/src/test_data/databases/homology/meta.txt
+++ b/src/test_data/databases/homology/meta.txt
@@ -80,3 +80,4 @@
 112	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 113	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 114	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
+115	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again

--- a/src/test_data/databases/homology/table.sql
+++ b/src/test_data/databases/homology/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=115 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=116 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/mysqlimport_test/meta.txt
+++ b/src/test_data/databases/mysqlimport_test/meta.txt
@@ -19,3 +19,4 @@
 35	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 36	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 37	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
+38	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again

--- a/src/test_data/databases/mysqlimport_test/table.sql
+++ b/src/test_data/databases/mysqlimport_test/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=38 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=39 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/orth_qm_goc/meta.txt
+++ b/src/test_data/databases/orth_qm_goc/meta.txt
@@ -86,3 +86,4 @@
 111	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 112	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 113	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
+114	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again

--- a/src/test_data/databases/orth_qm_goc/table.sql
+++ b/src/test_data/databases/orth_qm_goc/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=114 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=115 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/orth_qm_wga/cc21_pair_species/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_pair_species/meta.txt
@@ -86,3 +86,4 @@
 163	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 164	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 165	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
+166	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again

--- a/src/test_data/databases/orth_qm_wga/cc21_pair_species/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_pair_species/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=166 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=167 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/meta.txt
@@ -86,3 +86,4 @@
 163	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 164	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 165	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
+166	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again

--- a/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=166 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=167 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/meta.txt
@@ -86,3 +86,4 @@
 163	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 164	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 165	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
+166	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again

--- a/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=166 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=167 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/orth_qm_wga/cc21_select_mlss/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_select_mlss/meta.txt
@@ -86,3 +86,4 @@
 163	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 164	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 165	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
+166	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again

--- a/src/test_data/databases/orth_qm_wga/cc21_select_mlss/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_select_mlss/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=166 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=167 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/parse_pair_aligner_conf/meta.txt
+++ b/src/test_data/databases/parse_pair_aligner_conf/meta.txt
@@ -52,3 +52,4 @@
 70	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 71	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 72	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
+73	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again

--- a/src/test_data/databases/parse_pair_aligner_conf/table.sql
+++ b/src/test_data/databases/parse_pair_aligner_conf/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=73 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=74 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/test_master/meta.txt
+++ b/src/test_data/databases/test_master/meta.txt
@@ -125,3 +125,4 @@
 165	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 166	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 167	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
+168	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again

--- a/src/test_data/databases/test_master/table.sql
+++ b/src/test_data/databases/test_master/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=168 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=169 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/update_homologies_test/meta.txt
+++ b/src/test_data/databases/update_homologies_test/meta.txt
@@ -27,3 +27,4 @@
 35	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 36	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 37	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
+38	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again

--- a/src/test_data/databases/update_homologies_test/table.sql
+++ b/src/test_data/databases/update_homologies_test/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=38 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=39 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/update_msa_test/meta.txt
+++ b/src/test_data/databases/update_msa_test/meta.txt
@@ -15,3 +15,4 @@
 167	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 168	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 169	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
+170	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again

--- a/src/test_data/databases/update_msa_test/table.sql
+++ b/src/test_data/databases/update_msa_test/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=170 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=171 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/src/test_data/databases/vertebrates/meta.txt
+++ b/src/test_data/databases/vertebrates/meta.txt
@@ -125,3 +125,4 @@
 165	\N	patch	patch_108_109_b.sql|gene_member_qc_key
 166	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 167	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
+168	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again

--- a/src/test_data/databases/vertebrates/table.sql
+++ b/src/test_data/databases/vertebrates/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -437,7 +437,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=168 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=169 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -541,7 +541,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,


### PR DESCRIPTION
## Description

During Ensembl Metazoa Compara 107 production, two Metazoa gene stable IDs — g3689 in _Lingula anatina_ and G3689 in _Crassostrea gigas_ — were found to clash in a case-insensitive way. To preserve stable ID uniqueness, columns `gene_member_qc.gene_member_stable_id`, `seq_member.stable_id` and `gene_member.stable_id` were altered (by `patch_106_107_b.sql`) to have binary collation.

The risk of further inter-genome stable ID clashes has motivated changes in the Compara schema, API and other code in order to allow for duplicate stable IDs between genomes. As part of these efforts, `Compara::Member` method `fetch_by_stable_id` has been deprecated, and replacement method `fetch_by_stable_id_GenomeDB` has been implemented.

The chance of a stable ID clash increases as the number of species included in EnsEMBL grows, so it is necessary and indeed quite urgent to remove the Compara member `fetch_by_stable_id` method as soon as is practical, in order to minimise the negative impact on users of the Compara API.

At the same time, an overly short deprecation period could also have a negative impact on Compara API users who have to update their code to use `fetch_by_stable_id_GenomeDB`. To allow for the possibility of extending the period of  deprecation of `fetch_by_stable_id`, this PR reinstates the binary collation of columns `seq_member.stable_id` and `gene_member.stable_id`. (Column `gene_member_qc.gene_member_stable_id` has been removed since release 107.)

**Related JIRA tickets:**
- ENSCOMPARASW-5270

## Overview of changes
The Compara SQL schema is updated and test databases are patched.

#### Update of schema

A patch file `sql/patch_108_109_e.sql` reinstates changes made in the patch `patch_106_107_b.sql`,
so that `gene_member` and `seq_member` `stable_id` columns once again use binary collation.

The schema file `sql/table.sql` is updated to register this patch and to reflect its changes.

#### Patch of test databases

Test databases are patched with `patch_108_109_e.sql`.

## Testing

The Perl test suite passed locally after the test databases had been patched.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
