### PR TITLE
Fix flow into cleanup_strains_clusters

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/CultivarsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/CultivarsProteinTrees_conf.pm
@@ -121,7 +121,7 @@ sub tweak_analyses {
     $analyses_by_name->{'store_results'}->{'-parameters'} = {'dbname' => '#db_name#'};
 
     # Wire up cultivar-specific analyses
-    $analyses_by_name->{'remove_blacklisted_genes'}->{'-flow_into'} = ['check_strains_cluster_factory'];
+    $analyses_by_name->{'remove_blocklisted_genes'}->{'-flow_into'} = ['check_strains_cluster_factory'];
     push @{$analyses_by_name->{'backbone_pipeline_finished'}->{'-flow_into'}}, 'remove_overlapping_homologies';
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
@@ -127,7 +127,7 @@ sub tweak_analyses {
     $analyses_by_name->{'store_results'}->{'-parameters'} = {'dbname' => '#db_name#'};
 
     # wire up strain-specific analyses
-    $analyses_by_name->{'remove_blacklisted_genes'}->{'-flow_into'} = ['check_strains_cluster_factory'];
+    $analyses_by_name->{'remove_blocklisted_genes'}->{'-flow_into'} = ['check_strains_cluster_factory'];
     push @{$analyses_by_name->{'backbone_pipeline_finished'}->{'-flow_into'}}, 'remove_overlapping_homologies';
 }
 


### PR DESCRIPTION
## Description

With the recent renaming of the protein-trees analysis `remove_blacklisted_genes` to `remove_blocklisted_genes`,
strain-level pipeline config files with tweaks connecting this analysis to `check_strains_cluster_factory` were not updated, so any strain-level pipelines would have failed to remove clusters overlapping the default collection.

## Overview of changes
This is a quick fix to update the affected tweaks with the renamed analysis.

## Testing
The fix was tested by initialising two 'reconnected' test pipelines: `mysql://ensro@mysql-ens-compara-prod-9:4647/twalsh_reconnected_murinae_ptrees_20221205` and `mysql://ensro@mysql-ens-compara-prod-9:4647/twalsh_reconnected_wheat_ptrees_20221205`. In both cases `remove_blocklisted_genes` was correctly connected to `check_strains_cluster_factory`.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
