### PR TITLE
Update to accommodate metazoa field name with a comma

### DIFF
--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -145,8 +145,8 @@ process prepareGenomeFromDb {
             mkdir -p processed
             python ${params.fetch_genomes_exe} -u ${params.url} -c "${params.collection}" -s "${params.species_set}" -d ${absDumpPath} -o input_genomes.csv
             while read -r line; do
-                source=`echo \$line | cut -d ',' -f 8`
-                target=`echo \$line | cut -d ',' -f 10`
+                source=`echo "\$line" | cut -f 8`
+                target=`echo "\$line" | cut -f 10`
                 echo Processing: \$source -> \$target
                 ${params.seqkit_exe} -j 5 grep -n -v -r -p "PATCH_*,HAP" \$source > processed/\$target
                 # Add a dummy softmasked sequence to prevent disabling of

--- a/pipelines/SpeciesTreeFromBusco/scripts/fetch_genomes_from_db.py
+++ b/pipelines/SpeciesTreeFromBusco/scripts/fetch_genomes_from_db.py
@@ -98,7 +98,7 @@ if __name__ == '__main__':
     missing_fas = []
     with engine.connect() as conn, open(args.o, "w") as ofh:
         result = conn.execute(text(query))
-        writer = csv.writer(ofh, lineterminator="\n")
+        writer = csv.writer(ofh, delimiter="\t", lineterminator="\n")
         for row in result:
             gpath = _build_dump_path(row)
             fa_name = str(row.name) + "_" + str(row.assembly)

--- a/pipelines/SpeciesTreeFromBusco/scripts/fix_leaf_names.py
+++ b/pipelines/SpeciesTreeFromBusco/scripts/fix_leaf_names.py
@@ -41,7 +41,7 @@ parser.add_argument(
 if __name__ == '__main__':
     args = parser.parse_args()
 
-    df = pd.read_csv(args.c, header=None)
+    df = pd.read_csv(args.c, delimiter="\t", header=None)
     trans_map = {}
     for r in df.itertuples():
         trans_map[r[10]] = r[2]


### PR DESCRIPTION
The code was updated to accommodate the metazoa field name that had a comma. The delimiter option for cut was removed, which means it defaulted to the tab delimiter.   

It was tested by running the Busco tree pipeline for Metazoa division.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
