### PR TITLE
Add option to create_mlss.pl with binomial names

### DIFF
--- a/scripts/pipeline/create_mlss.pl
+++ b/scripts/pipeline/create_mlss.pl
@@ -53,6 +53,7 @@ perl create_mlss.pl
     [--ref_species] when using --pw, only produce pairs with ref present
     [--sg] singleton
     [--use_genomedb_ids] use GenomeDB IDs in MLSS name than truncated GenomeDB names
+    [--use_binomials]
     [--species_set_name species_set_name] 
     [--taxon_id taxon_id]
     [--only_with_karyotype]
@@ -122,6 +123,16 @@ in the list i.e. [1] [2] [3] [4] for a given  method link.
 Force the names of the create MLSS to use the Genome DB ID rather than the truncated form
 of its name (which is normally of the form H.sap).
 
+=item B<[--use_binomials]>
+
+Force the created MLSS to use abbreviated names derived from the first
+two parts of the full Genome DB name, ignoring any subsequent parts.
+
+This option is useful if you have many trinomial Genome DB
+names with a common prefix in the third part of their name.
+
+If the '--use_genomedb_ids' flag is specified, this option is ignored.
+
 =item B<[--species_set_name species_set_name]>
 
 Set the name for this species_set.
@@ -189,6 +200,7 @@ my $force = 0;
 my $pairwise = 0;
 my $singleton = 0;
 my $use_genomedb_ids = 0;
+my $use_binomials = 0;
 my $species_set_name;
 my $collection;
 my $release;
@@ -213,6 +225,7 @@ GetOptions(
     "sg" => \$singleton,
     "ref_species=s" => \$ref_name,
     "use_genomedb_ids" => \$use_genomedb_ids,
+    "use_binomials" => \$use_binomials,
     "species_set_name|species_set_tag=s" => \$species_set_name,
     "collection=s" => \$collection,
     'release' => \$release,
@@ -458,6 +471,13 @@ sub create_mlss {
         foreach my $gdb (@{$all_genome_dbs}) {
           my $species_name = $gdb->name;
           $species_name =~ s/\b(\w)/\U$1/g;
+
+          if ($use_binomials) {
+            my @species_name_split = split('_', $species_name);
+            my @first_two_species_name_split = @species_name_split[0, 1];
+            $species_name = join('_', @first_two_species_name_split);
+          }
+
           $species_name =~ s/(\S)\S+\_/$1\./;
           $species_name = substr($species_name, 0, 5);
           push @individual_names, $species_name;


### PR DESCRIPTION
## Description

With the species naming convention used by WBPS, where the relevant BioProject accession is included in the species production name (and consequently the Compara GenomeDB name), the species-set and MLSS names generated by `create_mlss.pl` for WBPS genomes tend to have a common suffix (`pr`). This leads to many MLSS and species-set names being indistinguishable, and consequently not very meaningful.

## Overview of changes

The core of the proposed changes are based on PR #486 by @digrigor. The main difference is that the proposed changes from that PR are now controlled by a `--use_binomials` flag. If that flag is set, MLSS and species-set names use an abbreviation of the GenomeDB name formed from the first two terms of the GenomeDB name. Otherwise, the current default behaviour remains in place.

## Testing

A test master database was created (`mysql://ensro@mysql-ens-compara-prod-9:4647/twalsh_dev_ensembl_compara_master_20220104`), with 4 GenomeDB entries: two mouse strains (`mus_musculus_aj` and `mus_musculus_lpj`) and two similarly named nematode species (`caenorhabditis_brenneri_prjna20035` and `caenorhabditis_briggsae_prjna10731`).

The `create_mlss.pl` script was used _without_ the `--use_binomials` flag to generate an `ENSEMBL_ORTHOLOGUES` MLSS for the two mouse strains, creating a species-set with name `M.aj-M.lpj` and MLSS with name `M.aj-M.lpj orthologues`, as expected.

The `create_mlss.pl` script was used _with_ the `--use_binomials` flag to generate an `ENSEMBL_ORTHOLOGUES` MLSS for the two nematodes, creating a species-set with name `C.bre-C.bri` and MLSS with name `C.bre-C.bri orthologues`, again as expected.


---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
