### PR TITLE
Metazoa/MergeDBsIntoRelease_conf: deal with both default and protostomes collections

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/MergeDBsIntoRelease_conf.pm
@@ -53,7 +53,7 @@ sub default_options {
         'src_db_aliases'    => {
             'master_db'                 => 'compara_master',
             'default_protein_db'        => 'compara_ptrees',
-            'protostomes_protein_db'    => 'protostomes_compara_ptrees',
+            'protostomes_protein_db'    => 'protostomes_ptrees',
             'members_db'                => 'compara_members',
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/MergeDBsIntoRelease_conf.pm
@@ -42,34 +42,47 @@ use warnings;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::MergeDBsIntoRelease_conf');
 
-
 sub default_options {
     my ($self) = @_;
-
     return {
         %{$self->SUPER::default_options},
-
         'division' => 'metazoa',
 
         # All the source databases
-        'src_db_aliases' => {
-            'master_db'     => 'compara_master',
-            'protein_db'    => 'compara_ptrees',
+        # edit the reg_conf file rather than adding URLs
+        'src_db_aliases'    => {
+            'master_db'                 => 'compara_master',
+            'default_protein_db'        => 'compara_ptrees',
+            'protostomes_protein_db'    => 'protostomes_compara_ptrees',
+            'members_db'                => 'compara_members',
         },
 
         # From these databases, only copy these tables
-        'only_tables' => {
-            # Cannot be copied by populate_new_database because it does not contain the new
-            # mapping_session_ids yet
-            'master_db' => [ qw(mapping_session) ],
+        'only_tables'       => {
+           # Cannot be copied by populate_new_database because it doesn't contain the new mapping_session_ids yet
+           'master_db'     => [qw(mapping_session)],
         },
 
-        # These tables have a unique source. Content from other databases is ignored.
-        'exclusive_tables' => {
-            'mapping_session'         => 'master_db',
+        # These tables have a unique source. Content from other databases is ignored
+        'exclusive_tables'  => {
+            'mapping_session'                   => 'master_db',
+            'hmm_annot'                         => 'default_protein_db',
+            'gene_member'                       => 'members_db',
+            'seq_member'                        => 'members_db',
+            'other_member_sequence'             => 'members_db',
+            'sequence'                          => 'members_db',
+            'exon_boundaries'                   => 'members_db',
+            'method_link_species_set_attr'      => 'default_protein_db',
+            'method_link_species_set_tag'       => 'default_protein_db',
+            'peptide_align_feature%'            => 'default_protein_db',
         },
-    };
+
+        # In these databases, ignore these tables
+        'ignored_tables' => {
+            # Mapping 'db_alias' => Arrayref of table names
+            'default_protein_db'        => [qw(ortholog_quality id_generator id_assignments datacheck_results)],
+            'protostomes_protein_db'    => [qw(ortholog_quality id_generator id_assignments datacheck_results)],
+        }
+    }
 }
-
-
 1;


### PR DESCRIPTION
## Description

In release 110 there will be 2 gene tree collections generated: default and protostomes. This PR makes changes to the metazoa gene tree merging pipeline in order to deal with this.

**Related JIRA tickets:**
- ENSCOMPARASW-6104

## Overview of changes

Metazoa/MergeDBsIntoRelease_conf was updated based on the vertebrates pipeline config file which solves the problem for murinae and pig breeds.

## Testing

The pipeline was tested with the following compara registry:

```
my $compara_dbs = {
    # general compara dbs
    #'compara_master' => [ 'mysql-ens-compara-prod-6', 'ensembl_compara_master_metazoa' ],
    'compara_master' => [ 'mysql-ens-compara-prod-3', 'twalsh_dev_ensembl_compara_master_metazoans' ],
    'compara_curr'   => [ 'mysql-ens-compara-prod-9', "sbotond_test_ensembl_compara_metazoa_221206" ],
    'compara_prev'   => [ 'mysql-ens-compara-prod-6', "ensembl_compara_metazoa_${curr_eg_release}_${curr_release}" ],

    # homology dbs
    #'compara_members'  => [ 'mysql-ens-compara-prod-6', 'thiagogenez_metazoa_load_members_109' ],
    'compara_members'  => [ 'mysql-ens-compara-prod-3', 'twalsh_dev_metazoans_load_members_20221123' ],
    #'compara_ptrees'   => [ 'mysql-ens-compara-prod-6', 'dthybert_default_metazoa_protein_trees_109' ],

    'compara_ptrees'   => [ 'mysql-ens-compara-prod-3', 'twalsh_dev_default_metazoans_protein_trees_20221124' ],
    'protostomes_ptrees'   => [ 'mysql-ens-compara-prod-9', 'twalsh_dev_protostomes_metazoans_protein_trees_20221124' ],

    # LastZ dbs
    # 'lastz_batch_1' => [ 'mysql-ens-compara-prod-X', '' ],
    # 'lastz_batch_2' => [ 'mysql-ens-compara-prod-X', '' ],

    # synteny
    # 'compara_syntenies' => [ 'mysql-ens-compara-prod-X', '' ],
};
```

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
