### PR TITLE
Deactivating the File::Find nlink optimisation

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ComparaHMM/LoadPanther.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ComparaHMM/LoadPanther.pm
@@ -160,6 +160,7 @@ sub _concatenate_profiles {
     print STDERR "concatenating the HMM profiles ...\n" if ( $self->debug );
     my @hmm_list;
 
+    local $File::Find::dont_use_nlink = 1;
     find( sub { push @hmm_list, $File::Find::name if -f && /\.hmm$/ }, $self->param('panther_dir') );
 
     $self->param( 'local_hmm_library', $self->param('panther_dir') . "/" . $self->param('library_name') );

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ComparaHMM/PrepareHmmProfiles.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ComparaHMM/PrepareHmmProfiles.pm
@@ -58,8 +58,8 @@ package Bio::EnsEMBL::Compara::RunnableDB::ComparaHMM::PrepareHmmProfiles;
 use strict;
 use warnings;
 
-use File::Find;
-use LWP::Simple;
+#use File::Find;
+#use LWP::Simple;
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 


### PR DESCRIPTION
## Description

Deactivating the File::Find nlink optimisation in ComparaHMM modules

**Related JIRA tickets:**
[ENSCOMPARASW-4652](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-4652)

## Overview of changes
There is an optimisation in Perl module 'File::Find' that may incorrectly prevent searching in subdirectories on some filesystems (e.g. NFS on Codon). This is switched off by default in current versions of Perl, but needed to be explicitly deactivated in older versions. 

#### Change 1
- I have deactivated the File::Find nlink in LoadPanther.pm

#### Change 2
- I have commented the unused modules in PrepareHmmProfiles.pm

