### PR TITLE
Reinstate production name of O. bimaculoides to community annotation 

### DIFF
--- a/conf/metazoa/allowed_species.json
+++ b/conf/metazoa/allowed_species.json
@@ -130,7 +130,7 @@
     "neodiprion_lecontei_gca021901455v1",
     "neodiprion_pinetum_gca021155775v1",
     "nilaparvata_lugens_gca014356525v1",
-    "octopus_bimaculoides_gca001194135v1",
+    "octopus_bimaculoides",
     "octopus_sinensis_gca006345805v1",
     "onchocerca_volvulus",
     "onthophagus_taurus_gca000648695v2",

--- a/conf/metazoa/mlss_conf.xml
+++ b/conf/metazoa/mlss_conf.xml
@@ -75,7 +75,7 @@
       <genome name="haliotis_rufescens_gca023055435v1rs"/>
       <genome name="lottia_gigantea"/>
       <genome name="mizuhopecten_yessoensis_gca002113885v2"/>
-      <genome name="octopus_bimaculoides_gca001194135v1"/>
+      <genome name="octopus_bimaculoides"/>
       <!-- Included species from Nematoda -->
       <genome name="caenorhabditis_elegans"/>
       <genome name="loa_loa"/>
@@ -140,7 +140,7 @@
       <genome name="lottia_gigantea"/>
       <genome name="mercenaria_mercenaria_gca014805675v2"/>
       <genome name="mizuhopecten_yessoensis_gca002113885v2"/>
-      <genome name="octopus_bimaculoides_gca001194135v1"/>
+      <genome name="octopus_bimaculoides"/>
       <genome name="octopus_sinensis_gca006345805v1"/>
       <genome name="pomacea_canaliculata_gca003073045v1"/>
       <!-- Included species from Nematoda -->

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/PrepareMasterDatabaseForRelease_conf.pm
@@ -103,7 +103,7 @@ sub default_options {
                               'stegodyphus_mimosarum',
                               'schistosoma_mansoni',
                               'pediculus_humanus',
-                              'octopus_bimaculoides_gca001194135v1',
+                              'octopus_bimaculoides',
                               'nematostella_vectensis',
                               'mnemiopsis_leidyi',
                               'lottia_gigantea',


### PR DESCRIPTION
## Description

PR to reinstate _Octopus bimaculoides_ production name (replacing RefSeq-CoreDB linked production name)

**Related JIRA tickets:**
[ENSCOMPARASW-1411](https://www.ebi.ac.uk/panda/jira/browse/ENSINT-1411)

## Overview of changes
Due to policy update to how Ensembl Metazoa Main site should host species with >1 annotation per GCA, opting for retention of older community annotation. 
This PR reverts change of production name to community annotation linked Core DB just for this one species ([Previous PR](https://github.com/Ensembl/ensembl-compara/pull/544) changed production_name to RefSeq, but RefSeq core will be made into other features DB). 

#### Change 1
octopus_bimaculoides_gca001194135v1 changed back to -> octopus_bimaculoides

## Testing
No testing done.

## Notes
NONE
---

## PR review checklist

- [yes ] Is the PR against an appropriate branch?
- [ yes] Does the code adhere to coding guidelines?
- [ yes ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
