### PR TITLE
Main release patch to increase name field of ncbi_taxa_name table to 500 characters

### DIFF
--- a/sql/patch_109_110_c.sql
+++ b/sql/patch_109_110_c.sql
@@ -13,7 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-# patch_105_106_b.sql
+# patch_109_110_c.sql
 #
 # Title: Widen the name field in ncbi_taxa_name.
 #
@@ -24,4 +24,4 @@ ALTER TABLE ncbi_taxa_name MODIFY COLUMN name VARCHAR(500) NOT NULL;
 
 # Patch identifier
 INSERT INTO meta (species_id, meta_key, meta_value)
-  VALUES (NULL, 'patch', 'patch_109_110_b.sql|ncbi_taxa_name_varchar500');
+  VALUES (NULL, 'patch', 'patch_109_110_c.sql|ncbi_taxa_name_varchar500');

--- a/sql/patch_109_110_c.sql
+++ b/sql/patch_109_110_c.sql
@@ -1,0 +1,27 @@
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_105_106_b.sql
+#
+# Title: Widen the name field in ncbi_taxa_name.
+#
+# Description:
+#   Widen the name field in ncbi_taxa_name table to allow for longer values.
+
+ALTER TABLE ncbi_taxa_name MODIFY COLUMN name VARCHAR(500) NOT NULL;
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_109_110_b.sql|ncbi_taxa_name_varchar500');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -122,7 +122,7 @@ CREATE TABLE ncbi_taxa_node (
 
 CREATE TABLE ncbi_taxa_name (
   taxon_id                    int(10) unsigned NOT NULL,
-  name                        varchar(255) NOT NULL,
+  name                        varchar(500) NOT NULL,
   name_class                  varchar(50) NOT NULL,
 
   FOREIGN KEY (taxon_id) REFERENCES ncbi_taxa_node(taxon_id),
@@ -2284,6 +2284,7 @@ INSERT INTO meta (species_id, meta_key, meta_value) VALUES (NULL, 'schema_type',
 # Patch identifier
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_109_110_a.sql|schema_version');
-
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_109_110_b.sql|case_insensitive_stable_id_again');
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_109_110_c.sql|ncbi_taxa_name_varchar500');

--- a/src/test_data/databases/homology/meta.txt
+++ b/src/test_data/databases/homology/meta.txt
@@ -84,3 +84,4 @@
 116	\N	patch	patch_108_109_f.sql|stable_id_key_again
 118	\N	patch	patch_109_110_a.sql|schema_version
 119	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
+120	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/homology/meta.txt
+++ b/src/test_data/databases/homology/meta.txt
@@ -84,4 +84,4 @@
 116	\N	patch	patch_108_109_f.sql|stable_id_key_again
 118	\N	patch	patch_109_110_a.sql|schema_version
 119	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
-120	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500
+120	\N	patch	patch_109_110_c.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/homology/table.sql
+++ b/src/test_data/databases/homology/table.sql
@@ -9,7 +9,7 @@ CREATE TABLE `CAFE_gene_family` (
   KEY `lca_id` (`lca_id`),
   KEY `root_id` (`root_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=100000103 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=100000103 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `CAFE_species_gene` (
   `cafe_gene_family_id` int(10) unsigned NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE `CAFE_species_gene` (
   `pvalue` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`cafe_gene_family_id`,`node_id`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `conservation_score` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL,
@@ -27,7 +27,7 @@ CREATE TABLE `conservation_score` (
   `expected_score` blob,
   `diff_score` blob,
   KEY `genomic_align_block_id` (`genomic_align_block_id`,`window_size`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `constrained_element` (
   `constrained_element_id` bigint(20) unsigned NOT NULL,
@@ -41,7 +41,7 @@ CREATE TABLE `constrained_element` (
   KEY `dnafrag_id` (`dnafrag_id`),
   KEY `constrained_element_id_idx` (`constrained_element_id`),
   KEY `mlssid_dfId_dfStart_dfEnd_idx` (`method_link_species_set_id`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag` (
   `dnafrag_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -54,14 +54,14 @@ CREATE TABLE `dnafrag` (
   `codon_table_id` tinyint(3) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`dnafrag_id`),
   UNIQUE KEY `name` (`genome_db_id`,`name`)
-) ENGINE=MyISAM AUTO_INCREMENT=14026981 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=14026981 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dnafrag_alt_region` (
   `dnafrag_id` bigint(20) unsigned NOT NULL,
   `dnafrag_start` int(10) unsigned NOT NULL,
   `dnafrag_end` int(10) unsigned NOT NULL,
   PRIMARY KEY (`dnafrag_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag_region` (
   `synteny_region_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -71,7 +71,7 @@ CREATE TABLE `dnafrag_region` (
   `dnafrag_strand` tinyint(4) NOT NULL DEFAULT '0',
   KEY `synteny` (`synteny_region_id`,`dnafrag_id`),
   KEY `synteny_reversed` (`dnafrag_id`,`synteny_region_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `exon_boundaries` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -82,7 +82,7 @@ CREATE TABLE `exon_boundaries` (
   `left_over` tinyint(3) unsigned NOT NULL DEFAULT '0',
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
   `external_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -97,7 +97,7 @@ CREATE TABLE `external_db` (
   `description` text,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family` (
   `family_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -110,7 +110,7 @@ CREATE TABLE `family` (
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `description` (`description`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=2611 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=2611 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family_member` (
   `family_id` int(10) unsigned NOT NULL,
@@ -118,7 +118,7 @@ CREATE TABLE `family_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`family_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align` (
   `gene_align_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -126,7 +126,7 @@ CREATE TABLE `gene_align` (
   `aln_method` varchar(40) NOT NULL DEFAULT '',
   `aln_length` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_align_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=100002018 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=100002018 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align_member` (
   `gene_align_id` int(10) unsigned NOT NULL,
@@ -134,7 +134,7 @@ CREATE TABLE `gene_align_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`gene_align_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -161,7 +161,7 @@ CREATE TABLE `gene_member` (
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=100281325 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM AUTO_INCREMENT=100281325 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_hom_stats` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -173,7 +173,7 @@ CREATE TABLE `gene_member_hom_stats` (
   `paralogues` int(10) unsigned NOT NULL DEFAULT '0',
   `homoeologues` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_member_id`,`collection`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_qc` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -186,7 +186,7 @@ CREATE TABLE `gene_member_qc` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_node` (
   `node_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -200,7 +200,7 @@ CREATE TABLE `gene_tree_node` (
   KEY `parent_id` (`parent_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `root_id_left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=100462681 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=100462681 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_attr` (
   `node_id` int(10) unsigned NOT NULL,
@@ -210,7 +210,7 @@ CREATE TABLE `gene_tree_node_attr` (
   `duplication_confidence_score` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`node_id`),
   KEY `species_tree_node_id` (`species_tree_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_tag` (
   `node_id` int(10) unsigned NOT NULL,
@@ -218,14 +218,14 @@ CREATE TABLE `gene_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_object_store` (
   `root_id` int(10) unsigned NOT NULL,
   `data_label` varchar(255) NOT NULL,
   `compressed_data` mediumblob NOT NULL,
   PRIMARY KEY (`root_id`,`data_label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root` (
   `root_id` int(10) unsigned NOT NULL,
@@ -244,7 +244,7 @@ CREATE TABLE `gene_tree_root` (
   KEY `gene_align_id` (`gene_align_id`),
   KEY `ref_root_id` (`ref_root_id`),
   KEY `tree_type` (`tree_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_attr` (
   `root_id` int(10) unsigned NOT NULL,
@@ -274,7 +274,7 @@ CREATE TABLE `gene_tree_root_attr` (
   PRIMARY KEY (`root_id`),
   KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
   KEY `lca_node_id` (`lca_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_tag` (
   `root_id` int(10) unsigned NOT NULL,
@@ -282,7 +282,7 @@ CREATE TABLE `gene_tree_root_tag` (
   `value` mediumtext NOT NULL,
   KEY `root_id_tag` (`root_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_db` (
   `genome_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -301,7 +301,7 @@ CREATE TABLE `genome_db` (
   PRIMARY KEY (`genome_db_id`),
   UNIQUE KEY `name` (`name`,`assembly`,`genome_component`),
   KEY `taxon_id` (`taxon_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=2089 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=2089 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align` (
   `genomic_align_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -319,7 +319,7 @@ CREATE TABLE `genomic_align` (
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `dnafrag` (`dnafrag_id`,`method_link_species_set_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align_block` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -332,7 +332,7 @@ CREATE TABLE `genomic_align_block` (
   `direction` tinyint(3) unsigned DEFAULT NULL,
   PRIMARY KEY (`genomic_align_block_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `genomic_align_tree` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -346,7 +346,7 @@ CREATE TABLE `genomic_align_tree` (
   PRIMARY KEY (`node_id`),
   KEY `parent_id` (`parent_id`),
   KEY `left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `hmm_annot` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -354,7 +354,7 @@ CREATE TABLE `hmm_annot` (
   `evalue` float DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_curated_annot` (
   `seq_member_stable_id` varchar(40) NOT NULL,
@@ -364,7 +364,7 @@ CREATE TABLE `hmm_curated_annot` (
   `reason` mediumtext,
   PRIMARY KEY (`seq_member_stable_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_profile` (
   `model_id` varchar(40) NOT NULL,
@@ -373,7 +373,7 @@ CREATE TABLE `hmm_profile` (
   `compressed_profile` mediumblob,
   `consensus` mediumtext,
   PRIMARY KEY (`model_id`,`type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `homology` (
   `homology_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -396,7 +396,7 @@ CREATE TABLE `homology` (
   KEY `species_tree_node_id` (`species_tree_node_id`),
   KEY `gene_tree_node_id` (`gene_tree_node_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=100990070 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=100990070 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `homology_member` (
   `homology_id` bigint(20) unsigned NOT NULL,
@@ -409,7 +409,7 @@ CREATE TABLE `homology_member` (
   PRIMARY KEY (`homology_id`,`gene_member_id`),
   KEY `gene_member_id` (`gene_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
   `mapping_session_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -420,7 +420,7 @@ CREATE TABLE `mapping_session` (
   `prefix` char(4) NOT NULL,
   PRIMARY KEY (`mapping_session_id`),
   UNIQUE KEY `type` (`type`,`rel_from`,`rel_to`,`prefix`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `member_xref` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -428,7 +428,7 @@ CREATE TABLE `member_xref` (
   `external_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`gene_member_id`,`dbprimary_acc`,`external_db_id`),
   KEY `external_db_id` (`external_db_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -438,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=120 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=121 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -447,7 +447,7 @@ CREATE TABLE `method_link` (
   `display_name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`method_link_id`),
   UNIQUE KEY `type` (`type`)
-) ENGINE=MyISAM AUTO_INCREMENT=403 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=403 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set` (
   `method_link_species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -461,7 +461,7 @@ CREATE TABLE `method_link_species_set` (
   PRIMARY KEY (`method_link_species_set_id`),
   UNIQUE KEY `method_link_id` (`method_link_id`,`species_set_id`),
   KEY `species_set_id` (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=100070 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=100070 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set_attr` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -476,7 +476,7 @@ CREATE TABLE `method_link_species_set_attr` (
   `perc_orth_above_wga_thresh` float DEFAULT NULL,
   `threshold_on_ds` int(11) DEFAULT NULL,
   PRIMARY KEY (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `method_link_species_set_tag` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -484,16 +484,16 @@ CREATE TABLE `method_link_species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`method_link_species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_name` (
   `taxon_id` int(10) unsigned NOT NULL,
-  `name` varchar(255) NOT NULL,
+  `name` varchar(500) NOT NULL,
   `name_class` varchar(50) NOT NULL,
   KEY `taxon_id` (`taxon_id`),
   KEY `name` (`name`),
   KEY `name_class` (`name_class`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_node` (
   `taxon_id` int(10) unsigned NOT NULL,
@@ -508,7 +508,7 @@ CREATE TABLE `ncbi_taxa_node` (
   KEY `rank` (`rank`),
   KEY `left_index` (`left_index`),
   KEY `right_index` (`right_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `other_member_sequence` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -516,7 +516,7 @@ CREATE TABLE `other_member_sequence` (
   `length` int(10) unsigned NOT NULL,
   `sequence` mediumtext NOT NULL,
   PRIMARY KEY (`seq_member_id`,`seq_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `peptide_align_feature` (
   `peptide_align_feature_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -538,7 +538,7 @@ CREATE TABLE `peptide_align_feature` (
   `hit_rank` smallint(5) unsigned NOT NULL,
   `cigar_line` mediumtext,
   PRIMARY KEY (`peptide_align_feature_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -567,7 +567,7 @@ CREATE TABLE `seq_member` (
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=100289438 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM AUTO_INCREMENT=100289438 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member_projection` (
   `source_seq_member_id` int(10) unsigned NOT NULL,
@@ -575,14 +575,14 @@ CREATE TABLE `seq_member_projection` (
   `identity` float(5,2) DEFAULT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_seq_member_id` (`source_seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_member_projection_stable_id` (
   `target_seq_member_id` int(10) unsigned NOT NULL,
   `source_stable_id` varchar(128) NOT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_stable_id` (`source_stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `sequence` (
   `sequence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -591,14 +591,14 @@ CREATE TABLE `sequence` (
   `sequence` longtext NOT NULL,
   PRIMARY KEY (`sequence_id`),
   KEY `md5sum` (`md5sum`)
-) ENGINE=MyISAM AUTO_INCREMENT=100259313 DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000;
+) ENGINE=MyISAM AUTO_INCREMENT=100259313 DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set` (
   `species_set_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`species_set_id`,`genome_db_id`),
   KEY `genome_db_id` (`genome_db_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_set_header` (
   `species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -607,7 +607,7 @@ CREATE TABLE `species_set_header` (
   `first_release` smallint(6) DEFAULT NULL,
   `last_release` smallint(6) DEFAULT NULL,
   PRIMARY KEY (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=100000 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=100000 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set_tag` (
   `species_set_id` int(10) unsigned NOT NULL,
@@ -615,7 +615,7 @@ CREATE TABLE `species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -632,7 +632,7 @@ CREATE TABLE `species_tree_node` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `parent_id` (`parent_id`),
   KEY `root_id` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=40102221 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=40102221 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node_attr` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -662,7 +662,7 @@ CREATE TABLE `species_tree_node_attr` (
   `root_nb_genes` int(11) DEFAULT NULL,
   `root_nb_trees` int(11) DEFAULT NULL,
   PRIMARY KEY (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_tree_node_tag` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -670,7 +670,7 @@ CREATE TABLE `species_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_root` (
   `root_id` bigint(20) unsigned NOT NULL,
@@ -678,7 +678,7 @@ CREATE TABLE `species_tree_root` (
   `label` varchar(256) NOT NULL DEFAULT 'default',
   PRIMARY KEY (`root_id`),
   UNIQUE KEY `method_link_species_set_id` (`method_link_species_set_id`,`label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_history` (
   `mapping_session_id` int(10) unsigned NOT NULL,
@@ -688,12 +688,12 @@ CREATE TABLE `stable_id_history` (
   `version_to` int(10) unsigned DEFAULT NULL,
   `contribution` float DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`,`stable_id_from`,`stable_id_to`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `synteny_region` (
   `synteny_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `method_link_species_set_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`synteny_region_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 

--- a/src/test_data/databases/mysqlimport_test/meta.txt
+++ b/src/test_data/databases/mysqlimport_test/meta.txt
@@ -23,3 +23,4 @@
 39	\N	patch	patch_108_109_f.sql|stable_id_key_again
 41	\N	patch	patch_109_110_a.sql|schema_version
 42	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
+43	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/mysqlimport_test/meta.txt
+++ b/src/test_data/databases/mysqlimport_test/meta.txt
@@ -23,4 +23,4 @@
 39	\N	patch	patch_108_109_f.sql|stable_id_key_again
 41	\N	patch	patch_109_110_a.sql|schema_version
 42	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
-43	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500
+43	\N	patch	patch_109_110_c.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/mysqlimport_test/table.sql
+++ b/src/test_data/databases/mysqlimport_test/table.sql
@@ -9,7 +9,7 @@ CREATE TABLE `CAFE_gene_family` (
   KEY `lca_id` (`lca_id`),
   KEY `root_id` (`root_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `CAFE_species_gene` (
   `cafe_gene_family_id` int(10) unsigned NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE `CAFE_species_gene` (
   `pvalue` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`cafe_gene_family_id`,`node_id`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `conservation_score` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL,
@@ -27,7 +27,7 @@ CREATE TABLE `conservation_score` (
   `expected_score` blob,
   `diff_score` blob,
   KEY `genomic_align_block_id` (`genomic_align_block_id`,`window_size`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `constrained_element` (
   `constrained_element_id` bigint(20) unsigned NOT NULL,
@@ -41,7 +41,7 @@ CREATE TABLE `constrained_element` (
   KEY `dnafrag_id` (`dnafrag_id`),
   KEY `constrained_element_id_idx` (`constrained_element_id`),
   KEY `mlssid_dfId_dfStart_dfEnd_idx` (`method_link_species_set_id`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag` (
   `dnafrag_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -54,14 +54,14 @@ CREATE TABLE `dnafrag` (
   `codon_table_id` tinyint(3) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`dnafrag_id`),
   UNIQUE KEY `name` (`genome_db_id`,`name`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dnafrag_alt_region` (
   `dnafrag_id` bigint(20) unsigned NOT NULL,
   `dnafrag_start` int(10) unsigned NOT NULL,
   `dnafrag_end` int(10) unsigned NOT NULL,
   PRIMARY KEY (`dnafrag_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag_region` (
   `synteny_region_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -71,7 +71,7 @@ CREATE TABLE `dnafrag_region` (
   `dnafrag_strand` tinyint(4) NOT NULL DEFAULT '0',
   KEY `synteny` (`synteny_region_id`,`dnafrag_id`),
   KEY `synteny_reversed` (`dnafrag_id`,`synteny_region_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `exon_boundaries` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -82,7 +82,7 @@ CREATE TABLE `exon_boundaries` (
   `left_over` tinyint(3) unsigned NOT NULL DEFAULT '0',
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
   `external_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -97,7 +97,7 @@ CREATE TABLE `external_db` (
   `description` text,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family` (
   `family_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -110,7 +110,7 @@ CREATE TABLE `family` (
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `description` (`description`(255))
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family_member` (
   `family_id` int(10) unsigned NOT NULL,
@@ -118,7 +118,7 @@ CREATE TABLE `family_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`family_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align` (
   `gene_align_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -126,7 +126,7 @@ CREATE TABLE `gene_align` (
   `aln_method` varchar(40) NOT NULL DEFAULT '',
   `aln_length` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_align_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align_member` (
   `gene_align_id` int(10) unsigned NOT NULL,
@@ -134,7 +134,7 @@ CREATE TABLE `gene_align_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`gene_align_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -161,7 +161,7 @@ CREATE TABLE `gene_member` (
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_hom_stats` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -173,7 +173,7 @@ CREATE TABLE `gene_member_hom_stats` (
   `paralogues` int(10) unsigned NOT NULL DEFAULT '0',
   `homoeologues` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_member_id`,`collection`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_qc` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -186,7 +186,7 @@ CREATE TABLE `gene_member_qc` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_node` (
   `node_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -200,7 +200,7 @@ CREATE TABLE `gene_tree_node` (
   KEY `parent_id` (`parent_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `root_id_left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_attr` (
   `node_id` int(10) unsigned NOT NULL,
@@ -210,7 +210,7 @@ CREATE TABLE `gene_tree_node_attr` (
   `duplication_confidence_score` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`node_id`),
   KEY `species_tree_node_id` (`species_tree_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_tag` (
   `node_id` int(10) unsigned NOT NULL,
@@ -218,14 +218,14 @@ CREATE TABLE `gene_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_object_store` (
   `root_id` int(10) unsigned NOT NULL,
   `data_label` varchar(255) NOT NULL,
   `compressed_data` mediumblob NOT NULL,
   PRIMARY KEY (`root_id`,`data_label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root` (
   `root_id` int(10) unsigned NOT NULL,
@@ -244,7 +244,7 @@ CREATE TABLE `gene_tree_root` (
   KEY `gene_align_id` (`gene_align_id`),
   KEY `ref_root_id` (`ref_root_id`),
   KEY `tree_type` (`tree_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_attr` (
   `root_id` int(10) unsigned NOT NULL,
@@ -274,7 +274,7 @@ CREATE TABLE `gene_tree_root_attr` (
   PRIMARY KEY (`root_id`),
   KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
   KEY `lca_node_id` (`lca_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_tag` (
   `root_id` int(10) unsigned NOT NULL,
@@ -282,7 +282,7 @@ CREATE TABLE `gene_tree_root_tag` (
   `value` mediumtext NOT NULL,
   KEY `root_id_tag` (`root_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_db` (
   `genome_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -301,7 +301,7 @@ CREATE TABLE `genome_db` (
   PRIMARY KEY (`genome_db_id`),
   UNIQUE KEY `name` (`name`,`assembly`,`genome_component`),
   KEY `taxon_id` (`taxon_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align` (
   `genomic_align_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -319,7 +319,7 @@ CREATE TABLE `genomic_align` (
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `dnafrag` (`dnafrag_id`,`method_link_species_set_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align_block` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -332,7 +332,7 @@ CREATE TABLE `genomic_align_block` (
   `direction` tinyint(3) unsigned DEFAULT NULL,
   PRIMARY KEY (`genomic_align_block_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `genomic_align_tree` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -346,7 +346,7 @@ CREATE TABLE `genomic_align_tree` (
   PRIMARY KEY (`node_id`),
   KEY `parent_id` (`parent_id`),
   KEY `left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `hmm_annot` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -354,7 +354,7 @@ CREATE TABLE `hmm_annot` (
   `evalue` float DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_curated_annot` (
   `seq_member_stable_id` varchar(40) NOT NULL,
@@ -364,7 +364,7 @@ CREATE TABLE `hmm_curated_annot` (
   `reason` mediumtext,
   PRIMARY KEY (`seq_member_stable_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_profile` (
   `model_id` varchar(40) NOT NULL,
@@ -373,7 +373,7 @@ CREATE TABLE `hmm_profile` (
   `compressed_profile` mediumblob,
   `consensus` mediumtext,
   PRIMARY KEY (`model_id`,`type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `homology` (
   `homology_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -396,7 +396,7 @@ CREATE TABLE `homology` (
   KEY `species_tree_node_id` (`species_tree_node_id`),
   KEY `gene_tree_node_id` (`gene_tree_node_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `homology_member` (
   `homology_id` bigint(20) unsigned NOT NULL,
@@ -409,7 +409,7 @@ CREATE TABLE `homology_member` (
   PRIMARY KEY (`homology_id`,`gene_member_id`),
   KEY `gene_member_id` (`gene_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
   `mapping_session_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -420,7 +420,7 @@ CREATE TABLE `mapping_session` (
   `prefix` char(4) NOT NULL,
   PRIMARY KEY (`mapping_session_id`),
   UNIQUE KEY `type` (`type`,`rel_from`,`rel_to`,`prefix`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `member_xref` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -428,7 +428,7 @@ CREATE TABLE `member_xref` (
   `external_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`gene_member_id`,`dbprimary_acc`,`external_db_id`),
   KEY `external_db_id` (`external_db_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -438,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=43 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=44 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -447,7 +447,7 @@ CREATE TABLE `method_link` (
   `display_name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`method_link_id`),
   UNIQUE KEY `type` (`type`)
-) ENGINE=MyISAM AUTO_INCREMENT=202 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=202 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set` (
   `method_link_species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -461,7 +461,7 @@ CREATE TABLE `method_link_species_set` (
   PRIMARY KEY (`method_link_species_set_id`),
   UNIQUE KEY `method_link_id` (`method_link_id`,`species_set_id`),
   KEY `species_set_id` (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=1235 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=1235 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set_attr` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -476,7 +476,7 @@ CREATE TABLE `method_link_species_set_attr` (
   `perc_orth_above_wga_thresh` float DEFAULT NULL,
   `threshold_on_ds` int(11) DEFAULT NULL,
   PRIMARY KEY (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `method_link_species_set_tag` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -484,16 +484,16 @@ CREATE TABLE `method_link_species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`method_link_species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_name` (
   `taxon_id` int(10) unsigned NOT NULL,
-  `name` varchar(255) NOT NULL,
+  `name` varchar(500) NOT NULL,
   `name_class` varchar(50) NOT NULL,
   KEY `taxon_id` (`taxon_id`),
   KEY `name` (`name`),
   KEY `name_class` (`name_class`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_node` (
   `taxon_id` int(10) unsigned NOT NULL,
@@ -508,7 +508,7 @@ CREATE TABLE `ncbi_taxa_node` (
   KEY `rank` (`rank`),
   KEY `left_index` (`left_index`),
   KEY `right_index` (`right_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `other_member_sequence` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -516,7 +516,7 @@ CREATE TABLE `other_member_sequence` (
   `length` int(10) unsigned NOT NULL,
   `sequence` mediumtext NOT NULL,
   PRIMARY KEY (`seq_member_id`,`seq_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `peptide_align_feature` (
   `peptide_align_feature_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -538,7 +538,7 @@ CREATE TABLE `peptide_align_feature` (
   `hit_rank` smallint(5) unsigned NOT NULL,
   `cigar_line` mediumtext,
   PRIMARY KEY (`peptide_align_feature_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -567,7 +567,7 @@ CREATE TABLE `seq_member` (
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member_projection` (
   `source_seq_member_id` int(10) unsigned NOT NULL,
@@ -575,14 +575,14 @@ CREATE TABLE `seq_member_projection` (
   `identity` float(5,2) DEFAULT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_seq_member_id` (`source_seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_member_projection_stable_id` (
   `target_seq_member_id` int(10) unsigned NOT NULL,
   `source_stable_id` varchar(128) NOT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_stable_id` (`source_stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `sequence` (
   `sequence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -591,14 +591,14 @@ CREATE TABLE `sequence` (
   `sequence` longtext NOT NULL,
   PRIMARY KEY (`sequence_id`),
   KEY `md5sum` (`md5sum`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set` (
   `species_set_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`species_set_id`,`genome_db_id`),
   KEY `genome_db_id` (`genome_db_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_set_header` (
   `species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -607,7 +607,7 @@ CREATE TABLE `species_set_header` (
   `first_release` smallint(6) DEFAULT NULL,
   `last_release` smallint(6) DEFAULT NULL,
   PRIMARY KEY (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=1235 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=1235 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set_tag` (
   `species_set_id` int(10) unsigned NOT NULL,
@@ -615,7 +615,7 @@ CREATE TABLE `species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -632,7 +632,7 @@ CREATE TABLE `species_tree_node` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `parent_id` (`parent_id`),
   KEY `root_id` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node_attr` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -662,7 +662,7 @@ CREATE TABLE `species_tree_node_attr` (
   `root_nb_genes` int(11) DEFAULT NULL,
   `root_nb_trees` int(11) DEFAULT NULL,
   PRIMARY KEY (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_tree_node_tag` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -670,7 +670,7 @@ CREATE TABLE `species_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_root` (
   `root_id` bigint(20) unsigned NOT NULL,
@@ -678,7 +678,7 @@ CREATE TABLE `species_tree_root` (
   `label` varchar(256) NOT NULL DEFAULT 'default',
   PRIMARY KEY (`root_id`),
   UNIQUE KEY `method_link_species_set_id` (`method_link_species_set_id`,`label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_history` (
   `mapping_session_id` int(10) unsigned NOT NULL,
@@ -688,12 +688,12 @@ CREATE TABLE `stable_id_history` (
   `version_to` int(10) unsigned DEFAULT NULL,
   `contribution` float DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`,`stable_id_from`,`stable_id_to`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `synteny_region` (
   `synteny_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `method_link_species_set_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`synteny_region_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 

--- a/src/test_data/databases/orth_qm_goc/meta.txt
+++ b/src/test_data/databases/orth_qm_goc/meta.txt
@@ -90,3 +90,4 @@
 115	\N	patch	patch_108_109_f.sql|stable_id_key_again
 117	\N	patch	patch_109_110_a.sql|schema_version
 118	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
+119	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/orth_qm_goc/meta.txt
+++ b/src/test_data/databases/orth_qm_goc/meta.txt
@@ -90,4 +90,4 @@
 115	\N	patch	patch_108_109_f.sql|stable_id_key_again
 117	\N	patch	patch_109_110_a.sql|schema_version
 118	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
-119	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500
+119	\N	patch	patch_109_110_c.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/orth_qm_goc/table.sql
+++ b/src/test_data/databases/orth_qm_goc/table.sql
@@ -9,7 +9,7 @@ CREATE TABLE `CAFE_gene_family` (
   KEY `lca_id` (`lca_id`),
   KEY `root_id` (`root_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `CAFE_species_gene` (
   `cafe_gene_family_id` int(10) unsigned NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE `CAFE_species_gene` (
   `pvalue` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`cafe_gene_family_id`,`node_id`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `conservation_score` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL,
@@ -27,7 +27,7 @@ CREATE TABLE `conservation_score` (
   `expected_score` blob,
   `diff_score` blob,
   KEY `genomic_align_block_id` (`genomic_align_block_id`,`window_size`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `constrained_element` (
   `constrained_element_id` bigint(20) unsigned NOT NULL,
@@ -41,7 +41,7 @@ CREATE TABLE `constrained_element` (
   KEY `dnafrag_id` (`dnafrag_id`),
   KEY `constrained_element_id_idx` (`constrained_element_id`),
   KEY `mlssid_dfId_dfStart_dfEnd_idx` (`method_link_species_set_id`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag` (
   `dnafrag_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -54,14 +54,14 @@ CREATE TABLE `dnafrag` (
   `codon_table_id` tinyint(3) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`dnafrag_id`),
   UNIQUE KEY `name` (`genome_db_id`,`name`)
-) ENGINE=MyISAM AUTO_INCREMENT=8 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=8 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dnafrag_alt_region` (
   `dnafrag_id` bigint(20) unsigned NOT NULL,
   `dnafrag_start` int(10) unsigned NOT NULL,
   `dnafrag_end` int(10) unsigned NOT NULL,
   PRIMARY KEY (`dnafrag_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag_region` (
   `synteny_region_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -71,7 +71,7 @@ CREATE TABLE `dnafrag_region` (
   `dnafrag_strand` tinyint(4) NOT NULL DEFAULT '0',
   KEY `synteny` (`synteny_region_id`,`dnafrag_id`),
   KEY `synteny_reversed` (`dnafrag_id`,`synteny_region_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `exon_boundaries` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -82,7 +82,7 @@ CREATE TABLE `exon_boundaries` (
   `left_over` tinyint(3) unsigned NOT NULL DEFAULT '0',
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
   `external_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -97,7 +97,7 @@ CREATE TABLE `external_db` (
   `description` text,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family` (
   `family_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -110,7 +110,7 @@ CREATE TABLE `family` (
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `description` (`description`(255))
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family_member` (
   `family_id` int(10) unsigned NOT NULL,
@@ -118,7 +118,7 @@ CREATE TABLE `family_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`family_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align` (
   `gene_align_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -126,7 +126,7 @@ CREATE TABLE `gene_align` (
   `aln_method` varchar(40) NOT NULL DEFAULT '',
   `aln_length` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_align_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align_member` (
   `gene_align_id` int(10) unsigned NOT NULL,
@@ -134,7 +134,7 @@ CREATE TABLE `gene_align_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`gene_align_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -161,7 +161,7 @@ CREATE TABLE `gene_member` (
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=74 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM AUTO_INCREMENT=74 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_hom_stats` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -173,7 +173,7 @@ CREATE TABLE `gene_member_hom_stats` (
   `paralogues` int(10) unsigned NOT NULL DEFAULT '0',
   `homoeologues` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_member_id`,`collection`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_qc` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -186,7 +186,7 @@ CREATE TABLE `gene_member_qc` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_node` (
   `node_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -200,7 +200,7 @@ CREATE TABLE `gene_tree_node` (
   KEY `parent_id` (`parent_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `root_id_left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_attr` (
   `node_id` int(10) unsigned NOT NULL,
@@ -210,7 +210,7 @@ CREATE TABLE `gene_tree_node_attr` (
   `duplication_confidence_score` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`node_id`),
   KEY `species_tree_node_id` (`species_tree_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_tag` (
   `node_id` int(10) unsigned NOT NULL,
@@ -218,14 +218,14 @@ CREATE TABLE `gene_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_object_store` (
   `root_id` int(10) unsigned NOT NULL,
   `data_label` varchar(255) NOT NULL,
   `compressed_data` mediumblob NOT NULL,
   PRIMARY KEY (`root_id`,`data_label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root` (
   `root_id` int(10) unsigned NOT NULL,
@@ -244,7 +244,7 @@ CREATE TABLE `gene_tree_root` (
   KEY `gene_align_id` (`gene_align_id`),
   KEY `ref_root_id` (`ref_root_id`),
   KEY `tree_type` (`tree_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_attr` (
   `root_id` int(10) unsigned NOT NULL,
@@ -274,7 +274,7 @@ CREATE TABLE `gene_tree_root_attr` (
   PRIMARY KEY (`root_id`),
   KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
   KEY `lca_node_id` (`lca_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_tag` (
   `root_id` int(10) unsigned NOT NULL,
@@ -282,7 +282,7 @@ CREATE TABLE `gene_tree_root_tag` (
   `value` mediumtext NOT NULL,
   KEY `root_id_tag` (`root_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_db` (
   `genome_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -301,7 +301,7 @@ CREATE TABLE `genome_db` (
   PRIMARY KEY (`genome_db_id`),
   UNIQUE KEY `name` (`name`,`assembly`,`genome_component`),
   KEY `taxon_id` (`taxon_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=6 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align` (
   `genomic_align_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -319,7 +319,7 @@ CREATE TABLE `genomic_align` (
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `dnafrag` (`dnafrag_id`,`method_link_species_set_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align_block` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -332,7 +332,7 @@ CREATE TABLE `genomic_align_block` (
   `direction` tinyint(3) unsigned DEFAULT NULL,
   PRIMARY KEY (`genomic_align_block_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `genomic_align_tree` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -346,7 +346,7 @@ CREATE TABLE `genomic_align_tree` (
   PRIMARY KEY (`node_id`),
   KEY `parent_id` (`parent_id`),
   KEY `left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `hmm_annot` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -354,7 +354,7 @@ CREATE TABLE `hmm_annot` (
   `evalue` float DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_curated_annot` (
   `seq_member_stable_id` varchar(40) NOT NULL,
@@ -364,7 +364,7 @@ CREATE TABLE `hmm_curated_annot` (
   `reason` mediumtext,
   PRIMARY KEY (`seq_member_stable_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_profile` (
   `model_id` varchar(40) NOT NULL,
@@ -373,7 +373,7 @@ CREATE TABLE `hmm_profile` (
   `compressed_profile` mediumblob,
   `consensus` mediumtext,
   PRIMARY KEY (`model_id`,`type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `homology` (
   `homology_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -396,7 +396,7 @@ CREATE TABLE `homology` (
   KEY `species_tree_node_id` (`species_tree_node_id`),
   KEY `gene_tree_node_id` (`gene_tree_node_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=29 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=29 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `homology_member` (
   `homology_id` bigint(20) unsigned NOT NULL,
@@ -409,7 +409,7 @@ CREATE TABLE `homology_member` (
   PRIMARY KEY (`homology_id`,`gene_member_id`),
   KEY `gene_member_id` (`gene_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
   `mapping_session_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -420,7 +420,7 @@ CREATE TABLE `mapping_session` (
   `prefix` char(4) NOT NULL,
   PRIMARY KEY (`mapping_session_id`),
   UNIQUE KEY `type` (`type`,`rel_from`,`rel_to`,`prefix`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `member_xref` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -428,7 +428,7 @@ CREATE TABLE `member_xref` (
   `external_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`gene_member_id`,`dbprimary_acc`,`external_db_id`),
   KEY `external_db_id` (`external_db_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -438,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=119 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=120 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -447,7 +447,7 @@ CREATE TABLE `method_link` (
   `display_name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`method_link_id`),
   UNIQUE KEY `type` (`type`)
-) ENGINE=MyISAM AUTO_INCREMENT=207 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=207 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set` (
   `method_link_species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -461,7 +461,7 @@ CREATE TABLE `method_link_species_set` (
   PRIMARY KEY (`method_link_species_set_id`),
   UNIQUE KEY `method_link_id` (`method_link_id`,`species_set_id`),
   KEY `species_set_id` (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=1004 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=1004 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set_attr` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -476,7 +476,7 @@ CREATE TABLE `method_link_species_set_attr` (
   `perc_orth_above_wga_thresh` float DEFAULT NULL,
   `threshold_on_ds` int(11) DEFAULT NULL,
   PRIMARY KEY (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `method_link_species_set_tag` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -484,16 +484,16 @@ CREATE TABLE `method_link_species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`method_link_species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_name` (
   `taxon_id` int(10) unsigned NOT NULL,
-  `name` varchar(255) NOT NULL,
+  `name` varchar(500) NOT NULL,
   `name_class` varchar(50) NOT NULL,
   KEY `taxon_id` (`taxon_id`),
   KEY `name` (`name`),
   KEY `name_class` (`name_class`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_node` (
   `taxon_id` int(10) unsigned NOT NULL,
@@ -508,7 +508,7 @@ CREATE TABLE `ncbi_taxa_node` (
   KEY `rank` (`rank`),
   KEY `left_index` (`left_index`),
   KEY `right_index` (`right_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `other_member_sequence` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -516,7 +516,7 @@ CREATE TABLE `other_member_sequence` (
   `length` int(10) unsigned NOT NULL,
   `sequence` mediumtext NOT NULL,
   PRIMARY KEY (`seq_member_id`,`seq_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `peptide_align_feature` (
   `peptide_align_feature_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -538,7 +538,7 @@ CREATE TABLE `peptide_align_feature` (
   `hit_rank` smallint(5) unsigned NOT NULL,
   `cigar_line` mediumtext,
   PRIMARY KEY (`peptide_align_feature_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -567,7 +567,7 @@ CREATE TABLE `seq_member` (
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=74 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM AUTO_INCREMENT=74 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member_projection` (
   `source_seq_member_id` int(10) unsigned NOT NULL,
@@ -575,14 +575,14 @@ CREATE TABLE `seq_member_projection` (
   `identity` float(5,2) DEFAULT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_seq_member_id` (`source_seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_member_projection_stable_id` (
   `target_seq_member_id` int(10) unsigned NOT NULL,
   `source_stable_id` varchar(128) NOT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_stable_id` (`source_stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `sequence` (
   `sequence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -591,14 +591,14 @@ CREATE TABLE `sequence` (
   `sequence` longtext NOT NULL,
   PRIMARY KEY (`sequence_id`),
   KEY `md5sum` (`md5sum`)
-) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000;
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set` (
   `species_set_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`species_set_id`,`genome_db_id`),
   KEY `genome_db_id` (`genome_db_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_set_header` (
   `species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -607,7 +607,7 @@ CREATE TABLE `species_set_header` (
   `first_release` smallint(6) DEFAULT NULL,
   `last_release` smallint(6) DEFAULT NULL,
   PRIMARY KEY (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set_tag` (
   `species_set_id` int(10) unsigned NOT NULL,
@@ -615,7 +615,7 @@ CREATE TABLE `species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -632,7 +632,7 @@ CREATE TABLE `species_tree_node` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `parent_id` (`parent_id`),
   KEY `root_id` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node_attr` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -662,7 +662,7 @@ CREATE TABLE `species_tree_node_attr` (
   `root_nb_genes` int(11) DEFAULT NULL,
   `root_nb_trees` int(11) DEFAULT NULL,
   PRIMARY KEY (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_tree_node_tag` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -670,7 +670,7 @@ CREATE TABLE `species_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_root` (
   `root_id` bigint(20) unsigned NOT NULL,
@@ -678,7 +678,7 @@ CREATE TABLE `species_tree_root` (
   `label` varchar(256) NOT NULL DEFAULT 'default',
   PRIMARY KEY (`root_id`),
   UNIQUE KEY `method_link_species_set_id` (`method_link_species_set_id`,`label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_history` (
   `mapping_session_id` int(10) unsigned NOT NULL,
@@ -688,12 +688,12 @@ CREATE TABLE `stable_id_history` (
   `version_to` int(10) unsigned DEFAULT NULL,
   `contribution` float DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`,`stable_id_from`,`stable_id_to`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `synteny_region` (
   `synteny_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `method_link_species_set_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`synteny_region_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 

--- a/src/test_data/databases/orth_qm_wga/cc21_pair_species/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_pair_species/meta.txt
@@ -90,3 +90,4 @@
 167	\N	patch	patch_108_109_f.sql|stable_id_key_again
 169	\N	patch	patch_109_110_a.sql|schema_version
 170	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
+171	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/orth_qm_wga/cc21_pair_species/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_pair_species/meta.txt
@@ -90,4 +90,4 @@
 167	\N	patch	patch_108_109_f.sql|stable_id_key_again
 169	\N	patch	patch_109_110_a.sql|schema_version
 170	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
-171	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500
+171	\N	patch	patch_109_110_c.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/orth_qm_wga/cc21_pair_species/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_pair_species/table.sql
@@ -9,7 +9,7 @@ CREATE TABLE `CAFE_gene_family` (
   KEY `lca_id` (`lca_id`),
   KEY `root_id` (`root_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `CAFE_species_gene` (
   `cafe_gene_family_id` int(10) unsigned NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE `CAFE_species_gene` (
   `pvalue` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`cafe_gene_family_id`,`node_id`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `conservation_score` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL,
@@ -27,7 +27,7 @@ CREATE TABLE `conservation_score` (
   `expected_score` blob,
   `diff_score` blob,
   KEY `genomic_align_block_id` (`genomic_align_block_id`,`window_size`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `constrained_element` (
   `constrained_element_id` bigint(20) unsigned NOT NULL,
@@ -41,7 +41,7 @@ CREATE TABLE `constrained_element` (
   KEY `dnafrag_id` (`dnafrag_id`),
   KEY `constrained_element_id_idx` (`constrained_element_id`),
   KEY `mlssid_dfId_dfStart_dfEnd_idx` (`method_link_species_set_id`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag` (
   `dnafrag_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -54,14 +54,14 @@ CREATE TABLE `dnafrag` (
   `codon_table_id` tinyint(3) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`dnafrag_id`),
   UNIQUE KEY `name` (`genome_db_id`,`name`)
-) ENGINE=MyISAM AUTO_INCREMENT=200000000000001 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=200000000000001 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dnafrag_alt_region` (
   `dnafrag_id` bigint(20) unsigned NOT NULL,
   `dnafrag_start` int(10) unsigned NOT NULL,
   `dnafrag_end` int(10) unsigned NOT NULL,
   PRIMARY KEY (`dnafrag_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag_region` (
   `synteny_region_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -71,7 +71,7 @@ CREATE TABLE `dnafrag_region` (
   `dnafrag_strand` tinyint(4) NOT NULL DEFAULT '0',
   KEY `synteny` (`synteny_region_id`,`dnafrag_id`),
   KEY `synteny_reversed` (`dnafrag_id`,`synteny_region_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `exon_boundaries` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -82,7 +82,7 @@ CREATE TABLE `exon_boundaries` (
   `left_over` tinyint(3) unsigned NOT NULL DEFAULT '0',
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
   `external_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -97,7 +97,7 @@ CREATE TABLE `external_db` (
   `description` text,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family` (
   `family_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -110,7 +110,7 @@ CREATE TABLE `family` (
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `description` (`description`(255))
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family_member` (
   `family_id` int(10) unsigned NOT NULL,
@@ -118,7 +118,7 @@ CREATE TABLE `family_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`family_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align` (
   `gene_align_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -126,7 +126,7 @@ CREATE TABLE `gene_align` (
   `aln_method` varchar(40) NOT NULL DEFAULT '',
   `aln_length` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_align_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align_member` (
   `gene_align_id` int(10) unsigned NOT NULL,
@@ -134,7 +134,7 @@ CREATE TABLE `gene_align_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`gene_align_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -161,7 +161,7 @@ CREATE TABLE `gene_member` (
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_hom_stats` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -173,7 +173,7 @@ CREATE TABLE `gene_member_hom_stats` (
   `paralogues` int(10) unsigned NOT NULL DEFAULT '0',
   `homoeologues` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_member_id`,`collection`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_qc` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -186,7 +186,7 @@ CREATE TABLE `gene_member_qc` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_node` (
   `node_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -200,7 +200,7 @@ CREATE TABLE `gene_tree_node` (
   KEY `parent_id` (`parent_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `root_id_left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_attr` (
   `node_id` int(10) unsigned NOT NULL,
@@ -210,7 +210,7 @@ CREATE TABLE `gene_tree_node_attr` (
   `duplication_confidence_score` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`node_id`),
   KEY `species_tree_node_id` (`species_tree_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_tag` (
   `node_id` int(10) unsigned NOT NULL,
@@ -218,14 +218,14 @@ CREATE TABLE `gene_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_object_store` (
   `root_id` int(10) unsigned NOT NULL,
   `data_label` varchar(255) NOT NULL,
   `compressed_data` mediumblob NOT NULL,
   PRIMARY KEY (`root_id`,`data_label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root` (
   `root_id` int(10) unsigned NOT NULL,
@@ -244,7 +244,7 @@ CREATE TABLE `gene_tree_root` (
   KEY `gene_align_id` (`gene_align_id`),
   KEY `ref_root_id` (`ref_root_id`),
   KEY `tree_type` (`tree_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_attr` (
   `root_id` int(10) unsigned NOT NULL,
@@ -274,7 +274,7 @@ CREATE TABLE `gene_tree_root_attr` (
   PRIMARY KEY (`root_id`),
   KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
   KEY `lca_node_id` (`lca_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_tag` (
   `root_id` int(10) unsigned NOT NULL,
@@ -282,7 +282,7 @@ CREATE TABLE `gene_tree_root_tag` (
   `value` mediumtext NOT NULL,
   KEY `root_id_tag` (`root_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_db` (
   `genome_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -301,7 +301,7 @@ CREATE TABLE `genome_db` (
   PRIMARY KEY (`genome_db_id`),
   UNIQUE KEY `name` (`name`,`assembly`,`genome_component`),
   KEY `taxon_id` (`taxon_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=143 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=143 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align` (
   `genomic_align_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -319,7 +319,7 @@ CREATE TABLE `genomic_align` (
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `dnafrag` (`dnafrag_id`,`method_link_species_set_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6010002016891 DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60;
+) ENGINE=MyISAM AUTO_INCREMENT=6010002016891 DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align_block` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -332,7 +332,7 @@ CREATE TABLE `genomic_align_block` (
   `direction` tinyint(3) unsigned DEFAULT NULL,
   PRIMARY KEY (`genomic_align_block_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6010001008446 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=6010001008446 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `genomic_align_tree` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -346,7 +346,7 @@ CREATE TABLE `genomic_align_tree` (
   PRIMARY KEY (`node_id`),
   KEY `parent_id` (`parent_id`),
   KEY `left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=5990003608527 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=5990003608527 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `hmm_annot` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -354,7 +354,7 @@ CREATE TABLE `hmm_annot` (
   `evalue` float DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_curated_annot` (
   `seq_member_stable_id` varchar(40) NOT NULL,
@@ -364,7 +364,7 @@ CREATE TABLE `hmm_curated_annot` (
   `reason` mediumtext,
   PRIMARY KEY (`seq_member_stable_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_profile` (
   `model_id` varchar(40) NOT NULL,
@@ -373,7 +373,7 @@ CREATE TABLE `hmm_profile` (
   `compressed_profile` mediumblob,
   `consensus` mediumtext,
   PRIMARY KEY (`model_id`,`type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `homology` (
   `homology_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -396,7 +396,7 @@ CREATE TABLE `homology` (
   KEY `species_tree_node_id` (`species_tree_node_id`),
   KEY `gene_tree_node_id` (`gene_tree_node_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `homology_member` (
   `homology_id` bigint(20) unsigned NOT NULL,
@@ -409,7 +409,7 @@ CREATE TABLE `homology_member` (
   PRIMARY KEY (`homology_id`,`gene_member_id`),
   KEY `gene_member_id` (`gene_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
   `mapping_session_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -420,7 +420,7 @@ CREATE TABLE `mapping_session` (
   `prefix` char(4) NOT NULL,
   PRIMARY KEY (`mapping_session_id`),
   UNIQUE KEY `type` (`type`,`rel_from`,`rel_to`,`prefix`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `member_xref` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -428,7 +428,7 @@ CREATE TABLE `member_xref` (
   `external_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`gene_member_id`,`dbprimary_acc`,`external_db_id`),
   KEY `external_db_id` (`external_db_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -438,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=171 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=172 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -447,7 +447,7 @@ CREATE TABLE `method_link` (
   `display_name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`method_link_id`),
   UNIQUE KEY `type` (`type`)
-) ENGINE=MyISAM AUTO_INCREMENT=502 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=502 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set` (
   `method_link_species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -461,7 +461,7 @@ CREATE TABLE `method_link_species_set` (
   PRIMARY KEY (`method_link_species_set_id`),
   UNIQUE KEY `method_link_id` (`method_link_id`,`species_set_id`),
   KEY `species_set_id` (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=50041 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=50041 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set_attr` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -476,7 +476,7 @@ CREATE TABLE `method_link_species_set_attr` (
   `perc_orth_above_wga_thresh` float DEFAULT NULL,
   `threshold_on_ds` int(11) DEFAULT NULL,
   PRIMARY KEY (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `method_link_species_set_tag` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -484,16 +484,16 @@ CREATE TABLE `method_link_species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`method_link_species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_name` (
   `taxon_id` int(10) unsigned NOT NULL,
-  `name` varchar(255) NOT NULL,
+  `name` varchar(500) NOT NULL,
   `name_class` varchar(50) NOT NULL,
   KEY `taxon_id` (`taxon_id`),
   KEY `name` (`name`),
   KEY `name_class` (`name_class`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_node` (
   `taxon_id` int(10) unsigned NOT NULL,
@@ -508,7 +508,7 @@ CREATE TABLE `ncbi_taxa_node` (
   KEY `rank` (`rank`),
   KEY `left_index` (`left_index`),
   KEY `right_index` (`right_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `other_member_sequence` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -516,7 +516,7 @@ CREATE TABLE `other_member_sequence` (
   `length` int(10) unsigned NOT NULL,
   `sequence` mediumtext NOT NULL,
   PRIMARY KEY (`seq_member_id`,`seq_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `peptide_align_feature` (
   `peptide_align_feature_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -538,7 +538,7 @@ CREATE TABLE `peptide_align_feature` (
   `hit_rank` smallint(5) unsigned NOT NULL,
   `cigar_line` mediumtext,
   PRIMARY KEY (`peptide_align_feature_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -567,7 +567,7 @@ CREATE TABLE `seq_member` (
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member_projection` (
   `source_seq_member_id` int(10) unsigned NOT NULL,
@@ -575,14 +575,14 @@ CREATE TABLE `seq_member_projection` (
   `identity` float(5,2) DEFAULT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_seq_member_id` (`source_seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_member_projection_stable_id` (
   `target_seq_member_id` int(10) unsigned NOT NULL,
   `source_stable_id` varchar(128) NOT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_stable_id` (`source_stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `sequence` (
   `sequence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -591,14 +591,14 @@ CREATE TABLE `sequence` (
   `sequence` longtext NOT NULL,
   PRIMARY KEY (`sequence_id`),
   KEY `md5sum` (`md5sum`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set` (
   `species_set_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`species_set_id`,`genome_db_id`),
   KEY `genome_db_id` (`genome_db_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=35400 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=35400 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_set_header` (
   `species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -607,7 +607,7 @@ CREATE TABLE `species_set_header` (
   `first_release` smallint(6) DEFAULT NULL,
   `last_release` smallint(6) DEFAULT NULL,
   PRIMARY KEY (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=35400 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=35400 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set_tag` (
   `species_set_id` int(10) unsigned NOT NULL,
@@ -615,7 +615,7 @@ CREATE TABLE `species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -632,7 +632,7 @@ CREATE TABLE `species_tree_node` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `parent_id` (`parent_id`),
   KEY `root_id` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=501315726 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=501315726 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node_attr` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -662,7 +662,7 @@ CREATE TABLE `species_tree_node_attr` (
   `root_nb_genes` int(11) DEFAULT NULL,
   `root_nb_trees` int(11) DEFAULT NULL,
   PRIMARY KEY (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_tree_node_tag` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -670,7 +670,7 @@ CREATE TABLE `species_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_root` (
   `root_id` bigint(20) unsigned NOT NULL,
@@ -678,7 +678,7 @@ CREATE TABLE `species_tree_root` (
   `label` varchar(256) NOT NULL DEFAULT 'default',
   PRIMARY KEY (`root_id`),
   UNIQUE KEY `method_link_species_set_id` (`method_link_species_set_id`,`label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_history` (
   `mapping_session_id` int(10) unsigned NOT NULL,
@@ -688,12 +688,12 @@ CREATE TABLE `stable_id_history` (
   `version_to` int(10) unsigned DEFAULT NULL,
   `contribution` float DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`,`stable_id_from`,`stable_id_to`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `synteny_region` (
   `synteny_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `method_link_species_set_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`synteny_region_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=44726 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=44726 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 

--- a/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/meta.txt
@@ -90,3 +90,4 @@
 167	\N	patch	patch_108_109_f.sql|stable_id_key_again
 169	\N	patch	patch_109_110_a.sql|schema_version
 170	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
+171	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/meta.txt
@@ -90,4 +90,4 @@
 167	\N	patch	patch_108_109_f.sql|stable_id_key_again
 169	\N	patch	patch_109_110_a.sql|schema_version
 170	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
-171	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500
+171	\N	patch	patch_109_110_c.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_prepare_orth/table.sql
@@ -9,7 +9,7 @@ CREATE TABLE `CAFE_gene_family` (
   KEY `lca_id` (`lca_id`),
   KEY `root_id` (`root_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `CAFE_species_gene` (
   `cafe_gene_family_id` int(10) unsigned NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE `CAFE_species_gene` (
   `pvalue` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`cafe_gene_family_id`,`node_id`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `conservation_score` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL,
@@ -27,7 +27,7 @@ CREATE TABLE `conservation_score` (
   `expected_score` blob,
   `diff_score` blob,
   KEY `genomic_align_block_id` (`genomic_align_block_id`,`window_size`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `constrained_element` (
   `constrained_element_id` bigint(20) unsigned NOT NULL,
@@ -41,7 +41,7 @@ CREATE TABLE `constrained_element` (
   KEY `dnafrag_id` (`dnafrag_id`),
   KEY `constrained_element_id_idx` (`constrained_element_id`),
   KEY `mlssid_dfId_dfStart_dfEnd_idx` (`method_link_species_set_id`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag` (
   `dnafrag_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -54,14 +54,14 @@ CREATE TABLE `dnafrag` (
   `codon_table_id` tinyint(3) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`dnafrag_id`),
   UNIQUE KEY `name` (`genome_db_id`,`name`)
-) ENGINE=MyISAM AUTO_INCREMENT=200000000000001 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=200000000000001 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dnafrag_alt_region` (
   `dnafrag_id` bigint(20) unsigned NOT NULL,
   `dnafrag_start` int(10) unsigned NOT NULL,
   `dnafrag_end` int(10) unsigned NOT NULL,
   PRIMARY KEY (`dnafrag_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag_region` (
   `synteny_region_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -71,7 +71,7 @@ CREATE TABLE `dnafrag_region` (
   `dnafrag_strand` tinyint(4) NOT NULL DEFAULT '0',
   KEY `synteny` (`synteny_region_id`,`dnafrag_id`),
   KEY `synteny_reversed` (`dnafrag_id`,`synteny_region_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `exon_boundaries` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -82,7 +82,7 @@ CREATE TABLE `exon_boundaries` (
   `left_over` tinyint(3) unsigned NOT NULL DEFAULT '0',
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
   `external_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -97,7 +97,7 @@ CREATE TABLE `external_db` (
   `description` text,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family` (
   `family_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -110,7 +110,7 @@ CREATE TABLE `family` (
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `description` (`description`(255))
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family_member` (
   `family_id` int(10) unsigned NOT NULL,
@@ -118,7 +118,7 @@ CREATE TABLE `family_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`family_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align` (
   `gene_align_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -126,7 +126,7 @@ CREATE TABLE `gene_align` (
   `aln_method` varchar(40) NOT NULL DEFAULT '',
   `aln_length` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_align_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align_member` (
   `gene_align_id` int(10) unsigned NOT NULL,
@@ -134,7 +134,7 @@ CREATE TABLE `gene_align_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`gene_align_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -161,7 +161,7 @@ CREATE TABLE `gene_member` (
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=9284239 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM AUTO_INCREMENT=9284239 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_hom_stats` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -173,7 +173,7 @@ CREATE TABLE `gene_member_hom_stats` (
   `paralogues` int(10) unsigned NOT NULL DEFAULT '0',
   `homoeologues` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_member_id`,`collection`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_qc` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -186,7 +186,7 @@ CREATE TABLE `gene_member_qc` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_node` (
   `node_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -200,7 +200,7 @@ CREATE TABLE `gene_tree_node` (
   KEY `parent_id` (`parent_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `root_id_left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_attr` (
   `node_id` int(10) unsigned NOT NULL,
@@ -210,7 +210,7 @@ CREATE TABLE `gene_tree_node_attr` (
   `duplication_confidence_score` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`node_id`),
   KEY `species_tree_node_id` (`species_tree_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_tag` (
   `node_id` int(10) unsigned NOT NULL,
@@ -218,14 +218,14 @@ CREATE TABLE `gene_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_object_store` (
   `root_id` int(10) unsigned NOT NULL,
   `data_label` varchar(255) NOT NULL,
   `compressed_data` mediumblob NOT NULL,
   PRIMARY KEY (`root_id`,`data_label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root` (
   `root_id` int(10) unsigned NOT NULL,
@@ -244,7 +244,7 @@ CREATE TABLE `gene_tree_root` (
   KEY `gene_align_id` (`gene_align_id`),
   KEY `ref_root_id` (`ref_root_id`),
   KEY `tree_type` (`tree_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_attr` (
   `root_id` int(10) unsigned NOT NULL,
@@ -274,7 +274,7 @@ CREATE TABLE `gene_tree_root_attr` (
   PRIMARY KEY (`root_id`),
   KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
   KEY `lca_node_id` (`lca_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_tag` (
   `root_id` int(10) unsigned NOT NULL,
@@ -282,7 +282,7 @@ CREATE TABLE `gene_tree_root_tag` (
   `value` mediumtext NOT NULL,
   KEY `root_id_tag` (`root_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_db` (
   `genome_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -301,7 +301,7 @@ CREATE TABLE `genome_db` (
   PRIMARY KEY (`genome_db_id`),
   UNIQUE KEY `name` (`name`,`assembly`,`genome_component`),
   KEY `taxon_id` (`taxon_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=151 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=151 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align` (
   `genomic_align_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -319,7 +319,7 @@ CREATE TABLE `genomic_align` (
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `dnafrag` (`dnafrag_id`,`method_link_species_set_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6010002016891 DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60;
+) ENGINE=MyISAM AUTO_INCREMENT=6010002016891 DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align_block` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -332,7 +332,7 @@ CREATE TABLE `genomic_align_block` (
   `direction` tinyint(3) unsigned DEFAULT NULL,
   PRIMARY KEY (`genomic_align_block_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6010001008446 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=6010001008446 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `genomic_align_tree` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -346,7 +346,7 @@ CREATE TABLE `genomic_align_tree` (
   PRIMARY KEY (`node_id`),
   KEY `parent_id` (`parent_id`),
   KEY `left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=5990003608527 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=5990003608527 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `hmm_annot` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -354,7 +354,7 @@ CREATE TABLE `hmm_annot` (
   `evalue` float DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_curated_annot` (
   `seq_member_stable_id` varchar(40) NOT NULL,
@@ -364,7 +364,7 @@ CREATE TABLE `hmm_curated_annot` (
   `reason` mediumtext,
   PRIMARY KEY (`seq_member_stable_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_profile` (
   `model_id` varchar(40) NOT NULL,
@@ -373,7 +373,7 @@ CREATE TABLE `hmm_profile` (
   `compressed_profile` mediumblob,
   `consensus` mediumtext,
   PRIMARY KEY (`model_id`,`type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `homology` (
   `homology_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -396,7 +396,7 @@ CREATE TABLE `homology` (
   KEY `species_tree_node_id` (`species_tree_node_id`),
   KEY `gene_tree_node_id` (`gene_tree_node_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=104 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=104 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `homology_member` (
   `homology_id` bigint(20) unsigned NOT NULL,
@@ -409,7 +409,7 @@ CREATE TABLE `homology_member` (
   PRIMARY KEY (`homology_id`,`gene_member_id`),
   KEY `gene_member_id` (`gene_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
   `mapping_session_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -420,7 +420,7 @@ CREATE TABLE `mapping_session` (
   `prefix` char(4) NOT NULL,
   PRIMARY KEY (`mapping_session_id`),
   UNIQUE KEY `type` (`type`,`rel_from`,`rel_to`,`prefix`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `member_xref` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -428,7 +428,7 @@ CREATE TABLE `member_xref` (
   `external_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`gene_member_id`,`dbprimary_acc`,`external_db_id`),
   KEY `external_db_id` (`external_db_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -438,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=171 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=172 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -447,7 +447,7 @@ CREATE TABLE `method_link` (
   `display_name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`method_link_id`),
   UNIQUE KEY `type` (`type`)
-) ENGINE=MyISAM AUTO_INCREMENT=601 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=601 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set` (
   `method_link_species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -461,7 +461,7 @@ CREATE TABLE `method_link_species_set` (
   PRIMARY KEY (`method_link_species_set_id`),
   UNIQUE KEY `method_link_id` (`method_link_id`,`species_set_id`),
   KEY `species_set_id` (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=50977 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=50977 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set_attr` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -476,7 +476,7 @@ CREATE TABLE `method_link_species_set_attr` (
   `perc_orth_above_wga_thresh` float DEFAULT NULL,
   `threshold_on_ds` int(11) DEFAULT NULL,
   PRIMARY KEY (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `method_link_species_set_tag` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -484,16 +484,16 @@ CREATE TABLE `method_link_species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`method_link_species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_name` (
   `taxon_id` int(10) unsigned NOT NULL,
-  `name` varchar(255) NOT NULL,
+  `name` varchar(500) NOT NULL,
   `name_class` varchar(50) NOT NULL,
   KEY `taxon_id` (`taxon_id`),
   KEY `name` (`name`),
   KEY `name_class` (`name_class`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_node` (
   `taxon_id` int(10) unsigned NOT NULL,
@@ -508,7 +508,7 @@ CREATE TABLE `ncbi_taxa_node` (
   KEY `rank` (`rank`),
   KEY `left_index` (`left_index`),
   KEY `right_index` (`right_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `other_member_sequence` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -516,7 +516,7 @@ CREATE TABLE `other_member_sequence` (
   `length` int(10) unsigned NOT NULL,
   `sequence` mediumtext NOT NULL,
   PRIMARY KEY (`seq_member_id`,`seq_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `peptide_align_feature` (
   `peptide_align_feature_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -538,7 +538,7 @@ CREATE TABLE `peptide_align_feature` (
   `hit_rank` smallint(5) unsigned NOT NULL,
   `cigar_line` mediumtext,
   PRIMARY KEY (`peptide_align_feature_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -567,7 +567,7 @@ CREATE TABLE `seq_member` (
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=9688110 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM AUTO_INCREMENT=9688110 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member_projection` (
   `source_seq_member_id` int(10) unsigned NOT NULL,
@@ -575,14 +575,14 @@ CREATE TABLE `seq_member_projection` (
   `identity` float(5,2) DEFAULT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_seq_member_id` (`source_seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_member_projection_stable_id` (
   `target_seq_member_id` int(10) unsigned NOT NULL,
   `source_stable_id` varchar(128) NOT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_stable_id` (`source_stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `sequence` (
   `sequence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -591,14 +591,14 @@ CREATE TABLE `sequence` (
   `sequence` longtext NOT NULL,
   PRIMARY KEY (`sequence_id`),
   KEY `md5sum` (`md5sum`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set` (
   `species_set_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`species_set_id`,`genome_db_id`),
   KEY `genome_db_id` (`genome_db_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=35674 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=35674 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_set_header` (
   `species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -607,7 +607,7 @@ CREATE TABLE `species_set_header` (
   `first_release` smallint(6) DEFAULT NULL,
   `last_release` smallint(6) DEFAULT NULL,
   PRIMARY KEY (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=35674 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=35674 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set_tag` (
   `species_set_id` int(10) unsigned NOT NULL,
@@ -615,7 +615,7 @@ CREATE TABLE `species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -632,7 +632,7 @@ CREATE TABLE `species_tree_node` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `parent_id` (`parent_id`),
   KEY `root_id` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=501315726 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=501315726 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node_attr` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -662,7 +662,7 @@ CREATE TABLE `species_tree_node_attr` (
   `root_nb_genes` int(11) DEFAULT NULL,
   `root_nb_trees` int(11) DEFAULT NULL,
   PRIMARY KEY (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_tree_node_tag` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -670,7 +670,7 @@ CREATE TABLE `species_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_root` (
   `root_id` bigint(20) unsigned NOT NULL,
@@ -678,7 +678,7 @@ CREATE TABLE `species_tree_root` (
   `label` varchar(256) NOT NULL DEFAULT 'default',
   PRIMARY KEY (`root_id`),
   UNIQUE KEY `method_link_species_set_id` (`method_link_species_set_id`,`label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_history` (
   `mapping_session_id` int(10) unsigned NOT NULL,
@@ -688,12 +688,12 @@ CREATE TABLE `stable_id_history` (
   `version_to` int(10) unsigned DEFAULT NULL,
   `contribution` float DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`,`stable_id_from`,`stable_id_to`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `synteny_region` (
   `synteny_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `method_link_species_set_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`synteny_region_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=44726 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=44726 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 

--- a/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/meta.txt
@@ -90,3 +90,4 @@
 167	\N	patch	patch_108_109_f.sql|stable_id_key_again
 169	\N	patch	patch_109_110_a.sql|schema_version
 170	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
+171	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/meta.txt
@@ -90,4 +90,4 @@
 167	\N	patch	patch_108_109_f.sql|stable_id_key_again
 169	\N	patch	patch_109_110_a.sql|schema_version
 170	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
-171	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500
+171	\N	patch	patch_109_110_c.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_prev_orth_test/table.sql
@@ -9,7 +9,7 @@ CREATE TABLE `CAFE_gene_family` (
   KEY `lca_id` (`lca_id`),
   KEY `root_id` (`root_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `CAFE_species_gene` (
   `cafe_gene_family_id` int(10) unsigned NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE `CAFE_species_gene` (
   `pvalue` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`cafe_gene_family_id`,`node_id`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `conservation_score` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL,
@@ -27,7 +27,7 @@ CREATE TABLE `conservation_score` (
   `expected_score` blob,
   `diff_score` blob,
   KEY `genomic_align_block_id` (`genomic_align_block_id`,`window_size`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `constrained_element` (
   `constrained_element_id` bigint(20) unsigned NOT NULL,
@@ -41,7 +41,7 @@ CREATE TABLE `constrained_element` (
   KEY `dnafrag_id` (`dnafrag_id`),
   KEY `constrained_element_id_idx` (`constrained_element_id`),
   KEY `mlssid_dfId_dfStart_dfEnd_idx` (`method_link_species_set_id`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag` (
   `dnafrag_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -54,14 +54,14 @@ CREATE TABLE `dnafrag` (
   `codon_table_id` tinyint(3) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`dnafrag_id`),
   UNIQUE KEY `name` (`genome_db_id`,`name`)
-) ENGINE=MyISAM AUTO_INCREMENT=200000000000001 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=200000000000001 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dnafrag_alt_region` (
   `dnafrag_id` bigint(20) unsigned NOT NULL,
   `dnafrag_start` int(10) unsigned NOT NULL,
   `dnafrag_end` int(10) unsigned NOT NULL,
   PRIMARY KEY (`dnafrag_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag_region` (
   `synteny_region_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -71,7 +71,7 @@ CREATE TABLE `dnafrag_region` (
   `dnafrag_strand` tinyint(4) NOT NULL DEFAULT '0',
   KEY `synteny` (`synteny_region_id`,`dnafrag_id`),
   KEY `synteny_reversed` (`dnafrag_id`,`synteny_region_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `exon_boundaries` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -82,7 +82,7 @@ CREATE TABLE `exon_boundaries` (
   `left_over` tinyint(3) unsigned NOT NULL DEFAULT '0',
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
   `external_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -97,7 +97,7 @@ CREATE TABLE `external_db` (
   `description` text,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family` (
   `family_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -110,7 +110,7 @@ CREATE TABLE `family` (
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `description` (`description`(255))
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family_member` (
   `family_id` int(10) unsigned NOT NULL,
@@ -118,7 +118,7 @@ CREATE TABLE `family_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`family_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align` (
   `gene_align_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -126,7 +126,7 @@ CREATE TABLE `gene_align` (
   `aln_method` varchar(40) NOT NULL DEFAULT '',
   `aln_length` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_align_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align_member` (
   `gene_align_id` int(10) unsigned NOT NULL,
@@ -134,7 +134,7 @@ CREATE TABLE `gene_align_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`gene_align_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -161,7 +161,7 @@ CREATE TABLE `gene_member` (
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=9284239 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM AUTO_INCREMENT=9284239 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_hom_stats` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -173,7 +173,7 @@ CREATE TABLE `gene_member_hom_stats` (
   `paralogues` int(10) unsigned NOT NULL DEFAULT '0',
   `homoeologues` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_member_id`,`collection`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_qc` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -186,7 +186,7 @@ CREATE TABLE `gene_member_qc` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_node` (
   `node_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -200,7 +200,7 @@ CREATE TABLE `gene_tree_node` (
   KEY `parent_id` (`parent_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `root_id_left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_attr` (
   `node_id` int(10) unsigned NOT NULL,
@@ -210,7 +210,7 @@ CREATE TABLE `gene_tree_node_attr` (
   `duplication_confidence_score` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`node_id`),
   KEY `species_tree_node_id` (`species_tree_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_tag` (
   `node_id` int(10) unsigned NOT NULL,
@@ -218,14 +218,14 @@ CREATE TABLE `gene_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_object_store` (
   `root_id` int(10) unsigned NOT NULL,
   `data_label` varchar(255) NOT NULL,
   `compressed_data` mediumblob NOT NULL,
   PRIMARY KEY (`root_id`,`data_label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root` (
   `root_id` int(10) unsigned NOT NULL,
@@ -244,7 +244,7 @@ CREATE TABLE `gene_tree_root` (
   KEY `gene_align_id` (`gene_align_id`),
   KEY `ref_root_id` (`ref_root_id`),
   KEY `tree_type` (`tree_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_attr` (
   `root_id` int(10) unsigned NOT NULL,
@@ -274,7 +274,7 @@ CREATE TABLE `gene_tree_root_attr` (
   PRIMARY KEY (`root_id`),
   KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
   KEY `lca_node_id` (`lca_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_tag` (
   `root_id` int(10) unsigned NOT NULL,
@@ -282,7 +282,7 @@ CREATE TABLE `gene_tree_root_tag` (
   `value` mediumtext NOT NULL,
   KEY `root_id_tag` (`root_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_db` (
   `genome_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -301,7 +301,7 @@ CREATE TABLE `genome_db` (
   PRIMARY KEY (`genome_db_id`),
   UNIQUE KEY `name` (`name`,`assembly`,`genome_component`),
   KEY `taxon_id` (`taxon_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=151 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=151 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align` (
   `genomic_align_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -319,7 +319,7 @@ CREATE TABLE `genomic_align` (
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `dnafrag` (`dnafrag_id`,`method_link_species_set_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6010002016891 DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60;
+) ENGINE=MyISAM AUTO_INCREMENT=6010002016891 DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align_block` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -332,7 +332,7 @@ CREATE TABLE `genomic_align_block` (
   `direction` tinyint(3) unsigned DEFAULT NULL,
   PRIMARY KEY (`genomic_align_block_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6010001008446 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=6010001008446 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `genomic_align_tree` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -346,7 +346,7 @@ CREATE TABLE `genomic_align_tree` (
   PRIMARY KEY (`node_id`),
   KEY `parent_id` (`parent_id`),
   KEY `left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=5990003608527 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=5990003608527 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `hmm_annot` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -354,7 +354,7 @@ CREATE TABLE `hmm_annot` (
   `evalue` float DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_curated_annot` (
   `seq_member_stable_id` varchar(40) NOT NULL,
@@ -364,7 +364,7 @@ CREATE TABLE `hmm_curated_annot` (
   `reason` mediumtext,
   PRIMARY KEY (`seq_member_stable_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_profile` (
   `model_id` varchar(40) NOT NULL,
@@ -373,7 +373,7 @@ CREATE TABLE `hmm_profile` (
   `compressed_profile` mediumblob,
   `consensus` mediumtext,
   PRIMARY KEY (`model_id`,`type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `homology` (
   `homology_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -396,7 +396,7 @@ CREATE TABLE `homology` (
   KEY `species_tree_node_id` (`species_tree_node_id`),
   KEY `gene_tree_node_id` (`gene_tree_node_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=169 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=169 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `homology_member` (
   `homology_id` bigint(20) unsigned NOT NULL,
@@ -409,7 +409,7 @@ CREATE TABLE `homology_member` (
   PRIMARY KEY (`homology_id`,`gene_member_id`),
   KEY `gene_member_id` (`gene_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
   `mapping_session_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -420,7 +420,7 @@ CREATE TABLE `mapping_session` (
   `prefix` char(4) NOT NULL,
   PRIMARY KEY (`mapping_session_id`),
   UNIQUE KEY `type` (`type`,`rel_from`,`rel_to`,`prefix`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `member_xref` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -428,7 +428,7 @@ CREATE TABLE `member_xref` (
   `external_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`gene_member_id`,`dbprimary_acc`,`external_db_id`),
   KEY `external_db_id` (`external_db_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -438,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=171 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=172 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -447,7 +447,7 @@ CREATE TABLE `method_link` (
   `display_name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`method_link_id`),
   UNIQUE KEY `type` (`type`)
-) ENGINE=MyISAM AUTO_INCREMENT=601 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=601 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set` (
   `method_link_species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -461,7 +461,7 @@ CREATE TABLE `method_link_species_set` (
   PRIMARY KEY (`method_link_species_set_id`),
   UNIQUE KEY `method_link_id` (`method_link_id`,`species_set_id`),
   KEY `species_set_id` (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=50977 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=50977 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set_attr` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -476,7 +476,7 @@ CREATE TABLE `method_link_species_set_attr` (
   `perc_orth_above_wga_thresh` float DEFAULT NULL,
   `threshold_on_ds` int(11) DEFAULT NULL,
   PRIMARY KEY (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `method_link_species_set_tag` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -484,16 +484,16 @@ CREATE TABLE `method_link_species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`method_link_species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_name` (
   `taxon_id` int(10) unsigned NOT NULL,
-  `name` varchar(255) NOT NULL,
+  `name` varchar(500) NOT NULL,
   `name_class` varchar(50) NOT NULL,
   KEY `taxon_id` (`taxon_id`),
   KEY `name` (`name`),
   KEY `name_class` (`name_class`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_node` (
   `taxon_id` int(10) unsigned NOT NULL,
@@ -508,7 +508,7 @@ CREATE TABLE `ncbi_taxa_node` (
   KEY `rank` (`rank`),
   KEY `left_index` (`left_index`),
   KEY `right_index` (`right_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `other_member_sequence` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -516,7 +516,7 @@ CREATE TABLE `other_member_sequence` (
   `length` int(10) unsigned NOT NULL,
   `sequence` mediumtext NOT NULL,
   PRIMARY KEY (`seq_member_id`,`seq_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `peptide_align_feature` (
   `peptide_align_feature_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -538,7 +538,7 @@ CREATE TABLE `peptide_align_feature` (
   `hit_rank` smallint(5) unsigned NOT NULL,
   `cigar_line` mediumtext,
   PRIMARY KEY (`peptide_align_feature_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -567,7 +567,7 @@ CREATE TABLE `seq_member` (
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=9688110 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM AUTO_INCREMENT=9688110 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member_projection` (
   `source_seq_member_id` int(10) unsigned NOT NULL,
@@ -575,14 +575,14 @@ CREATE TABLE `seq_member_projection` (
   `identity` float(5,2) DEFAULT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_seq_member_id` (`source_seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_member_projection_stable_id` (
   `target_seq_member_id` int(10) unsigned NOT NULL,
   `source_stable_id` varchar(128) NOT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_stable_id` (`source_stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `sequence` (
   `sequence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -591,14 +591,14 @@ CREATE TABLE `sequence` (
   `sequence` longtext NOT NULL,
   PRIMARY KEY (`sequence_id`),
   KEY `md5sum` (`md5sum`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set` (
   `species_set_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`species_set_id`,`genome_db_id`),
   KEY `genome_db_id` (`genome_db_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=35674 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=35674 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_set_header` (
   `species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -607,7 +607,7 @@ CREATE TABLE `species_set_header` (
   `first_release` smallint(6) DEFAULT NULL,
   `last_release` smallint(6) DEFAULT NULL,
   PRIMARY KEY (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=35674 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=35674 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set_tag` (
   `species_set_id` int(10) unsigned NOT NULL,
@@ -615,7 +615,7 @@ CREATE TABLE `species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -632,7 +632,7 @@ CREATE TABLE `species_tree_node` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `parent_id` (`parent_id`),
   KEY `root_id` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=501315726 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=501315726 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node_attr` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -662,7 +662,7 @@ CREATE TABLE `species_tree_node_attr` (
   `root_nb_genes` int(11) DEFAULT NULL,
   `root_nb_trees` int(11) DEFAULT NULL,
   PRIMARY KEY (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_tree_node_tag` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -670,7 +670,7 @@ CREATE TABLE `species_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_root` (
   `root_id` bigint(20) unsigned NOT NULL,
@@ -678,7 +678,7 @@ CREATE TABLE `species_tree_root` (
   `label` varchar(256) NOT NULL DEFAULT 'default',
   PRIMARY KEY (`root_id`),
   UNIQUE KEY `method_link_species_set_id` (`method_link_species_set_id`,`label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_history` (
   `mapping_session_id` int(10) unsigned NOT NULL,
@@ -688,12 +688,12 @@ CREATE TABLE `stable_id_history` (
   `version_to` int(10) unsigned DEFAULT NULL,
   `contribution` float DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`,`stable_id_from`,`stable_id_to`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `synteny_region` (
   `synteny_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `method_link_species_set_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`synteny_region_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=44726 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=44726 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 

--- a/src/test_data/databases/orth_qm_wga/cc21_select_mlss/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_select_mlss/meta.txt
@@ -90,3 +90,4 @@
 167	\N	patch	patch_108_109_f.sql|stable_id_key_again
 169	\N	patch	patch_109_110_a.sql|schema_version
 170	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
+171	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/orth_qm_wga/cc21_select_mlss/meta.txt
+++ b/src/test_data/databases/orth_qm_wga/cc21_select_mlss/meta.txt
@@ -90,4 +90,4 @@
 167	\N	patch	patch_108_109_f.sql|stable_id_key_again
 169	\N	patch	patch_109_110_a.sql|schema_version
 170	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
-171	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500
+171	\N	patch	patch_109_110_c.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/orth_qm_wga/cc21_select_mlss/table.sql
+++ b/src/test_data/databases/orth_qm_wga/cc21_select_mlss/table.sql
@@ -9,7 +9,7 @@ CREATE TABLE `CAFE_gene_family` (
   KEY `lca_id` (`lca_id`),
   KEY `root_id` (`root_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `CAFE_species_gene` (
   `cafe_gene_family_id` int(10) unsigned NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE `CAFE_species_gene` (
   `pvalue` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`cafe_gene_family_id`,`node_id`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `conservation_score` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL,
@@ -27,7 +27,7 @@ CREATE TABLE `conservation_score` (
   `expected_score` blob,
   `diff_score` blob,
   KEY `genomic_align_block_id` (`genomic_align_block_id`,`window_size`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `constrained_element` (
   `constrained_element_id` bigint(20) unsigned NOT NULL,
@@ -41,7 +41,7 @@ CREATE TABLE `constrained_element` (
   KEY `dnafrag_id` (`dnafrag_id`),
   KEY `constrained_element_id_idx` (`constrained_element_id`),
   KEY `mlssid_dfId_dfStart_dfEnd_idx` (`method_link_species_set_id`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag` (
   `dnafrag_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -54,14 +54,14 @@ CREATE TABLE `dnafrag` (
   `codon_table_id` tinyint(3) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`dnafrag_id`),
   UNIQUE KEY `name` (`genome_db_id`,`name`)
-) ENGINE=MyISAM AUTO_INCREMENT=200000000000001 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=200000000000001 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dnafrag_alt_region` (
   `dnafrag_id` bigint(20) unsigned NOT NULL,
   `dnafrag_start` int(10) unsigned NOT NULL,
   `dnafrag_end` int(10) unsigned NOT NULL,
   PRIMARY KEY (`dnafrag_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag_region` (
   `synteny_region_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -71,7 +71,7 @@ CREATE TABLE `dnafrag_region` (
   `dnafrag_strand` tinyint(4) NOT NULL DEFAULT '0',
   KEY `synteny` (`synteny_region_id`,`dnafrag_id`),
   KEY `synteny_reversed` (`dnafrag_id`,`synteny_region_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `exon_boundaries` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -82,7 +82,7 @@ CREATE TABLE `exon_boundaries` (
   `left_over` tinyint(3) unsigned NOT NULL DEFAULT '0',
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
   `external_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -97,7 +97,7 @@ CREATE TABLE `external_db` (
   `description` text,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family` (
   `family_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -110,7 +110,7 @@ CREATE TABLE `family` (
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `description` (`description`(255))
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family_member` (
   `family_id` int(10) unsigned NOT NULL,
@@ -118,7 +118,7 @@ CREATE TABLE `family_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`family_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align` (
   `gene_align_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -126,7 +126,7 @@ CREATE TABLE `gene_align` (
   `aln_method` varchar(40) NOT NULL DEFAULT '',
   `aln_length` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_align_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align_member` (
   `gene_align_id` int(10) unsigned NOT NULL,
@@ -134,7 +134,7 @@ CREATE TABLE `gene_align_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`gene_align_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -161,7 +161,7 @@ CREATE TABLE `gene_member` (
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_hom_stats` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -173,7 +173,7 @@ CREATE TABLE `gene_member_hom_stats` (
   `paralogues` int(10) unsigned NOT NULL DEFAULT '0',
   `homoeologues` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_member_id`,`collection`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_qc` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -186,7 +186,7 @@ CREATE TABLE `gene_member_qc` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_node` (
   `node_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -200,7 +200,7 @@ CREATE TABLE `gene_tree_node` (
   KEY `parent_id` (`parent_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `root_id_left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_attr` (
   `node_id` int(10) unsigned NOT NULL,
@@ -210,7 +210,7 @@ CREATE TABLE `gene_tree_node_attr` (
   `duplication_confidence_score` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`node_id`),
   KEY `species_tree_node_id` (`species_tree_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_tag` (
   `node_id` int(10) unsigned NOT NULL,
@@ -218,14 +218,14 @@ CREATE TABLE `gene_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_object_store` (
   `root_id` int(10) unsigned NOT NULL,
   `data_label` varchar(255) NOT NULL,
   `compressed_data` mediumblob NOT NULL,
   PRIMARY KEY (`root_id`,`data_label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root` (
   `root_id` int(10) unsigned NOT NULL,
@@ -244,7 +244,7 @@ CREATE TABLE `gene_tree_root` (
   KEY `gene_align_id` (`gene_align_id`),
   KEY `ref_root_id` (`ref_root_id`),
   KEY `tree_type` (`tree_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_attr` (
   `root_id` int(10) unsigned NOT NULL,
@@ -274,7 +274,7 @@ CREATE TABLE `gene_tree_root_attr` (
   PRIMARY KEY (`root_id`),
   KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
   KEY `lca_node_id` (`lca_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_tag` (
   `root_id` int(10) unsigned NOT NULL,
@@ -282,7 +282,7 @@ CREATE TABLE `gene_tree_root_tag` (
   `value` mediumtext NOT NULL,
   KEY `root_id_tag` (`root_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_db` (
   `genome_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -301,7 +301,7 @@ CREATE TABLE `genome_db` (
   PRIMARY KEY (`genome_db_id`),
   UNIQUE KEY `name` (`name`,`assembly`,`genome_component`),
   KEY `taxon_id` (`taxon_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=151 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=151 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align` (
   `genomic_align_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -319,7 +319,7 @@ CREATE TABLE `genomic_align` (
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `dnafrag` (`dnafrag_id`,`method_link_species_set_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6010002016891 DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60;
+) ENGINE=MyISAM AUTO_INCREMENT=6010002016891 DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align_block` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -332,7 +332,7 @@ CREATE TABLE `genomic_align_block` (
   `direction` tinyint(3) unsigned DEFAULT NULL,
   PRIMARY KEY (`genomic_align_block_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6010001008446 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=6010001008446 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `genomic_align_tree` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -346,7 +346,7 @@ CREATE TABLE `genomic_align_tree` (
   PRIMARY KEY (`node_id`),
   KEY `parent_id` (`parent_id`),
   KEY `left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=5990003608527 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=5990003608527 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `hmm_annot` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -354,7 +354,7 @@ CREATE TABLE `hmm_annot` (
   `evalue` float DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_curated_annot` (
   `seq_member_stable_id` varchar(40) NOT NULL,
@@ -364,7 +364,7 @@ CREATE TABLE `hmm_curated_annot` (
   `reason` mediumtext,
   PRIMARY KEY (`seq_member_stable_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_profile` (
   `model_id` varchar(40) NOT NULL,
@@ -373,7 +373,7 @@ CREATE TABLE `hmm_profile` (
   `compressed_profile` mediumblob,
   `consensus` mediumtext,
   PRIMARY KEY (`model_id`,`type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `homology` (
   `homology_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -396,7 +396,7 @@ CREATE TABLE `homology` (
   KEY `species_tree_node_id` (`species_tree_node_id`),
   KEY `gene_tree_node_id` (`gene_tree_node_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `homology_member` (
   `homology_id` bigint(20) unsigned NOT NULL,
@@ -409,7 +409,7 @@ CREATE TABLE `homology_member` (
   PRIMARY KEY (`homology_id`,`gene_member_id`),
   KEY `gene_member_id` (`gene_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
   `mapping_session_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -420,7 +420,7 @@ CREATE TABLE `mapping_session` (
   `prefix` char(4) NOT NULL,
   PRIMARY KEY (`mapping_session_id`),
   UNIQUE KEY `type` (`type`,`rel_from`,`rel_to`,`prefix`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `member_xref` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -428,7 +428,7 @@ CREATE TABLE `member_xref` (
   `external_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`gene_member_id`,`dbprimary_acc`,`external_db_id`),
   KEY `external_db_id` (`external_db_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -438,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=171 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=172 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -447,7 +447,7 @@ CREATE TABLE `method_link` (
   `display_name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`method_link_id`),
   UNIQUE KEY `type` (`type`)
-) ENGINE=MyISAM AUTO_INCREMENT=502 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=502 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set` (
   `method_link_species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -461,7 +461,7 @@ CREATE TABLE `method_link_species_set` (
   PRIMARY KEY (`method_link_species_set_id`),
   UNIQUE KEY `method_link_id` (`method_link_id`,`species_set_id`),
   KEY `species_set_id` (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=50041 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=50041 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set_attr` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -476,7 +476,7 @@ CREATE TABLE `method_link_species_set_attr` (
   `perc_orth_above_wga_thresh` float DEFAULT NULL,
   `threshold_on_ds` int(11) DEFAULT NULL,
   PRIMARY KEY (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `method_link_species_set_tag` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -484,16 +484,16 @@ CREATE TABLE `method_link_species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`method_link_species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_name` (
   `taxon_id` int(10) unsigned NOT NULL,
-  `name` varchar(255) NOT NULL,
+  `name` varchar(500) NOT NULL,
   `name_class` varchar(50) NOT NULL,
   KEY `taxon_id` (`taxon_id`),
   KEY `name` (`name`),
   KEY `name_class` (`name_class`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_node` (
   `taxon_id` int(10) unsigned NOT NULL,
@@ -508,7 +508,7 @@ CREATE TABLE `ncbi_taxa_node` (
   KEY `rank` (`rank`),
   KEY `left_index` (`left_index`),
   KEY `right_index` (`right_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `other_member_sequence` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -516,7 +516,7 @@ CREATE TABLE `other_member_sequence` (
   `length` int(10) unsigned NOT NULL,
   `sequence` mediumtext NOT NULL,
   PRIMARY KEY (`seq_member_id`,`seq_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `peptide_align_feature` (
   `peptide_align_feature_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -538,7 +538,7 @@ CREATE TABLE `peptide_align_feature` (
   `hit_rank` smallint(5) unsigned NOT NULL,
   `cigar_line` mediumtext,
   PRIMARY KEY (`peptide_align_feature_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -567,7 +567,7 @@ CREATE TABLE `seq_member` (
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member_projection` (
   `source_seq_member_id` int(10) unsigned NOT NULL,
@@ -575,14 +575,14 @@ CREATE TABLE `seq_member_projection` (
   `identity` float(5,2) DEFAULT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_seq_member_id` (`source_seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_member_projection_stable_id` (
   `target_seq_member_id` int(10) unsigned NOT NULL,
   `source_stable_id` varchar(128) NOT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_stable_id` (`source_stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `sequence` (
   `sequence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -591,14 +591,14 @@ CREATE TABLE `sequence` (
   `sequence` longtext NOT NULL,
   PRIMARY KEY (`sequence_id`),
   KEY `md5sum` (`md5sum`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set` (
   `species_set_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`species_set_id`,`genome_db_id`),
   KEY `genome_db_id` (`genome_db_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=35715 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=35715 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_set_header` (
   `species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -607,7 +607,7 @@ CREATE TABLE `species_set_header` (
   `first_release` smallint(6) DEFAULT NULL,
   `last_release` smallint(6) DEFAULT NULL,
   PRIMARY KEY (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=35715 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=35715 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set_tag` (
   `species_set_id` int(10) unsigned NOT NULL,
@@ -615,7 +615,7 @@ CREATE TABLE `species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -632,7 +632,7 @@ CREATE TABLE `species_tree_node` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `parent_id` (`parent_id`),
   KEY `root_id` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=501315726 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=501315726 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node_attr` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -662,7 +662,7 @@ CREATE TABLE `species_tree_node_attr` (
   `root_nb_genes` int(11) DEFAULT NULL,
   `root_nb_trees` int(11) DEFAULT NULL,
   PRIMARY KEY (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_tree_node_tag` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -670,7 +670,7 @@ CREATE TABLE `species_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_root` (
   `root_id` bigint(20) unsigned NOT NULL,
@@ -678,7 +678,7 @@ CREATE TABLE `species_tree_root` (
   `label` varchar(256) NOT NULL DEFAULT 'default',
   PRIMARY KEY (`root_id`),
   UNIQUE KEY `method_link_species_set_id` (`method_link_species_set_id`,`label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_history` (
   `mapping_session_id` int(10) unsigned NOT NULL,
@@ -688,12 +688,12 @@ CREATE TABLE `stable_id_history` (
   `version_to` int(10) unsigned DEFAULT NULL,
   `contribution` float DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`,`stable_id_from`,`stable_id_to`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `synteny_region` (
   `synteny_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `method_link_species_set_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`synteny_region_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=44726 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=44726 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 

--- a/src/test_data/databases/parse_pair_aligner_conf/meta.txt
+++ b/src/test_data/databases/parse_pair_aligner_conf/meta.txt
@@ -56,4 +56,4 @@
 74	\N	patch	patch_108_109_f.sql|stable_id_key_again
 76	\N	patch	patch_109_110_a.sql|schema_version
 77	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
-78	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500
+78	\N	patch	patch_109_110_c.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/parse_pair_aligner_conf/meta.txt
+++ b/src/test_data/databases/parse_pair_aligner_conf/meta.txt
@@ -56,3 +56,4 @@
 74	\N	patch	patch_108_109_f.sql|stable_id_key_again
 76	\N	patch	patch_109_110_a.sql|schema_version
 77	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
+78	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/parse_pair_aligner_conf/table.sql
+++ b/src/test_data/databases/parse_pair_aligner_conf/table.sql
@@ -9,7 +9,7 @@ CREATE TABLE `CAFE_gene_family` (
   KEY `lca_id` (`lca_id`),
   KEY `root_id` (`root_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `CAFE_species_gene` (
   `cafe_gene_family_id` int(10) unsigned NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE `CAFE_species_gene` (
   `pvalue` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`cafe_gene_family_id`,`node_id`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `conservation_score` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL,
@@ -27,7 +27,7 @@ CREATE TABLE `conservation_score` (
   `expected_score` blob,
   `diff_score` blob,
   KEY `genomic_align_block_id` (`genomic_align_block_id`,`window_size`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `constrained_element` (
   `constrained_element_id` bigint(20) unsigned NOT NULL,
@@ -41,7 +41,7 @@ CREATE TABLE `constrained_element` (
   KEY `dnafrag_id` (`dnafrag_id`),
   KEY `constrained_element_id_idx` (`constrained_element_id`),
   KEY `mlssid_dfId_dfStart_dfEnd_idx` (`method_link_species_set_id`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag` (
   `dnafrag_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -54,14 +54,14 @@ CREATE TABLE `dnafrag` (
   `codon_table_id` tinyint(3) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`dnafrag_id`),
   UNIQUE KEY `name` (`genome_db_id`,`name`)
-) ENGINE=MyISAM AUTO_INCREMENT=200000000000001 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=200000000000001 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dnafrag_alt_region` (
   `dnafrag_id` bigint(20) unsigned NOT NULL,
   `dnafrag_start` int(10) unsigned NOT NULL,
   `dnafrag_end` int(10) unsigned NOT NULL,
   PRIMARY KEY (`dnafrag_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag_region` (
   `synteny_region_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -71,7 +71,7 @@ CREATE TABLE `dnafrag_region` (
   `dnafrag_strand` tinyint(4) NOT NULL DEFAULT '0',
   KEY `synteny` (`synteny_region_id`,`dnafrag_id`),
   KEY `synteny_reversed` (`dnafrag_id`,`synteny_region_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `exon_boundaries` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -82,7 +82,7 @@ CREATE TABLE `exon_boundaries` (
   `left_over` tinyint(3) unsigned NOT NULL DEFAULT '0',
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
   `external_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -97,7 +97,7 @@ CREATE TABLE `external_db` (
   `description` text,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family` (
   `family_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -110,7 +110,7 @@ CREATE TABLE `family` (
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `description` (`description`(255))
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family_member` (
   `family_id` int(10) unsigned NOT NULL,
@@ -118,7 +118,7 @@ CREATE TABLE `family_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`family_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align` (
   `gene_align_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -126,7 +126,7 @@ CREATE TABLE `gene_align` (
   `aln_method` varchar(40) NOT NULL DEFAULT '',
   `aln_length` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_align_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align_member` (
   `gene_align_id` int(10) unsigned NOT NULL,
@@ -134,7 +134,7 @@ CREATE TABLE `gene_align_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`gene_align_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -161,7 +161,7 @@ CREATE TABLE `gene_member` (
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_hom_stats` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -173,7 +173,7 @@ CREATE TABLE `gene_member_hom_stats` (
   `paralogues` int(10) unsigned NOT NULL DEFAULT '0',
   `homoeologues` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_member_id`,`collection`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_qc` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -186,7 +186,7 @@ CREATE TABLE `gene_member_qc` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_node` (
   `node_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -200,7 +200,7 @@ CREATE TABLE `gene_tree_node` (
   KEY `parent_id` (`parent_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `root_id_left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_attr` (
   `node_id` int(10) unsigned NOT NULL,
@@ -210,7 +210,7 @@ CREATE TABLE `gene_tree_node_attr` (
   `duplication_confidence_score` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`node_id`),
   KEY `species_tree_node_id` (`species_tree_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_tag` (
   `node_id` int(10) unsigned NOT NULL,
@@ -218,14 +218,14 @@ CREATE TABLE `gene_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_object_store` (
   `root_id` int(10) unsigned NOT NULL,
   `data_label` varchar(255) NOT NULL,
   `compressed_data` mediumblob NOT NULL,
   PRIMARY KEY (`root_id`,`data_label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root` (
   `root_id` int(10) unsigned NOT NULL,
@@ -244,7 +244,7 @@ CREATE TABLE `gene_tree_root` (
   KEY `gene_align_id` (`gene_align_id`),
   KEY `ref_root_id` (`ref_root_id`),
   KEY `tree_type` (`tree_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_attr` (
   `root_id` int(10) unsigned NOT NULL,
@@ -274,7 +274,7 @@ CREATE TABLE `gene_tree_root_attr` (
   PRIMARY KEY (`root_id`),
   KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
   KEY `lca_node_id` (`lca_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_tag` (
   `root_id` int(10) unsigned NOT NULL,
@@ -282,7 +282,7 @@ CREATE TABLE `gene_tree_root_tag` (
   `value` mediumtext NOT NULL,
   KEY `root_id_tag` (`root_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_db` (
   `genome_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -301,7 +301,7 @@ CREATE TABLE `genome_db` (
   PRIMARY KEY (`genome_db_id`),
   UNIQUE KEY `name` (`name`,`assembly`,`genome_component`),
   KEY `taxon_id` (`taxon_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=222 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=222 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align` (
   `genomic_align_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -319,7 +319,7 @@ CREATE TABLE `genomic_align` (
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `dnafrag` (`dnafrag_id`,`method_link_species_set_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6010002016891 DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60;
+) ENGINE=MyISAM AUTO_INCREMENT=6010002016891 DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align_block` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -332,7 +332,7 @@ CREATE TABLE `genomic_align_block` (
   `direction` tinyint(3) unsigned DEFAULT NULL,
   PRIMARY KEY (`genomic_align_block_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6010001008446 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=6010001008446 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `genomic_align_tree` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -346,7 +346,7 @@ CREATE TABLE `genomic_align_tree` (
   PRIMARY KEY (`node_id`),
   KEY `parent_id` (`parent_id`),
   KEY `left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=5990003608527 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=5990003608527 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `hmm_annot` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -354,7 +354,7 @@ CREATE TABLE `hmm_annot` (
   `evalue` float DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_curated_annot` (
   `seq_member_stable_id` varchar(40) NOT NULL,
@@ -364,7 +364,7 @@ CREATE TABLE `hmm_curated_annot` (
   `reason` mediumtext,
   PRIMARY KEY (`seq_member_stable_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_profile` (
   `model_id` varchar(40) NOT NULL,
@@ -373,7 +373,7 @@ CREATE TABLE `hmm_profile` (
   `compressed_profile` mediumblob,
   `consensus` mediumtext,
   PRIMARY KEY (`model_id`,`type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `homology` (
   `homology_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -396,7 +396,7 @@ CREATE TABLE `homology` (
   KEY `species_tree_node_id` (`species_tree_node_id`),
   KEY `gene_tree_node_id` (`gene_tree_node_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `homology_member` (
   `homology_id` bigint(20) unsigned NOT NULL,
@@ -409,7 +409,7 @@ CREATE TABLE `homology_member` (
   PRIMARY KEY (`homology_id`,`gene_member_id`),
   KEY `gene_member_id` (`gene_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
   `mapping_session_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -420,7 +420,7 @@ CREATE TABLE `mapping_session` (
   `prefix` char(4) NOT NULL,
   PRIMARY KEY (`mapping_session_id`),
   UNIQUE KEY `type` (`type`,`rel_from`,`rel_to`,`prefix`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `member_xref` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -428,7 +428,7 @@ CREATE TABLE `member_xref` (
   `external_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`gene_member_id`,`dbprimary_acc`,`external_db_id`),
   KEY `external_db_id` (`external_db_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -438,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=78 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=79 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -447,7 +447,7 @@ CREATE TABLE `method_link` (
   `display_name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`method_link_id`),
   UNIQUE KEY `type` (`type`)
-) ENGINE=MyISAM AUTO_INCREMENT=502 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=502 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set` (
   `method_link_species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -461,7 +461,7 @@ CREATE TABLE `method_link_species_set` (
   PRIMARY KEY (`method_link_species_set_id`),
   UNIQUE KEY `method_link_id` (`method_link_id`,`species_set_id`),
   KEY `species_set_id` (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=50041 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=50041 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set_attr` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -476,7 +476,7 @@ CREATE TABLE `method_link_species_set_attr` (
   `perc_orth_above_wga_thresh` float DEFAULT NULL,
   `threshold_on_ds` int(11) DEFAULT NULL,
   PRIMARY KEY (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `method_link_species_set_tag` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -484,16 +484,16 @@ CREATE TABLE `method_link_species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`method_link_species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_name` (
   `taxon_id` int(10) unsigned NOT NULL,
-  `name` varchar(255) NOT NULL,
+  `name` varchar(500) NOT NULL,
   `name_class` varchar(50) NOT NULL,
   KEY `taxon_id` (`taxon_id`),
   KEY `name` (`name`),
   KEY `name_class` (`name_class`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_node` (
   `taxon_id` int(10) unsigned NOT NULL,
@@ -508,7 +508,7 @@ CREATE TABLE `ncbi_taxa_node` (
   KEY `rank` (`rank`),
   KEY `left_index` (`left_index`),
   KEY `right_index` (`right_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `other_member_sequence` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -516,7 +516,7 @@ CREATE TABLE `other_member_sequence` (
   `length` int(10) unsigned NOT NULL,
   `sequence` mediumtext NOT NULL,
   PRIMARY KEY (`seq_member_id`,`seq_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `peptide_align_feature` (
   `peptide_align_feature_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -538,7 +538,7 @@ CREATE TABLE `peptide_align_feature` (
   `hit_rank` smallint(5) unsigned NOT NULL,
   `cigar_line` mediumtext,
   PRIMARY KEY (`peptide_align_feature_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -567,7 +567,7 @@ CREATE TABLE `seq_member` (
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member_projection` (
   `source_seq_member_id` int(10) unsigned NOT NULL,
@@ -575,14 +575,14 @@ CREATE TABLE `seq_member_projection` (
   `identity` float(5,2) DEFAULT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_seq_member_id` (`source_seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_member_projection_stable_id` (
   `target_seq_member_id` int(10) unsigned NOT NULL,
   `source_stable_id` varchar(128) NOT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_stable_id` (`source_stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `sequence` (
   `sequence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -591,14 +591,14 @@ CREATE TABLE `sequence` (
   `sequence` longtext NOT NULL,
   PRIMARY KEY (`sequence_id`),
   KEY `md5sum` (`md5sum`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set` (
   `species_set_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`species_set_id`,`genome_db_id`),
   KEY `genome_db_id` (`genome_db_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=34883 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=34883 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_set_header` (
   `species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -607,7 +607,7 @@ CREATE TABLE `species_set_header` (
   `first_release` smallint(6) DEFAULT NULL,
   `last_release` smallint(6) DEFAULT NULL,
   PRIMARY KEY (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=34884 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=34884 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set_tag` (
   `species_set_id` int(10) unsigned NOT NULL,
@@ -615,7 +615,7 @@ CREATE TABLE `species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -632,7 +632,7 @@ CREATE TABLE `species_tree_node` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `parent_id` (`parent_id`),
   KEY `root_id` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=501315726 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=501315726 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node_attr` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -662,7 +662,7 @@ CREATE TABLE `species_tree_node_attr` (
   `root_nb_genes` int(11) DEFAULT NULL,
   `root_nb_trees` int(11) DEFAULT NULL,
   PRIMARY KEY (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_tree_node_tag` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -670,7 +670,7 @@ CREATE TABLE `species_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_root` (
   `root_id` bigint(20) unsigned NOT NULL,
@@ -678,7 +678,7 @@ CREATE TABLE `species_tree_root` (
   `label` varchar(256) NOT NULL DEFAULT 'default',
   PRIMARY KEY (`root_id`),
   UNIQUE KEY `method_link_species_set_id` (`method_link_species_set_id`,`label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_history` (
   `mapping_session_id` int(10) unsigned NOT NULL,
@@ -688,12 +688,12 @@ CREATE TABLE `stable_id_history` (
   `version_to` int(10) unsigned DEFAULT NULL,
   `contribution` float DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`,`stable_id_from`,`stable_id_to`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `synteny_region` (
   `synteny_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `method_link_species_set_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`synteny_region_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=44726 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=44726 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 

--- a/src/test_data/databases/test_master/meta.txt
+++ b/src/test_data/databases/test_master/meta.txt
@@ -129,3 +129,4 @@
 169	\N	patch	patch_108_109_f.sql|stable_id_key_again
 171	\N	patch	patch_109_110_a.sql|schema_version
 172	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
+173	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/test_master/meta.txt
+++ b/src/test_data/databases/test_master/meta.txt
@@ -129,4 +129,4 @@
 169	\N	patch	patch_108_109_f.sql|stable_id_key_again
 171	\N	patch	patch_109_110_a.sql|schema_version
 172	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
-173	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500
+173	\N	patch	patch_109_110_c.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/test_master/table.sql
+++ b/src/test_data/databases/test_master/table.sql
@@ -9,7 +9,7 @@ CREATE TABLE `CAFE_gene_family` (
   KEY `lca_id` (`lca_id`),
   KEY `root_id` (`root_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `CAFE_species_gene` (
   `cafe_gene_family_id` int(10) unsigned NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE `CAFE_species_gene` (
   `pvalue` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`cafe_gene_family_id`,`node_id`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `conservation_score` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL,
@@ -27,7 +27,7 @@ CREATE TABLE `conservation_score` (
   `expected_score` blob,
   `diff_score` blob,
   KEY `genomic_align_block_id` (`genomic_align_block_id`,`window_size`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `constrained_element` (
   `constrained_element_id` bigint(20) unsigned NOT NULL,
@@ -41,7 +41,7 @@ CREATE TABLE `constrained_element` (
   KEY `dnafrag_id` (`dnafrag_id`),
   KEY `constrained_element_id_idx` (`constrained_element_id`),
   KEY `mlssid_dfId_dfStart_dfEnd_idx` (`method_link_species_set_id`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag` (
   `dnafrag_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -54,14 +54,14 @@ CREATE TABLE `dnafrag` (
   `codon_table_id` tinyint(3) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`dnafrag_id`),
   UNIQUE KEY `name` (`genome_db_id`,`name`)
-) ENGINE=MyISAM AUTO_INCREMENT=200000000000001 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=200000000000001 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dnafrag_alt_region` (
   `dnafrag_id` bigint(20) unsigned NOT NULL,
   `dnafrag_start` int(10) unsigned NOT NULL,
   `dnafrag_end` int(10) unsigned NOT NULL,
   PRIMARY KEY (`dnafrag_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag_region` (
   `synteny_region_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -71,7 +71,7 @@ CREATE TABLE `dnafrag_region` (
   `dnafrag_strand` tinyint(4) NOT NULL DEFAULT '0',
   KEY `synteny` (`synteny_region_id`,`dnafrag_id`),
   KEY `synteny_reversed` (`dnafrag_id`,`synteny_region_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `exon_boundaries` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -82,7 +82,7 @@ CREATE TABLE `exon_boundaries` (
   `left_over` tinyint(3) unsigned NOT NULL DEFAULT '0',
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
   `external_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -97,7 +97,7 @@ CREATE TABLE `external_db` (
   `description` text,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family` (
   `family_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -110,7 +110,7 @@ CREATE TABLE `family` (
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `description` (`description`(255))
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family_member` (
   `family_id` int(10) unsigned NOT NULL,
@@ -118,7 +118,7 @@ CREATE TABLE `family_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`family_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align` (
   `gene_align_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -126,7 +126,7 @@ CREATE TABLE `gene_align` (
   `aln_method` varchar(40) NOT NULL DEFAULT '',
   `aln_length` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_align_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align_member` (
   `gene_align_id` int(10) unsigned NOT NULL,
@@ -134,7 +134,7 @@ CREATE TABLE `gene_align_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`gene_align_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -161,7 +161,7 @@ CREATE TABLE `gene_member` (
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_hom_stats` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -173,7 +173,7 @@ CREATE TABLE `gene_member_hom_stats` (
   `paralogues` int(10) unsigned NOT NULL DEFAULT '0',
   `homoeologues` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_member_id`,`collection`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_qc` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -186,7 +186,7 @@ CREATE TABLE `gene_member_qc` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_node` (
   `node_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -200,7 +200,7 @@ CREATE TABLE `gene_tree_node` (
   KEY `parent_id` (`parent_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `root_id_left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_attr` (
   `node_id` int(10) unsigned NOT NULL,
@@ -210,7 +210,7 @@ CREATE TABLE `gene_tree_node_attr` (
   `duplication_confidence_score` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`node_id`),
   KEY `species_tree_node_id` (`species_tree_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_tag` (
   `node_id` int(10) unsigned NOT NULL,
@@ -218,14 +218,14 @@ CREATE TABLE `gene_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_object_store` (
   `root_id` int(10) unsigned NOT NULL,
   `data_label` varchar(255) NOT NULL,
   `compressed_data` mediumblob NOT NULL,
   PRIMARY KEY (`root_id`,`data_label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root` (
   `root_id` int(10) unsigned NOT NULL,
@@ -244,7 +244,7 @@ CREATE TABLE `gene_tree_root` (
   KEY `gene_align_id` (`gene_align_id`),
   KEY `ref_root_id` (`ref_root_id`),
   KEY `tree_type` (`tree_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_attr` (
   `root_id` int(10) unsigned NOT NULL,
@@ -274,7 +274,7 @@ CREATE TABLE `gene_tree_root_attr` (
   PRIMARY KEY (`root_id`),
   KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
   KEY `lca_node_id` (`lca_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_tag` (
   `root_id` int(10) unsigned NOT NULL,
@@ -282,7 +282,7 @@ CREATE TABLE `gene_tree_root_tag` (
   `value` mediumtext NOT NULL,
   KEY `root_id_tag` (`root_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_db` (
   `genome_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -301,7 +301,7 @@ CREATE TABLE `genome_db` (
   PRIMARY KEY (`genome_db_id`),
   UNIQUE KEY `name` (`name`,`assembly`,`genome_component`),
   KEY `taxon_id` (`taxon_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=141 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=141 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align` (
   `genomic_align_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -319,7 +319,7 @@ CREATE TABLE `genomic_align` (
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `dnafrag` (`dnafrag_id`,`method_link_species_set_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6010002016891 DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60;
+) ENGINE=MyISAM AUTO_INCREMENT=6010002016891 DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align_block` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -332,7 +332,7 @@ CREATE TABLE `genomic_align_block` (
   `direction` tinyint(3) unsigned DEFAULT NULL,
   PRIMARY KEY (`genomic_align_block_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6010001008446 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=6010001008446 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `genomic_align_tree` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -346,7 +346,7 @@ CREATE TABLE `genomic_align_tree` (
   PRIMARY KEY (`node_id`),
   KEY `parent_id` (`parent_id`),
   KEY `left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=5990003608527 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=5990003608527 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `hmm_annot` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -354,7 +354,7 @@ CREATE TABLE `hmm_annot` (
   `evalue` float DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_curated_annot` (
   `seq_member_stable_id` varchar(40) NOT NULL,
@@ -364,7 +364,7 @@ CREATE TABLE `hmm_curated_annot` (
   `reason` mediumtext,
   PRIMARY KEY (`seq_member_stable_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_profile` (
   `model_id` varchar(40) NOT NULL,
@@ -373,7 +373,7 @@ CREATE TABLE `hmm_profile` (
   `compressed_profile` mediumblob,
   `consensus` mediumtext,
   PRIMARY KEY (`model_id`,`type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `homology` (
   `homology_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -396,7 +396,7 @@ CREATE TABLE `homology` (
   KEY `species_tree_node_id` (`species_tree_node_id`),
   KEY `gene_tree_node_id` (`gene_tree_node_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `homology_member` (
   `homology_id` bigint(20) unsigned NOT NULL,
@@ -409,7 +409,7 @@ CREATE TABLE `homology_member` (
   PRIMARY KEY (`homology_id`,`gene_member_id`),
   KEY `gene_member_id` (`gene_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
   `mapping_session_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -420,7 +420,7 @@ CREATE TABLE `mapping_session` (
   `prefix` char(4) NOT NULL,
   PRIMARY KEY (`mapping_session_id`),
   UNIQUE KEY `type` (`type`,`rel_from`,`rel_to`,`prefix`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `member_xref` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -428,7 +428,7 @@ CREATE TABLE `member_xref` (
   `external_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`gene_member_id`,`dbprimary_acc`,`external_db_id`),
   KEY `external_db_id` (`external_db_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -438,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=173 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=174 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -447,7 +447,7 @@ CREATE TABLE `method_link` (
   `display_name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`method_link_id`),
   UNIQUE KEY `type` (`type`)
-) ENGINE=MyISAM AUTO_INCREMENT=502 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=502 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set` (
   `method_link_species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -461,7 +461,7 @@ CREATE TABLE `method_link_species_set` (
   PRIMARY KEY (`method_link_species_set_id`),
   UNIQUE KEY `method_link_id` (`method_link_id`,`species_set_id`),
   KEY `species_set_id` (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=123457 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=123457 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set_attr` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -476,7 +476,7 @@ CREATE TABLE `method_link_species_set_attr` (
   `perc_orth_above_wga_thresh` float DEFAULT NULL,
   `threshold_on_ds` int(11) DEFAULT NULL,
   PRIMARY KEY (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `method_link_species_set_tag` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -484,16 +484,16 @@ CREATE TABLE `method_link_species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`method_link_species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_name` (
   `taxon_id` int(10) unsigned NOT NULL,
-  `name` varchar(255) NOT NULL,
+  `name` varchar(500) NOT NULL,
   `name_class` varchar(50) NOT NULL,
   KEY `taxon_id` (`taxon_id`),
   KEY `name` (`name`),
   KEY `name_class` (`name_class`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_node` (
   `taxon_id` int(10) unsigned NOT NULL,
@@ -508,7 +508,7 @@ CREATE TABLE `ncbi_taxa_node` (
   KEY `rank` (`rank`),
   KEY `left_index` (`left_index`),
   KEY `right_index` (`right_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `other_member_sequence` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -516,7 +516,7 @@ CREATE TABLE `other_member_sequence` (
   `length` int(10) unsigned NOT NULL,
   `sequence` mediumtext NOT NULL,
   PRIMARY KEY (`seq_member_id`,`seq_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `peptide_align_feature` (
   `peptide_align_feature_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -538,7 +538,7 @@ CREATE TABLE `peptide_align_feature` (
   `hit_rank` smallint(5) unsigned NOT NULL,
   `cigar_line` mediumtext,
   PRIMARY KEY (`peptide_align_feature_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -567,7 +567,7 @@ CREATE TABLE `seq_member` (
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member_projection` (
   `source_seq_member_id` int(10) unsigned NOT NULL,
@@ -575,14 +575,14 @@ CREATE TABLE `seq_member_projection` (
   `identity` float(5,2) DEFAULT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_seq_member_id` (`source_seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_member_projection_stable_id` (
   `target_seq_member_id` int(10) unsigned NOT NULL,
   `source_stable_id` varchar(128) NOT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_stable_id` (`source_stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `sequence` (
   `sequence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -591,14 +591,14 @@ CREATE TABLE `sequence` (
   `sequence` longtext NOT NULL,
   PRIMARY KEY (`sequence_id`),
   KEY `md5sum` (`md5sum`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set` (
   `species_set_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`species_set_id`,`genome_db_id`),
   KEY `genome_db_id` (`genome_db_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=34883 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=34883 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_set_header` (
   `species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -607,7 +607,7 @@ CREATE TABLE `species_set_header` (
   `first_release` smallint(6) DEFAULT NULL,
   `last_release` smallint(6) DEFAULT NULL,
   PRIMARY KEY (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=34884 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=34884 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set_tag` (
   `species_set_id` int(10) unsigned NOT NULL,
@@ -615,7 +615,7 @@ CREATE TABLE `species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -632,7 +632,7 @@ CREATE TABLE `species_tree_node` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `parent_id` (`parent_id`),
   KEY `root_id` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=501315726 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=501315726 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node_attr` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -662,7 +662,7 @@ CREATE TABLE `species_tree_node_attr` (
   `root_nb_genes` int(11) DEFAULT NULL,
   `root_nb_trees` int(11) DEFAULT NULL,
   PRIMARY KEY (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_tree_node_tag` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -670,7 +670,7 @@ CREATE TABLE `species_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_root` (
   `root_id` bigint(20) unsigned NOT NULL,
@@ -678,7 +678,7 @@ CREATE TABLE `species_tree_root` (
   `label` varchar(256) NOT NULL DEFAULT 'default',
   PRIMARY KEY (`root_id`),
   UNIQUE KEY `method_link_species_set_id` (`method_link_species_set_id`,`label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_history` (
   `mapping_session_id` int(10) unsigned NOT NULL,
@@ -688,12 +688,12 @@ CREATE TABLE `stable_id_history` (
   `version_to` int(10) unsigned DEFAULT NULL,
   `contribution` float DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`,`stable_id_from`,`stable_id_to`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `synteny_region` (
   `synteny_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `method_link_species_set_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`synteny_region_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=44726 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=44726 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 

--- a/src/test_data/databases/update_homologies_test/meta.txt
+++ b/src/test_data/databases/update_homologies_test/meta.txt
@@ -31,4 +31,4 @@
 39	\N	patch	patch_108_109_f.sql|stable_id_key_again
 41	\N	patch	patch_109_110_a.sql|schema_version
 42	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
-43	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500
+43	\N	patch	patch_109_110_c.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/update_homologies_test/meta.txt
+++ b/src/test_data/databases/update_homologies_test/meta.txt
@@ -31,3 +31,4 @@
 39	\N	patch	patch_108_109_f.sql|stable_id_key_again
 41	\N	patch	patch_109_110_a.sql|schema_version
 42	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
+43	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/update_homologies_test/table.sql
+++ b/src/test_data/databases/update_homologies_test/table.sql
@@ -9,7 +9,7 @@ CREATE TABLE `CAFE_gene_family` (
   KEY `lca_id` (`lca_id`),
   KEY `root_id` (`root_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `CAFE_species_gene` (
   `cafe_gene_family_id` int(10) unsigned NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE `CAFE_species_gene` (
   `pvalue` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`cafe_gene_family_id`,`node_id`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `conservation_score` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL,
@@ -27,7 +27,7 @@ CREATE TABLE `conservation_score` (
   `expected_score` blob,
   `diff_score` blob,
   KEY `genomic_align_block_id` (`genomic_align_block_id`,`window_size`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `constrained_element` (
   `constrained_element_id` bigint(20) unsigned NOT NULL,
@@ -41,7 +41,7 @@ CREATE TABLE `constrained_element` (
   KEY `dnafrag_id` (`dnafrag_id`),
   KEY `constrained_element_id_idx` (`constrained_element_id`),
   KEY `mlssid_dfId_dfStart_dfEnd_idx` (`method_link_species_set_id`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag` (
   `dnafrag_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -54,14 +54,14 @@ CREATE TABLE `dnafrag` (
   `codon_table_id` tinyint(3) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`dnafrag_id`),
   UNIQUE KEY `name` (`genome_db_id`,`name`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dnafrag_alt_region` (
   `dnafrag_id` bigint(20) unsigned NOT NULL,
   `dnafrag_start` int(10) unsigned NOT NULL,
   `dnafrag_end` int(10) unsigned NOT NULL,
   PRIMARY KEY (`dnafrag_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag_region` (
   `synteny_region_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -71,7 +71,7 @@ CREATE TABLE `dnafrag_region` (
   `dnafrag_strand` tinyint(4) NOT NULL DEFAULT '0',
   KEY `synteny` (`synteny_region_id`,`dnafrag_id`),
   KEY `synteny_reversed` (`dnafrag_id`,`synteny_region_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `exon_boundaries` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -82,7 +82,7 @@ CREATE TABLE `exon_boundaries` (
   `left_over` tinyint(3) unsigned NOT NULL DEFAULT '0',
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
   `external_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -97,7 +97,7 @@ CREATE TABLE `external_db` (
   `description` text,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family` (
   `family_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -110,7 +110,7 @@ CREATE TABLE `family` (
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `description` (`description`(255))
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family_member` (
   `family_id` int(10) unsigned NOT NULL,
@@ -118,7 +118,7 @@ CREATE TABLE `family_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`family_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align` (
   `gene_align_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -126,7 +126,7 @@ CREATE TABLE `gene_align` (
   `aln_method` varchar(40) NOT NULL DEFAULT '',
   `aln_length` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_align_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align_member` (
   `gene_align_id` int(10) unsigned NOT NULL,
@@ -134,7 +134,7 @@ CREATE TABLE `gene_align_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`gene_align_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -161,7 +161,7 @@ CREATE TABLE `gene_member` (
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_hom_stats` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -173,7 +173,7 @@ CREATE TABLE `gene_member_hom_stats` (
   `paralogues` int(10) unsigned NOT NULL DEFAULT '0',
   `homoeologues` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_member_id`,`collection`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_qc` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -186,7 +186,7 @@ CREATE TABLE `gene_member_qc` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_node` (
   `node_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -200,7 +200,7 @@ CREATE TABLE `gene_tree_node` (
   KEY `parent_id` (`parent_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `root_id_left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_attr` (
   `node_id` int(10) unsigned NOT NULL,
@@ -210,7 +210,7 @@ CREATE TABLE `gene_tree_node_attr` (
   `duplication_confidence_score` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`node_id`),
   KEY `species_tree_node_id` (`species_tree_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_tag` (
   `node_id` int(10) unsigned NOT NULL,
@@ -218,14 +218,14 @@ CREATE TABLE `gene_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_object_store` (
   `root_id` int(10) unsigned NOT NULL,
   `data_label` varchar(255) NOT NULL,
   `compressed_data` mediumblob NOT NULL,
   PRIMARY KEY (`root_id`,`data_label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root` (
   `root_id` int(10) unsigned NOT NULL,
@@ -244,7 +244,7 @@ CREATE TABLE `gene_tree_root` (
   KEY `gene_align_id` (`gene_align_id`),
   KEY `ref_root_id` (`ref_root_id`),
   KEY `tree_type` (`tree_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_attr` (
   `root_id` int(10) unsigned NOT NULL,
@@ -274,7 +274,7 @@ CREATE TABLE `gene_tree_root_attr` (
   PRIMARY KEY (`root_id`),
   KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
   KEY `lca_node_id` (`lca_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_tag` (
   `root_id` int(10) unsigned NOT NULL,
@@ -282,7 +282,7 @@ CREATE TABLE `gene_tree_root_tag` (
   `value` mediumtext NOT NULL,
   KEY `root_id_tag` (`root_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_db` (
   `genome_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -301,7 +301,7 @@ CREATE TABLE `genome_db` (
   PRIMARY KEY (`genome_db_id`),
   UNIQUE KEY `name` (`name`,`assembly`,`genome_component`),
   KEY `taxon_id` (`taxon_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align` (
   `genomic_align_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -319,7 +319,7 @@ CREATE TABLE `genomic_align` (
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `dnafrag` (`dnafrag_id`,`method_link_species_set_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align_block` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -332,7 +332,7 @@ CREATE TABLE `genomic_align_block` (
   `direction` tinyint(3) unsigned DEFAULT NULL,
   PRIMARY KEY (`genomic_align_block_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `genomic_align_tree` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -346,7 +346,7 @@ CREATE TABLE `genomic_align_tree` (
   PRIMARY KEY (`node_id`),
   KEY `parent_id` (`parent_id`),
   KEY `left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `hmm_annot` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -354,7 +354,7 @@ CREATE TABLE `hmm_annot` (
   `evalue` float DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_curated_annot` (
   `seq_member_stable_id` varchar(40) NOT NULL,
@@ -364,7 +364,7 @@ CREATE TABLE `hmm_curated_annot` (
   `reason` mediumtext,
   PRIMARY KEY (`seq_member_stable_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_profile` (
   `model_id` varchar(40) NOT NULL,
@@ -373,7 +373,7 @@ CREATE TABLE `hmm_profile` (
   `compressed_profile` mediumblob,
   `consensus` mediumtext,
   PRIMARY KEY (`model_id`,`type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `homology` (
   `homology_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -396,7 +396,7 @@ CREATE TABLE `homology` (
   KEY `species_tree_node_id` (`species_tree_node_id`),
   KEY `gene_tree_node_id` (`gene_tree_node_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `homology_member` (
   `homology_id` bigint(20) unsigned NOT NULL,
@@ -409,7 +409,7 @@ CREATE TABLE `homology_member` (
   PRIMARY KEY (`homology_id`,`gene_member_id`),
   KEY `gene_member_id` (`gene_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
   `mapping_session_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -420,7 +420,7 @@ CREATE TABLE `mapping_session` (
   `prefix` char(4) NOT NULL,
   PRIMARY KEY (`mapping_session_id`),
   UNIQUE KEY `type` (`type`,`rel_from`,`rel_to`,`prefix`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `member_xref` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -428,7 +428,7 @@ CREATE TABLE `member_xref` (
   `external_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`gene_member_id`,`dbprimary_acc`,`external_db_id`),
   KEY `external_db_id` (`external_db_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -438,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=43 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=44 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -447,7 +447,7 @@ CREATE TABLE `method_link` (
   `display_name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`method_link_id`),
   UNIQUE KEY `type` (`type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set` (
   `method_link_species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -461,7 +461,7 @@ CREATE TABLE `method_link_species_set` (
   PRIMARY KEY (`method_link_species_set_id`),
   UNIQUE KEY `method_link_id` (`method_link_id`,`species_set_id`),
   KEY `species_set_id` (`species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set_attr` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -476,7 +476,7 @@ CREATE TABLE `method_link_species_set_attr` (
   `perc_orth_above_wga_thresh` float DEFAULT NULL,
   `threshold_on_ds` int(11) DEFAULT NULL,
   PRIMARY KEY (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `method_link_species_set_tag` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -484,16 +484,16 @@ CREATE TABLE `method_link_species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`method_link_species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_name` (
   `taxon_id` int(10) unsigned NOT NULL,
-  `name` varchar(255) NOT NULL,
+  `name` varchar(500) NOT NULL,
   `name_class` varchar(50) NOT NULL,
   KEY `taxon_id` (`taxon_id`),
   KEY `name` (`name`),
   KEY `name_class` (`name_class`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_node` (
   `taxon_id` int(10) unsigned NOT NULL,
@@ -508,7 +508,7 @@ CREATE TABLE `ncbi_taxa_node` (
   KEY `rank` (`rank`),
   KEY `left_index` (`left_index`),
   KEY `right_index` (`right_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `other_member_sequence` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -516,7 +516,7 @@ CREATE TABLE `other_member_sequence` (
   `length` int(10) unsigned NOT NULL,
   `sequence` mediumtext NOT NULL,
   PRIMARY KEY (`seq_member_id`,`seq_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `peptide_align_feature` (
   `peptide_align_feature_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -538,7 +538,7 @@ CREATE TABLE `peptide_align_feature` (
   `hit_rank` smallint(5) unsigned NOT NULL,
   `cigar_line` mediumtext,
   PRIMARY KEY (`peptide_align_feature_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -567,7 +567,7 @@ CREATE TABLE `seq_member` (
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member_projection` (
   `source_seq_member_id` int(10) unsigned NOT NULL,
@@ -575,14 +575,14 @@ CREATE TABLE `seq_member_projection` (
   `identity` float(5,2) DEFAULT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_seq_member_id` (`source_seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_member_projection_stable_id` (
   `target_seq_member_id` int(10) unsigned NOT NULL,
   `source_stable_id` varchar(128) NOT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_stable_id` (`source_stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `sequence` (
   `sequence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -591,14 +591,14 @@ CREATE TABLE `sequence` (
   `sequence` longtext NOT NULL,
   PRIMARY KEY (`sequence_id`),
   KEY `md5sum` (`md5sum`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set` (
   `species_set_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`species_set_id`,`genome_db_id`),
   KEY `genome_db_id` (`genome_db_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_set_header` (
   `species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -607,7 +607,7 @@ CREATE TABLE `species_set_header` (
   `first_release` smallint(6) DEFAULT NULL,
   `last_release` smallint(6) DEFAULT NULL,
   PRIMARY KEY (`species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set_tag` (
   `species_set_id` int(10) unsigned NOT NULL,
@@ -615,7 +615,7 @@ CREATE TABLE `species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -632,7 +632,7 @@ CREATE TABLE `species_tree_node` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `parent_id` (`parent_id`),
   KEY `root_id` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node_attr` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -662,7 +662,7 @@ CREATE TABLE `species_tree_node_attr` (
   `root_nb_genes` int(11) DEFAULT NULL,
   `root_nb_trees` int(11) DEFAULT NULL,
   PRIMARY KEY (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_tree_node_tag` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -670,7 +670,7 @@ CREATE TABLE `species_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_root` (
   `root_id` bigint(20) unsigned NOT NULL,
@@ -678,7 +678,7 @@ CREATE TABLE `species_tree_root` (
   `label` varchar(256) NOT NULL DEFAULT 'default',
   PRIMARY KEY (`root_id`),
   UNIQUE KEY `method_link_species_set_id` (`method_link_species_set_id`,`label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_history` (
   `mapping_session_id` int(10) unsigned NOT NULL,
@@ -688,12 +688,12 @@ CREATE TABLE `stable_id_history` (
   `version_to` int(10) unsigned DEFAULT NULL,
   `contribution` float DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`,`stable_id_from`,`stable_id_to`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `synteny_region` (
   `synteny_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `method_link_species_set_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`synteny_region_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 

--- a/src/test_data/databases/update_msa_test/meta.txt
+++ b/src/test_data/databases/update_msa_test/meta.txt
@@ -18,4 +18,4 @@
 20	\N	patch	patch_108_109_f.sql|stable_id_key_again
 22	\N	patch	patch_109_110_a.sql|schema_version
 23	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
-24	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500
+24	\N	patch	patch_109_110_c.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/update_msa_test/meta.txt
+++ b/src/test_data/databases/update_msa_test/meta.txt
@@ -18,3 +18,4 @@
 20	\N	patch	patch_108_109_f.sql|stable_id_key_again
 22	\N	patch	patch_109_110_a.sql|schema_version
 23	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
+24	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/update_msa_test/table.sql
+++ b/src/test_data/databases/update_msa_test/table.sql
@@ -9,7 +9,7 @@ CREATE TABLE `CAFE_gene_family` (
   KEY `lca_id` (`lca_id`),
   KEY `root_id` (`root_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `CAFE_species_gene` (
   `cafe_gene_family_id` int(10) unsigned NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE `CAFE_species_gene` (
   `pvalue` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`cafe_gene_family_id`,`node_id`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `conservation_score` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL,
@@ -27,7 +27,7 @@ CREATE TABLE `conservation_score` (
   `expected_score` blob,
   `diff_score` blob,
   KEY `genomic_align_block_id` (`genomic_align_block_id`,`window_size`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `constrained_element` (
   `constrained_element_id` bigint(20) unsigned NOT NULL,
@@ -41,7 +41,7 @@ CREATE TABLE `constrained_element` (
   KEY `dnafrag_id` (`dnafrag_id`),
   KEY `constrained_element_id_idx` (`constrained_element_id`),
   KEY `mlssid_dfId_dfStart_dfEnd_idx` (`method_link_species_set_id`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag` (
   `dnafrag_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -54,14 +54,14 @@ CREATE TABLE `dnafrag` (
   `codon_table_id` tinyint(3) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`dnafrag_id`),
   UNIQUE KEY `name` (`genome_db_id`,`name`)
-) ENGINE=MyISAM AUTO_INCREMENT=200000000000001 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=200000000000001 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dnafrag_alt_region` (
   `dnafrag_id` bigint(20) unsigned NOT NULL,
   `dnafrag_start` int(10) unsigned NOT NULL,
   `dnafrag_end` int(10) unsigned NOT NULL,
   PRIMARY KEY (`dnafrag_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag_region` (
   `synteny_region_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -71,7 +71,7 @@ CREATE TABLE `dnafrag_region` (
   `dnafrag_strand` tinyint(4) NOT NULL DEFAULT '0',
   KEY `synteny` (`synteny_region_id`,`dnafrag_id`),
   KEY `synteny_reversed` (`dnafrag_id`,`synteny_region_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `exon_boundaries` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -82,7 +82,7 @@ CREATE TABLE `exon_boundaries` (
   `left_over` tinyint(3) unsigned NOT NULL DEFAULT '0',
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
   `external_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -97,7 +97,7 @@ CREATE TABLE `external_db` (
   `description` text,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family` (
   `family_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -110,7 +110,7 @@ CREATE TABLE `family` (
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `description` (`description`(255))
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family_member` (
   `family_id` int(10) unsigned NOT NULL,
@@ -118,7 +118,7 @@ CREATE TABLE `family_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`family_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align` (
   `gene_align_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -126,7 +126,7 @@ CREATE TABLE `gene_align` (
   `aln_method` varchar(40) NOT NULL DEFAULT '',
   `aln_length` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_align_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align_member` (
   `gene_align_id` int(10) unsigned NOT NULL,
@@ -134,7 +134,7 @@ CREATE TABLE `gene_align_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`gene_align_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -161,7 +161,7 @@ CREATE TABLE `gene_member` (
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_hom_stats` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -173,7 +173,7 @@ CREATE TABLE `gene_member_hom_stats` (
   `paralogues` int(10) unsigned NOT NULL DEFAULT '0',
   `homoeologues` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_member_id`,`collection`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_qc` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -186,7 +186,7 @@ CREATE TABLE `gene_member_qc` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_node` (
   `node_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -200,7 +200,7 @@ CREATE TABLE `gene_tree_node` (
   KEY `parent_id` (`parent_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `root_id_left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_attr` (
   `node_id` int(10) unsigned NOT NULL,
@@ -210,7 +210,7 @@ CREATE TABLE `gene_tree_node_attr` (
   `duplication_confidence_score` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`node_id`),
   KEY `species_tree_node_id` (`species_tree_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_tag` (
   `node_id` int(10) unsigned NOT NULL,
@@ -218,14 +218,14 @@ CREATE TABLE `gene_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_object_store` (
   `root_id` int(10) unsigned NOT NULL,
   `data_label` varchar(255) NOT NULL,
   `compressed_data` mediumblob NOT NULL,
   PRIMARY KEY (`root_id`,`data_label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root` (
   `root_id` int(10) unsigned NOT NULL,
@@ -244,7 +244,7 @@ CREATE TABLE `gene_tree_root` (
   KEY `gene_align_id` (`gene_align_id`),
   KEY `ref_root_id` (`ref_root_id`),
   KEY `tree_type` (`tree_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_attr` (
   `root_id` int(10) unsigned NOT NULL,
@@ -274,7 +274,7 @@ CREATE TABLE `gene_tree_root_attr` (
   PRIMARY KEY (`root_id`),
   KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
   KEY `lca_node_id` (`lca_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_tag` (
   `root_id` int(10) unsigned NOT NULL,
@@ -282,7 +282,7 @@ CREATE TABLE `gene_tree_root_tag` (
   `value` mediumtext NOT NULL,
   KEY `root_id_tag` (`root_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_db` (
   `genome_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -301,7 +301,7 @@ CREATE TABLE `genome_db` (
   PRIMARY KEY (`genome_db_id`),
   UNIQUE KEY `name` (`name`,`assembly`,`genome_component`),
   KEY `taxon_id` (`taxon_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=141 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=141 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align` (
   `genomic_align_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -319,7 +319,7 @@ CREATE TABLE `genomic_align` (
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `dnafrag` (`dnafrag_id`,`method_link_species_set_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6010002016891 DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60;
+) ENGINE=MyISAM AUTO_INCREMENT=6010002016891 DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align_block` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -332,7 +332,7 @@ CREATE TABLE `genomic_align_block` (
   `direction` tinyint(3) unsigned DEFAULT NULL,
   PRIMARY KEY (`genomic_align_block_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6010001008446 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=6010001008446 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `genomic_align_tree` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -346,7 +346,7 @@ CREATE TABLE `genomic_align_tree` (
   PRIMARY KEY (`node_id`),
   KEY `parent_id` (`parent_id`),
   KEY `left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=5990003608527 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=5990003608527 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `hmm_annot` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -354,7 +354,7 @@ CREATE TABLE `hmm_annot` (
   `evalue` float DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_curated_annot` (
   `seq_member_stable_id` varchar(40) NOT NULL,
@@ -364,7 +364,7 @@ CREATE TABLE `hmm_curated_annot` (
   `reason` mediumtext,
   PRIMARY KEY (`seq_member_stable_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_profile` (
   `model_id` varchar(40) NOT NULL,
@@ -373,7 +373,7 @@ CREATE TABLE `hmm_profile` (
   `compressed_profile` mediumblob,
   `consensus` mediumtext,
   PRIMARY KEY (`model_id`,`type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `homology` (
   `homology_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -396,7 +396,7 @@ CREATE TABLE `homology` (
   KEY `species_tree_node_id` (`species_tree_node_id`),
   KEY `gene_tree_node_id` (`gene_tree_node_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `homology_member` (
   `homology_id` bigint(20) unsigned NOT NULL,
@@ -409,7 +409,7 @@ CREATE TABLE `homology_member` (
   PRIMARY KEY (`homology_id`,`gene_member_id`),
   KEY `gene_member_id` (`gene_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
   `mapping_session_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -420,7 +420,7 @@ CREATE TABLE `mapping_session` (
   `prefix` char(4) NOT NULL,
   PRIMARY KEY (`mapping_session_id`),
   UNIQUE KEY `type` (`type`,`rel_from`,`rel_to`,`prefix`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `member_xref` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -428,7 +428,7 @@ CREATE TABLE `member_xref` (
   `external_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`gene_member_id`,`dbprimary_acc`,`external_db_id`),
   KEY `external_db_id` (`external_db_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -438,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=24 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=25 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -447,7 +447,7 @@ CREATE TABLE `method_link` (
   `display_name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`method_link_id`),
   UNIQUE KEY `type` (`type`)
-) ENGINE=MyISAM AUTO_INCREMENT=502 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=502 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set` (
   `method_link_species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -461,7 +461,7 @@ CREATE TABLE `method_link_species_set` (
   PRIMARY KEY (`method_link_species_set_id`),
   UNIQUE KEY `method_link_id` (`method_link_id`,`species_set_id`),
   KEY `species_set_id` (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=123457 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=123457 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set_attr` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -476,7 +476,7 @@ CREATE TABLE `method_link_species_set_attr` (
   `perc_orth_above_wga_thresh` float DEFAULT NULL,
   `threshold_on_ds` int(11) DEFAULT NULL,
   PRIMARY KEY (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `method_link_species_set_tag` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -484,16 +484,16 @@ CREATE TABLE `method_link_species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`method_link_species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_name` (
   `taxon_id` int(10) unsigned NOT NULL,
-  `name` varchar(255) NOT NULL,
+  `name` varchar(500) NOT NULL,
   `name_class` varchar(50) NOT NULL,
   KEY `taxon_id` (`taxon_id`),
   KEY `name` (`name`),
   KEY `name_class` (`name_class`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_node` (
   `taxon_id` int(10) unsigned NOT NULL,
@@ -508,7 +508,7 @@ CREATE TABLE `ncbi_taxa_node` (
   KEY `rank` (`rank`),
   KEY `left_index` (`left_index`),
   KEY `right_index` (`right_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `other_member_sequence` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -516,7 +516,7 @@ CREATE TABLE `other_member_sequence` (
   `length` int(10) unsigned NOT NULL,
   `sequence` mediumtext NOT NULL,
   PRIMARY KEY (`seq_member_id`,`seq_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `peptide_align_feature` (
   `peptide_align_feature_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -538,7 +538,7 @@ CREATE TABLE `peptide_align_feature` (
   `hit_rank` smallint(5) unsigned NOT NULL,
   `cigar_line` mediumtext,
   PRIMARY KEY (`peptide_align_feature_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -567,7 +567,7 @@ CREATE TABLE `seq_member` (
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member_projection` (
   `source_seq_member_id` int(10) unsigned NOT NULL,
@@ -575,14 +575,14 @@ CREATE TABLE `seq_member_projection` (
   `identity` float(5,2) DEFAULT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_seq_member_id` (`source_seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_member_projection_stable_id` (
   `target_seq_member_id` int(10) unsigned NOT NULL,
   `source_stable_id` varchar(128) NOT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_stable_id` (`source_stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `sequence` (
   `sequence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -591,14 +591,14 @@ CREATE TABLE `sequence` (
   `sequence` longtext NOT NULL,
   PRIMARY KEY (`sequence_id`),
   KEY `md5sum` (`md5sum`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set` (
   `species_set_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`species_set_id`,`genome_db_id`),
   KEY `genome_db_id` (`genome_db_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=34883 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=34883 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_set_header` (
   `species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -607,7 +607,7 @@ CREATE TABLE `species_set_header` (
   `first_release` smallint(6) DEFAULT NULL,
   `last_release` smallint(6) DEFAULT NULL,
   PRIMARY KEY (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=34884 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=34884 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set_tag` (
   `species_set_id` int(10) unsigned NOT NULL,
@@ -615,7 +615,7 @@ CREATE TABLE `species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -632,7 +632,7 @@ CREATE TABLE `species_tree_node` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `parent_id` (`parent_id`),
   KEY `root_id` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=501315726 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=501315726 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node_attr` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -662,7 +662,7 @@ CREATE TABLE `species_tree_node_attr` (
   `root_nb_genes` int(11) DEFAULT NULL,
   `root_nb_trees` int(11) DEFAULT NULL,
   PRIMARY KEY (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_tree_node_tag` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -670,7 +670,7 @@ CREATE TABLE `species_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_root` (
   `root_id` bigint(20) unsigned NOT NULL,
@@ -678,7 +678,7 @@ CREATE TABLE `species_tree_root` (
   `label` varchar(256) NOT NULL DEFAULT 'default',
   PRIMARY KEY (`root_id`),
   UNIQUE KEY `method_link_species_set_id` (`method_link_species_set_id`,`label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_history` (
   `mapping_session_id` int(10) unsigned NOT NULL,
@@ -688,12 +688,12 @@ CREATE TABLE `stable_id_history` (
   `version_to` int(10) unsigned DEFAULT NULL,
   `contribution` float DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`,`stable_id_from`,`stable_id_to`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `synteny_region` (
   `synteny_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `method_link_species_set_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`synteny_region_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=44726 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=44726 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 

--- a/src/test_data/databases/vertebrates/meta.txt
+++ b/src/test_data/databases/vertebrates/meta.txt
@@ -129,3 +129,4 @@
 169	\N	patch	patch_108_109_f.sql|stable_id_key_again
 171	\N	patch	patch_109_110_a.sql|schema_version
 172	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
+173	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/vertebrates/meta.txt
+++ b/src/test_data/databases/vertebrates/meta.txt
@@ -129,4 +129,4 @@
 169	\N	patch	patch_108_109_f.sql|stable_id_key_again
 171	\N	patch	patch_109_110_a.sql|schema_version
 172	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
-173	\N	patch	patch_109_110_b.sql|ncbi_taxa_name_varchar500
+173	\N	patch	patch_109_110_c.sql|ncbi_taxa_name_varchar500

--- a/src/test_data/databases/vertebrates/table.sql
+++ b/src/test_data/databases/vertebrates/table.sql
@@ -9,7 +9,7 @@ CREATE TABLE `CAFE_gene_family` (
   KEY `lca_id` (`lca_id`),
   KEY `root_id` (`root_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `CAFE_species_gene` (
   `cafe_gene_family_id` int(10) unsigned NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE `CAFE_species_gene` (
   `pvalue` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`cafe_gene_family_id`,`node_id`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `conservation_score` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL,
@@ -27,7 +27,7 @@ CREATE TABLE `conservation_score` (
   `expected_score` blob,
   `diff_score` blob,
   KEY `genomic_align_block_id` (`genomic_align_block_id`,`window_size`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=15000000 AVG_ROW_LENGTH=841 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `constrained_element` (
   `constrained_element_id` bigint(20) unsigned NOT NULL,
@@ -41,7 +41,7 @@ CREATE TABLE `constrained_element` (
   KEY `dnafrag_id` (`dnafrag_id`),
   KEY `constrained_element_id_idx` (`constrained_element_id`),
   KEY `mlssid_dfId_dfStart_dfEnd_idx` (`method_link_species_set_id`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag` (
   `dnafrag_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -54,14 +54,14 @@ CREATE TABLE `dnafrag` (
   `codon_table_id` tinyint(3) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`dnafrag_id`),
   UNIQUE KEY `name` (`genome_db_id`,`name`)
-) ENGINE=MyISAM AUTO_INCREMENT=200000000000001 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=200000000000001 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dnafrag_alt_region` (
   `dnafrag_id` bigint(20) unsigned NOT NULL,
   `dnafrag_start` int(10) unsigned NOT NULL,
   `dnafrag_end` int(10) unsigned NOT NULL,
   PRIMARY KEY (`dnafrag_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dnafrag_region` (
   `synteny_region_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -71,7 +71,7 @@ CREATE TABLE `dnafrag_region` (
   `dnafrag_strand` tinyint(4) NOT NULL DEFAULT '0',
   KEY `synteny` (`synteny_region_id`,`dnafrag_id`),
   KEY `synteny_reversed` (`dnafrag_id`,`synteny_region_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `exon_boundaries` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -82,7 +82,7 @@ CREATE TABLE `exon_boundaries` (
   `left_over` tinyint(3) unsigned NOT NULL DEFAULT '0',
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
   `external_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -97,7 +97,7 @@ CREATE TABLE `external_db` (
   `description` text,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family` (
   `family_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -110,7 +110,7 @@ CREATE TABLE `family` (
   UNIQUE KEY `stable_id` (`stable_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `description` (`description`(255))
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `family_member` (
   `family_id` int(10) unsigned NOT NULL,
@@ -118,7 +118,7 @@ CREATE TABLE `family_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`family_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align` (
   `gene_align_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -126,7 +126,7 @@ CREATE TABLE `gene_align` (
   `aln_method` varchar(40) NOT NULL DEFAULT '',
   `aln_length` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_align_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_align_member` (
   `gene_align_id` int(10) unsigned NOT NULL,
@@ -134,7 +134,7 @@ CREATE TABLE `gene_align_member` (
   `cigar_line` mediumtext,
   PRIMARY KEY (`gene_align_id`,`seq_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -161,7 +161,7 @@ CREATE TABLE `gene_member` (
   KEY `biotype_dnafrag_id_start_end` (`biotype_group`,`dnafrag_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `genome_db_id_biotype` (`genome_db_id`,`biotype_group`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=915675731 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM AUTO_INCREMENT=915675731 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_hom_stats` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -173,7 +173,7 @@ CREATE TABLE `gene_member_hom_stats` (
   `paralogues` int(10) unsigned NOT NULL DEFAULT '0',
   `homoeologues` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`gene_member_id`,`collection`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_member_qc` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -186,7 +186,7 @@ CREATE TABLE `gene_member_qc` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `gene_member_id` (`gene_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_node` (
   `node_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -200,7 +200,7 @@ CREATE TABLE `gene_tree_node` (
   KEY `parent_id` (`parent_id`),
   KEY `seq_member_id` (`seq_member_id`),
   KEY `root_id_left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_attr` (
   `node_id` int(10) unsigned NOT NULL,
@@ -210,7 +210,7 @@ CREATE TABLE `gene_tree_node_attr` (
   `duplication_confidence_score` double(5,4) DEFAULT NULL,
   PRIMARY KEY (`node_id`),
   KEY `species_tree_node_id` (`species_tree_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `gene_tree_node_tag` (
   `node_id` int(10) unsigned NOT NULL,
@@ -218,14 +218,14 @@ CREATE TABLE `gene_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_object_store` (
   `root_id` int(10) unsigned NOT NULL,
   `data_label` varchar(255) NOT NULL,
   `compressed_data` mediumblob NOT NULL,
   PRIMARY KEY (`root_id`,`data_label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root` (
   `root_id` int(10) unsigned NOT NULL,
@@ -244,7 +244,7 @@ CREATE TABLE `gene_tree_root` (
   KEY `gene_align_id` (`gene_align_id`),
   KEY `ref_root_id` (`ref_root_id`),
   KEY `tree_type` (`tree_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_attr` (
   `root_id` int(10) unsigned NOT NULL,
@@ -274,7 +274,7 @@ CREATE TABLE `gene_tree_root_attr` (
   PRIMARY KEY (`root_id`),
   KEY `mcoffee_scores_gene_align_id` (`mcoffee_scores_gene_align_id`),
   KEY `lca_node_id` (`lca_node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_tree_root_tag` (
   `root_id` int(10) unsigned NOT NULL,
@@ -282,7 +282,7 @@ CREATE TABLE `gene_tree_root_tag` (
   `value` mediumtext NOT NULL,
   KEY `root_id_tag` (`root_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_db` (
   `genome_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -301,7 +301,7 @@ CREATE TABLE `genome_db` (
   PRIMARY KEY (`genome_db_id`),
   UNIQUE KEY `name` (`name`,`assembly`,`genome_component`),
   KEY `taxon_id` (`taxon_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=137 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=137 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align` (
   `genomic_align_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -319,7 +319,7 @@ CREATE TABLE `genomic_align` (
   KEY `method_link_species_set_id` (`method_link_species_set_id`),
   KEY `dnafrag` (`dnafrag_id`,`method_link_species_set_id`,`dnafrag_start`,`dnafrag_end`),
   KEY `node_id` (`node_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6010002016891 DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60;
+) ENGINE=MyISAM AUTO_INCREMENT=6010002016891 DEFAULT CHARSET=latin1 MAX_ROWS=1000000000 AVG_ROW_LENGTH=60 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genomic_align_block` (
   `genomic_align_block_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -332,7 +332,7 @@ CREATE TABLE `genomic_align_block` (
   `direction` tinyint(3) unsigned DEFAULT NULL,
   PRIMARY KEY (`genomic_align_block_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6010001008446 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=6010001008446 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `genomic_align_tree` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -346,7 +346,7 @@ CREATE TABLE `genomic_align_tree` (
   PRIMARY KEY (`node_id`),
   KEY `parent_id` (`parent_id`),
   KEY `left_index` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=5990003608527 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=5990003608527 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `hmm_annot` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -354,7 +354,7 @@ CREATE TABLE `hmm_annot` (
   `evalue` float DEFAULT NULL,
   PRIMARY KEY (`seq_member_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_curated_annot` (
   `seq_member_stable_id` varchar(40) NOT NULL,
@@ -364,7 +364,7 @@ CREATE TABLE `hmm_curated_annot` (
   `reason` mediumtext,
   PRIMARY KEY (`seq_member_stable_id`),
   KEY `model_id` (`model_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `hmm_profile` (
   `model_id` varchar(40) NOT NULL,
@@ -373,7 +373,7 @@ CREATE TABLE `hmm_profile` (
   `compressed_profile` mediumblob,
   `consensus` mediumtext,
   PRIMARY KEY (`model_id`,`type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `homology` (
   `homology_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -396,7 +396,7 @@ CREATE TABLE `homology` (
   KEY `species_tree_node_id` (`species_tree_node_id`),
   KEY `gene_tree_node_id` (`gene_tree_node_id`),
   KEY `gene_tree_root_id` (`gene_tree_root_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `homology_member` (
   `homology_id` bigint(20) unsigned NOT NULL,
@@ -409,7 +409,7 @@ CREATE TABLE `homology_member` (
   PRIMARY KEY (`homology_id`,`gene_member_id`),
   KEY `gene_member_id` (`gene_member_id`),
   KEY `seq_member_id` (`seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=300000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
   `mapping_session_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -420,7 +420,7 @@ CREATE TABLE `mapping_session` (
   `prefix` char(4) NOT NULL,
   PRIMARY KEY (`mapping_session_id`),
   UNIQUE KEY `type` (`type`,`rel_from`,`rel_to`,`prefix`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `member_xref` (
   `gene_member_id` int(10) unsigned NOT NULL,
@@ -428,7 +428,7 @@ CREATE TABLE `member_xref` (
   `external_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`gene_member_id`,`dbprimary_acc`,`external_db_id`),
   KEY `external_db_id` (`external_db_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -438,7 +438,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=173 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=174 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -447,7 +447,7 @@ CREATE TABLE `method_link` (
   `display_name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`method_link_id`),
   UNIQUE KEY `type` (`type`)
-) ENGINE=MyISAM AUTO_INCREMENT=502 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=502 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set` (
   `method_link_species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -461,7 +461,7 @@ CREATE TABLE `method_link_species_set` (
   PRIMARY KEY (`method_link_species_set_id`),
   UNIQUE KEY `method_link_id` (`method_link_id`,`species_set_id`),
   KEY `species_set_id` (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=50041 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=50041 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `method_link_species_set_attr` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -476,7 +476,7 @@ CREATE TABLE `method_link_species_set_attr` (
   `perc_orth_above_wga_thresh` float DEFAULT NULL,
   `threshold_on_ds` int(11) DEFAULT NULL,
   PRIMARY KEY (`method_link_species_set_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `method_link_species_set_tag` (
   `method_link_species_set_id` int(10) unsigned NOT NULL,
@@ -484,16 +484,16 @@ CREATE TABLE `method_link_species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`method_link_species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_name` (
   `taxon_id` int(10) unsigned NOT NULL,
-  `name` varchar(255) NOT NULL,
+  `name` varchar(500) NOT NULL,
   `name_class` varchar(50) NOT NULL,
   KEY `taxon_id` (`taxon_id`),
   KEY `name` (`name`),
   KEY `name_class` (`name_class`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ncbi_taxa_node` (
   `taxon_id` int(10) unsigned NOT NULL,
@@ -508,7 +508,7 @@ CREATE TABLE `ncbi_taxa_node` (
   KEY `rank` (`rank`),
   KEY `left_index` (`left_index`),
   KEY `right_index` (`right_index`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `other_member_sequence` (
   `seq_member_id` int(10) unsigned NOT NULL,
@@ -516,7 +516,7 @@ CREATE TABLE `other_member_sequence` (
   `length` int(10) unsigned NOT NULL,
   `sequence` mediumtext NOT NULL,
   PRIMARY KEY (`seq_member_id`,`seq_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=60000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `peptide_align_feature` (
   `peptide_align_feature_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -538,7 +538,7 @@ CREATE TABLE `peptide_align_feature` (
   `hit_rank` smallint(5) unsigned NOT NULL,
   `cigar_line` mediumtext,
   PRIMARY KEY (`peptide_align_feature_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=133 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -567,7 +567,7 @@ CREATE TABLE `seq_member` (
   KEY `dnafrag_id_end` (`dnafrag_id`,`dnafrag_end`),
   KEY `seq_member_gene_member_id_end` (`seq_member_id`,`gene_member_id`),
   KEY `stable_id` (`stable_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=952569014 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
+) ENGINE=MyISAM AUTO_INCREMENT=952569014 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_member_projection` (
   `source_seq_member_id` int(10) unsigned NOT NULL,
@@ -575,14 +575,14 @@ CREATE TABLE `seq_member_projection` (
   `identity` float(5,2) DEFAULT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_seq_member_id` (`source_seq_member_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_member_projection_stable_id` (
   `target_seq_member_id` int(10) unsigned NOT NULL,
   `source_stable_id` varchar(128) NOT NULL,
   PRIMARY KEY (`target_seq_member_id`),
   KEY `source_stable_id` (`source_stable_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `sequence` (
   `sequence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -591,14 +591,14 @@ CREATE TABLE `sequence` (
   `sequence` longtext NOT NULL,
   PRIMARY KEY (`sequence_id`),
   KEY `md5sum` (`md5sum`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=10000000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set` (
   `species_set_id` int(10) unsigned NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`species_set_id`,`genome_db_id`),
   KEY `genome_db_id` (`genome_db_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=34883 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=34883 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_set_header` (
   `species_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -607,7 +607,7 @@ CREATE TABLE `species_set_header` (
   `first_release` smallint(6) DEFAULT NULL,
   `last_release` smallint(6) DEFAULT NULL,
   PRIMARY KEY (`species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=34884 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=34884 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_set_tag` (
   `species_set_id` int(10) unsigned NOT NULL,
@@ -615,7 +615,7 @@ CREATE TABLE `species_set_tag` (
   `value` mediumtext NOT NULL,
   PRIMARY KEY (`species_set_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node` (
   `node_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -632,7 +632,7 @@ CREATE TABLE `species_tree_node` (
   KEY `genome_db_id` (`genome_db_id`),
   KEY `parent_id` (`parent_id`),
   KEY `root_id` (`root_id`,`left_index`)
-) ENGINE=MyISAM AUTO_INCREMENT=501315726 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=501315726 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_node_attr` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -662,7 +662,7 @@ CREATE TABLE `species_tree_node_attr` (
   `root_nb_genes` int(11) DEFAULT NULL,
   `root_nb_trees` int(11) DEFAULT NULL,
   PRIMARY KEY (`node_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `species_tree_node_tag` (
   `node_id` bigint(20) unsigned NOT NULL,
@@ -670,7 +670,7 @@ CREATE TABLE `species_tree_node_tag` (
   `value` mediumtext NOT NULL,
   KEY `node_id_tag` (`node_id`,`tag`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `species_tree_root` (
   `root_id` bigint(20) unsigned NOT NULL,
@@ -678,7 +678,7 @@ CREATE TABLE `species_tree_root` (
   `label` varchar(256) NOT NULL DEFAULT 'default',
   PRIMARY KEY (`root_id`),
   UNIQUE KEY `method_link_species_set_id` (`method_link_species_set_id`,`label`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_history` (
   `mapping_session_id` int(10) unsigned NOT NULL,
@@ -688,12 +688,12 @@ CREATE TABLE `stable_id_history` (
   `version_to` int(10) unsigned DEFAULT NULL,
   `contribution` float DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`,`stable_id_from`,`stable_id_to`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `synteny_region` (
   `synteny_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `method_link_species_set_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`synteny_region_id`),
   KEY `method_link_species_set_id` (`method_link_species_set_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=44726 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=44726 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 


### PR DESCRIPTION
## Description

Due to the need to store a long author list, production increased the size of the name field in the ncbi_taxa_name table to `varchar(500)`. To accomodate this change we needed to increase the size of the corresponding field in the compara schema.

**Related JIRA tickets:**
- ENSCOMPARASW-6124

## Overview of changes

#### Change 1
Altered the type of the name field of the ncbi_taxa_name table to `varchar(500)`.

#### Change 2
Added the corresponding patch and the insert statement to register the patch under the name `patch_109_110_c.sql|ncbi_taxa_name_varchar500`.

#### Change 3
Patched the test databases.

## Testing
After patching the test databases the full set of unittest were run on cp1.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
