### PR TITLE
Extend criteria for skipping query-reference pair

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -135,6 +135,7 @@ sub executable_locations {
         'DumpGFFAlignmentsForSynteny_exe'   => $self->check_exe_in_ensembl('ensembl-compara/scripts/synteny/DumpGFFAlignmentsForSynteny.pl'),
         'DumpGFFHomologuesForSynteny_exe'   => $self->check_exe_in_ensembl('ensembl-compara/scripts/synteny/DumpGFFHomologuesForSynteny.pl'),
         'emf2maf_program'                   => $self->check_exe_in_ensembl('ensembl-compara/scripts/dumps/emf2maf.pl'),
+        'get_genebuild_id_exe'              => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/get_core_genebuild_id.pl'),
         'msa_stats_report_exe'              => $self->check_exe_in_ensembl('ensembl-compara/scripts/production/msa_stats.pl'),
         'patch_db_exe'                      => $self->check_exe_in_ensembl('ensembl-compara/scripts/production/patch_database.pl'),
         'populate_new_database_exe'         => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/populate_new_database.pl'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
@@ -39,6 +39,8 @@ package Bio::EnsEMBL::Compara::PipeConfig::HomologyAnnotation_conf;
 use strict;
 use warnings;
 
+use File::Spec::Functions;
+
 use Bio::EnsEMBL::Hive::Version 2.5;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For WHEN and INPUT_PLUS
 
@@ -263,6 +265,8 @@ sub core_pipeline_analyses {
         {   -logic_name    => 'diamond_factory',
             -module        => 'Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::BlastFactory',
             -parameters    => {
+                'get_genebuild_id_exe' => $self->o('get_genebuild_id_exe'),
+                'ref_reg_conf'         => catfile($self->o('ensembl_root_dir'), 'ensembl-compara', 'conf', 'references', 'production_reg_conf.pl'),
                 'step'  => $self->o('num_sequences_per_blast_job'),
             },
             -rc_name       => '1Gb_job',

--- a/scripts/pipeline/get_core_genebuild_id.pl
+++ b/scripts/pipeline/get_core_genebuild_id.pl
@@ -1,0 +1,91 @@
+#!/usr/bin/env perl
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+=head1 NAME
+
+get_core_genebuild_id.pl
+
+=head1 DESCRIPTION
+
+Retrieves the Genebuild ID from the core database of the given species.
+
+=head1 EXAMPLE
+
+    perl $ENSEMBL_ROOT_DIR/ensembl-compara/scripts/pipeline/get_core_genebuild_id.pl \
+        --reg_conf $ENSEMBL_ROOT_DIR/ensembl-compara/conf/references/production_reg_conf.pl \
+        --species gallus_gallus
+
+=head1 OPTIONS
+
+=over
+
+=item B<[--help]>
+
+Prints help message and exits.
+
+=item B<[--reg_conf file_path]>
+
+Registry file path.
+
+=item B<[--species genome_name]>
+
+Production name of the genome whose Genebuild ID is to be retrieved.
+
+=back
+
+=cut
+
+
+use strict;
+use warnings;
+
+use Getopt::Long;
+use JSON qw(encode_json);
+use Pod::Usage;
+
+use Bio::EnsEMBL::Registry;
+
+
+my ($help, $reg_conf, $species);
+GetOptions(
+    'help'       => \$help,
+    'reg_conf=s' => \$reg_conf,
+    'species=s'  => \$species,
+) or pod2usage(-verbose => 2);
+
+# Handle "print usage" scenarios
+pod2usage(-exitvalue => 0, -verbose => 1) if $help;
+pod2usage(-verbose => 1) if !$reg_conf or !$species;
+
+
+my $registry = 'Bio::EnsEMBL::Registry';
+$registry->load_all($reg_conf, 0, 0, 0, 'throw_if_missing');
+
+my $meta_container = $registry->get_adaptor($species, 'Core', 'MetaContainer');
+
+my $genebuild_id = $meta_container->single_value_by_key('genebuild.id');
+
+if (defined $genebuild_id) {
+    $genebuild_id += 0  # hack so that genebuild_id is output as an integer
+} else {
+    $genebuild_id = JSON::null;
+}
+
+my $result = {
+    'genebuild_id' => $genebuild_id,
+};
+
+print STDOUT encode_json($result) . "\n";


### PR DESCRIPTION
## Description

The Compara homology annotation pipeline (in [lines 112-113 of HomologyAnnotation::BlastFactory](https://github.com/Ensembl/ensembl-compara/blob/c05dfaeef365c5da11a586fe29de78f2007d097e/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/BlastFactory.pm#L112-L113)) compares the production name of each Rapid-Release genome against each reference genome, and skips the given reference genome if the production names match.

However, 23 Rapid-Release (query) genomes are essentially the same as one of their Rapid-Release reference genomes despite having a different production name, which has led to unexpected homology annotations of each of these genomes against itself.

This PR addresses the issue by adding a supplementary identity check of key attributes of each query-reference pair: the GenomeDB `taxon_id`, `assembly` and `genebuild`, as well as the `genebuild.id` core meta entry. If all of these key attributes match between a Rapid-Release genome and its reference, then that query-reference pair is not included in homology annotation.

**Related JIRA tickets:**
- ENSCOMPARASW-6454
- [ENSRR-550](https://www.ebi.ac.uk/panda/jira/browse/ENSRR-550)

## Overview of changes

This PR adds a supplementary check of key attributes of each query-reference pair, to ensure that a reference genome which is essentially the same as a given query genome can be identified and skipped even if they do not have matching production names.

- The supplementary check is added in `RunnableDB::HomologyAnnotation::BlastFactory`, and a warning message is issued if a given query-reference pair is matched and skipped.
- Supporting script `get_core_genebuild_id.pl` is added to enable the `genebuild.id` meta entry to be accessed from the core database of the given reference.
- Supporting changes are made in the `HomologyAnnotation` and `ENV` pipeline config modules.

## Testing

This PR was tested by running the homology annotation pipeline as far as the relevant analysis (`diamond_factory`) and checking its warning output to confirm that the expected query-reference pairs were being skipped. For more details on testing, see ENSCOMPARASW-6454.

---

## PR review checklist

- [ ] Is the PR against an appropriate branch?
- [ ] Does the code adhere to coding guidelines?
- [ ] Does the code do what it claims to do?
- [ ] Is the code readable? Is it appropriately documented?
- [ ] Is the logic in the correct place?
- [ ] Was the code tested appropriately? Are there unit tests? Are unit tests self-contained and non-redundant?
- [ ] Did Travis CI pass for the code in the PR? Is Codecov acceptable based on the included/updated unit tests?
- [ ] Will the new code fail gracefully?
- [ ] Does the code follow good practice for writing performant code (e.g. using a database transaction rather than repeated queries outside of a transaction)?
- [ ] Does it bring in an unnecessary dependency?
- [ ] If you are reviewing a new analysis, is it future-proof and pluggable?
- [ ] Does the PR meet agile guidelines?
