### PR TITLE
Add must-reuse list to Metazoa config

### DIFF
--- a/conf/metazoa/must_reuse_species.json
+++ b/conf/metazoa/must_reuse_species.json
@@ -1,0 +1,13 @@
+[
+    "acyrthosiphon_pisum_gca005508785v2rs",
+    "anopheles_gambiae",
+    "apis_mellifera",
+    "bombus_terrestris",
+    "bombyx_mori",
+    "cimex_lectularius",
+    "diabrotica_virgifera_gca917563875v2rs",
+    "drosophila_melanogaster",
+    "schistocerca_americana_gca021461395v2rs",
+    "tribolium_castaneum",
+    "zootermopsis_nevadensis"
+]

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/LoadMembers_conf.pm
@@ -35,6 +35,8 @@ package Bio::EnsEMBL::Compara::PipeConfig::Metazoa::LoadMembers_conf;
 use strict;
 use warnings;
 
+use File::Spec::Functions;
+
 use base ('Bio::EnsEMBL::Compara::PipeConfig::LoadMembers_conf');
 
 
@@ -54,6 +56,13 @@ sub default_options {
         'store_ncrna'   => 0,  # Store ncRNA genes
         'store_others'  => 0,  # Store other genes
     };
+}
+
+sub tweak_analyses {
+    my $self = shift;
+    my $analyses_by_name = shift;
+
+    $analyses_by_name->{'check_reusability'}->{'-parameters'}{'must_reuse_list_file'} = catfile($self->o('config_dir'), 'must_reuse_species.json');
 }
 
 


### PR DESCRIPTION
## Description

The Metazoa`insects` protein-trees collection to be processed in e111 is expected to contain a subset of species (11 species as of the date of submission of this PR) which are also in one or both of the `default` or `protostomes` collections processed in e110. The gene members from these overlap species must be reused in e111.

This PR adds an automatic check to ensure that the gene sets of the overlap species are reused.

**Related JIRA tickets:**
- ENSCOMPARASW-6128

## Overview of changes

- A `must_reuse_species.json` file is added to the Metazoa config.
- If specified as a parameter in the `CheckGenomeReusability` runnable, the given genome is checked against the must-reuse list. The runnable dies if the genome is in the must-reuse list but has not been marked for reuse.
- The must-reuse list is set as a parameter of the `check_reusability` step of the Metazoa `LoadMembers` pipeline.

## Testing
A `LoadMembers` test pipeline was run successfully using the Metazoa must-reuse list.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
