### PR TITLE
Merge non-overlapping homology MLSS attr data

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/MergeDBsIntoRelease_conf.pm
@@ -72,8 +72,6 @@ sub default_options {
             'other_member_sequence'             => 'members_db',
             'sequence'                          => 'members_db',
             'exon_boundaries'                   => 'members_db',
-            'method_link_species_set_attr'      => 'default_protein_db',
-            'method_link_species_set_tag'       => 'default_protein_db',
             'peptide_align_feature%'            => 'default_protein_db',
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/MergeDBsIntoRelease_conf.pm
@@ -81,7 +81,6 @@ sub default_options {
             'sequence'                => 'members_db',
             'hmm_annot'               => 'protein_db',
             'peptide_align_feature%'  => 'protein_db',
-            'method_link_species_set_attr'    => 'protein_db',
         },
 
         # In these databases, ignore these tables

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MergeDBsIntoRelease_conf.pm
@@ -89,7 +89,6 @@ sub default_options {
             'sequence'              => 'members_db',
             'exon_boundaries'       => 'members_db',
             'seq_member_projection_stable_id' => 'members_db',
-            'method_link_species_set_attr'    => 'protein_db',
             'seq_member_projection' => 'protein_db',
             'peptide_align_feature%' => 'protein_db',
         },

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RemoveOverlappingHomologies.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RemoveOverlappingHomologies.pm
@@ -76,6 +76,7 @@ sub _remove_homologies {
     $self->compara_dba->dbc->do('DELETE homology_member FROM homology_member JOIN homology USING (homology_id) WHERE method_link_species_set_id = ?', undef, $mlss_id);
     $self->compara_dba->dbc->do('DELETE FROM homology WHERE method_link_species_set_id = ?',                                                          undef, $mlss_id);
     $self->compara_dba->dbc->do('DELETE FROM method_link_species_set_tag WHERE method_link_species_set_id = ?',                                       undef, $mlss_id);
+    $self->compara_dba->dbc->do('DELETE FROM method_link_species_set_attr WHERE method_link_species_set_id = ?',                                      undef, $mlss_id);
 }
 
 1;


### PR DESCRIPTION
## Description

With the introduction of the new Metazoa protein-trees collections in Ensembl 110 and 111, the default collection will contain a minority of the species in the division, so copying the `method_link_species_set_attr` table exclusively from the default protein-tree database could represent a significant effective data loss. Removing overlapping homology MLSS attribute data from this table and merging the non-overlapping homology MLSS attribute data would allow inclusion of `method_link_species_set_attr` rows from the Protostomes and Insects protein-tree collections in the Compara release database.

Doing this for Vertebrates and Plants divisions would similarly allow non-overlapping homology MLSS attribute data to be merged into the release database.

**Related JIRA tickets:**
- ENSCOMPARASW-6125

## Overview of changes

In divisions with multiple protein-trees collections, overlapping homology MLSS attribute rows are removed from the protein-trees pipeline database, so that non-overlapping rows can be merged into the release database.

#### Remove overlapping homology MLSS data

The `RemoveOverlappingHomologies` runnable deletes `method_link_species_set_attr` rows associated with a homology MLSS that overlaps with the reference collection.

#### Merge method_link_species_set_attr tables

The `method_link_species_set_attr` table is removed from the `exclusive_tables` config of the `MergeDBsIntoRelease` pipeline, so that this table will be merged from all configured protein-trees databases.

## Testing

The updated `RemoveOverlappingHomologies` runnable was tested on a copy of a small-scale pilot run of the Protostomes protein-trees. MLSS attribute rows associated with overlapping homologies were successfully removed.

The Protostomes protein-trees pipeline database (with overlapping data removed) was then used as input to the `MergeDBsIntoRelease` pipeline, with the `method_link_species_set_attr` table removed from the `exclusive_tables` config, so that this table would be merged from both the Default and Protostomes protein-trees pipeline databases. Merging of the `method_link_species_set_attr` table was successful. See ENSCOMPARASW-6125 for more details on testing.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
