### PR TITLE
Update ftp links to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ And run this makefile
 
 Alignments using the _method_ `CACTUS_HAL` or `CACTUS_HAL_PW` require extra
 files to be downloaded from
-<ftp://ftp.ensembl.org/pub/data_files/multi/hal_files/> in order to be fetched with the
+<https://ftp.ensembl.org/pub/data_files/multi/hal_files/> in order to be fetched with the
 API. The files must have the same name as on the FTP and must be placed
 under `multi/hal_files/` within your directory of choice.
 Finally, you need to define the environment variable `COMPARA_HAL_DIR` to

--- a/docs/production/READMEs/protein_trees.rst
+++ b/docs/production/READMEs/protein_trees.rst
@@ -44,7 +44,7 @@ Perl libraries:
 Any compiled binaries mentioned in ``ensembl-compara/modules/Bio/EnsEMBL/Compara/PipeConfig/Example/EnsemblProteinTrees_conf.pm``
 Here is the list of the versions that we used for the e78 production:
 
-* NCBI-blast 2.2.28+   - ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.2.28/
+* NCBI-blast 2.2.28+   - https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.2.28/
 * mcoffee 9.03.r1318   - http://www.tcoffee.org/Projects/mcoffee/
 * MAFFT 7.113          - http://mafft.cbrc.jp/alignment/software/
 * hcluster_sg          - http://treesoft.svn.sourceforge.net/viewvc/treesoft/branches/lh3/hcluster/

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Families_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Families_conf.pm
@@ -74,8 +74,8 @@ sub default_options {
         'blastdb_dir'     => $self->o('pipeline_dir').'/blast_db',
         'blastdb_name'    => $self->o('file_basename').'.pep',
 
-        'uniprot_rel_url' => 'ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/taxonomic_divisions/reldate.txt',
-        'uniprot_ftp_url' => 'ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/taxonomic_divisions/uniprot_#uniprot_source#_#tax_div#.dat.gz',
+        'uniprot_rel_url' => 'https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/taxonomic_divisions/reldate.txt',
+        'uniprot_ftp_url' => 'https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/taxonomic_divisions/uniprot_#uniprot_source#_#tax_div#.dat.gz',
 
         'blast_params'    => '', # By default C++ binary has composition stats on and -seg masking off
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
@@ -70,8 +70,8 @@ sub default_options {
         'load_uniprot_members'      => 0,
         'work_dir'        => $self->o('pipeline_dir'),
         'uniprot_dir'     => $self->o('work_dir').'/uniprot',
-        'uniprot_rel_url' => 'ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/taxonomic_divisions/reldate.txt',
-        'uniprot_ftp_url' => 'ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/taxonomic_divisions/uniprot_#uniprot_source#_#tax_div#.dat.gz',
+        'uniprot_rel_url' => 'https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/taxonomic_divisions/reldate.txt',
+        'uniprot_ftp_url' => 'https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/taxonomic_divisions/uniprot_#uniprot_source#_#tax_div#.dat.gz',
 
     # hive_capacity values for some analyses:
         'reuse_capacity'            =>   3,

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/RegisterHALFile_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/RegisterHALFile_conf.pm
@@ -32,7 +32,7 @@ Mini-pipeline to load the species-tree and the chromosome-name mapping from a HA
 
 NOTE: Alignments using the _method_ `CACTUS_HAL` or `CACTUS_HAL_PW` require extra
 files to be downloaded from
-<ftp://ftp.ensembl.org/pub/data_files/multi/hal_files/> in order to be fetched with the
+<https://ftp.ensembl.org/pub/data_files/multi/hal_files/> in order to be fetched with the
 API. The files must have the same name as on the FTP and must be placed
 under `multi/hal_files/` within your directory of choice.
 Finally, you need to define the environment variable `COMPARA_HAL_DIR` to

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -131,7 +131,7 @@ sub default_options {
         'hc_batch_size' => 10,
 
         # RFAM parameters
-        'rfam_ftp_url'           => 'ftp://ftp.ebi.ac.uk/pub/databases/Rfam/12.0/',
+        'rfam_ftp_url'           => 'https://ftp.ebi.ac.uk/pub/databases/Rfam/12.0/',
         'rfam_remote_file'       => 'Rfam.cm.gz',
         'rfam_expanded_basename' => 'Rfam.cm',
         'rfam_expander'          => 'gunzip ',

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ComparaHMM/LoadInfernalHMMModels.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ComparaHMM/LoadInfernalHMMModels.pm
@@ -28,7 +28,7 @@ Bio::EnsEMBL::Compara::RunnableDB::ComparaHMM::LoadInfernalHMMModels
 =head1 SYNOPSIS
 
 To load RFAM models from the FTP, use these parameters:
- url: ftp://ftp.ebi.ac.uk/pub/databases/Rfam/12.0/
+ url: https://ftp.ebi.ac.uk/pub/databases/Rfam/12.0/
  remote_file: Rfam.cm.gz
  expander: gunzip
  expanded_basename: Rfam.cm


### PR DESCRIPTION
As part of migrating ftp links to be accessible over https, I've checked for ftp URLs accross all Ensembl repos.
This PR updates ftp URLs in this repo from `http://` and `ftp://` protocol to https.
The affected hostnames have been tested to work with https.
Other affected repos are listed in the JIRA ticket.

Webteam JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6632
Sandbox: http://wp-np2-1d.ebi.ac.uk:1680/