### PR TITLE
Open FASTA files with with statement in SplitFasta

### DIFF
--- a/src/python/lib/ensembl/compara/runnable/SplitFasta.py
+++ b/src/python/lib/ensembl/compara/runnable/SplitFasta.py
@@ -90,17 +90,10 @@ class SplitFasta(eHive.BaseRunnable):
         num_seqs = self.param('num_seqs')
         out_dir = self.param('out_dir')
 
-        records_written = 0
         files_written = 1
-        dst_file = os.path.join(out_dir, f"{file_prefix}.{files_written}.fasta")
-        out_file = open(dst_file, 'w')
-        for fasta_record in fasta_records:
-            if (records_written > 0) and (records_written % num_seqs == 0):
-                out_file.close()
-                files_written += 1
-                dst_file = os.path.join(out_dir, f"{file_prefix}.{files_written}.fasta")
-                out_file = open(dst_file, 'w')
-
-            out_file.write(f">{fasta_record[0]}\n{fasta_record[1]}\n")
-            records_written += 1
-        out_file.close()
+        for seq_idx in range(0, len(fasta_records), num_seqs):
+            dst_file = os.path.join(out_dir, f"{file_prefix}.{files_written}.fasta")
+            with open(dst_file, 'w') as out_file:
+                for fasta_record in fasta_records[seq_idx:seq_idx+num_seqs]:
+                    out_file.write(f">{fasta_record[0]}\n{fasta_record[1]}\n")
+            files_written += 1


### PR DESCRIPTION
## Description

In Travis test logs on the `feature/homology_annotation` branch, `pylint` is encouraging us to [consider using with](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/consider-using-with.html) when opening files in the `SplitFasta` runnable.

Though this issue doesn't prevent Travis checks from passing, when Travis does fail, the test log will include messages about the issue, causing needless distraction from whatever the actual cause of the Travis failure might be.

Using a `with` statement would make it easier to get to the heart of the problem when Travis fails.

## Overview of changes

The `SplitFasta` runnable is updated to open output FASTA files using a `with` statement.

## Testing

The [SplitFasta unit test](https://github.com/Ensembl/ensembl-compara/blob/11608400e56695fe3b3be78066ecab1c5f19b577/modules/t/SplitFasta.t) was brought out of retirement for testing purposes, and all subtests passed locally.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
