### PR TITLE
Restore MemberAdaptor::fetch_by_stable_id

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/MemberAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/MemberAdaptor.pm
@@ -15,17 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::DBSQL::MemberAdaptor
@@ -38,15 +27,6 @@ Base adaptor for Member objects.  This adaptor cannot be used directly.
 
   Bio::EnsEMBL::Compara::DBSQL::MemberAdaptor
   +- Bio::EnsEMBL::Compara::DBSQL::BaseAdaptor
-
-=head1 AUTHORSHIP
-
-Ensembl Team. Individual contributions can be found in the GIT log.
-
-=head1 APPENDIX
-
-The rest of the documentation details each of the object methods.
-Internal methods are usually preceded with an underscore (_)
 
 =cut
 

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/MemberAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/MemberAdaptor.pm
@@ -76,6 +76,33 @@ use base qw(Bio::EnsEMBL::Compara::DBSQL::BaseAdaptor);
 #
 #####################
 
+sub fetch_by_stable_id { ## DEPRECATED
+    my ($self, $stable_id) = @_;
+
+    deprecate(
+        "MemberAdaptor::fetch_by_stable_id() is deprecated and will be removed in e110. Please use fetch_by_stable_id_GenomeDB instead."
+    );
+
+    throw("MemberAdaptor::fetch_by_stable_id() must have an stable_id") unless $stable_id;
+
+    my $constraint = 'm.stable_id = ?';
+    $self->bind_param_generic_fetch($stable_id, SQL_VARCHAR);
+    my $m = $self->generic_fetch_one($constraint);
+    return $m if $m;
+
+    my $vindex = rindex($stable_id, '.');
+    return undef if $vindex <= 0;  # bail out if there is no dot, or if the string starts with a dot (since that would make the stable_id part empty)
+    my $version = substr($stable_id,$vindex+1);
+    if (looks_like_number($version)) {  # to avoid DBI complains
+        $constraint = 'm.stable_id = ? AND m.version = ?';
+        $self->bind_param_generic_fetch(substr($stable_id,0,$vindex), SQL_VARCHAR);
+        $self->bind_param_generic_fetch($version, SQL_INTEGER);
+        return $self->generic_fetch_one($constraint);
+    } else {
+        return undef;
+    }
+}
+
 =head2 fetch_by_stable_id_GenomeDB
   Arg [1]       : string $stable_id
   Arg [2]       : integer $genome_db_id or Bio::EnsEMBL::Compara::GenomeDB object


### PR DESCRIPTION
## Description

During Ensembl Metazoa Compara 107 production, two Metazoa gene stable IDs — g3689 in _Lingula anatina_ and G3689 in _Crassostrea gigas_ — were found to clash in a case-insensitive way. To preserve stable ID uniqueness, relevant `stable_id` columns were altered (by `patch_106_107_b.sql`) to have binary collation.

The risk of further inter-genome stable ID clashes has motivated changes in the Compara schema, API and other code in order to allow for duplicate stable IDs between genomes. As part of these efforts, `Compara::Member` method `fetch_by_stable_id` has been deprecated, and replacement method `fetch_by_stable_id_GenomeDB` has been implemented.

After input from key stakeholders, the removal of `MemberAdaptor::fetch_by_stable_id` has been set for Ensembl 110. This necessitates the restoration of `MemberAdaptor::fetch_by_stable_id` in `release/109`, with a view to removing it again in `release/110`.

**Related JIRA tickets:**
- ENSCOMPARASW-6049

## Overview of changes
Method `MemberAdaptor::fetch_by_stable_id` has been temporarily restored.

## Testing

The restored `MemberAdaptor::fetch_by_stable_id` was tested with the following code on `ensembl_compara_metazoa_56_109`. This database has been patched with `patch_108_109_e.sql`, which revived binary collation of relevant `stable_id` columns, so it should be possible to retrieve the correct gene member even where that member has a case-insensitive stable ID clash in another metazoan species:
```perl
use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;

my $compara_url = 'mysql://ensro@mysql-ens-compara-prod-6:4616/ensembl_compara_metazoa_56_109';
my $compara_dba = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba($compara_url);
my $member_dba = $compara_dba->get_GeneMemberAdaptor();

my %id_to_species = (
    'g5'  => 'lingula_anatina',
    'g6'  => 'lingula_anatina',
    'g8'  => 'lingula_anatina',
    'g9'  => 'lingula_anatina',
    'g10' => 'lingula_anatina',
    'G5'  => 'crassostrea_gigas',
    'G6'  => 'crassostrea_gigas',
    'G8'  => 'crassostrea_gigas',
    'G9'  => 'crassostrea_gigas',
    'G10' => 'crassostrea_gigas',
);

while (my ($stable_id, $exp_species) = each %id_to_species) {
    my $gene_member = $member_dba->fetch_by_stable_id($stable_id);
    my $obs_species = $gene_member->genome_db->name;
    my $does_or_does_not_match = $obs_species eq $exp_species ? 'does match' : 'does not match' ;
    print("observed species ($obs_species) $does_or_does_not_match expected".
          " species ($exp_species) for stable ID '$stable_id'\n");
}
```

The output confirmed that `fetch_by_stable_id` was retrieving the correct gene member in each case.
```
observed species (lingula_anatina) does match expected species (lingula_anatina) for stable ID 'g6'
observed species (crassostrea_gigas) does match expected species (crassostrea_gigas) for stable ID 'G8'
observed species (lingula_anatina) does match expected species (lingula_anatina) for stable ID 'g10'
observed species (crassostrea_gigas) does match expected species (crassostrea_gigas) for stable ID 'G5'
observed species (crassostrea_gigas) does match expected species (crassostrea_gigas) for stable ID 'G9'
observed species (lingula_anatina) does match expected species (lingula_anatina) for stable ID 'g8'
observed species (lingula_anatina) does match expected species (lingula_anatina) for stable ID 'g5'
observed species (lingula_anatina) does match expected species (lingula_anatina) for stable ID 'g9'
observed species (crassostrea_gigas) does match expected species (crassostrea_gigas) for stable ID 'G10'
observed species (crassostrea_gigas) does match expected species (crassostrea_gigas) for stable ID 'G6'
```