### PR TITLE
Add resource classes with Slurm time limits

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateHmmProfiles_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateHmmProfiles_conf.pm
@@ -836,7 +836,7 @@ sub core_pipeline_analyses {
                 'blast_db'                  => '#fasta_dir#/unannotated.fasta',
                 %blastp_parameters,
             },
-            -rc_name       => '250Mb_6_hour_job',
+            -rc_name       => '1Gb_6_hour_job',
             -flow_into => {
                -1 => [ 'blastp_unannotated_himem' ],  # MEMLIMIT
                -2 => 'break_batch',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -141,303 +141,447 @@ sub executable_locations {
 }
 
 
+
+# Methods 'resource_classes_single_thread' and 'resource_classes_multi_thread' generate
+# a set of resource classes from the resource-class templates, and the former also has
+# additional resource classes. By the end of the process, every resource class should
+# have config for supported meadows, with each meadow config being a two-element arrayref
+# of the form: '[$submission_cmd_args, $worker_cmd_args]'.
+
 sub resource_classes_single_thread {
     my ($self) = @_;
-    my $reg_requirement = '--reg_conf '.$self->o('reg_conf');
-    return {
+
+    my $resource_class_templates = {
         # 1 Gb seems to be the minimum we need nowadays
-        'default' => {
-            'LSF'   => ['-C0 -M1000 -R"select[mem>1000] rusage[mem=1000]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --time=24:00:00 --mem=1g', $reg_requirement],
-            'LOCAL' => ['', $reg_requirement],
-        },
-
-        '500Mb_job'    => {
-            'LSF'   => ['-C0 -M500 -R"select[mem>500] rusage[mem=500]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --time=24:00:00 --mem=500m', $reg_requirement],
-            'LOCAL' => [ '', $reg_requirement ]
-        },
-
         '1Gb_job' => {
-            'LSF'   => ['-C0 -M1000 -R"select[mem>1000] rusage[mem=1000]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --time=24:00:00 --mem=1g', $reg_requirement],
-            'LOCAL' => ['', $reg_requirement],
+            'LSF'   => '-C0 -M1000 -R"select[mem>1000] rusage[mem=1000]"',
+            'SLURM' => '--partition=standard --mem=1g',
         },
 
         '2Gb_job' => {
-            'LSF'   => ['-C0 -M2000 -R"select[mem>2000] rusage[mem=2000]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --time=24:00:00 --mem=2g', $reg_requirement],
-            'LOCAL' => ['', $reg_requirement],
+            'LSF'   => '-C0 -M2000 -R"select[mem>2000] rusage[mem=2000]"',
+            'SLURM' => '--partition=standard --mem=2g',
         },
 
         '4Gb_job' => {
-            'LSF'   => ['-C0 -M4000 -R"select[mem>4000] rusage[mem=4000]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --time=24:00:00 --mem=4g', $reg_requirement],
-            'LOCAL' => ['', $reg_requirement],
+            'LSF'   => '-C0 -M4000 -R"select[mem>4000] rusage[mem=4000]"',
+            'SLURM' => '--partition=standard --mem=4g',
         },
 
         '8Gb_job' => {
-            'LSF'   => ['-C0 -M8000 -R"select[mem>8000] rusage[mem=8000]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --time=24:00:00 --mem=8g', $reg_requirement],
-            'LOCAL' => ['', $reg_requirement],
+            'LSF'   => '-C0 -M8000 -R"select[mem>8000] rusage[mem=8000]"',
+            'SLURM' => '--partition=standard --mem=8g',
         },
 
         '16Gb_job' => {
-            'LSF'   => ['-C0 -M16000 -R"select[mem>16000] rusage[mem=16000]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --time=24:00:00 --mem=16g', $reg_requirement],
-            'LOCAL' => ['', $reg_requirement],
+            'LSF'   => '-C0 -M16000 -R"select[mem>16000] rusage[mem=16000]"',
+            'SLURM' => '--partition=standard --mem=16g',
         },
 
         '24Gb_job' => {
-            'LSF'   => ['-C0 -M24000 -R"select[mem>24000] rusage[mem=24000]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --time=24:00:00 --mem=24g', $reg_requirement],
-            'LOCAL' => ['', $reg_requirement],
+            'LSF'   => '-C0 -M24000 -R"select[mem>24000] rusage[mem=24000]"',
+            'SLURM' => '--partition=standard --mem=24g',
         },
 
         '32Gb_job' => {
-            'LSF'   => ['-C0 -M32000 -R"select[mem>32000] rusage[mem=32000]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --time=24:00:00 --mem=32g', $reg_requirement],
-            'LOCAL' => ['', $reg_requirement],
+            'LSF'   => '-C0 -M32000 -R"select[mem>32000] rusage[mem=32000]"',
+            'SLURM' => '--partition=standard --mem=32g',
         },
 
         '48Gb_job' => {
-            'LSF'   => ['-C0 -M48000 -R"select[mem>48000] rusage[mem=48000]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --time=24:00:00 --mem=48g', $reg_requirement],
-            'LOCAL' => ['', $reg_requirement],
+            'LSF'   => '-C0 -M48000 -R"select[mem>48000] rusage[mem=48000]"',
+            'SLURM' => '--partition=standard --mem=48g',
         },
 
         '64Gb_job' => {
-            'LSF'   => ['-C0 -M64000 -R"select[mem>64000] rusage[mem=64000]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --time=24:00:00 --mem=64g', $reg_requirement],
-            'LOCAL' => ['', $reg_requirement],
+            'LSF'   => '-C0 -M64000 -R"select[mem>64000] rusage[mem=64000]"',
+            'SLURM' => '--partition=standard --mem=64g',
         },
 
         '96Gb_job' => {
-            'LSF'   => ['-C0 -M96000 -R"select[mem>96000] rusage[mem=96000]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --time=24:00:00 --mem=96g', $reg_requirement],
-            'LOCAL' => ['', $reg_requirement],
+            'LSF'   => '-C0 -M96000 -R"select[mem>96000] rusage[mem=96000]"',
+            'SLURM' => '--partition=standard --mem=96g',
         },
 
         '512Gb_job' => {
-            'LSF'   => ['-q bigmem -C0 -M512000 -R"select[mem>512000] rusage[mem=512000]"', $reg_requirement],
-            'SLURM' => ['--partition=bigmem --time=24:00:00 --mem=512g', $reg_requirement],
-            'LOCAL' => ['', $reg_requirement],
+            'LSF'   => '-q bigmem -C0 -M512000 -R"select[mem>512000] rusage[mem=512000]"',
+            'SLURM' => '--partition=bigmem --mem=512g',
         },
+    };
 
-        '250Mb_6_hour_job' => {
-            'LSF'   => ['-C0 -W 6:00 -M250 -R"select[mem>250] rusage[mem=250]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --time=6:00:00 --mem=250m', $reg_requirement],
-            'LOCAL' => ['', $reg_requirement],
-        },
+    my $long_running_rc_keys = [
+        '1Gb_job',
+        '8Gb_job',
+        '64Gb_job',
+        '96Gb_job',
+    ];
 
-        '500Mb_6_hour_job' => {
-            'LSF'   => ['-C0 -W 6:00 -M500 -R"select[mem>500] rusage[mem=500]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --time=6:00:00 --mem=500m', $reg_requirement],
-            'LOCAL' => ['', $reg_requirement],
+    my $resource_classes = _generate_resource_classes($resource_class_templates, $long_running_rc_keys);
+
+    # Some resource classes do not fit the typical pattern, so we add them here.
+    my %additional_resource_classes = (
+
+        '1Gb_6_hour_job' => {
+            'LSF'   => ['-C0 -M500 -R"select[mem>500] rusage[mem=500]" -W 6:00'],
+            'SLURM' => ['--partition=standard --mem=500m --time=6:00:00'],
         },
 
         '2Gb_6_hour_job' => {
-            'LSF'   => ['-C0 -W 6:00 -M2000 -R"select[mem>2000] rusage[mem=2000]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --time=6:00:00 --mem=2g', $reg_requirement],
-            'LOCAL' => ['', $reg_requirement],
+            'LSF'   => ['-C0 -M2000 -R"select[mem>2000] rusage[mem=2000]" -W 6:00'],
+            'SLURM' => ['--partition=standard --mem=2g --time=6:00:00'],
         },
 
         '1Gb_datamover_job' => {
-            'LSF'   => ['-q datamover -C0 -M1000 -R"select[mem>1000] rusage[mem=1000]"', $reg_requirement],
-            'SLURM' => ['--partition=datamover --time=24:00:00 --mem=1g', $reg_requirement],
-            'LOCAL' => ['', $reg_requirement],
+            'LSF'   => ['-q datamover -C0 -M1000 -R"select[mem>1000] rusage[mem=1000]"'],
+            'SLURM' => ['--partition=datamover --mem=1g --time=24:00:00'],
         },
-    };
+    );
+    %{$resource_classes} = (%{$resource_classes}, %additional_resource_classes);
+
+    _apply_common_rc_config($resource_classes);
+
+    $resource_classes->{'default'} = \%{$resource_classes->{'1Gb_job'}};
+
+    return $resource_classes;
 }
 
 sub resource_classes_multi_thread {
     my ($self) = @_;
-    my $reg_requirement = '--reg_conf '.$self->o('reg_conf');
-    return {
-        # In theory, LOCAL should also be defined, but I assumed it is very unlikely we use it for multi-threaded jobs
 
-        '500Mb_2c_job' => {
-            'LSF'   => ['-C0 -n 2 -M500 -R"span[hosts=1] select[mem>500] rusage[mem=500]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=2 --time=24:00:00 --mem=500m', $reg_requirement],
+    my $resource_class_templates = {
+
+        '1Gb_2c_job' => {
+            'LSF'   => '-C0 -n 2 -M1000 -R"span[hosts=1] select[mem>1000] rusage[mem=1000]"',
+            'SLURM' => '--partition=standard --cpus-per-task=2 --mem=1g',
         },
 
-        '1Gb_2c_job'   => {
-            'LSF'   => ['-C0 -n 2 -M1000 -R"span[hosts=1] select[mem>1000] rusage[mem=1000]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=2 --time=24:00:00 --mem=1g', $reg_requirement],
+        '2Gb_2c_job' => {
+            'LSF'   => '-C0 -n 2 -M2000 -R"span[hosts=1] select[mem>2000] rusage[mem=2000]"',
+            'SLURM' => '--partition=standard --cpus-per-task=2 --mem=2g',
         },
 
-        '2Gb_2c_job'   => {
-            'LSF'   => ['-C0 -n 2 -M2000 -R"span[hosts=1] select[mem>2000] rusage[mem=2000]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=2 --time=24:00:00 --mem=2g', $reg_requirement],
+        '4Gb_2c_job' => {
+            'LSF'   => '-C0 -n 2 -M4000 -R"span[hosts=1] select[mem>4000] rusage[mem=4000]"',
+            'SLURM' => '--partition=standard --cpus-per-task=2 --mem=4g',
         },
 
-        '4Gb_2c_job'   => {
-            'LSF'   => ['-C0 -n 2 -M4000 -R"span[hosts=1] select[mem>4000] rusage[mem=4000]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=2 --time=24:00:00 --mem=4g', $reg_requirement],
+        '8Gb_2c_job' => {
+            'LSF'   => '-C0 -n 2 -M8000 -R"span[hosts=1] select[mem>8000] rusage[mem=8000]"',
+            'SLURM' => '--partition=standard --cpus-per-task=2 --mem=8g',
         },
 
-        '8Gb_2c_job'   => {
-            'LSF'   => ['-C0 -n 2 -M8000 -R"span[hosts=1] select[mem>8000] rusage[mem=8000]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=2 --time=24:00:00 --mem=8g', $reg_requirement],
+        '1Gb_4c_job' => {
+            'LSF'   => '-n 4 -C0 -M1000 -R"select[mem>1000] rusage[mem=1000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=4 --mem=1g',
         },
 
-        '1Gb_4c_job'   => {
-            'LSF'   => ['-n 4 -C0 -M1000 -R"select[mem>1000] rusage[mem=1000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=4 --time=24:00:00 --mem=1g', $reg_requirement],
+        '2Gb_4c_job' => {
+            'LSF'   => '-n 4 -C0 -M2000 -R"select[mem>2000] rusage[mem=2000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=4 --mem=2g',
         },
 
-        '2Gb_4c_job'   => {
-            'LSF'   => ['-n 4 -C0 -M2000 -R"select[mem>2000] rusage[mem=2000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=4 --time=24:00:00 --mem=2g', $reg_requirement],
+        '4Gb_4c_job' => {
+            'LSF'   => '-n 4 -C0 -M4000 -R"select[mem>4000] rusage[mem=4000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=4 --mem=4g',
         },
 
-        '4Gb_4c_job'   => {
-            'LSF'   => ['-n 4 -C0 -M4000 -R"select[mem>4000] rusage[mem=4000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=4 --time=24:00:00 --mem=4g', $reg_requirement],
+        '8Gb_4c_job' => {
+            'LSF'   => '-n 4 -C0 -M8000 -R"select[mem>8000] rusage[mem=8000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=4 --mem=8g',
         },
 
-        '8Gb_4c_job'   => {
-            'LSF'   => ['-n 4 -C0 -M8000 -R"select[mem>8000] rusage[mem=8000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=4 --time=24:00:00 --mem=8g', $reg_requirement],
+        '16Gb_4c_job' => {
+            'LSF'   => '-n 4 -C0 -M16000 -R"select[mem>16000] rusage[mem=16000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=4 --mem=16g',
         },
 
-        '16Gb_4c_job'  => {
-            'LSF'   => ['-n 4 -C0 -M16000 -R"select[mem>16000] rusage[mem=16000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=4 --time=24:00:00 --mem=16g', $reg_requirement],
+        '32Gb_4c_job' => {
+            'LSF'   => '-n 4 -C0 -M32000 -R"select[mem>32000] rusage[mem=32000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=4 --mem=32g',
         },
 
-        '32Gb_4c_job'  => {
-            'LSF'   => ['-n 4 -C0 -M32000 -R"select[mem>32000] rusage[mem=32000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=4 --time=24:00:00 --mem=32g', $reg_requirement],
+        '1Gb_8c_job' => {
+            'LSF'   => '-n 8 -C0 -M1000 -R"select[mem>1000] rusage[mem=1000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=8 --mem=1g',
         },
 
-        '2Gb_8c_job'   => {
-            'LSF'   => ['-n 8 -C0 -M2000 -R"select[mem>2000] rusage[mem=2000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=8 --time=24:00:00 --mem=2g', $reg_requirement],
+        '2Gb_8c_job' => {
+            'LSF'   => '-n 8 -C0 -M2000 -R"select[mem>2000] rusage[mem=2000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=8 --mem=2g',
         },
 
-        '4Gb_8c_job'   => {
-            'LSF'   => ['-n 8 -C0 -M4000 -R"select[mem>4000] rusage[mem=4000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=8 --time=24:00:00 --mem=4g', $reg_requirement],
+        '2Gb_8c_job' => {
+            'LSF'   => '-n 8 -C0 -M2000 -R"select[mem>2000] rusage[mem=2000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=8 --mem=2g',
         },
 
-        '8Gb_8c_job'   => {
-            'LSF'   => ['-n 8 -C0 -M8000 -R"select[mem>8000] rusage[mem=8000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=8 --time=24:00:00 --mem=8g', $reg_requirement],
+        '4Gb_8c_job' => {
+            'LSF'   => '-n 8 -C0 -M4000 -R"select[mem>4000] rusage[mem=4000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=8 --mem=4g',
         },
 
-        '16Gb_8c_job'  => {
-            'LSF'   => ['-n 8 -C0 -M16000 -R"select[mem>16000] rusage[mem=16000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=8 --time=24:00:00 --mem=16g', $reg_requirement],
+        '8Gb_8c_job' => {
+            'LSF'   => '-n 8 -C0 -M8000 -R"select[mem>8000] rusage[mem=8000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=8 --mem=8g',
         },
 
-        '32Gb_8c_job'  => {
-            'LSF'   => ['-n 8 -C0 -M32000 -R"select[mem>32000] rusage[mem=32000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=8 --time=24:00:00 --mem=32g', $reg_requirement],
+        '16Gb_8c_job' => {
+            'LSF'   => '-n 8 -C0 -M16000 -R"select[mem>16000] rusage[mem=16000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=8 --mem=16g',
         },
 
-        '64Gb_8c_job'  => {
-            'LSF'   => ['-n 8 -C0 -M64000 -R"select[mem>64000] rusage[mem=64000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=8 --time=24:00:00 --mem=64g', $reg_requirement],
+        '32Gb_8c_job' => {
+            'LSF'   => '-n 8 -C0 -M32000 -R"select[mem>32000] rusage[mem=32000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=8 --mem=32g',
         },
 
-        '96Gb_8c_job'  => {
-            'LSF'   => ['-n 8 -C0 -M96000 -R"select[mem>96000] rusage[mem=96000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=8 --time=24:00:00 --mem=96g', $reg_requirement],
+        '64Gb_8c_job' => {
+            'LSF'   => '-n 8 -C0 -M64000 -R"select[mem>64000] rusage[mem=64000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=8 --mem=64g',
         },
 
-        '8Gb_16c_job'  => {
-            'LSF'   => ['-n 16 -C0 -M8000 -R"select[mem>8000] rusage[mem=8000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=16 --time=24:00:00 --mem=8g', $reg_requirement],
+        '96Gb_8c_job' => {
+            'LSF'   => '-n 8 -C0 -M96000 -R"select[mem>96000] rusage[mem=96000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=8 --mem=96g',
+        },
+
+        '8Gb_16c_job' => {
+            'LSF'   => '-n 16 -C0 -M8000 -R"select[mem>8000] rusage[mem=8000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=16 --mem=8g',
         },
 
         '16Gb_16c_job' => {
-            'LSF'   => ['-n 16 -C0 -M16000 -R"select[mem>16000] rusage[mem=16000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=16 --time=24:00:00 --mem=16g', $reg_requirement],
+            'LSF'   => '-n 16 -C0 -M16000 -R"select[mem>16000] rusage[mem=16000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=16 --mem=16g',
         },
 
         '32Gb_16c_job' => {
-            'LSF'   => ['-n 16 -C0 -M16000 -R"select[mem>32000] rusage[mem=32000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=16 --time=24:00:00 --mem=32g', $reg_requirement],
+            'LSF'   => '-n 16 -C0 -M32000 -R"select[mem>32000] rusage[mem=32000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=16 --mem=32g',
         },
 
         '64Gb_16c_job' => {
-            'LSF'   => ['-n 16 -C0 -M64000 -R"select[mem>64000] rusage[mem=64000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=16 --time=24:00:00 --mem=64g', $reg_requirement],
+            'LSF'   => '-n 16 -C0 -M64000 -R"select[mem>64000] rusage[mem=64000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=16 --mem=64g',
         },
 
-        '128Gb_16c_job'  => {
-            'LSF' => ['-n 16 -C0 -M128000 -R"select[mem>128000] rusage[mem=128000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=16 --time=24:00:00 --mem=128g', $reg_requirement],
+        '128Gb_16c_job' => {
+            'LSF'   => '-n 16 -C0 -M128000 -R"select[mem>128000] rusage[mem=128000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=16 --mem=128g',
         },
 
         '16Gb_32c_job' => {
-            'LSF' => ['-n 32 -C0 -M16000 -R"select[mem>16000] rusage[mem=16000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=32 --time=24:00:00 --mem=16g', $reg_requirement],
+            'LSF'   => '-n 32 -C0 -M16000 -R"select[mem>16000] rusage[mem=16000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=32 --mem=16g',
         },
 
         '32Gb_32c_job' => {
-            'LSF' => ['-n 32 -C0 -M32000 -R"select[mem>32000] rusage[mem=32000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=32 --time=24:00:00 --mem=32g', $reg_requirement],
+            'LSF'   => '-n 32 -C0 -M32000 -R"select[mem>32000] rusage[mem=32000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=32 --mem=32g',
         },
 
         '64Gb_32c_job' => {
-            'LSF' => ['-n 32 -C0 -M64000 -R"select[mem>64000] rusage[mem=64000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=32 --time=24:00:00 --mem=64g', $reg_requirement],
+            'LSF'   => '-n 32 -C0 -M64000 -R"select[mem>64000] rusage[mem=64000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=32 --mem=64g',
         },
 
         '128Gb_32c_job' => {
-            'LSF' => ['-n 32 -C0 -M128000 -R"select[mem>128000] rusage[mem=128000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=32 --time=24:00:00 --mem=128g', $reg_requirement],
+            'LSF'   => '-n 32 -C0 -M128000 -R"select[mem>128000] rusage[mem=128000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=32 --mem=128g',
         },
 
-        '16Gb_64c_job' => {
-            'LSF' => ['-n 64 -C0 -M16000 -R"select[mem>16000] rusage[mem=16000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=64 --time=24:00:00 --mem=16g', $reg_requirement],
+        '4Gb_48c_job' => {
+            'LSF'   => '-n 48 -C0 -M4000 -R"span[hosts=1] select[mem>4000] rusage[mem=4000]"',
+            'SLURM' => '--partition=standard --cpus-per-task=48 --mem=4g',
         },
 
-        '32Gb_64c_job' => {
-            'LSF' => ['-n 64 -C0 -M32000 -R"select[mem>32000] rusage[mem=32000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=64 --time=24:00:00 --mem=32g', $reg_requirement],
+        '16Gb_48c_job' => {
+            'LSF'   => '-n 48 -C0 -M16000 -R"select[mem>16000] rusage[mem=16000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=48 --mem=16g',
         },
 
-        '64Gb_64c_job' => {
-            'LSF' => ['-n 64 -C0 -M64000 -R"select[mem>64000] rusage[mem=64000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=64 --time=24:00:00 --mem=64g', $reg_requirement],
+        '32Gb_48c_job' => {
+            'LSF'   => '-n 48 -C0 -M32000 -R"select[mem>32000] rusage[mem=32000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=48 --mem=32g',
         },
 
-        '128Gb_64c_job' => {
-            'LSF' => ['-n 64 -C0 -M128000 -R"select[mem>128000] rusage[mem=128000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=64 --time=24:00:00 --mem=128g', $reg_requirement],
+        '64Gb_48c_job' => {
+            'LSF'   => '-n 48 -C0 -M64000 -R"select[mem>64000] rusage[mem=64000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=48 --mem=64g',
         },
 
-        '256Gb_64c_job' => {
-            'LSF' => ['-n 64 -C0 -M256000 -R"select[mem>256000] rusage[mem=256000] span[hosts=1]"', $reg_requirement],
-            'SLURM' => ['--partition=standard --cpus-per-task=64 --time=24:00:00 --mem=256g', $reg_requirement],
+        '128Gb_48c_job' => {
+            'LSF'   => '-n 48 -C0 -M128000 -R"select[mem>128000] rusage[mem=128000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=48 --mem=128g',
         },
 
-        '8Gb_4c_mpi'   => {'LSF' => ['-q mpi -n 4  -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=4]"', $reg_requirement] },
-        '8Gb_8c_mpi'   => {'LSF' => ['-q mpi -n 8  -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=8]"', $reg_requirement] },
-        '8Gb_16c_mpi'  => {'LSF' => ['-q mpi -n 16 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=16]"', $reg_requirement] },
-        '8Gb_24c_mpi'  => {'LSF' => ['-q mpi -n 24 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=12]"', $reg_requirement] },
-        '8Gb_32c_mpi'  => {'LSF' => ['-q mpi -n 32 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=16]"', $reg_requirement] },
-        '8Gb_64c_mpi'  => {'LSF' => ['-q mpi -n 64 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=16]"', $reg_requirement] },
+        '256Gb_48c_job' => {
+            'LSF'   => '-n 48 -C0 -M256000 -R"select[mem>256000] rusage[mem=256000] span[hosts=1]"',
+            'SLURM' => '--partition=standard --cpus-per-task=48 --mem=256g',
+        },
 
-        '16Gb_4c_mpi'  => {'LSF' => ['-q mpi -n 4  -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=4]"', $reg_requirement] },
-        '16Gb_8c_mpi'  => {'LSF' => ['-q mpi -n 8  -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=8]"', $reg_requirement] },
-        '16Gb_16c_mpi' => {'LSF' => ['-q mpi -n 16 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=16]"', $reg_requirement] },
-        '16Gb_24c_mpi' => {'LSF' => ['-q mpi -n 24 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=12]"', $reg_requirement] },
-        '16Gb_32c_mpi' => {'LSF' => ['-q mpi -n 32 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=16]"', $reg_requirement] },
 
-        '32Gb_4c_mpi'  => {'LSF' => ['-q mpi -n 4  -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=4]"', $reg_requirement] },
-        '32Gb_8c_mpi'  => {'LSF' => ['-q mpi -n 8  -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=8]"', $reg_requirement] },
-        '32Gb_16c_mpi' => {'LSF' => ['-q mpi -n 16 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=16]"', $reg_requirement] },
-        '32Gb_24c_mpi' => {'LSF' => ['-q mpi -n 24 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=12]"', $reg_requirement] },
-        '32Gb_32c_mpi' => {'LSF' => ['-q mpi -n 32 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=16]"', $reg_requirement] },
-        '32Gb_64c_mpi' => {'LSF' => ['-q mpi -n 64 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=16]"', $reg_requirement] },
+        '8Gb_4c_mpi' => {
+            'LSF'   => '-q mpi -n 4 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=4]"',
+        },
 
-        '64Gb_4c_mpi'  => {'LSF' => ['-q mpi -n 4  -M64000 -R"select[mem>64000] rusage[mem=64000] same[model] span[ptile=4]"', $reg_requirement] },
+        '8Gb_8c_mpi' => {
+            'LSF'    => '-q mpi -n 8 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=8]"',
+        },
+
+        '8Gb_16c_mpi' => {
+            'LSF'    => '-q mpi -n 16 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=16]"',
+        },
+
+        '8Gb_24c_mpi' => {
+            'LSF'    => '-q mpi -n 24 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=12]"',
+        },
+
+        '8Gb_32c_mpi' => {
+            'LSF'    => '-q mpi -n 32 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=16]"',
+        },
+
+        '8Gb_64c_mpi' => {
+            'LSF'    => '-q mpi -n 64 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=16]"',
+        },
+
+        '16Gb_4c_mpi' => {
+            'LSF'    => '-q mpi -n 4 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=4]"',
+        },
+
+        '16Gb_8c_mpi' => {
+            'LSF' => '-q mpi -n 8 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=8]"',
+        },
+
+        '16Gb_16c_mpi' => {
+            'LSF'    => '-q mpi -n 16 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=16]"',
+        },
+
+        '16Gb_24c_mpi' => {
+            'LSF'    => '-q mpi -n 24 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=12]"',
+        },
+
+        '16Gb_32c_mpi' => {
+            'LSF'    => '-q mpi -n 32 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=16]"',
+        },
+
+        '32Gb_4c_mpi' => {
+            'LSF'    => '-q mpi -n 4 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=4]"',
+        },
+
+        '32Gb_8c_mpi' => {
+            'LSF'    => '-q mpi -n 8 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=8]"',
+        },
+
+        '32Gb_16c_mpi' => {
+            'LSF'    => '-q mpi -n 16 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=16]"',
+        },
+
+        '32Gb_24c_mpi' => {
+            'LSF'    => '-q mpi -n 24 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=12]"',
+        },
+
+        '32Gb_32c_mpi' => {
+            'LSF'    => '-q mpi -n 32 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=16]"',
+        },
+
+        '32Gb_64c_mpi' => {
+            'LSF'    => '-q mpi -n 64 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=16]"',
+        },
+
+        '64Gb_4c_mpi' => {
+            'LSF'    => '-q mpi -n 4 -M64000 -R"select[mem>64000] rusage[mem=64000] same[model] span[ptile=4]"',
+        },
     };
+
+    my $long_running_rc_keys = [
+        '2Gb_2c_job',
+        '4Gb_4c_job',
+        '8Gb_8c_job',
+        '64Gb_8c_job',
+        '96Gb_8c_job',
+        '8Gb_16c_job',
+        '32Gb_16c_job',
+        '64Gb_16c_job',
+        '128Gb_16c_job',
+        '16Gb_32c_job',
+        '32Gb_32c_job',
+        '64Gb_32c_job',
+        '128Gb_32c_job',
+        '16Gb_48c_job',
+        '64Gb_48c_job',
+        '128Gb_48c_job',
+        '256Gb_48c_job',
+    ];
+
+    my $resource_classes = _generate_resource_classes($resource_class_templates, $long_running_rc_keys);
+
+    _apply_common_rc_config($resource_classes);
+
+    return $resource_classes;
+}
+
+sub _apply_common_rc_config {
+    my ($resource_classes) = @_;
+
+    my $local_submission_cmd_args = '';
+    my $worker_cmd_args = '--reg_conf production_reg_conf.pl';
+    while (my ($rc_name, $rc_config) = each %{$resource_classes}) {
+        $rc_config->{'LOCAL'} = [$local_submission_cmd_args];
+
+        while (my ($meadow_name, $meadow_config) = each %{$rc_config}) {
+            push(@{$meadow_config}, $worker_cmd_args);
+        }
+    }
+}
+
+sub _generate_resource_classes {
+    my ($resource_class_templates, $long_running_rc_keys) = @_;
+
+    my %time_limits = (
+        '1_hour' => {
+            'LSF'   => '',
+            'SLURM' => '--time=1:00:00',
+        },
+        '24_hour' => {
+            'LSF'   => '',
+            'SLURM' => '--time=24:00:00',
+        },
+        '168_hour' => {
+            'LSF'   => '',
+            'SLURM' => '--time=168:00:00',
+        },
+        '720_hour' => {
+            'LSF'   => '-q long -W 720:00',
+            'SLURM' => '--time=720:00:00',
+        },
+    );
+
+    my $resource_classes;
+    while (my ($rc_key, $submission_cmd_config) = each %{$resource_class_templates}) {
+        while (my ($time_limit_name, $time_limit_config) = each %time_limits) {
+
+            if ($time_limit_name eq '720_hour' && !grep { $_ eq $rc_key } @{$long_running_rc_keys}) {
+                next;
+            }
+
+            my $rc_name = $rc_key;
+            if ($time_limit_name ne '24_hour') {
+                next if ($rc_key =~ /_mpi$/);
+                $rc_name =~ s/(?=_job$)/_${time_limit_name}/;
+            }
+
+            while (my ($meadow_name, $submission_cmd_args) = each %{$submission_cmd_config}) {
+                my $time_limit_arg = $time_limit_config->{$meadow_name};
+                if ($time_limit_arg) {
+                    $submission_cmd_args = "$submission_cmd_args $time_limit_arg";
+                }
+                $resource_classes->{$rc_name}{$meadow_name} = [$submission_cmd_args];
+            }
+        }
+    }
+
+    return $resource_classes;
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/UpdateMemberNamesDescriptions.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/UpdateMemberNamesDescriptions.pm
@@ -38,7 +38,7 @@ This pipeline assumes the param_stack is turned on. There is 1 stream
 of jobs per species, so you will have to set 'update_capacity' not to
 overload the database.
 
-Jobs usually take 500MB of memory and expect the 500Mb_job resource-class
+Jobs usually take 500MB of memory and expect the default resource-class
 to be defined.
 
 =head2 Seeding

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
@@ -121,7 +121,7 @@ sub tweak_analyses {
     $analyses_by_name->{'threshold_on_dS'}->{'-rc_name'}          = '1Gb_job';
     $analyses_by_name->{'HMMer_classifyPantherScore'}->{'-rc_name'} = '2Gb_job';
     $analyses_by_name->{'HMMer_classifyPantherScore'}->{'-hive_capacity'} = '2000';
-    $analyses_by_name->{'blastp'}->{'-rc_name'} = '500Mb_6_hour_job';
+    $analyses_by_name->{'blastp'}->{'-rc_name'} = '1Gb_6_hour_job';
     $analyses_by_name->{'get_species_set'}->{'-parameters'}->{'polyploid_genomes'} = 0;
     $analyses_by_name->{'quick_tree_break_himem'}->{'-rc_name'}   = '16Gb_job';
     $analyses_by_name->{'quick_tree_break'}->{'-rc_name'}   = '4Gb_job';

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -1255,7 +1255,7 @@ sub core_pipeline_analyses {
                 'blast_db'                  => '#fasta_dir#/unannotated.fasta',
                 %blastp_parameters,
             },
-            -rc_name       => '250Mb_6_hour_job',
+            -rc_name       => '1Gb_6_hour_job',
             -flow_into => {
                -1 => [ 'blastp_unannotated_himem' ],  # MEMLIMIT
                -2 => 'break_batch_unannotated',
@@ -1423,7 +1423,7 @@ sub core_pipeline_analyses {
                 %blastp_parameters,
             },
             -batch_size    => 25,
-            -rc_name       => '250Mb_6_hour_job',
+            -rc_name       => '1Gb_6_hour_job',
             -flow_into => {
                -1 => [ 'blastp_himem' ],  # MEMLIMIT
                -2 => [ 'break_batch' ],   # RUNLIMIT
@@ -2279,7 +2279,7 @@ sub core_pipeline_analyses {
                     '(#raxml_cores# >  4)  && (#raxml_cores# <= 8)'     => 'raxml_parsimony_8_cores',
                     '(#raxml_cores# >  8)  && (#raxml_cores# <= 16)'    => 'raxml_parsimony_16_cores',
                     '(#raxml_cores# >  16) && (#raxml_cores# <= 32)'    => 'raxml_parsimony_32_cores',
-                    '(#raxml_cores# >  32)'                             => 'raxml_parsimony_64_cores',
+                    '(#raxml_cores# >  32)'                             => 'raxml_parsimony_48_cores',
                 ),
                 'A->1' => 'raxml_decision',
             },
@@ -2427,31 +2427,31 @@ sub core_pipeline_analyses {
             -rc_name 		=> '32Gb_32c_job',
         },
 
-        {   -logic_name => 'raxml_parsimony_64_cores',
+        {   -logic_name => 'raxml_parsimony_48_cores',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RAxML_parsimony',
             -parameters => {
                 %raxml_parsimony_parameters,
-                'raxml_number_of_cores'     => 64,
+                'raxml_number_of_cores'     => 48,
                 'cmd_max_runtime'           => '518400',
                 'escape_branch'             => -1,
             },
             -hive_capacity  => $self->o('raxml_capacity'),
-            -rc_name 		=> '16Gb_64c_job',
+            -rc_name 		=> '16Gb_48c_job',
             -flow_into      => {
-                -1 => [ 'raxml_parsimony_64_cores_himem' ],
+                -1 => [ 'raxml_parsimony_48_cores_himem' ],
                 -2 => [ 'fasttree' ],
             }
         },
 
-        {   -logic_name => 'raxml_parsimony_64_cores_himem',
+        {   -logic_name => 'raxml_parsimony_48_cores_himem',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RAxML_parsimony',
             -parameters => {
                 %raxml_parsimony_parameters,
-                'raxml_number_of_cores'     => 64,
+                'raxml_number_of_cores'     => 48,
                 'cmd_max_runtime'           => '518400',
             },
             -hive_capacity  => $self->o('raxml_capacity'),
-            -rc_name 		=> '32Gb_64c_job',
+            -rc_name 		=> '32Gb_48c_job',
             -flow_into      => {
                 -2 => [ 'fasttree' ],
             }
@@ -2485,9 +2485,9 @@ sub core_pipeline_analyses {
                     '(#raxml_cores# >  8)  && (#raxml_cores# <= 16)'    => 'raxml_16_cores',
                     # examl can handle ~4x more patterns
                     '(#raxml_cores# >  16) && (#raxml_cores# <= 32)'    => 'examl_8_cores',
-                    '(#raxml_cores# >  32) && (#raxml_cores# <= 64)'    => 'examl_16_cores',
-                    '(#raxml_cores# >  64) && (#raxml_cores# <= 128)'   => 'examl_32_cores',
-                    '(#raxml_cores# >  128)'                            => 'examl_64_cores',
+                    '(#raxml_cores# >  32) && (#raxml_cores# <= 48)'    => 'examl_16_cores',
+                    '(#raxml_cores# >  48) && (#raxml_cores# <= 96)'    => 'examl_32_cores',
+                    '(#raxml_cores# >  96)'                             => 'examl_48_cores',
                 ),
             },
         },
@@ -2550,7 +2550,7 @@ sub core_pipeline_analyses {
             -rc_name => '8Gb_32c_mpi',
             -flow_into => {
                -1 => [ 'examl_32_cores_himem' ],  # MEMLIMIT
-               -2 => [ 'examl_64_cores' ],  	  # RUNTIME
+               -2 => [ 'examl_48_cores' ],  	  # RUNTIME
             }
         },
 
@@ -2903,7 +2903,7 @@ sub core_pipeline_analyses {
                     '(#tree_gene_count# > 500)  && (#tree_gene_count# <= 1000)' => 'raxml_bl_8',
                     '(#tree_gene_count# > 1000) && (#tree_gene_count# <= 2000)' => 'raxml_bl_16',
                     '(#tree_gene_count# > 3000) && (#tree_gene_count# <= 10000)' => 'raxml_bl_32',
-                    '(#tree_gene_count# > 10000)'                                => 'raxml_bl_64',
+                    '(#tree_gene_count# > 10000)'                                => 'raxml_bl_48',
                 ),
             },
             %decision_analysis_params,
@@ -2964,14 +2964,14 @@ sub core_pipeline_analyses {
             }
         },
 
-        {   -logic_name => 'raxml_bl_64',
+        {   -logic_name => 'raxml_bl_48',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RAxML_bl',
             -parameters => {
                 %raxml_bl_parameters,
-                'raxml_number_of_cores'     => 64,
+                'raxml_number_of_cores'     => 48,
             },
             -hive_capacity        => $self->o('raxml_capacity'),
-            -rc_name    => '256Gb_64c_job',
+            -rc_name    => '256Gb_48c_job',
             -flow_into  => {
                 1  => [ 'copy_raxml_bl_tree_2_default_tree' ],
                 2 => [ 'copy_treebest_tree_2_raxml_bl_tree' ],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -927,7 +927,7 @@ sub core_pipeline_analyses {
                             2 => [ 'secondary_structure_decision' ],
                             3 => [ 'pre_sec_struct_tree_4_cores' ],
                           },
-            -rc_name => '500Mb_2c_job',
+            -rc_name => '1Gb_2c_job',
         },
 
         {   -logic_name    => 'pre_sec_struct_tree_4_cores', ## pre_sec_struct_tree
@@ -1004,7 +1004,7 @@ sub core_pipeline_analyses {
                            -1 => [ 'sec_struct_model_tree_4_cores' ],   # This analysis has more cores *and* more memory
                             3 => [ 'sec_struct_model_tree_4_cores' ],
                        },
-            -rc_name => '500Mb_2c_job',
+            -rc_name => '1Gb_2c_job',
         },
 
         {   -logic_name    => 'sec_struct_model_tree_4_cores', ## sec_struct_model_tree

--- a/scripts/production/dump_hive_rc_config.pl
+++ b/scripts/production/dump_hive_rc_config.pl
@@ -1,0 +1,75 @@
+#!/usr/bin/env perl
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+=head1 NAME
+
+dump_hive_rc_config.pl
+
+=head1 DESCRIPTION
+
+Dumps the current Compara Hive resource-class configuration to a JSON file.
+
+=head1 EXAMPLE
+
+    perl $ENSEMBL_ROOT_DIR/ensembl-compara/scripts/production/dump_hive_rc_config.pl \
+        --outfile compara_hive_rc_config.json
+
+=head1 OPTIONS
+
+=over
+
+=item B<[--help]>
+
+Prints help message and exits.
+
+=item B<[--outfile file_path]>
+
+Path of output JSON file.
+
+=back
+
+=cut
+
+
+use strict;
+use warnings;
+
+use Getopt::Long;
+use JSON;
+use Pod::Usage;
+
+use Bio::EnsEMBL::Compara::PipeConfig::ENV;
+use Bio::EnsEMBL::Utils::Exception qw(throw);
+
+
+my ( $help, $outfile, $genome_db_id, $mlss_id );
+GetOptions(
+    "help|?"    => \$help,
+    "outfile=s" => \$outfile,
+) or pod2usage(-verbose => 2);
+
+pod2usage(-exitvalue => 0, -verbose => 1) if $help;
+pod2usage(-verbose => 1) if !$outfile;
+
+
+my $hive_rc_config;
+
+$hive_rc_config->{'resource_classes_single_thread'} = Bio::EnsEMBL::Compara::PipeConfig::ENV::resource_classes_single_thread();
+$hive_rc_config->{'resource_classes_multi_thread'} = Bio::EnsEMBL::Compara::PipeConfig::ENV::resource_classes_multi_thread();
+
+open(my $fh, '>', $outfile) or throw("Could not open file [$outfile]");
+print $fh JSON->new->pretty->encode($hive_rc_config) . "\n";
+close($fh) or throw("Could not close file [$outfile]");


### PR DESCRIPTION
## Description

Compara-specific Hive resource classes are configured in `Bio::EnsEMBL::Compara::PipeConfig::ENV`. With the transition to Slurm, we will need to configure resource classes for the Slurm meadow.

Due to the need to set a time limit on Slurm jobs, it will be necessary to set, for each existing resource class, multiple new resource classes configuring different Slurm time limits, resulting in a significant increase in the number of resource classes.

**Related JIRA tickets:**
- ENSCOMPARASW-6467

## Overview of changes

This PR revises the Hive configuration in the Compara `PipeConfig::ENV` module to mitigate the expansion in the number of resource classes by explicitly configuring only the scheduler submission command arguments of the resource classes (configured by default with a 24-hour time limit on the Slurm meadow), and then dynamically generating the counterparts of those resource classes with time limits set to 1 hour, 168 hours, and for a subset of resource classes, 720 hours.

- Standard resource classes are configured as 'templates', containing only the scheduler submission command arguments, which are then used to dynamically generate the resource-class config. A small number of atypical resource classes are configured directly.
- Resource classes previously configured to use less than 1 Gigabyte are changed to their 1-Gigabyte counterpart (e.g. `250Mb_6_hour_job` becomes `1Gb_6_hour_job`). All 64-core resource classes are changed to be 48-core resource classes, to fit better with the Slurm cluster (e.g. `16Gb_64c_job` becomes `16Gb_48c_job`). All instances of use of these resource classes are updated to use the closest appropriate resource class in the updated configuration.
- A small number of errors in the previous provisional Slurm config are fixed.
- Utility script `dump_compara_hive_rc_config.pl` is added to enable the full set of resource classes to be dumped to a JSON file.

## Testing

The utility script `dump_compara_hive_rc_config.pl` was used to generate a JSON file (attached to ENSCOMPARASW-6467) showing the dynamically generated resource class configuration.

## Notes

- Slurm configuration of MPI resource classes are not included in this update.
- Time limits are not configured for the LSF meadow except in the 6-hour and 720-hour resource classes.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
