### PR TITLE
Include genome taxon_id in orphan-ratio lineage

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/PerGenomeGroupsetQC.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/PerGenomeGroupsetQC.pm
@@ -32,9 +32,19 @@ Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::PerGenomeGroupsetQC
 
 =head1 DESCRIPTION
 
-This Analysis will take the sequences from a cluster, the cm from
-nc_profile and run a profiled alignment, storing the results as
-cigar_lines for each sequence.
+For a given genome, this runnable calculates and stores various statistics,
+such as the number of genes (i.e. 'nb_genes'), the number of genes mapped to
+a cluster (i.e. 'nb_genes_in_unfiltered_cluster'), and the number of genes
+not mapped to any cluster (i.e. 'nb_orphan_genes').
+
+In addition, it calculates a mapped-gene ratio: the fraction of genes in the given
+genome that have been mapped to a cluster. If this mapped-gene ratio does not meet
+the taxon-specific threshold taken from the parameter 'mapped_gene_ratio_per_taxon',
+the runnable dies.
+
+A mapped-gene ratio check may fail due to issues with genome assembly, gene
+annotation, flow control in the gene-trees pipeline, or an overly stringent
+mapped-gene ratio threshold.
 
 =head1 SYNOPSIS
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/PerGenomeGroupsetQC.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/PerGenomeGroupsetQC.pm
@@ -180,12 +180,13 @@ sub fetch_gdb_orphan_genes {
 sub _is_above_orphan_ratio {
     my ( $self, $genome_db_id, $ncbi_taxon_adaptor ) = @_;
 
-    my $taxon     = $ncbi_taxon_adaptor->fetch_node_by_genome_db_id($genome_db_id);
-    my $ancestors = $taxon->get_all_ancestors();
+    my $genome_db_taxon = $ncbi_taxon_adaptor->fetch_node_by_genome_db_id($genome_db_id);
+    my $ancestors       = $genome_db_taxon->get_all_ancestors();
+    my @lineage         = ($genome_db_taxon, @$ancestors);
 
-    foreach my $ancestor (@$ancestors) {
-        if ( exists( $self->param('mapped_gene_ratio_per_taxon')->{ $ancestor->taxon_id } ) ) {
-            if ( $self->param('mapped_gene_ratio') >= $self->param('mapped_gene_ratio_per_taxon')->{ $ancestor->taxon_id } ) {
+    foreach my $taxon (@lineage) {
+        if ( exists( $self->param('mapped_gene_ratio_per_taxon')->{ $taxon->taxon_id } ) ) {
+            if ( $self->param('mapped_gene_ratio') >= $self->param('mapped_gene_ratio_per_taxon')->{ $taxon->taxon_id } ) {
                 return 1;
             } else {
                 return 0;


### PR DESCRIPTION
## Description

When checking the mapped-gene ratio, the  `PerGenomeGroupsetQC` runnable currently fetches a taxon-specific mapped-gene ratio threshold from a `mapped_gene_ratio_per_taxon` parameter, taking as a threshold the first `taxon_id` in the ancestral lineage of the given genome whose `taxon_id` is specified in `mapped_gene_ratio_per_taxon`. Including the `taxon_id` of the genome itself in the taxonomic lineage would enable a genome-specific threshold to be specified, allowing for finer-grained control and simplifying the process of handling failures in the per-genome QC analysis.

## Overview of changes

#### Orphan-ratio check considers genome taxon_id
- The internal method `_is_above_orphan_ratio` has been changed so that when fetching the taxon-specific  mapped-gene ratio threshold, the `taxon_id` of the genome itself is considered in addition to that of its ancestral lineage.

#### Documentation update
- A description has been added to the runnable.

## Testing
This change was tested successfully during the Ensembl Metazoa 109 Protostomes protein-trees pipeline.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
