### PR TITLE
Fix minor bugs in FTP sanity-check scripts

### DIFF
--- a/scripts/dumps/verify_ftp_dumps.pl
+++ b/scripts/dumps/verify_ftp_dumps.pl
@@ -20,6 +20,7 @@ use strict;
 
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
+use File::Spec::Functions;
 use Getopt::Long;
 
 my ( $help, $reg_conf, $compara_db, $ftp_root, $release, $eg_release, $division );
@@ -50,7 +51,7 @@ if (! $ftp_root) {
 die &helptext if ( $help || !($reg_conf && $compara_db && $division) );
 die "FTP root '$ftp_root' does not exist\n" unless -e $ftp_root;
 
-my %ftp_file_per_mlss = (
+my %glob_exp_per_mlss = (
 	LASTZ_NET                => 'maf/ensembl-compara/pairwise_alignments/#mlss_filename#*.tar*',
 	EPO                      => 'maf/ensembl-compara/multiple_alignments/#mlss_filename#/*',
 	EPO_EXTENDED             => 'maf/ensembl-compara/multiple_alignments/#mlss_filename#/*',
@@ -59,20 +60,23 @@ my %ftp_file_per_mlss = (
 	GERP_CONSERVATION_SCORE  => 'compara/conservation_scores/#mlss_filename#/*',
     PROTEIN_TREES            => "xml/ensembl-compara/homologies/Compara.$release.protein_#clusterset_id#.alltrees.orthoxml.xml.gz",
     NC_TREES                 => "xml/ensembl-compara/homologies/Compara.$release.ncrna_#clusterset_id#.alltrees.orthoxml.xml.gz",
-    ENSEMBL_ORTHOLOGUES      => 'tsv/ensembl-compara/homologies/#species_name#/*',
-    ENSEMBL_PARALOGUES       => 'tsv/ensembl-compara/homologies/#species_name#/*',
+    ENSEMBL_ORTHOLOGUES      => 'tsv/ensembl-compara/homologies/#species_name#/*.tsv.gz tsv/ensembl-compara/homologies/*_collection/#species_name#/*.tsv.gz',
+    ENSEMBL_PARALOGUES       => 'tsv/ensembl-compara/homologies/#species_name#/*.tsv.gz tsv/ensembl-compara/homologies/*_collection/#species_name#/*.tsv.gz',
     SPECIES_TREE             => 'compara/species_trees/*.nh',
     CACTUS_HAL               => 'compara/species_trees/*.nh',
 );
 
-# Get every dumped file present in the ftp_root
-my @existing_files;
-my %ftp_paths = map { $_ => 1 } values %ftp_file_per_mlss;
-foreach my $path (keys %ftp_paths) {
-    $path =~ s/#\w+#\*?/*/;
-    push @existing_files, glob "$ftp_root/$path";
+# Prepend ftp_root to each segment of the glob expression
+while (my ($method_type, $glob_exp) = each %glob_exp_per_mlss) {
+    $glob_exp_per_mlss{$method_type} = join(' ', map { catfile($ftp_root, $_) } split(/\s+/, $glob_exp));
 }
-my %existing_files = map { $_ => 1 } @existing_files;
+
+# Get every dumped file present in the ftp_root
+my %existing_files;
+foreach my $glob_exp (values %glob_exp_per_mlss) {
+    $glob_exp =~ s/#\w+#\*?/*/g;
+    $existing_files{$_} = 1 foreach glob $glob_exp;
+}
 
 my $registry = 'Bio::EnsEMBL::Registry';
 $registry->load_all($reg_conf, 0, 0, 0, "throw_if_missing") if $reg_conf;
@@ -81,64 +85,59 @@ my $mlsses = $dba->get_MethodLinkSpeciesSetAdaptor->fetch_all_current;
 
 # Remove from the list of existing files those corresponding to each current MLSS
 foreach my $mlss ( @$mlsses ) {
-    my $file_for_type = $ftp_file_per_mlss{$mlss->method->type};
-    next unless defined $file_for_type;
+    my $glob_exp_for_type = $glob_exp_per_mlss{$mlss->method->type};
+    next unless defined $glob_exp_for_type;
     
-    if ( $file_for_type =~ /#mlss_filename#/ ) {
+    if ( $glob_exp_for_type =~ /#mlss_filename#/ ) {
         my $mlss_filename = $mlss->filename;
-        $file_for_type =~ s/#mlss_filename#/$mlss_filename/ig;
-        $file_for_type = "$ftp_root/$file_for_type";
-        my @files = glob $file_for_type;
+        $glob_exp_for_type =~ s/#mlss_filename#/$mlss_filename/ig;
+        my @files = glob $glob_exp_for_type;
         if ( (!defined $files[0] || !-e $files[0]) && $mlss->method->type eq 'LASTZ_NET' ) {
             # try different order of species
             my $orig_mlss_filename = $mlss_filename;
             $mlss_filename =~ /(.+)\.v\.(.+)\.lastz_net/;
             $mlss_filename = "$2.v.$1.lastz_net";
-            $file_for_type =~ s/$orig_mlss_filename/$mlss_filename/;
-            @files = glob $file_for_type;
+            $glob_exp_for_type =~ s/$orig_mlss_filename/$mlss_filename/g;
+            @files = glob $glob_exp_for_type;
         }
-        die "Could not find file for MethodLinkSpeciesSet dbID " . $mlss->dbID . " (" . $mlss->name . "): $file_for_type" unless scalar(@files) && -e $files[0];
+        die "Could not find file for MethodLinkSpeciesSet dbID " . $mlss->dbID . " (" . $mlss->name . "): $glob_exp_for_type" unless scalar(@files) && -e $files[0];
         delete @existing_files{@files};
-    } elsif ( $file_for_type =~ /#collection_name#/ ) {
+    } elsif ( $glob_exp_for_type =~ /#collection_name#/ ) {
         my $collection_name = $mlss->species_set->name;
         $collection_name =~ s/collection-//;
-        $file_for_type =~ s/#collection_name#/$collection_name/;
-        $file_for_type = "$ftp_root/$file_for_type";
-        my @files = glob $file_for_type;
-        die "Could not find file for MethodLinkSpeciesSet dbID " . $mlss->dbID . " (" . $mlss->name . "): $file_for_type" unless scalar(@files) && -e $files[0];
+        $glob_exp_for_type =~ s/#collection_name#/$collection_name/g;
+        my @files = glob $glob_exp_for_type;
+        die "Could not find file for MethodLinkSpeciesSet dbID " . $mlss->dbID . " (" . $mlss->name . "): $glob_exp_for_type" unless scalar(@files) && -e $files[0];
         delete @existing_files{@files};
-    } elsif ( $file_for_type =~ /#clusterset_id#/ ) {
+    } elsif ( $glob_exp_for_type =~ /#clusterset_id#/ ) {
         my $clusterset_id = 'default';
         if ( $division eq 'vertebrates' ) {
             my $collection_name = $mlss->species_set->name;
             $collection_name =~ s/collection-//;
             $clusterset_id = $collection_name;
         }
-        $file_for_type =~ s/#clusterset_id#/$clusterset_id/;
-        $file_for_type = "$ftp_root/$file_for_type";
-        my @files = glob $file_for_type;
-        die "Could not find file for MethodLinkSpeciesSet dbID " . $mlss->dbID . " (" . $mlss->name . "): $file_for_type" unless scalar(@files) && -e $files[0];
+        $glob_exp_for_type =~ s/#clusterset_id#/$clusterset_id/g;
+        my @files = glob $glob_exp_for_type;
+        die "Could not find file for MethodLinkSpeciesSet dbID " . $mlss->dbID . " (" . $mlss->name . "): $glob_exp_for_type" unless scalar(@files) && -e $files[0];
         delete @existing_files{@files};
-    } elsif ( $file_for_type =~ /#species_name#/ ) {
-        $file_for_type = "$ftp_root/$file_for_type";
+    } elsif ( $glob_exp_for_type =~ /#species_name#/ ) {
         foreach my $gdb ( @{ $mlss->species_set->genome_dbs } ) {
-            my $this_species_file_for_type = $file_for_type;
+            my $this_species_glob_exp_for_type = $glob_exp_for_type;
             my $this_species_name = $gdb->name;
-            $this_species_file_for_type =~ s/#species_name#/$this_species_name/;
-            my @files = glob $this_species_file_for_type;
+            $this_species_glob_exp_for_type =~ s/#species_name#/$this_species_name/g;
+            my @files = glob $this_species_glob_exp_for_type;
             unless (scalar(@files) && -e $files[0]) {
                 # Try with a collection
-                my $this_collection_species_file_for_type = $file_for_type;
-                $this_collection_species_file_for_type =~ s/#species_name#/*_collection\/$this_species_name/;
-                @files = glob $this_collection_species_file_for_type;
-                die "Could not find file for MethodLinkSpeciesSet dbID " . $mlss->dbID . " (" . $mlss->name . "): $this_species_file_for_type" unless scalar(@files) && -e $files[0];
+                my $this_collection_species_glob_exp_for_type = $glob_exp_for_type;
+                $this_collection_species_glob_exp_for_type =~ s/#species_name#/*_collection\/$this_species_name/g;
+                @files = glob $this_collection_species_glob_exp_for_type;
+                die "Could not find file for MethodLinkSpeciesSet dbID " . $mlss->dbID . " (" . $mlss->name . "): $this_collection_species_glob_exp_for_type" unless scalar(@files) && -e $files[0];
             }
             delete @existing_files{@files};
         }
     } else {
-        $file_for_type = "$ftp_root/$file_for_type";
-        my @files = glob $file_for_type;
-        die "Could not find file for MethodLinkSpeciesSet dbID " . $mlss->dbID . " (" . $mlss->name . "): $file_for_type" unless scalar(@files) && -e $files[0];
+        my @files = glob $glob_exp_for_type;
+        die "Could not find file for MethodLinkSpeciesSet dbID " . $mlss->dbID . " (" . $mlss->name . "): $glob_exp_for_type" unless scalar(@files) && -e $files[0];
         delete @existing_files{@files};
     }
 }

--- a/scripts/production/compare_ftp_dir.pl
+++ b/scripts/production/compare_ftp_dir.pl
@@ -194,6 +194,7 @@ sub extract_stats {
     while (my $filename = readdir($dirh)) {
         next if $filename eq '.';
         next if $filename eq '..';
+        next if $filename eq 'CHECKSUMS';
         if (-l $filename) {
             $filename = readlink $filename;
         }
@@ -259,6 +260,7 @@ foreach my $d (@compara_dirs) {
     my $curr_dir = File::Spec->catfile($curr_base_path, $d);
     my $prev_dir = File::Spec->catfile($prev_base_path, $d);
     subtest $d, sub {
+        plan skip_all => 'Reference directory does not exist' unless(-e $prev_dir);
         # A) Check completeness
         ok(-d $curr_dir, "Directory exists");
         return unless -d $curr_dir;
@@ -284,6 +286,7 @@ foreach my $f (@compara_files) {
     my $curr_file = File::Spec->catfile($curr_base_path, $f);
     my $prev_file = File::Spec->catfile($prev_base_path, $f);
     subtest $f, sub {
+        plan skip_all => 'Reference file does not exist' unless(-e $prev_file);
         # A) Check completeness
         ok(-f $curr_file, 'File exists');
         # B) Compare against another directory


### PR DESCRIPTION
## Description

There are some minor bugs in the Compara FTP sanity-check scripts.

## Overview of changes

#### verify_ftp_dumps.pl

- **Change homology TSV glob expressions to match collection databases**: The homology TSV file glob was not matching homology TSV file dumps of species from collection databases. The updated glob expression and code can now match these, reducing the number of spurious warnings.

#### compare_ftp_dir.pl 

- Skip checks of directories that do not exist in the reference FTP dump.
- Ignore CHECKSUMS files, as these are irrelevant to the specific checks being done.

## Testing

Testing was done by running the updated scripts on the FTP dumps of affected divisions.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
