### PR TITLE
fixing HALXS makefile and upgrade perl to 5.25.2

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/HAL/HALXS/Makefile-Linuxbrew.PL
+++ b/modules/Bio/EnsEMBL/Compara/HAL/HALXS/Makefile-Linuxbrew.PL
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-use 5.014002;
+use v5.26.2;
 use ExtUtils::MakeMaker;
 
 # Version of Makefile.pl that assumes that all the dependencies can be found via linuxbrew
@@ -23,7 +22,7 @@ my $linuxbrew_home = $ARGV[0] || $ENV{LINUXBREW_HOME};
 die "The path to the linuxbrew installation must be provided, either on the command-line or via the environment LINUXBREW_HOME" unless $linuxbrew_home;
 
 my $lib_location = $linuxbrew_home.'/lib';
-# We need hdf5 1.10 (1.8 is not compatible)
+# We need hdf5 1.10 because Linuxbrew's HAL has been compilied using hdf5@1.10
 my $hdf5_location = $linuxbrew_home.'/opt/hdf5@1.10';
 
 print "! Using linuxbrew installation at $ENV{LINUXBREW_HOME}\n";
@@ -50,4 +49,9 @@ WriteMakefile(
     MYEXTLIB => "$lib_location/halChain.a $lib_location/halLod.a $lib_location/halLiftover.a $lib_location/halLib.a $lib_location/halMaf.a $lib_location/sonLib.a",
     # Un-comment this if you add C files to link with later:
     # OBJECT            => '$(O_FILES)', # link all the C files too
+    # Variable below is used for the library dynamic linking process,
+    # however the this MakeMaker doesn't include (somehow!) the hdf5_location/lib 
+    # into the LDDLFLAGS inside the generated Makefile
+    # Un-comment the line below if you want to LDDLFLAGS be created automatically
+    LDDLFLAGS =>  "-shared -O2 -L$hdf5_location/lib,/usr/local/lib,$lib_location/opt/libnsl/lib -fstack-protector-strong",
 );

--- a/modules/Bio/EnsEMBL/Compara/HAL/HALXS/lib/HALXS.pm
+++ b/modules/Bio/EnsEMBL/Compara/HAL/HALXS/lib/HALXS.pm
@@ -15,11 +15,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
+=head1 NAME
+
+HALXS - Compara XS HAL module
+
 =cut
 
 package HALXS;
 
-use 5.014002;
+use v5.26.2;
 use strict;
 use warnings;
 


### PR DESCRIPTION
## Description

Bumping Perl version 5.14 to 5.26 on the bits regarding HALXS and improving the makefile contents


## Overview of changes

#### Change 1
Bumping Perl version 5.14 to 5.26 in both files 
```perl
use v5.26.2;
```
#### Change 2
- Improving the message by explaining the reason we *must* use `hdf5@1.10`
- Adding `LDDLFLAGS` into `Makefile-Linuxbrew.PL` to force the inclusion of `hdf5@1.10` location into the `LDDLFLAGS` of Makefile. Otherwise, a manual intervention into the generated `Makefile` would be necessary because the compilation calls for the dynamic link of `hdf5@1.10`'s library.
```perl
LDDLFLAGS => "-shared -O2 -L$hdf5_location/lib,/usr/local/lib,$lib_location/opt/libnsl/lib -fstack-protector-strong",
```

#### Disclaimer
Others `Makefile-*.PL` still needs review as it may be not working anymore