### PR TITLE
Select the appropriate method link in the reindexing pipeline.

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ReindexMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ReindexMembers_conf.pm
@@ -219,7 +219,8 @@ sub core_pipeline_analyses {
         {   -logic_name => 'create_mlss_ss',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::PrepareSpeciesSetsMLSS',
             -parameters => {
-                'whole_method_links'        => [ 'PROTEIN_TREES', 'NC_TREES' ],
+                # 'whole_method_links'        => [ 'PROTEIN_TREES', 'NC_TREES' ],
+                'whole_method_links'        => [ $self->o('member_type') eq "protein" ? 'PROTEIN_TREES' : 'NC_TREES' ],
                 'singleton_method_links'    => [ 'ENSEMBL_PARALOGUES', 'ENSEMBL_HOMOEOLOGUES' ],
                 'pairwise_method_links'     => [ 'ENSEMBL_ORTHOLOGUES' ],
             },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ReindexMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ReindexMembers_conf.pm
@@ -219,7 +219,6 @@ sub core_pipeline_analyses {
         {   -logic_name => 'create_mlss_ss',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::PrepareSpeciesSetsMLSS',
             -parameters => {
-                # 'whole_method_links'        => [ 'PROTEIN_TREES', 'NC_TREES' ],
                 'whole_method_links'        => [ $self->o('member_type') eq "protein" ? 'PROTEIN_TREES' : 'NC_TREES' ],
                 'singleton_method_links'    => [ 'ENSEMBL_PARALOGUES', 'ENSEMBL_HOMOEOLOGUES' ],
                 'pairwise_method_links'     => [ 'ENSEMBL_ORTHOLOGUES' ],


### PR DESCRIPTION
## Description

The datachecks CheckGeneTreeRootMLSS and CheckSpeciesTrees were failing in the ncRNA reindexing pipeline. This was due to selecting the protein trees method link beside the ncRNA one.

**Related JIRA tickets:**
- ENSCOMPARASW-5651

## Overview of changes
Now only the appropriate method link is selected in the reindexing pipelines.

## Testing
The modified code was tested by running the muriane ncRNA trees reindexing pipeline on the e109 database.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
