### PR TITLE
Enable line-count healthcheck of homology TSV dump

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
@@ -414,7 +414,7 @@ sub tweak_analyses {
     my $self = shift;
     my $analyses_by_name = shift;
 
-    $analyses_by_name->{'dump_per_genome_homologies_tsv'}->{'-parameters'}{'healthcheck'} = 'unexpected_nulls';
+    $analyses_by_name->{'dump_per_genome_homologies_tsv'}{'-parameters'}{'healthcheck_list'} = ['line_count', 'unexpected_nulls'];
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/DumpHomologiesTSV.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/DumpHomologiesTSV.pm
@@ -44,6 +44,7 @@ use warnings;
 
 use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
 use Bio::EnsEMBL::Compara::Utils::FlatFile qw(check_for_null_characters check_line_counts);
+use Bio::EnsEMBL::Hive::Utils qw(destringify);
 
 use File::Basename qw/dirname/;
 use File::Path qw/make_path/;
@@ -114,7 +115,7 @@ sub fetch_input {
         $self->param('extra_filter', "AND h.method_link_species_set_id = $mlss_id");
     }
     
-    make_path(dirname($self->param('output_file')));
+    make_path(dirname($self->param_required('output_file')));
     $compara_dba->dbc->disconnect_if_idle; # hive code will open a new connection regardless
 
     $self->SUPER::fetch_input();
@@ -123,7 +124,9 @@ sub fetch_input {
 sub write_output {
     my $self = shift;
 
-    $self->_healthcheck($self->param('healthcheck')) if $self->param('healthcheck');
+    if ( $self->param_is_defined('healthcheck') || $self->param_is_defined('healthcheck_list') ) {
+        $self->_healthcheck();
+    }
 
     $self->SUPER::write_output();
 }
@@ -131,14 +134,26 @@ sub write_output {
 sub _healthcheck {
     my $self = shift;
 
-    my $hc_type = $self->param('healthcheck');
-    if ( $hc_type eq 'line_count' ) {
-        my $exp_line_count = $self->param('exp_line_count') + 1; # incl header line
-        check_line_counts($self->param('output_file'), $exp_line_count);
-    } elsif ( $hc_type eq 'unexpected_nulls' ) {
-        check_for_null_characters($self->param('output_file'));
+    my $healthcheck_list;
+    if ( $self->param_is_defined('healthcheck') && $self->param_is_defined('healthcheck_list') ) {
+        $self->throw("Only one of parameters 'healthcheck' or 'healthcheck_list' can be defined")
+    } elsif ( $self->param_is_defined('healthcheck') ) {
+        $healthcheck_list = [$self->param('healthcheck')];
+    } elsif ( $self->param_is_defined('healthcheck_list') ) {
+        $healthcheck_list = destringify($self->param('healthcheck_list'));
     } else {
-        die "Healthcheck type '$hc_type' not recognised";
+        $self->throw("One of parameters 'healthcheck' or 'healthcheck_list' must be defined")
+    }
+
+    foreach my $hc_type (@{$healthcheck_list}) {
+        if ( $hc_type eq 'line_count' ) {
+            my $exp_line_count = $self->param_required('exp_line_count') + 1; # incl header line
+            check_line_counts($self->param('output_file'), $exp_line_count);
+        } elsif ( $hc_type eq 'unexpected_nulls' ) {
+            check_for_null_characters($self->param('output_file'));
+        } else {
+            die "Healthcheck type '$hc_type' not recognised";
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Homology TSV dumps are subject to several kinds of error that could be detected by doing a line count on the dumped file.

The Compara runnable `GeneTrees::DumpHomologiesTSV` can be configured to perform such a line count, but this cannot currently be used in the `dump_per_genome_homologies_tsv` step of the `DumpAllForRelease` pipeline because the expected line-count parameter (`exp_line_count`) is not being set.

Errors resulting in a discrepant line count currently have the potential to go unnoticed until the Compara FTP dump pipeline has reached `convert_tsv_to_orthoxml` further downstream. Enabling this line-count healthcheck in the `dump_per_genome_homologies_tsv` step would catch such errors more quickly, and has the potential to save a significant amount of time and effort.

## Overview of changes

- Optional parameter `healthcheck_list` is added to the Compara `DumpHomologiesTSV` runnable, allowing for multiple healthchecks to be enabled.
- Both healthchecks supported for this runnable — `line_count` and `unexpected_nulls` — are enabled in the pipeline config for the `DumpAllForRelease` pipeline.
- A new analysis to fetch the expected line count of a given homology TSV file (`fetch_exp_line_count_per_genome`) is added to the Compara `DumpAllForRelease` pipeline, so that the line-count healthcheck can check the observed number of lines in a homology TSV against the expected number of lines.

## Testing

A `DumpAllForRelease` test pipeline was run for Pan, up to the point where all homology TSV files for that division had been dumped and passed healthchecks.


---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
