### PR TITLE
Set Travis to clone e107 Ensembl repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,15 +27,15 @@ before_install:
     # yamllint disable rule:line-length
     - git clone --depth 1 https://github.com/Ensembl/ensembl-git-tools.git
     - export PATH=$PATH:$PWD/ensembl-git-tools/bin
-    - git clone --branch release/106 --depth 1 https://github.com/Ensembl/ensembl-test.git || git-ensembl --clone --branch main --depth 1 ensembl-test
-    - git clone --branch release/106 --depth 1 https://github.com/Ensembl/ensembl-rest.git || git-ensembl --clone --branch main --depth 1 ensembl-rest
-    - git clone --branch release/106 --depth 1 https://github.com/Ensembl/ensembl-funcgen.git || git-ensembl --clone --branch main --depth 1 ensembl-funcgen
-    - git clone --branch release/106 --depth 1 https://github.com/Ensembl/ensembl-variation.git || git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-variation
-    - git clone --branch release/106 --depth 1 https://github.com/Ensembl/ensembl-io.git || git-ensembl --clone --branch main --depth 1 ensembl-io
-    - git clone --branch release/106 --depth 1 https://github.com/Ensembl/ensembl.git || git-ensembl --clone --branch main --depth 1 ensembl
-    - git clone --branch release/106 --depth 1 https://github.com/Ensembl/ensembl-datacheck.git || git-ensembl --clone --branch main --depth 1 ensembl-datacheck
-    - git clone --branch release/106 --depth 1 https://github.com/Ensembl/ensembl-production.git || git-ensembl --clone --branch main --depth 1 ensembl-production
-    - git clone --branch release/106 --depth 1 https://github.com/Ensembl/ensembl-metadata.git || git-ensembl --clone --branch main --depth 1 ensembl-metadata
+    - git-ensembl --clone --branch release/107 --secondary_branch main --depth 1 ensembl-test
+    - git-ensembl --clone --branch release/107 --secondary_branch main --depth 1 ensembl-rest
+    - git-ensembl --clone --branch release/107 --secondary_branch main --depth 1 ensembl-funcgen
+    - git-ensembl --clone --branch release/107 --secondary_branch main --depth 1 ensembl-variation
+    - git-ensembl --clone --branch release/107 --secondary_branch main --depth 1 ensembl-io
+    - git-ensembl --clone --branch release/107 --secondary_branch main --depth 1 ensembl
+    - git-ensembl --clone --branch release/107 --secondary_branch main --depth 1 ensembl-datacheck
+    - git-ensembl --clone --branch release/107 --secondary_branch main --depth 1 ensembl-production
+    - git-ensembl --clone --branch release/107 --secondary_branch main --depth 1 ensembl-metadata
     # yamllint enable rule:line-length
     - git-ensembl --clone --branch main --depth 1 ensembl-hive
     - git-ensembl --clone --branch main --depth 1 ensembl-taxonomy


### PR DESCRIPTION
## Description
Ensembl repos are being cloned into the Travis environment from their `release/106` branch.

## Overview of changes
With these changes, Ensembl repos will be cloned into the Travis environment from their `release/107` branch.

## Testing
Travis checks.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
