### PR TITLE
Species tree pipeline: work with compara collections

### DIFF
--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -766,22 +766,44 @@ process scaleToNucleotide {
 *@input path to unrooted input tree
 *@output path to rooted output tree
 */
-process outgroupRooting {
+process outgroupRootingNeutral {
     label 'rc_2Gb'
 
-    publishDir "${params.results_dir}/", pattern: "rooted_astral_species_tree_neutral_bl.nwk", mode: "copy",  overwrite: true
+    publishDir "${params.results_dir}/", pattern: "rooted_*.nwk", mode: "copy",  overwrite: true
 
     input:
         path utree
 
     output:
-        path "rooted_astral_species_tree_neutral_bl.nwk", emit: tree
+        path "rooted_*.nwk", emit: tree
     when: params.outgroup != ""
     script:
     """
-    ${params.rooting_exe} -t $utree -o ${params.outgroup} > rooted_astral_species_tree_neutral_bl.nwk
+    ${params.rooting_exe} -t $utree -o ${params.outgroup} > rooted_`basename $utree`
     """
 }
+
+/**
+*@input path to unrooted input tree
+*@output path to rooted output tree
+*/
+process outgroupRootingProt {
+    label 'rc_2Gb'
+
+    publishDir "${params.results_dir}/", pattern: "rooted_*.nwk", mode: "copy",  overwrite: true
+
+    input:
+        path utree
+
+    output:
+        path "rooted_*.nwk", emit: tree
+    when: params.outgroup != ""
+    script:
+    """
+    ${params.rooting_exe} -t $utree -o ${params.outgroup} > rooted_`basename $utree`
+    """
+}
+
 
 // Function to check if a genome is present in
 // the annotation cache.
@@ -896,5 +918,6 @@ workflow {
     // scaleToNucleotide(calcCodonBranchesAstral.out.newick)
 
     // Perform outgroup rooting:
-    outgroupRooting(calcNeutralBranchesAstral.out.newick)
+    outgroupRootingNeutral(calcNeutralBranchesAstral.out.newick)
+    outgroupRootingProt(calcProtBranchesAstral.out.newick)
 }

--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -22,7 +22,23 @@ include { ensemblLogo } from './../utilities.nf'
 def helpMessage() {
     log.info ensemblLogo()
     log.info """
-    Usage:
+    Usage examples:
+
+    * Basic usage:
+        \$ nextflow run main.nf --dir /path/to/fastas/ --results_dir ./Res
+
+    * Using cached annotations:
+        \$ nextflow run main.nf --dir /path/to/fastas/ --results_dir ./Res --anno_cache /absolute/path/to/Res/anno_cache
+
+    * Using collection in compara master database and shared dumps as input:
+        \$ nextflow run main.nf --url='mysql://ensro@mysql-ens-compara-prod-1:4485/ensembl_compara_master' --collection pig_breeds \
+        --dump_path /hps/nobackup/flicek/ensembl/compara/shared/genome_dumps/vertebrates --results_dir ./Res
+
+    * Using species set in compara master database and shared dumps as input:
+        \$ nextflow run main.nf --url='mysql://ensro@mysql-ens-compara-prod-1:4485/ensembl_compara_master' --species_set 81206 \
+        --dump_path /hps/nobackup/flicek/ensembl/compara/shared/genome_dumps/vertebrates --results_dir ./Res
+
+    See 'nextflow.config' for additional options.
 
     """.stripIndent()
 }

--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -814,11 +814,6 @@ def annoInCache(genome, anno_cache) {
     return file.exists()
 }
 
-if (params.dir != "") {
-    genomes = Channel.fromPath("${params.dir}/*.fa*", type: 'file')
-} else {
-    genomes = null
-}
 workflow {
     println(ensemblLogo())
 

--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -825,16 +825,21 @@ workflow {
 
     // Prepare input genomes:
     if (params.dir != "") {
-        genomes = Channel.fromPath("${params.dir}/*.*", type: 'file')
+        // Get a channel of input genomes if directory is specified:
+        genomes = Channel.fromPath("${params.dir}/*.fa*", type: 'file')
     } else {
+        // Otherwise initialise an empty channel to avoid nextflow crash:
         genomes = Channel.of()
     }
     prepareGenome(genomes)
     prepareGenomeFromDb()
 
     if (params.dir == "") {
+        // The input is from DB, the genomes CSV comes from the process:
         genCsvChan = prepareGenomeFromDb.out.input_genomes
     } else {
+        // The input is from fasta file, specify a dummy path for the
+        // CSV file so the branch length calculations are executed:
         genCsvChan = Channel.of("/dummy/path")
     }
 

--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -917,7 +917,8 @@ workflow {
     // Scale the branch lengths to nucleotide sites (removed):
     // scaleToNucleotide(calcCodonBranchesAstral.out.newick)
 
-    // Perform outgroup rooting:
+    // Perform outgroup rooting for tree with neutral branch lengths:
     outgroupRootingNeutral(calcNeutralBranchesAstral.out.newick)
+    // Perform outgroup rooting for tree with protein alignment based branch lengths:
     outgroupRootingProt(calcProtBranchesAstral.out.newick)
 }

--- a/pipelines/SpeciesTreeFromBusco/nextflow.config
+++ b/pipelines/SpeciesTreeFromBusco/nextflow.config
@@ -17,7 +17,11 @@
 includeConfig "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/nextflow.config"
 
 params {
-    dir = "$HPS_HOME/Workspace/busco_tree/species_fasta"
+    dir = ""
+    url = ""
+    species_set = ""
+    collection = ""
+    dump_path = ""
     anno_cache = ""
     busco_proteins = "$HPS_HOME/Workspace/busco_tree/eukaryota_odb10/refseq_db.faa"
     results_dir = "$HPS_HOME/Pipelines/SpeciesTreeRes"
@@ -32,6 +36,8 @@ params {
     collate_busco_results_exe = "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/SpeciesTreeFromBusco/scripts/collate_busco_results.py"
     alignments_to_partitions_exe = "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/SpeciesTreeFromBusco/scripts/alignments_to_partitions.py"
     pick_third_site_exe = "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/SpeciesTreeFromBusco/scripts/pick_third_site.py"
+    fetch_genomes_exe = "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/SpeciesTreeFromBusco/scripts/fetch_genomes_from_db.py"
+    fix_leaf_names_exe = "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/SpeciesTreeFromBusco/scripts/fix_leaf_names.py"
     rooting_exe = "$ENSEMBL_ROOT_DIR/ensembl-compara/scripts/species_tree/reroot_newick.py"
     mafft_exe = "$LINUXBREW_HOME/bin/mafft"
     iqtree_exe = "$COMPARA_SOFTWARE/build/iqtree2/2.2.0.3/bin/iqtree2"

--- a/pipelines/SpeciesTreeFromBusco/nextflow.config
+++ b/pipelines/SpeciesTreeFromBusco/nextflow.config
@@ -23,7 +23,7 @@ params {
     collection = ""
     dump_path = ""
     anno_cache = ""
-    busco_proteins = "$HPS_HOME/Workspace/busco_tree/eukaryota_odb10/refseq_db.faa"
+    busco_proteins = "$COMPARA_SOFTWARE/dataset/busco/v4/eukaryota_odb10/refseq_db.faa"
     results_dir = "./SpeciesTreeRes"
     cores = 32
     min_taxa = 0.5

--- a/pipelines/SpeciesTreeFromBusco/nextflow.config
+++ b/pipelines/SpeciesTreeFromBusco/nextflow.config
@@ -24,13 +24,14 @@ params {
     dump_path = ""
     anno_cache = ""
     busco_proteins = "$HPS_HOME/Workspace/busco_tree/eukaryota_odb10/refseq_db.faa"
-    results_dir = "$HPS_HOME/Pipelines/SpeciesTreeRes"
+    results_dir = "./SpeciesTreeRes"
     cores = 32
     min_taxa = 0.5
     outgroup = ""
 
-    anno_exe = "$HOME/gt/ensembl-anno/ensembl_anno.py"
     enscode = "$HOME/gt"
+
+    anno_exe = "$HOME/gt/ensembl-anno/ensembl_anno.py"
     gffread_exe = "$COMPARA_SOFTWARE/build/gffread/0.12.7/bin/gffread"
     longest_busco_filter_exe = "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/SpeciesTreeFromBusco/scripts/filter_for_longest_busco.py"
     collate_busco_results_exe = "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/SpeciesTreeFromBusco/scripts/collate_busco_results.py"
@@ -45,7 +46,7 @@ params {
     trimal_exe = "$LINUXBREW_HOME/bin/trimal"
     seqkit_exe = "$COMPARA_SOFTWARE/build/seqkit/2.2.0/bin/seqkit"
     pal2nal_exe = "$COMPARA_SOFTWARE/build/pal2nal/14/bin/pal2nal"
-    astral_jar = "$HOME/soft/sg/soft/ASTRAL-5.7.1/Astral/astral.5.7.1.jar"
-    macse_jar = "$HOME/soft/sg/soft/macse_v2.06.jar"
+    astral_jar = "$COMPARA_SOFTWARE/build/astral/5.7.1/Astral/astral.5.7.1.jar"
+    macse_jar = "$COMPARA_SOFTWARE/build/macse/2.06/macse_v2.06.jar"
 }
 

--- a/pipelines/SpeciesTreeFromBusco/nextflow.config
+++ b/pipelines/SpeciesTreeFromBusco/nextflow.config
@@ -17,36 +17,75 @@
 includeConfig "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/nextflow.config"
 
 params {
+    //
+    // Input and output parameters:
+    //
+
+    // Input directory with fasta files:
     dir = ""
+
+    // URL to compara master database:
     url = ""
+    // Input species set id:
     species_set = ""
+    // Input collection name:
     collection = ""
+    // Path to shared genome dump directory of the division:
     dump_path = ""
+    // Path to previously generated annotation cache:
+
     anno_cache = ""
+    // Path to unzipped BUSCO protein set:
     busco_proteins = "$COMPARA_SOFTWARE/dataset/busco/v4/eukaryota_odb10/refseq_db.faa"
+    // Directory for storing results:
     results_dir = "./SpeciesTreeRes"
+    // Number of cores to use:
     cores = 32
+    // Minimum taxa filter parameter:
     min_taxa = 0.5
+    // Name of outgroup taxon:
     outgroup = ""
 
-    enscode = "$HOME/gt"
+    //
+    // Software dependencies specifications:
+    //
 
+    // The parent directory of the "ensembl-anno" repository:
+    enscode = "$HOME/gt"
+    // The path to the "ensembl-anno" script:
     anno_exe = "$HOME/gt/ensembl-anno/ensembl_anno.py"
-    gffread_exe = "$COMPARA_SOFTWARE/build/gffread/0.12.7/bin/gffread"
+    // Path to script to select longest BUSCO isoforms:
     longest_busco_filter_exe = "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/SpeciesTreeFromBusco/scripts/filter_for_longest_busco.py"
+    // Path to script to collate BUSCO results:
     collate_busco_results_exe = "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/SpeciesTreeFromBusco/scripts/collate_busco_results.py"
+    // Path to script for merging alignments:
     alignments_to_partitions_exe = "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/SpeciesTreeFromBusco/scripts/alignments_to_partitions.py"
+    // Path to script for picking third codon site:
     pick_third_site_exe = "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/SpeciesTreeFromBusco/scripts/pick_third_site.py"
+    // Path to script for fetching input genomes from master database and dump directory:
     fetch_genomes_exe = "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/SpeciesTreeFromBusco/scripts/fetch_genomes_from_db.py"
+    // Path to script to replace leaf names with production names:
     fix_leaf_names_exe = "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/SpeciesTreeFromBusco/scripts/fix_leaf_names.py"
+    // Path to script performing outgroup rooting:
     rooting_exe = "$ENSEMBL_ROOT_DIR/ensembl-compara/scripts/species_tree/reroot_newick.py"
+
+    // Path to gffread binary:
+    gffread_exe = "$COMPARA_SOFTWARE/build/gffread/0.12.7/bin/gffread"
+    // Path to mafft binary:
     mafft_exe = "$LINUXBREW_HOME/bin/mafft"
+    // Path to iqtree2 binary:
     iqtree_exe = "$COMPARA_SOFTWARE/build/iqtree2/2.2.0.3/bin/iqtree2"
+    // Path to gotree binary:
     gotree_exe = "$COMPARA_SOFTWARE/build/gotree/0.4.4a/bin/gotree"
+    // Path to trimal binary:
     trimal_exe = "$LINUXBREW_HOME/bin/trimal"
+    // Path to seqkit binary:
     seqkit_exe = "$COMPARA_SOFTWARE/build/seqkit/2.2.0/bin/seqkit"
+    // Path to pal2nal script:
     pal2nal_exe = "$COMPARA_SOFTWARE/build/pal2nal/14/bin/pal2nal"
+    // Path to astral JAR:
     astral_jar = "$COMPARA_SOFTWARE/build/astral/5.7.1/Astral/astral.5.7.1.jar"
+    // Path to MACSE JAR:
     macse_jar = "$COMPARA_SOFTWARE/build/macse/2.06/macse_v2.06.jar"
 }
 

--- a/pipelines/SpeciesTreeFromBusco/scripts/fetch_genomes_from_db.py
+++ b/pipelines/SpeciesTreeFromBusco/scripts/fetch_genomes_from_db.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Locate genome dumps of a collection or a species set on disk.
+Example:
+    $ python fetch_genomes_from_db.py -u mysql://ensro@mysql-ens-compara-prod-1:4485/ensembl_compara_master -c pig_breeds -o test.tsv -d /hps/nobackup/flicek/ensembl/compara/shared/genome_dumps/vertebrates
+"""
+
+import sys
+import argparse
+from os import path
+from sqlalchemy import create_engine, text
+
+# Parse command line arguments:
+parser = argparse.ArgumentParser(
+    description='Locate genomes of a species set/collection in the dump directory.')
+parser.add_argument('-u', metavar='db_URL', type=str, help="Compara master db URL.", required=True)
+parser.add_argument(
+    '-d', metavar='dump_dir', type=str, help="Genome dump directory.", required=True)
+parser.add_argument(
+    '-s', metavar='ssid', type=str, help="Species set id.", required=False, default=None)
+parser.add_argument(
+    '-c', metavar='cid', type=str, help="Collection id.", required=False, default=None)
+parser.add_argument(
+    '-o', metavar='output', type=str, help="Output tsv.", required=True)
+
+
+def _dir_revhash(gid):
+    """Build directory hash from genome db id."""
+    dir_hash = list(reversed(str(gid)))
+    dir_hash.pop()
+    return '/'.join(dir_hash)
+
+
+def _build_dump_path(row):
+    gcomp = ""
+    if row.genome_component is not None:
+        gcomp = f"comp{row.genome_component}."
+    gpath = path.join(args.d, _dir_revhash(row.genome_db_id), f"{row.name}.{row.assembly}.{gcomp}soft.fa")
+    return gpath
+
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+
+    db_url = args.u
+    ss_id = args.s
+    if ss_id == "":
+        ss_id = None
+    coll_id = args.c
+    if coll_id == "":
+        coll_id = None
+    engine = create_engine(db_url, future=True)
+
+    if ss_id is None and coll_id is None:
+        sys.stderr.write("Either a collection name or a species set id must be specified!\n")
+        sys.exit(1)
+
+    if ss_id is not None and coll_id is not None:
+        sys.stderr.write("Specify either a collection name or a species set id!\n")
+        sys.exit(1)
+
+    ss_query = f"""
+        SELECT genome_db_id, genome_db.name, assembly, genebuild, strain_name, display_name, genome_component FROM species_set JOIN genome_db USING(genome_db_id) WHERE species_set_id = {ss_id};
+    """
+    c_query = f"""
+        SELECT genome_db_id, genome_db.name, assembly, genebuild,strain_name, display_name, genome_component FROM species_set_header JOIN species_set USING(species_set_id) JOIN genome_db USING(genome_db_id) where species_set_header.name='{coll_id}' AND species_set_header.last_release is NULL AND species_set_header.first_release IS NOT NULL;
+    """
+    query = ss_query
+    if coll_id is not None:
+        query = c_query
+
+    missing_fas = []
+    ofh = open(args.o, "w")
+    with engine.connect() as conn:
+        result = conn.execute(text(query))
+        for row in result:
+            gpath = _build_dump_path(row)
+            fa_name = str(row.name) + "_" + str(row.assembly)
+            dump_exists = path.exists(gpath)
+            if not dump_exists:
+                missing_fas.append(gpath)
+            fields = [str(row.genome_db_id), str(row.name), str(row.assembly), str(row.genebuild), str(row.strain_name), str(row.display_name), str(row.genome_component), gpath, str(dump_exists), fa_name]
+            tsv_row = ",".join(fields) + "\n"
+            ofh.write(tsv_row)
+    ofh.flush()
+    ofh.close()
+
+    if len(missing_fas) > 0:
+        sys.stderr.write("Fatal error! The following genome dumps are missing:\n")
+        for p in missing_fas:
+            sys.stderr.write(f"{p}\n")
+        sys.exit(1)

--- a/pipelines/SpeciesTreeFromBusco/scripts/fetch_genomes_from_db.py
+++ b/pipelines/SpeciesTreeFromBusco/scripts/fetch_genomes_from_db.py
@@ -45,7 +45,7 @@ def _dir_revhash(gid: int) -> str:
     """Build directory hash from genome db id."""
     dir_hash = list(reversed(str(gid)))
     dir_hash.pop()
-    return '/'.join(dir_hash)
+    return path.join(dir_hash)
 
 
 def _build_dump_path(row: Row) -> str:

--- a/pipelines/SpeciesTreeFromBusco/scripts/fetch_genomes_from_db.py
+++ b/pipelines/SpeciesTreeFromBusco/scripts/fetch_genomes_from_db.py
@@ -24,6 +24,7 @@ Example:
 import sys
 import argparse
 from os import path
+from sqlalchemy.engine.row import Row
 from sqlalchemy import create_engine, text
 
 # Parse command line arguments:
@@ -40,14 +41,14 @@ parser.add_argument(
     '-o', metavar='output', type=str, help="Output tsv.", required=True)
 
 
-def _dir_revhash(gid):
+def _dir_revhash(gid: int) -> str:
     """Build directory hash from genome db id."""
     dir_hash = list(reversed(str(gid)))
     dir_hash.pop()
     return '/'.join(dir_hash)
 
 
-def _build_dump_path(row):
+def _build_dump_path(row: Row) -> str:
     gcomp = ""
     if row.genome_component is not None:
         gcomp = f"comp{row.genome_component}."

--- a/pipelines/SpeciesTreeFromBusco/scripts/fix_leaf_names.py
+++ b/pipelines/SpeciesTreeFromBusco/scripts/fix_leaf_names.py
@@ -48,7 +48,6 @@ if __name__ == '__main__':
 
     tree = Phylo.read(args.t, format="newick")
     for leaf in tree.get_terminals():
-        print(leaf)
         leaf.name = trans_map[leaf.name]
 
     Phylo.write(

--- a/pipelines/SpeciesTreeFromBusco/scripts/fix_leaf_names.py
+++ b/pipelines/SpeciesTreeFromBusco/scripts/fix_leaf_names.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Replace leaf names in a species tree with production name.
+Example:
+    $ python fix_leaf_names.py -t astral_species_tree_neutral_bl.nwk -c input_genomes.csv -o test.nwk
+"""
+
+import sys
+import argparse
+from os import path
+from Bio import Phylo
+import pandas as pd
+
+# Parse command line arguments:
+parser = argparse.ArgumentParser(
+    description='Replace leafs of a species tree with production names.')
+parser.add_argument(
+    '-t', metavar='tree', type=str, help="Input tree.", required=True, default=None)
+parser.add_argument(
+    '-c', metavar='csv', type=str, help="Input CSV.", required=True, default=None)
+parser.add_argument(
+    '-o', metavar='output', type=str, help="Output tree.", required=True)
+
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.c, header=None)
+    trans_map = {}
+    for r in df.itertuples():
+        trans_map[r[10]] = r[2]
+
+    tree = Phylo.read(args.t, format="newick")
+    for leaf in tree.get_terminals():
+        print(leaf)
+        leaf.name = trans_map[leaf.name]
+
+    Phylo.write(
+        trees=tree,
+        file=args.o,
+        format="newick"
+    )

--- a/src/python/lib/ensembl/compara/filesys/dircmp.py
+++ b/src/python/lib/ensembl/compara/filesys/dircmp.py
@@ -22,7 +22,7 @@ import functools
 import itertools
 import os
 from pathlib import Path
-from typing import Callable, Deque, Dict, Iterator, List, Tuple, TypeVar, Union
+from typing import Callable, Deque, Dict, Iterator, List, Optional, Tuple, TypeVar, Union
 
 from ..utils import to_list
 
@@ -80,8 +80,8 @@ class DirCmp:
         for dirname in ref_dnames & target_dnames:
             self.subdirs[Path(dirname)] = DirCmp(self.ref_path / dirname, self.target_path / dirname)
 
-    def _traverse(self, attr: str, patterns: Union[str, List] = None,
-                  paths: Union[PathLike, List] = None) -> Iterator[str]:
+    def _traverse(self, attr: str, patterns: Optional[Union[str, List]] = None,
+                  paths: Optional[Union[PathLike, List]] = None) -> Iterator[str]:
         """Yields each element of the requested attribute found in the directory trees.
 
         This method traverses the shared directory tree in breadth-first order.
@@ -124,8 +124,8 @@ class DirCmp:
             for ename in elements:
                 yield str(dirname / str(ename))
 
-    def apply_test(self, test_func: Callable, patterns: Union[str, List] = None,
-                   paths: Union[PathLike, List] = None) -> List[str]:
+    def apply_test(self, test_func: Callable, patterns: Optional[Union[str, List]] = None,
+                   paths: Optional[Union[PathLike, List]] = None) -> List[str]:
         """Returns the files in the shared directory tree for which the test function returns True.
 
         Args:
@@ -144,7 +144,7 @@ class DirCmp:
                 positives.append(filepath)
         return positives
 
-    def common_list(self, patterns: Union[str, List] = None, paths: Union[PathLike, List] = None
+    def common_list(self, patterns: Optional[Union[str, List]] = None, paths: Optional[Union[PathLike, List]] = None
                    ) -> List[str]:
         """Returns the files/directories found in the shared directory tree.
 
@@ -155,7 +155,7 @@ class DirCmp:
         """
         return list(self._traverse('common_files', patterns, paths))
 
-    def ref_only_list(self, patterns: Union[str, List] = None, paths: Union[PathLike, List] = None
+    def ref_only_list(self, patterns: Optional[Union[str, List]] = None, paths: Optional[Union[PathLike, List]] = None
                      ) -> List[str]:
         """Returns the files/directories only found in the reference directory tree.
 
@@ -166,7 +166,7 @@ class DirCmp:
         """
         return list(self._traverse('ref_only', patterns, paths))
 
-    def target_only_list(self, patterns: Union[str, List] = None, paths: Union[PathLike, List] = None
+    def target_only_list(self, patterns: Optional[Union[str, List]] = None, paths: Optional[Union[PathLike, List]] = None
                         ) -> List[str]:
         """Returns the files/directories only found in the target directory tree.
 

--- a/src/python/lib/ensembl/compara/filesys/dircmp.py
+++ b/src/python/lib/ensembl/compara/filesys/dircmp.py
@@ -144,8 +144,8 @@ class DirCmp:
                 positives.append(filepath)
         return positives
 
-    def common_list(self, patterns: Optional[Union[str, List]] = None, paths: Optional[Union[PathLike, List]] = None
-                   ) -> List[str]:
+    def common_list(self, patterns: Optional[Union[str, List]] = None,
+                    paths: Optional[Union[PathLike, List]] = None) -> List[str]:
         """Returns the files/directories found in the shared directory tree.
 
         Args:
@@ -155,8 +155,8 @@ class DirCmp:
         """
         return list(self._traverse('common_files', patterns, paths))
 
-    def ref_only_list(self, patterns: Optional[Union[str, List]] = None, paths: Optional[Union[PathLike, List]] = None
-                     ) -> List[str]:
+    def ref_only_list(self, patterns: Optional[Union[str, List]] = None,
+                      paths: Optional[Union[PathLike, List]] = None) -> List[str]:
         """Returns the files/directories only found in the reference directory tree.
 
         Args:
@@ -166,8 +166,8 @@ class DirCmp:
         """
         return list(self._traverse('ref_only', patterns, paths))
 
-    def target_only_list(self, patterns: Optional[Union[str, List]] = None, paths: Optional[Union[PathLike, List]] = None
-                        ) -> List[str]:
+    def target_only_list(self, patterns: Optional[Union[str, List]] = None,
+                         paths: Optional[Union[PathLike, List]] = None) -> List[str]:
         """Returns the files/directories only found in the target directory tree.
 
         Args:


### PR DESCRIPTION
## Description

Adapt the species tree pipeline to allow for output from compara collections and species sets.

**Related JIRA tickets:**
- ENSCOMPARASW-5787

## Overview of changes

Added scripts and processes to the nextflow pipeline allowing it to work with compara species collections or species set as input. The genome dumps of the collections are located on disk based on the information stored in a compara master database.
The pipeline still accepts a directory of fasta files as an input.

## Testing

The pipeline was tested on the pig breeds species collection/set and fasta files of rice species.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
