### PR TITLE
Extend MemberAdaptor::fetch_by_stable_id deprecation

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -21,7 +21,7 @@ _All files (e.g. scripts) under these directories will be deleted_
 
 # Deprecated methods scheduled for deletion
 
-* `DBSQL::'*MemberAdaptor::fetch_by_stable_id()` in Ensembl 109
+* `DBSQL::'*MemberAdaptor::fetch_by_stable_id()` in Ensembl 110
 * `AlignedMember::get_cigar_breakout()` in Ensembl 102
 * `AlignedMember::get_cigar_array()` in Ensembl 102
 

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/MemberAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/MemberAdaptor.pm
@@ -80,7 +80,7 @@ sub fetch_by_stable_id { ## DEPRECATED
     my ($self, $stable_id) = @_;
 
     deprecate(
-        "MemberAdaptor::fetch_by_stable_id() is deprecated and will be removed in e109. Please use fetch_by_stable_id_GenomeDB instead."
+        "MemberAdaptor::fetch_by_stable_id() is deprecated and will be removed in e110. Please use fetch_by_stable_id_GenomeDB instead."
     );
 
     throw("MemberAdaptor::fetch_by_stable_id() must have an stable_id") unless $stable_id;


### PR DESCRIPTION
## Description

During Ensembl Metazoa Compara 107 production, two Metazoa gene stable IDs — g3689 in _Lingula anatina_ and G3689 in _Crassostrea gigas_ — were found to clash in a case-insensitive way. To preserve stable ID uniqueness, columns `gene_member_qc.gene_member_stable_id`, `seq_member.stable_id` and `gene_member.stable_id` were altered (by `patch_106_107_b.sql`) to have binary collation.

The risk of further inter-genome stable ID clashes has motivated changes in the Compara schema, API and other code in order to allow for duplicate stable IDs between genomes. As part of these efforts, `Compara::Member` method `fetch_by_stable_id` has been deprecated, and replacement method `fetch_by_stable_id_GenomeDB` has been implemented.

After input from key stakeholders, the removal of `MemberAdaptor::fetch_by_stable_id` has been set for Ensembl 110. This necessitates the update of all occurrences of the deprecation warning and documentation to reflect the revised deprecation period. This PR is being submitted on the `release/107` branch because that is the branch on which the deprecation was first introduced.

**Related JIRA tickets:**
- ENSCOMPARASW-6049

## Overview of changes

The `DEPRECATED.md` file and `MemberAdaptor::fetch_by_stable_id` method have been updated with the revised information on when this method will be removed.

## Testing
No testing was done. Changes were made only to documentation and a warning message.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
