### PR TITLE
Set default return value of fetch_all_by_stable_id

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/MemberAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/MemberAdaptor.pm
@@ -107,7 +107,7 @@ sub fetch_all_by_stable_id {
 
     throw("MemberAdaptor::fetch_all_by_stable_id() must have a stable_id") unless $stable_id;
 
-    my $members;
+    my $members = [];
 
     my $constraint1 = 'm.stable_id = ?';
     $self->bind_param_generic_fetch($stable_id, SQL_VARCHAR);


### PR DESCRIPTION
## Description

In its current form, the `MemberAdaptor` method `fetch_all_by_stable_id` returns `undef` if there are no members matching the given stable ID. This differs from the analogous method `fetch_all_by_stable_id_list`, which returns a reference to an empty array if there are no matching members.

Returning an empty array reference would make the behaviour of this method more consistent, and would simplify handling of the return value.

## Overview of changes

The default return value of `fetch_all_by_stable_id` is changed to be a reference to an empty array.

## Testing

The `memberAdaptor.t` unit test passes locally after applying this change.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
