### PR TITLE
Update WBParaSiteProteinTrees_conf.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/WBParaSiteProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/WBParaSiteProteinTrees_conf.pm
@@ -159,17 +159,17 @@ sub tweak_analyses {
   $analyses_by_name->{'hcluster_parse_output'}->{'-rc_name'} = '8Gb_job';
   $analyses_by_name->{'HMMer_classifyPantherScore_himem'}->{'-rc_name'} = '32Gb_job';
   $analyses_by_name->{'hc_global_tree_set'}->{'-rc_name'} = '32Gb_job';
-  $analyses_by_name->{'homology_dumps_mlss_id_factory'}->{'-rc_name'} = '8Gb_job'
-  $analyses_by_name->{'rib_group_1'}->{'-rc_name'} = '8Gb_job'
-  $analyses_by_name->{'rib_group_2'}->{'-rc_name'} = '8Gb_job'
-  $analyses_by_name->{'rib_group_3'}->{'-rc_name'} = '8Gb_job'
-  $analyses_by_name->{'rib_fire_tree_stats.resource_class_id'}->{'-rc_name'} = '8Gb_job'
-  $analyses_by_name->{'set_default_values'}->{'-rc_name'} = '8Gb_job'
-  $analyses_by_name->{'rib_fire_high_confidence_orths'}->{'-rc_name'} = '8Gb_job'
-  $analyses_by_name->{'paralogue_for_import_factory'}->{'-rc_name'} = '8Gb_job'
-  $analyses_by_name->{'mlss_id_for_high_confidence_factory'}->{'-rc_name'} = '8Gb_job'
-  $analyses_by_name->{'flag_high_confidence_orthologs'}->{'-rc_name'} = '2Gb_job'
-  $analyses_by_name->{'write_stn_tags'}->{'-rc_name'} = '8Gb_job'
+  $analyses_by_name->{'homology_dumps_mlss_id_factory'}->{'-rc_name'} = '8Gb_job';
+  $analyses_by_name->{'rib_group_1'}->{'-rc_name'} = '8Gb_job';
+  $analyses_by_name->{'rib_group_2'}->{'-rc_name'} = '8Gb_job';
+  $analyses_by_name->{'rib_group_3'}->{'-rc_name'} = '8Gb_job';
+  $analyses_by_name->{'rib_fire_tree_stats.resource_class_id'}->{'-rc_name'} = '8Gb_job';
+  $analyses_by_name->{'set_default_values'}->{'-rc_name'} = '8Gb_job';
+  $analyses_by_name->{'rib_fire_high_confidence_orths'}->{'-rc_name'} = '8Gb_job';
+  $analyses_by_name->{'paralogue_for_import_factory'}->{'-rc_name'} = '8Gb_job';
+  $analyses_by_name->{'mlss_id_for_high_confidence_factory'}->{'-rc_name'} = '8Gb_job';
+  $analyses_by_name->{'flag_high_confidence_orthologs'}->{'-rc_name'} = '2Gb_job';
+  $analyses_by_name->{'write_stn_tags'}->{'-rc_name'} = '8Gb_job';
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/WBParaSiteProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/WBParaSiteProteinTrees_conf.pm
@@ -93,8 +93,6 @@ sub default_options {
 
       'ortho_tree_capacity'     => 50,
       'other_paralogs_capacity' => 50,
-      
-      'old_server_uri' => ['mysql://ensro@mysql-ps-staging-1.ebi.ac.uk:4451/'],
 
 
       ######## THESE ARE PASSED INTO LOAD_REGISTRY_FROM_DB SO PASS IN DB_VERSION

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/WBParaSiteProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/WBParaSiteProteinTrees_conf.pm
@@ -93,6 +93,8 @@ sub default_options {
 
       'ortho_tree_capacity'     => 50,
       'other_paralogs_capacity' => 50,
+      
+      'old_server_uri' => ['mysql://ensro@mysql-ps-staging-1.ebi.ac.uk:4451/'],
 
 
       ######## THESE ARE PASSED INTO LOAD_REGISTRY_FROM_DB SO PASS IN DB_VERSION

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/WBParaSiteProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/WBParaSiteProteinTrees_conf.pm
@@ -68,7 +68,10 @@ sub default_options {
 
       # data directories:
       'work_dir'              =>  $ENV{PARASITE_SCRATCH} . '/compara/' . $self->o('pipeline_name'),
-      
+      'homology_dumps_shared_basedir' => $ENV{PARASITE_SCRATCH} . '/compara/' . '/homology_dumps/'. $self->o('division'),
+      'gene_tree_stats_shared_basedir' => $ENV{PARASITE_SCRATCH} . '/compara/' . '/gene_tree_stats/' . $self->o('division'),
+      'msa_stats_shared_basedir'       => $ENV{PARASITE_SCRATCH} . '/compara/' . '/msa_stats/' . $self->o('division'),
+            
       # tree building parameters:
       'species_tree_input_file'   =>  $ENV{PARASITE_CONF} . '/compara_guide_tree.wbparasite.tre',
 
@@ -154,7 +157,19 @@ sub tweak_analyses {
   $analyses_by_name->{'goc_entry_point'}->{'-rc_name'} = '1Gb_job';
   $analyses_by_name->{'dump_unannotated_members'}->{'-rc_name'} = '8Gb_job';
   $analyses_by_name->{'hcluster_parse_output'}->{'-rc_name'} = '8Gb_job';
-  
+  $analyses_by_name->{'HMMer_classifyPantherScore_himem'}->{'-rc_name'} = '32Gb_job';
+  $analyses_by_name->{'hc_global_tree_set'}->{'-rc_name'} = '32Gb_job';
+  $analyses_by_name->{'homology_dumps_mlss_id_factory'}->{'-rc_name'} = '8Gb_job'
+  $analyses_by_name->{'rib_group_1'}->{'-rc_name'} = '8Gb_job'
+  $analyses_by_name->{'rib_group_2'}->{'-rc_name'} = '8Gb_job'
+  $analyses_by_name->{'rib_group_3'}->{'-rc_name'} = '8Gb_job'
+  $analyses_by_name->{'rib_fire_tree_stats.resource_class_id'}->{'-rc_name'} = '8Gb_job'
+  $analyses_by_name->{'set_default_values'}->{'-rc_name'} = '8Gb_job'
+  $analyses_by_name->{'rib_fire_high_confidence_orths'}->{'-rc_name'} = '8Gb_job'
+  $analyses_by_name->{'paralogue_for_import_factory'}->{'-rc_name'} = '8Gb_job'
+  $analyses_by_name->{'mlss_id_for_high_confidence_factory'}->{'-rc_name'} = '8Gb_job'
+  $analyses_by_name->{'flag_high_confidence_orthologs'}->{'-rc_name'} = '2Gb_job'
+  $analyses_by_name->{'write_stn_tags'}->{'-rc_name'} = '8Gb_job'
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/WBParaSiteProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/WBParaSiteProteinTrees_conf.pm
@@ -163,7 +163,7 @@ sub tweak_analyses {
   $analyses_by_name->{'rib_group_1'}->{'-rc_name'} = '8Gb_job';
   $analyses_by_name->{'rib_group_2'}->{'-rc_name'} = '8Gb_job';
   $analyses_by_name->{'rib_group_3'}->{'-rc_name'} = '8Gb_job';
-  $analyses_by_name->{'rib_fire_tree_stats.resource_class_id'}->{'-rc_name'} = '8Gb_job';
+  $analyses_by_name->{'rib_fire_tree_stats'}->{'-rc_name'} = '8Gb_job';
   $analyses_by_name->{'set_default_values'}->{'-rc_name'} = '8Gb_job';
   $analyses_by_name->{'rib_fire_high_confidence_orths'}->{'-rc_name'} = '8Gb_job';
   $analyses_by_name->{'paralogue_for_import_factory'}->{'-rc_name'} = '8Gb_job';


### PR DESCRIPTION
WormBase ParaSite specific fixes we had to implement for WBPS18 (e108).

## Description

WormBase ParaSite runs this conf file to run ProteinTrees. We had to add some file paths that were missing and tweak the resource classes of some analyses that exceeded the memory requested.

**Related JIRA tickets:**
- ENSCOMPARASW-XXXX

## Overview of changes


#### Change 1
- Added some file paths specific to WormBase ParaSite production (i.e. homology_dumps_shared_basedir)

#### Change 2
- Added more analyses in the tweak_analyses sub, to alter their default resource class. (i.e. $analyses_by_name->{'rib_fire_high_confidence_orths'}->{'-rc_name'} = '8Gb_job')

## Testing
This code has sucessfully ran as part of WormBase ParaSite 18 production.

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
