### PR TITLE
Restore member stable_id key

### DIFF
--- a/sql/patch_108_109_f.sql
+++ b/sql/patch_108_109_f.sql
@@ -1,0 +1,29 @@
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_108_109_f.sql
+#
+# Title: Restore stable_id key to gene_member and seq_member tables.
+#
+# Description:
+#    Restore member stable_id key to prevent slowdown of MemberAdaptor methods
+#    such as fetch_by_stable_id (deprecated) and fetch_all_by_stable_id_list.
+
+ALTER TABLE gene_member ADD KEY stable_id (stable_id);
+ALTER TABLE seq_member ADD KEY stable_id (stable_id);
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_108_109_f.sql|stable_id_key_again');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1035,6 +1035,7 @@ CREATE TABLE gene_member (
 
   PRIMARY KEY (gene_member_id),
   UNIQUE KEY genome_db_stable_id (genome_db_id,stable_id),
+  KEY (stable_id),
   KEY (source_name),
   KEY (canonical_member_id),
   KEY dnafrag_id_start (dnafrag_id,dnafrag_start),
@@ -1139,6 +1140,7 @@ CREATE TABLE seq_member (
 
   PRIMARY KEY (seq_member_id),
   UNIQUE KEY genome_db_stable_id (genome_db_id,stable_id),
+  KEY (stable_id),
   KEY (source_name),
   KEY (sequence_id),
   KEY (gene_member_id),
@@ -2294,3 +2296,6 @@ INSERT INTO meta (species_id, meta_key, meta_value)
 
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_108_109_e.sql|case_sensitive_stable_id_again');
+
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_108_109_f.sql|stable_id_key_again');

--- a/src/test_data/databases/homology/meta.txt
+++ b/src/test_data/databases/homology/meta.txt
@@ -81,3 +81,4 @@
 113	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 114	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
 115	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again
+116	\N	patch	patch_108_109_f.sql|stable_id_key_again

--- a/src/test_data/databases/homology/table.sql
+++ b/src/test_data/databases/homology/table.sql
@@ -159,7 +159,8 @@ CREATE TABLE `gene_member` (
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
-  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`)
+  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=100281325 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `gene_member_hom_stats` (
@@ -437,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=116 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=117 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -564,7 +565,8 @@ CREATE TABLE `seq_member` (
   KEY `gene_member_id` (`gene_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
-  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`)
+  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=100289438 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `seq_member_projection` (

--- a/src/test_data/databases/mysqlimport_test/meta.txt
+++ b/src/test_data/databases/mysqlimport_test/meta.txt
@@ -20,3 +20,4 @@
 36	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 37	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
 38	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again
+39	\N	patch	patch_108_109_f.sql|stable_id_key_again

--- a/src/test_data/databases/mysqlimport_test/table.sql
+++ b/src/test_data/databases/mysqlimport_test/table.sql
@@ -159,7 +159,8 @@ CREATE TABLE `gene_member` (
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
-  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`)
+  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `gene_member_hom_stats` (
@@ -437,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=39 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=40 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -564,7 +565,8 @@ CREATE TABLE `seq_member` (
   KEY `gene_member_id` (`gene_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
-  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`)
+  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `seq_member_projection` (

--- a/src/test_data/databases/orth_qm_goc/meta.txt
+++ b/src/test_data/databases/orth_qm_goc/meta.txt
@@ -87,3 +87,4 @@
 112	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 113	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
 114	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again
+115	\N	patch	patch_108_109_f.sql|stable_id_key_again

--- a/src/test_data/databases/orth_qm_goc/table.sql
+++ b/src/test_data/databases/orth_qm_goc/table.sql
@@ -159,7 +159,8 @@ CREATE TABLE `gene_member` (
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
-  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`)
+  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=74 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `gene_member_hom_stats` (
@@ -437,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=115 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=116 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -564,7 +565,8 @@ CREATE TABLE `seq_member` (
   KEY `gene_member_id` (`gene_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
-  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`)
+  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=74 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `seq_member_projection` (

--- a/src/test_data/databases/orth_qm_wga/cc21_pair_species/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_pair_species/meta.txt
@@ -87,3 +87,4 @@
 164	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 165	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
 166	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again
+167	\N	patch	patch_108_109_f.sql|stable_id_key_again

--- a/src/test_data/databases/orth_qm_wga/cc21_pair_species/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_pair_species/table.sql
@@ -159,7 +159,8 @@ CREATE TABLE `gene_member` (
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
-  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`)
+  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `gene_member_hom_stats` (
@@ -437,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=167 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=168 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -564,7 +565,8 @@ CREATE TABLE `seq_member` (
   KEY `gene_member_id` (`gene_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
-  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`)
+  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `seq_member_projection` (

--- a/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/meta.txt
@@ -87,3 +87,4 @@
 164	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 165	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
 166	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again
+167	\N	patch	patch_108_109_f.sql|stable_id_key_again

--- a/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/table.sql
@@ -159,7 +159,8 @@ CREATE TABLE `gene_member` (
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
-  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`)
+  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=9284239 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `gene_member_hom_stats` (
@@ -437,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=167 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=168 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -564,7 +565,8 @@ CREATE TABLE `seq_member` (
   KEY `gene_member_id` (`gene_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
-  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`)
+  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=9688110 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `seq_member_projection` (

--- a/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/meta.txt
@@ -87,3 +87,4 @@
 164	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 165	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
 166	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again
+167	\N	patch	patch_108_109_f.sql|stable_id_key_again

--- a/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/table.sql
@@ -159,7 +159,8 @@ CREATE TABLE `gene_member` (
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
-  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`)
+  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=9284239 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `gene_member_hom_stats` (
@@ -437,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=167 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=168 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -564,7 +565,8 @@ CREATE TABLE `seq_member` (
   KEY `gene_member_id` (`gene_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
-  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`)
+  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=9688110 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `seq_member_projection` (

--- a/src/test_data/databases/orth_qm_wga/cc21_select_mlss/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_select_mlss/meta.txt
@@ -87,3 +87,4 @@
 164	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 165	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
 166	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again
+167	\N	patch	patch_108_109_f.sql|stable_id_key_again

--- a/src/test_data/databases/orth_qm_wga/cc21_select_mlss/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_select_mlss/table.sql
@@ -159,7 +159,8 @@ CREATE TABLE `gene_member` (
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
-  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`)
+  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `gene_member_hom_stats` (
@@ -437,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=167 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=168 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -564,7 +565,8 @@ CREATE TABLE `seq_member` (
   KEY `gene_member_id` (`gene_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
-  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`)
+  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `seq_member_projection` (

--- a/src/test_data/databases/parse_pair_aligner_conf/meta.txt
+++ b/src/test_data/databases/parse_pair_aligner_conf/meta.txt
@@ -53,3 +53,4 @@
 71	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 72	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
 73	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again
+74	\N	patch	patch_108_109_f.sql|stable_id_key_again

--- a/src/test_data/databases/parse_pair_aligner_conf/table.sql
+++ b/src/test_data/databases/parse_pair_aligner_conf/table.sql
@@ -159,7 +159,8 @@ CREATE TABLE `gene_member` (
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
-  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`)
+  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `gene_member_hom_stats` (
@@ -437,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=74 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=75 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -564,7 +565,8 @@ CREATE TABLE `seq_member` (
   KEY `gene_member_id` (`gene_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
-  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`)
+  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `seq_member_projection` (

--- a/src/test_data/databases/test_master/meta.txt
+++ b/src/test_data/databases/test_master/meta.txt
@@ -126,3 +126,4 @@
 166	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 167	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
 168	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again
+169	\N	patch	patch_108_109_f.sql|stable_id_key_again

--- a/src/test_data/databases/test_master/table.sql
+++ b/src/test_data/databases/test_master/table.sql
@@ -159,7 +159,8 @@ CREATE TABLE `gene_member` (
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
-  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`)
+  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `gene_member_hom_stats` (
@@ -437,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=169 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=170 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -564,7 +565,8 @@ CREATE TABLE `seq_member` (
   KEY `gene_member_id` (`gene_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
-  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`)
+  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `seq_member_projection` (

--- a/src/test_data/databases/update_homologies_test/meta.txt
+++ b/src/test_data/databases/update_homologies_test/meta.txt
@@ -28,3 +28,4 @@
 36	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 37	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
 38	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again
+39	\N	patch	patch_108_109_f.sql|stable_id_key_again

--- a/src/test_data/databases/update_homologies_test/table.sql
+++ b/src/test_data/databases/update_homologies_test/table.sql
@@ -159,7 +159,8 @@ CREATE TABLE `gene_member` (
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
-  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`)
+  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `gene_member_hom_stats` (
@@ -437,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=39 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=40 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -564,7 +565,8 @@ CREATE TABLE `seq_member` (
   KEY `gene_member_id` (`gene_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
-  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`)
+  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `seq_member_projection` (

--- a/src/test_data/databases/update_msa_test/meta.txt
+++ b/src/test_data/databases/update_msa_test/meta.txt
@@ -16,3 +16,4 @@
 168	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 169	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
 170	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again
+171	\N	patch	patch_108_109_f.sql|stable_id_key_again

--- a/src/test_data/databases/update_msa_test/table.sql
+++ b/src/test_data/databases/update_msa_test/table.sql
@@ -159,7 +159,8 @@ CREATE TABLE `gene_member` (
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
-  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`)
+  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `gene_member_hom_stats` (
@@ -437,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=171 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=172 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -564,7 +565,8 @@ CREATE TABLE `seq_member` (
   KEY `gene_member_id` (`gene_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
-  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`)
+  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `seq_member_projection` (

--- a/src/test_data/databases/vertebrates/meta.txt
+++ b/src/test_data/databases/vertebrates/meta.txt
@@ -126,3 +126,4 @@
 166	\N	patch	patch_108_109_c.sql|stable_id_unique_per_genome
 167	\N	patch	patch_108_109_d.sql|case_insensitive_stable_id
 168	\N	patch	patch_108_109_e.sql|case_sensitive_stable_id_again
+169	\N	patch	patch_108_109_f.sql|stable_id_key_again

--- a/src/test_data/databases/vertebrates/table.sql
+++ b/src/test_data/databases/vertebrates/table.sql
@@ -159,7 +159,8 @@ CREATE TABLE `gene_member` (
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
-  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`)
+  KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=915675731 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `gene_member_hom_stats` (
@@ -437,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=169 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=170 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -564,7 +565,8 @@ CREATE TABLE `seq_member` (
   KEY `gene_member_id` (`gene_member_id`),
   KEY `dnafrag_id_start` (`dnafrag_id`,`dnafrag_start`),
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
-  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`)
+  KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
+  KEY `stable_id` (`stable_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=952569014 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
 CREATE TABLE `seq_member_projection` (


### PR DESCRIPTION
In PR #499, the `gene_member` and `seq_member` `stable_id` keys were removed and replaced by a composite `genome_db_id`-`stable_id` key.

Most Compara code has already been updated to work with a combination of `GenomeDB` and `stable_id`, but there are still some parts of the API working solely with member stable IDs (e.g. `MemberAdaptor::fetch_all_by_stable_id_list`, `MemberAdaptor::fetch_by_stable_id`), and these suffered a significant slowdown in the absence of a `stable_id` key.

This PR fixes the slowdown by adding an SQL patch to restore the member `stable_id` keys.

**Related JIRA tickets:**
- ENSCOMPARASW-5750

## Overview of changes

### Update of schema

A patch file `sql/patch_108_109_f.sql` restores a `stable_id` key to the `gene_member` and `seq_member` tables.

The schema file `sql/table.sql` is updated to register this patch and to reflect its changes.

### Patch of test databases

Test databases are patched with `patch_108_109_f.sql`.

## Testing

After applying `patch_108_109_f.sql`, methods `MemberAdaptor::fetch_all_by_stable_id_list` and `MemberAdaptor::fetch_by_stable_id` were tested on a copy of the Metazoa Compara 109 database (`mysql://ensro@mysql-ens-compara-prod-3:4523/twalsh_test_compara_metazoa_56_109`), as well as on the unpatched release database. These methods took significantly longer to run on the unpatched database than on the database with `patch_108_109_f.sql` applied.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
