### PR TITLE
Remove MemberAdaptor::fetch_by_stable_id again

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -21,7 +21,6 @@ _All files (e.g. scripts) under these directories will be deleted_
 
 # Deprecated methods scheduled for deletion
 
-* `DBSQL::'*MemberAdaptor::fetch_by_stable_id()` in Ensembl 110
 * `AlignedMember::get_cigar_breakout()` in Ensembl 102
 * `AlignedMember::get_cigar_array()` in Ensembl 102
 
@@ -31,6 +30,10 @@ _All files (e.g. scripts) under these directories will be deleted_
 * `GenomicAlignTree::get_all_GenomicAligns()`
 
 # Methods removed in previous versions of Ensembl
+
+## Ensembl 110
+
+* `DBSQL::'*MemberAdaptor::fetch_by_stable_id()`
 
 ## Ensembl 100
 

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/MemberAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/MemberAdaptor.pm
@@ -56,33 +56,6 @@ use base qw(Bio::EnsEMBL::Compara::DBSQL::BaseAdaptor);
 #
 #####################
 
-sub fetch_by_stable_id { ## DEPRECATED
-    my ($self, $stable_id) = @_;
-
-    deprecate(
-        "MemberAdaptor::fetch_by_stable_id() is deprecated and will be removed in e110. Please use fetch_by_stable_id_GenomeDB instead."
-    );
-
-    throw("MemberAdaptor::fetch_by_stable_id() must have an stable_id") unless $stable_id;
-
-    my $constraint = 'm.stable_id = ?';
-    $self->bind_param_generic_fetch($stable_id, SQL_VARCHAR);
-    my $m = $self->generic_fetch_one($constraint);
-    return $m if $m;
-
-    my $vindex = rindex($stable_id, '.');
-    return undef if $vindex <= 0;  # bail out if there is no dot, or if the string starts with a dot (since that would make the stable_id part empty)
-    my $version = substr($stable_id,$vindex+1);
-    if (looks_like_number($version)) {  # to avoid DBI complains
-        $constraint = 'm.stable_id = ? AND m.version = ?';
-        $self->bind_param_generic_fetch(substr($stable_id,0,$vindex), SQL_VARCHAR);
-        $self->bind_param_generic_fetch($version, SQL_INTEGER);
-        return $self->generic_fetch_one($constraint);
-    } else {
-        return undef;
-    }
-}
-
 =head2 fetch_by_stable_id_GenomeDB
   Arg [1]       : string $stable_id
   Arg [2]       : integer $genome_db_id or Bio::EnsEMBL::Compara::GenomeDB object


### PR DESCRIPTION
## Description

During Ensembl Metazoa Compara 107 production, two Metazoa gene stable IDs — g3689 in _Lingula anatina_ and G3689 in _Crassostrea gigas_ — were found to clash in a case-insensitive way. To preserve stable ID uniqueness, relevant `stable_id` columns were altered to have binary collation.

The risk of further inter-genome stable ID clashes has motivated changes in the Compara schema, API and other code to allow for duplicate stable IDs between genomes. As part of this, `Compara::MemberAdaptor` method `fetch_by_stable_id` was deprecated.

With the removal of `MemberAdaptor::fetch_by_stable_id` set for Ensembl 110, this PR removes the method (again) and updates the relevant deprecation info.

**Related JIRA tickets:**
- ENSCOMPARASW-6049

## Overview of changes
- Method `MemberAdaptor::fetch_by_stable_id` has been removed again.
- The file `DEPRECATION.md` is updated to reflect the removal of this method.

## Testing

Other than Travis CI, no additional testing was done, as the removed method is not called in any actively used Compara production code.


---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
