### PR TITLE
Support multiple protein-tree ref collections

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ComplementaryProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ComplementaryProteinTrees_conf.pm
@@ -51,10 +51,13 @@ sub default_options {
 
     # complementary collection parameters:
 
-        # Collection in master that may have overlapping data. Potentially overlapping clusters
+        # Collection(s) in master that may have overlapping data. Potentially overlapping clusters
         # and homologies are removed during the complementary protein-trees pipeline. This should be
         # defined in the PipeConfig file for each complementary collection (or on the command line).
-        'ref_collection'   => undef,
+        'ref_collection_list' => undef,
+
+    # mapping parameters:
+
         'do_stable_id_mapping' => 0,
         'do_treefam_xref' => 0,
     };
@@ -66,7 +69,7 @@ sub pipeline_wide_parameters {
     return {
         %{$self->SUPER::pipeline_wide_parameters},
 
-        'ref_collection' => $self->o('ref_collection'),
+        'ref_collection_list' => $self->o('ref_collection_list'),
     }
 }
 
@@ -91,6 +94,9 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'cleanup_strains_clusters',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RemoveOverlappingClusters',
+             -parameters => {
+                 'collection'=> $self->o('collection'),
+             },
         },
 
         {
@@ -101,6 +107,9 @@ sub core_pipeline_analyses {
         {
              -logic_name => 'remove_overlapping_data_by_member',
              -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RemoveOverlappingDataByMember',
+             -parameters => {
+                 'collection'=> $self->o('collection'),
+             },
         },
     ]
 }

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProtostomesProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProtostomesProteinTrees_conf.pm
@@ -48,7 +48,7 @@ sub default_options {
 
         'collection'          => 'protostomes',
         'dbID_range_index'    => 10,
-        'ref_collection'      => 'default',
+        'ref_collection_list' => ['default'],
         'label_prefix' => 'protostomes_',
     };
 }

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/CultivarsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/CultivarsProteinTrees_conf.pm
@@ -98,6 +98,9 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'cleanup_strains_clusters',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RemoveOverlappingClusters',
+            -parameters => {
+                'collection'=> $self->o('collection'),
+            },
         },
 
         {   -logic_name => 'remove_overlapping_homologies',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsNcRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsNcRNAtrees_conf.pm
@@ -83,6 +83,9 @@ sub core_pipeline_analyses {
         },
         {   -logic_name => 'cleanup_strains_clusters',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RemoveOverlappingClusters',
+            -parameters => {
+                'collection'=> $self->o('collection'),
+            },
         },
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
@@ -102,7 +102,9 @@ sub core_pipeline_analyses {
         },
         {   -logic_name => 'cleanup_strains_clusters',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RemoveOverlappingClusters',
-
+            -parameters => {
+                 'collection'=> $self->o('collection'),
+            },
         },
 
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RemoveOverlappingHomologies.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RemoveOverlappingHomologies.pm
@@ -33,6 +33,8 @@ package Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::RemoveOverlappingHomologie
 use strict;
 use warnings;
 
+use Bio::EnsEMBL::Hive::Utils qw(destringify);
+
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
 
@@ -41,19 +43,34 @@ sub fetch_input {
 
     my $master_dba          = $self->get_cached_compara_dba('master_db');
     my $master_mlss_adaptor = $master_dba->get_MethodLinkSpeciesSetAdaptor;
-    my $ref_collection_name = $self->param_required('ref_collection');
-    my $ref_collection      = $master_dba->get_SpeciesSetAdaptor->fetch_collection_by_name($ref_collection_name);
-    die "Cannot find collection '$ref_collection_name' in master_db" unless $ref_collection;
-    my @ref_mlsses;
-    foreach my $ml ( qw(ENSEMBL_ORTHOLOGUES ENSEMBL_PARALOGUES ENSEMBL_HOMOEOLOGUES) ) {
-        foreach my $gdb1 ( @{ $ref_collection->genome_dbs } ) {
-            foreach my $gdb2 ( @{ $ref_collection->genome_dbs } ) {
-                my $mlss = $master_mlss_adaptor->fetch_by_method_link_type_GenomeDBs($ml, [$gdb1, $gdb2]);
-                next unless defined $mlss and $mlss->is_current;
-                push @ref_mlsses, $mlss;
+    my $master_ss_adaptor   = $master_dba->get_SpeciesSetAdaptor;
+
+    my $ref_collection_list;
+    if ( $self->param_is_defined('ref_collection') && $self->param_is_defined('ref_collection_list') ) {
+        $self->throw("Only one of parameters 'ref_collection' or 'ref_collection_list' can be defined")
+    } elsif ( $self->param_is_defined('ref_collection') ) {
+        $ref_collection_list = [$self->param('ref_collection')];
+    } elsif ( $self->param_is_defined('ref_collection_list') ) {
+        $ref_collection_list = destringify($self->param('ref_collection_list'));
+    } else {
+        $self->throw("One of parameters 'ref_collection' or 'ref_collection_list' must be defined")
+    }
+
+    my %ref_mlss_by_id;
+    foreach my $ref_collection_name (@{ $ref_collection_list }) {
+        my $ref_collection = $master_ss_adaptor->fetch_collection_by_name($ref_collection_name);
+        die "Cannot find collection '$ref_collection_name' in master_db" unless $ref_collection;
+        foreach my $ml ( qw(ENSEMBL_ORTHOLOGUES ENSEMBL_PARALOGUES ENSEMBL_HOMOEOLOGUES) ) {
+            foreach my $gdb1 ( @{ $ref_collection->genome_dbs } ) {
+                foreach my $gdb2 ( @{ $ref_collection->genome_dbs } ) {
+                    my $mlss = $master_mlss_adaptor->fetch_by_method_link_type_GenomeDBs($ml, [$gdb1, $gdb2]);
+                    next unless defined $mlss and $mlss->is_current;
+                    $ref_mlss_by_id{$mlss->dbID} = $mlss;
+                }
             }
         }
     }
+    my @ref_mlsses = values %ref_mlss_by_id;
 
     my $mlss_adaptor        = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor;
     my @overlapping_mlsss   = grep {$mlss_adaptor->fetch_by_dbID($_->dbID)} @ref_mlsses;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/RemoveOverlappingDataByMember.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/RemoveOverlappingDataByMember.pm
@@ -33,14 +33,33 @@ package Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RemoveOverlappingDataBy
 use strict;
 use warnings;
 
+use Bio::EnsEMBL::Compara::Utils::MasterDatabase;
+use Bio::EnsEMBL::Hive::Utils qw(destringify);
+
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
 
 sub run {
     my $self = shift;
 
-    my $overlapping_species = $self->_find_overlapping_species;
-    my $overlap_genome_db_ids = '(' . join(',', @{$self->param('overlapping_species')}) . ')';
+    my $master_dba = $self->get_cached_compara_dba('master_db');
+    my $collection_name = $self->param_required('collection');
+
+    my $ref_collection_names;
+    if ( $self->param_is_defined('ref_collection') && $self->param_is_defined('ref_collection_list') ) {
+        $self->throw("Only one of parameters 'ref_collection' or 'ref_collection_list' can be defined")
+    } elsif ( $self->param_is_defined('ref_collection') ) {
+        $ref_collection_names = [$self->param('ref_collection')];
+    } elsif ( $self->param_is_defined('ref_collection_list') ) {
+        $ref_collection_names = destringify($self->param('ref_collection_list'));
+    } else {
+        $self->throw("One of parameters 'ref_collection' or 'ref_collection_list' must be defined")
+    }
+
+    my $overlapping_species = Bio::EnsEMBL::Compara::Utils::MasterDatabase::find_overlapping_genome_db_ids($master_dba,
+                                                                                                           $collection_name,
+                                                                                                           $ref_collection_names);
+    my $overlap_genome_db_ids = '(' . join(',', @{$overlapping_species}) . ')';
 
     my $hmm_annot_sql = qq/
         DELETE 
@@ -75,26 +94,6 @@ sub run {
             hmember.genome_db_id IN $overlap_genome_db_ids
     /;
     $self->compara_dba->dbc->do($peptide_align_feature_sql);
-}
-
-
-sub _find_overlapping_species {
-    my $self = shift;
-
-    my $master_dba = $self->get_cached_compara_dba('master_db');
-    my $ref_collection_name = $self->param_required('ref_collection');
-    my $ref_collection = $master_dba->get_SpeciesSetAdaptor->fetch_collection_by_name($ref_collection_name);
-    die "Cannot find collection '$ref_collection_name' in master_db" unless $ref_collection;
-    my @ref_genome_ids = map { $_->dbID } @{ $ref_collection->genome_dbs };
-
-    my $this_gdb_adaptor = $self->compara_dba->get_GenomeDBAdaptor;
-    my @these_genome_ids = map { $_->dbID } @{ $this_gdb_adaptor->fetch_all };
-
-    my @overlapping_species;
-    foreach my $ref_gdb_id ( @ref_genome_ids ) {
-        push @overlapping_species, $ref_gdb_id if grep { $ref_gdb_id == $_ } @these_genome_ids;
-    }
-    $self->param('overlapping_species', \@overlapping_species);
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
@@ -275,6 +275,27 @@ sub _check_is_good_for_alignment {
 }
 
 
+sub find_overlapping_genome_db_ids {
+    my ($compara_dba, $collection_name, $ref_collection_names) = @_;
+
+    my $species_set_adaptor = $compara_dba->get_SpeciesSetAdaptor;
+
+    my %ref_genome_id_set;
+    foreach my $ref_collection_name (@{$ref_collection_names}) {
+        my $ref_collection = $species_set_adaptor->fetch_collection_by_name($ref_collection_name);
+        throw("Cannot find reference collection '$ref_collection_name' in database") unless $ref_collection;
+        foreach my $genome_db (@{$ref_collection->genome_dbs}) {
+            $ref_genome_id_set{$genome_db->dbID} = 1;
+        }
+    }
+
+    my $collection = $species_set_adaptor->fetch_collection_by_name($collection_name);
+    throw("Cannot find collection '$collection_name' in database") unless $collection;
+    my @collection_genome_ids = map { $_->dbID } @{$collection->genome_dbs};
+
+    return [grep { exists $ref_genome_id_set{$_} } @collection_genome_ids];
+}
+
 ############################################################
 #                 update_genome.pl methods                 #
 ############################################################


### PR DESCRIPTION
## Description

To prepare for the introduction of the new Metazoa 'insects' collection in Ensembl 111, the Metazoa complementary protein-trees pipeline will need to allow for multiple reference collections (i.e. 'default' and 'protostomes') to help identify and remove overlapping homology data.

**Related JIRA tickets:**
- ENSCOMPARASW-6107
- ENSCOMPARASW-6148

## Overview of changes

This PR adds a new 'ref_collection_list' parameter to the Metazoa complementary collection pipe-config files and to relevant runnables, and refactors the redundant `_find_overlapping_species` methods into a single function, `Compara::Utils::find_overlapping_genome_db_ids`.

#### Supporting multiple reference collections

- Runnables `RemoveOverlappingClusters`, `RemoveOverlappingHomologies`, and `RemoveOverlappingDataByMember` have been changed to allow for multiple reference collections, as controlled by 'ref_collection_list' parameter. As before, a single reference collection can be set using the 'ref_collection' parameter.
- The 'ref_collection' parameter has been replaced with a 'ref_collection_list' parameter in the `ComplementaryProteinTrees` and `ProtostomesProteinTrees` pipeline config files.

#### Compara::Utils::MasterDatabase::find_overlapping_genome_db_ids

- Methods `RemoveOverlappingClusters::_find_overlapping_species` and `RemoveOverlappingDataByMember::_find_overlapping_species` have been refactored to a single function, `Compara::Utils::MasterDatabase::find_overlapping_genome_db_ids`, which can be accessed from the protein-trees runnables `RemoveOverlappingClusters` and `RemoveOverlappingDataByMember`.
- The 'collection' parameter used by the new `find_overlapping_genome_db_ids` function has been explicitly set in the `cleanup_strains_clusters` and (where relevant) `remove_overlapping_data_by_member` analyses of the pipelines `ProtostomesProteinTrees`, `CultivarsProteinTrees`, `StrainsProteinTrees` and `StrainsNcRNAtrees`.

## Testing

To test the refactored `Compara::Utils::find_overlapping_genome_db_ids` function, a short Perl script was written which can be used to access a master database and print the names of species common to the collection of interest (e.g. `insects`) and its reference collections (e.g. `default` and `protostomes`).

The new 'ref_collection_list' parameter (implemented in `RemoveOverlappingClusters`, `RemoveOverlappingHomologies` and `RemoveOverlappingDataByMember`) was tested by doing a small-scale test run of the Protostomes protein-trees pipeline, which also served as an additional test of the refactored `find_overlapping_genome_db_ids` function. This Protostomes protein-trees pipeline database was then successfully used as input to a `Metazoa::MergeDBsIntoRelease` pipeline.

As the implementation of `find_overlapping_genome_db_ids` involves explicitly setting a 'collection' parameter in the `cleanup_strains_clusters` analysis used in strain- and cultivar-level protein trees, two test pipelines were initialised — one for Murinae and one for Wheat — to confirm that the changes in this PR did not introduce issues in those pipelines.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
