### PR TITLE
Fixed timetree loading in Compara/Utils/SpeciesTree

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/Utils/SpeciesTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/SpeciesTree.pm
@@ -400,9 +400,7 @@ sub get_timetree_estimate_for_node {
                 #foreach my $child2_rep (@{$child2->get_all_leaves()}) {
                     #next unless $child1_rep->taxon_id && $child2_rep->taxon_id;
                     #return 0 if $child1_rep->taxon_id == $child2_rep->taxon_id;
-            my $child1_name = $child1_rep->isa('Bio::EnsEMBL::Compara::NCBITaxon') ? $child1_rep->name : $child1_rep->taxon->name;
-            my $child2_name = $child2_rep->isa('Bio::EnsEMBL::Compara::NCBITaxon') ? $child2_rep->name : $child2_rep->taxon->name;
-            my $url = sprintf($url_template, uri_escape($child1_name), uri_escape($child2_name));
+            my $url = sprintf($url_template, $child1_rep->taxon_id, $child2_rep->taxon_id);
             $last_page = $url;
             my $timetree_page = get($url);
             next unless $timetree_page;

--- a/modules/t/Utils/SpeciesTree.t
+++ b/modules/t/Utils/SpeciesTree.t
@@ -435,8 +435,8 @@ sub get ($) {   ## no critic
     <h1 style="margin-bottom: 0px;">%s</h1> Million Years Ago
 BLABLA};
     warn $url;
-    return '' if $url =~ /Bos/;
-    return sprintf($html_template, '') if $url =~ /Equus/;
+    return '' if $url =~ /\D9913(\D|$)/;
+    return sprintf($html_template, '') if $url =~ /\D9796(\D|$)/;
     return sprintf($html_template, '16394');
 }
 


### PR DESCRIPTION
## Description
There were issues in loading the timetree data in e108 and e109. It seems that switching to taxon id based querying fixes the issue.

**Related JIRA tickets:**
- ENSCOMPARASW-5970

## Overview of changes

#### Change 1
Switched to taxon id based querying when loading timetree data.

## Testing

The fix was tested by running a standalone job:

```
standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::SpeciesTree::LoadTimeTree \
    -compara_db mysql://ensro@mysql-ens-compara-prod-2:4522/sbotond_compra_master_copy \
    --debug 9 --no_write
```
In large majority of cases loading the timetree data was succesful.
---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
