### PR TITLE
Add support to copy Cactus data

### DIFF
--- a/scripts/pipeline/copy_data.pl
+++ b/scripts/pipeline/copy_data.pl
@@ -265,6 +265,9 @@ foreach my $one_method_link_type (@method_link_types) {
                 } else {
                     print "\tSkipping empty MLSS '$one_mlss_name' with dbID '$one_mlss_id' found using method_link_type '$one_method_link_type'\n";
                 }
+            } elsif ($one_method_link_type =~ /^(CACTUS_HAL|CACTUS_HAL_PW)$/) {
+                print "Will be adding MLSS '$one_mlss_name' with dbID '$one_mlss_id' found using method_link_type '$one_method_link_type'\n";
+                $all_mlss_objects{ $one_mlss_id } = $one_mlss_object;
             }
         }
     } else {


### PR DESCRIPTION
## Description

The `copy_data.pl` wasn't copying Cactus data, but we need this functionality in order to merge Cactus data into the Compara release database from the `RegisterHALFile` production pipeline.

**Related JIRA tickets:**
- ENSCOMPARASW-6336

## Overview of changes

MLSSes with method type `CACTUS_HAL` and `CACTUS_HAL_PW` are now included in the set of MLSSes to be copied, where appropriate.

## Testing

This update was tested in production when merging the Rice and Wheat Cactus data.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
