### PR TITLE
Fix dangling links in genomic align tree deletion

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/GenomicAlignTreeAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/GenomicAlignTreeAdaptor.pm
@@ -795,6 +795,7 @@ sub delete {
     return;
   }
 
+  $self->dbc->sql_helper->transaction( -CALLBACK => sub {
     # first, delete genomic_align and genomic_align_block
     # objects (FK constraint)
     my $ga_sth = $self->prepare(
@@ -818,13 +819,29 @@ sub delete {
             right_node_id = NULL
         WHERE root_id = ?"
     );
+
+    my @node_ids = map { $_->node_id } @{$root->get_all_nodes()};
+    my @node_id_placeholders = (('?') x scalar(@node_ids));
+    my $node_id_placeholder_string = '(' . join(',', @node_id_placeholders) . ')';
+    my $nullify_inbound_left_links_sth = $self->prepare(
+        "UPDATE genomic_align_tree SET
+            left_node_id = NULL
+        WHERE left_node_id IN $node_id_placeholder_string"
+    );
+    my $nullify_inbound_right_links_sth = $self->prepare(
+        "UPDATE genomic_align_tree SET
+            right_node_id = NULL
+        WHERE right_node_id IN $node_id_placeholder_string"
+    );
+
     my $tree_delete_sth = $self->prepare(
       "DELETE FROM genomic_align_tree WHERE root_id = ?"
     );
     $tree_update_sth->execute($root->node_id);
-    $self->dbc->do("SET FOREIGN_KEY_CHECKS=0");
+    $nullify_inbound_left_links_sth->execute(@node_ids);
+    $nullify_inbound_right_links_sth->execute(@node_ids);
     $tree_delete_sth->execute($root->node_id);
-    $self->dbc->do("SET FOREIGN_KEY_CHECKS=1");
+  } );
 }
 
 


### PR DESCRIPTION
## Description

A recent fix in the EpoExtended pipeline (#537) brought to light another issue with the `GenomicAlignTreeAdaptor::delete` method, where dangling foreign keys resulted from the deletion of a `GenomicAlignTree`. The workaround used in that case was to switch off foreign-key checks.

This PR attempts to resolve this issue without disabling foreign-key checks by setting to `NULL` all the inbound `left_node_id` and `right_node_id` links to the `GenomicAlignTree` that is being deleted.

**Related JIRA tickets:**
- ENSCOMPARASW-6099

## Overview of changes

In the Compara API method `GenomicAlignTreeAdaptor::delete`:

- inbound `left_node_id` and `right_node_id` links are set to `NULL` immediately prior to deletion of the given `GenomicAlignTree`; and
- all the `GenomicAlignTree` is wrapped in a transaction, with a view to ensuring that a `GenomicAlignTree` is either deleted entirely or not at all.

## Testing

A test EpoExtended pipeline was run up to thte`DeleteEPO` runnable was completed. The pipeline database was then queried for any `genomic_align_tree` `node_id` values in the range used by the relevant EPO alignment, and all had been successfully removed.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
