### PR TITLE
Merge member-associated data from Protostomes

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ComplementaryProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ComplementaryProteinTrees_conf.pm
@@ -96,6 +96,11 @@ sub core_pipeline_analyses {
         {
              -logic_name => 'remove_overlapping_homologies',
              -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::RemoveOverlappingHomologies',
+             -flow_into  => [ 'remove_overlapping_data_by_member' ],
+        },
+        {
+             -logic_name => 'remove_overlapping_data_by_member',
+             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RemoveOverlappingDataByMember',
         },
     ]
 }

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/MergeDBsIntoRelease_conf.pm
@@ -66,18 +66,17 @@ sub default_options {
         # These tables have a unique source. Content from other databases is ignored
         'exclusive_tables'  => {
             'mapping_session'                   => 'master_db',
-            'hmm_annot'                         => 'default_protein_db',
             'gene_member'                       => 'members_db',
             'seq_member'                        => 'members_db',
             'other_member_sequence'             => 'members_db',
             'sequence'                          => 'members_db',
             'exon_boundaries'                   => 'members_db',
-            'peptide_align_feature%'            => 'default_protein_db',
         },
 
         # In these databases, ignore these tables
         'ignored_tables' => {
             # Mapping 'db_alias' => Arrayref of table names
+            'members_db'                => [qw(hmm_annot)],
             'default_protein_db'        => [qw(ortholog_quality id_generator id_assignments datacheck_results)],
             'protostomes_protein_db'    => [qw(ortholog_quality id_generator id_assignments datacheck_results)],
         }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/OffsetTables.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/OffsetTables.pm
@@ -56,6 +56,7 @@ sub param_defaults {
                     'ALTER TABLE gene_align        AUTO_INCREMENT=#offset#',
                     'ALTER TABLE gene_tree_node    AUTO_INCREMENT=#offset#',
                     'ALTER TABLE CAFE_gene_family  AUTO_INCREMENT=#offset#',
+                    'ALTER TABLE peptide_align_feature  AUTO_INCREMENT=#offset#',
                     'INSERT IGNORE INTO id_generator (label, next_id) VALUES ("homology", #offset#)',
                 ],
     }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/RemoveOverlappingDataByMember.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/RemoveOverlappingDataByMember.pm
@@ -1,0 +1,100 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RemoveOverlappingDataByMember
+
+=head1 DESCRIPTION
+
+When we infer protein trees for a complementary collection, we end up with some redundant homology data,
+which currently needs to be removed from the pipeline database of the complementary collection so that it
+does not clash with or duplicate the data in its reference collection(s). This runnable can be used to
+remove member-associated redundant homology data from a complementary collection pipeline database.
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RemoveOverlappingDataByMember;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub run {
+    my $self = shift;
+
+    my $overlapping_species = $self->_find_overlapping_species;
+    my $overlap_genome_db_ids = '(' . join(',', @{$self->param('overlapping_species')}) . ')';
+
+    my $hmm_annot_sql = qq/
+        DELETE 
+            hmm_annot
+        FROM
+            hmm_annot
+        JOIN
+            seq_member
+        USING
+            (seq_member_id)
+        WHERE
+            seq_member.genome_db_id IN $overlap_genome_db_ids
+    /;
+    $self->compara_dba->dbc->do($hmm_annot_sql);
+
+    my $peptide_align_feature_sql = qq/
+        DELETE 
+            peptide_align_feature
+        FROM
+            peptide_align_feature
+        JOIN
+            seq_member qmember
+        ON
+            qmember_id = qmember.seq_member_id
+        JOIN
+            seq_member hmember
+        ON
+            hmember_id = hmember.seq_member_id
+        WHERE
+            qmember.genome_db_id IN $overlap_genome_db_ids
+        AND
+            hmember.genome_db_id IN $overlap_genome_db_ids
+    /;
+    $self->compara_dba->dbc->do($peptide_align_feature_sql);
+}
+
+
+sub _find_overlapping_species {
+    my $self = shift;
+
+    my $master_dba = $self->get_cached_compara_dba('master_db');
+    my $ref_collection_name = $self->param_required('ref_collection');
+    my $ref_collection = $master_dba->get_SpeciesSetAdaptor->fetch_collection_by_name($ref_collection_name);
+    die "Cannot find collection '$ref_collection_name' in master_db" unless $ref_collection;
+    my @ref_genome_ids = map { $_->dbID } @{ $ref_collection->genome_dbs };
+
+    my $this_gdb_adaptor = $self->compara_dba->get_GenomeDBAdaptor;
+    my @these_genome_ids = map { $_->dbID } @{ $this_gdb_adaptor->fetch_all };
+
+    my @overlapping_species;
+    foreach my $ref_gdb_id ( @ref_genome_ids ) {
+        push @overlapping_species, $ref_gdb_id if grep { $ref_gdb_id == $_ } @these_genome_ids;
+    }
+    $self->param('overlapping_species', \@overlapping_species);
+}
+
+1;


### PR DESCRIPTION
## Description

With the introduction of the new Metazoa protein-trees collections in Ensembl 110 and 111, the default collection will contain a minority of the species in the division, so copying the `hmm_annot` and `peptide_align_feature` tables exclusively from the default protein-tree database could represent a substantial effective data loss.

If we remove overlapping homology data from these tables (as defined in terms of members or member pairs that come from species in the overlap between collections) and merge the non-overlapping data, it would be possible to include `hmm_annot` and `peptide_align_feature` rows from the Protostomes (and ultimately Insects) protein-tree collections in the Metazoa Compara release database.

**Related JIRA tickets:**
- ENSCOMPARASW-6105
- ENSCOMPARASW-6127

## Overview of changes

In the Metazoa complementary protein-trees pipeline, overlapping `hmm_annot` and `peptide_align_feature` rows are removed, so that non-overlapping rows can be automatically merged into the release database.

#### Offset AUTO_INCREMENT value of peptide_align_feature table

In the `OffsetTables` runnable, the `peptide_align_feature` table is included in the set of tables whose `AUTO_INCREMENT` value is offset in non-default collections. This will ensure that the `peptide_align_feature` table has no overlapping `peptide_align_feature_id` values across different Metazoa collections, so that this table can be merged automatically in `MergeDBsIntoRelease`.

#### Add RemoveOverlappingDataByMember runnable

A `RemoveOverlappingDataByMember` runnable is added and configured to flow from the `remove_overlapping_homologies` analysis in the `Metazoa::ComplementaryProteinTrees` pipeline. This runnable deletes rows from the `hmm_annot` and `peptide_align_feature` tables that are inferred to contain overlapping homology data, as defined in terms of members or member pairs that come from species in the overlap between the given collection (e.g. `protostomes`) and its reference collection (e.g. `default`).

- In the `hmm_annot` table, rows with a `seq_member_id` whose corresponding GenomeDB is in both the given collection and its reference collection are assumed to be redundant and deleted.

- In the `peptide_align_feature` table, rows where both the `qmember_id` and `hmember_id` correspond to a pair of GenomeDBs that are both in the given collection and its reference collection are assumed to be redundant and deleted.

#### Merge hmm_annot and peptide_align_feature tables in Metazoa

- The `hmm_annot` and `peptide_align_feature` tables are removed from the `exclusive_tables` config of the `Metazoa::MergeDBsIntoRelease` pipeline, so that these tables will be merged from all configured protein-trees databases.
- The `hmm_annot` table of the `members_db` is added to the `ignored_tables` config for the `Metazoa::MergeDBsIntoRelease` pipeline, to ensure that this table is only merged from protein-trees databases. (With the config currently in place, this particular table is effectively ignored anyway.)

## Testing

- The `RemoveOverlappingDataByMember` runnable was tested on a copy of a small-scale pilot run of the Protostomes protein-trees. Rows of the `hmm_annot` and `peptide_align_feature` tables associated with overlapping data were successfully removed.

- This Protostomes protein-trees pipeline database (with overlapping data removed) was then used as input to the `Metazoa::MergeDBsIntoRelease` pipeline.
  * With appropriately offset primary keys, merging of the `peptide_align_feature` was successful on the first attempt.
  * Merging of the `hmm_annot` table initially failed due to primary key clashes with the `hmm_annot` table of the `members_db`, but after the latter table was added to the `ignored_tables` config, the merge was successful. 

See ENSCOMPARASW-6127 for more details on testing.

## Notes

- The `peptide_align_feature` `AUTO_INCREMENT` offset added to the `OffsetTables` runnable would also be applied to the `peptide_align_feature` table in homology pipelines used in other divisions (e.g. `MurinaeProteinTrees`, `ImportAltAlleGroupsAsHomologies`), but no negative side effects are anticipated.
- The `RemoveOverlappingDataByMember` runnable introduces some code redundancy as it uses a copy of the `_find_overlapping_species` method from the `RemoveOverlappingClusters` runnable. A ticket (ENSCOMPARASW-6148) has been opened to refactor these two methods into one that can be used by both runnables.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
