### PR TITLE
Increase expected number of ACGTN-only proteins

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/SqlHealthChecks.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/SqlHealthChecks.pm
@@ -137,7 +137,7 @@ our $config = {
             {
                 description => 'The protein sequences should not be only ACGTN (unless a few exceptions like some immunoglobulin genes)',
                 query => 'SELECT seq_member_id FROM seq_member JOIN sequence USING (sequence_id) WHERE genome_db_id = #genome_db_id# AND source_name LIKE "%PEP" AND sequence REGEXP "^[ACGTN]*$"',
-                expected_size => '< 10',
+                expected_size => '< 11',
             },
             {
                 description => 'The ncRNA sequences have to be only ACGTN. Ambiguity codes have to be explicitly switched on',


### PR DESCRIPTION
## Description

Ten proteins in `culex_quinquefasciatus_gca015732765v1rs` consist entirely of asparagine (`N`).

During Rapid-Release homology annotation, these proteins have caused this genome to fail the `hc_members_per_genome` healthcheck, "[The protein sequences should not be only ACGTN ...](https://github.com/Ensembl/ensembl-compara/blob/3459dcc0c9892fc85b6b5e5473ee151ed1ee04b4/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/SqlHealthChecks.pm#L138-L140)".

When the healthcheck is forgiven and the genes are processed by the homology annotation pipeline, no homologies are inferred. This PR increases the threshold of the relevant healthcheck by 1 so that it will pass for `culex_quinquefasciatus_gca015732765v1rs`.

**Related JIRA tickets:**
- [ENSRR-538](https://www.ebi.ac.uk/panda/jira/browse/ENSRR-538)

## Overview of changes
The threshold of the ACGTN-only healthcheck has been turned up to 11.

## Testing
No testing was done.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
