### PR TITLE
adding thread parameter to CAFE

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/CAFE.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/CAFE.pm
@@ -130,8 +130,9 @@ sub pipeline_analyses_cafe {
 #                             'cafe_struct_taxons'  => $self->o('cafe_'),
                              'cafe_struct_tree_str' => $self->o('cafe_struct_tree_str'),
                              'cafe_shell'           => $self->o('cafe_shell'),
+                             'num_threads'          => 8,   
                             },
-             -rc_name => '1Gb_job',
+             -rc_name => '1Gb_8c_job',
              -hive_capacity => $self->o('cafe_capacity'),
              -meadow_type => 'LSF',
              -flow_into => {
@@ -148,8 +149,9 @@ sub pipeline_analyses_cafe {
 #                             'cafe_struct_taxons'  => $self->o('cafe_'),
                              'cafe_struct_tree_str' => $self->o('cafe_struct_tree_str'),
                              'cafe_shell'           => $self->o('cafe_shell'),
+                             'num_threads'          => 48,
                             },
-             -rc_name => '2Gb_job',
+             -rc_name => '4Gb_48c_job',
              -hive_capacity => $self->o('cafe_capacity'),
              -meadow_type => 'LSF',
              -flow_into => {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
@@ -127,7 +127,6 @@ sub tweak_analyses {
     $analyses_by_name->{'quick_tree_break'}->{'-rc_name'}   = '4Gb_job';
     $analyses_by_name->{'hc_cafe_species_tree'}->{'-rc_name'}   = '2Gb_job';
     $analyses_by_name->{'get_split_genes'}->{'-rc_name'}   = '2Gb_job';
-    $analyses_by_name->{'CAFE_analysis_himem'}->{'-rc_name'}   = '4Gb_job';
     $analyses_by_name->{'import_homology_table_himem'}->{'-rc_name'}   = '16Gb_job';
     $analyses_by_name->{'import_homology_table'}->{'-rc_name'}   = '1Gb_job';
     $analyses_by_name->{'check_file_copy'}->{'-rc_name'}   = '1Gb_job';

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CAFEAnalysis.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CAFEAnalysis.pm
@@ -81,6 +81,7 @@ sub fetch_input {
     $self->param_required('fam_id');
     $self->param_required('mlss_id');
     $self->param_required('lambda');
+    $self->param_required('num_threads');
 
     my $cafeTree_Adaptor = $self->compara_dba->get_CAFEGeneFamilyAdaptor;
     $self->param('cafeTree_Adaptor', $cafeTree_Adaptor);
@@ -117,6 +118,7 @@ sub run_cafe_script {
     my $mlss_id = $self->param('mlss_id');
     my $fam_id = $self->param('fam_id');
     my $pval_lim = $self->param('pvalue_lim');
+    my $num_threads = $self->param('num_threads');
 
     my $tmp_dir = $self->worker_temp_directory;
     my $cafe_table_file = $tmp_dir . "/cafe_${mlss_id}_${fam_id}.in";
@@ -141,7 +143,7 @@ sub run_cafe_script {
 
     print $sf '#!' . $cafe_shell . "\n\n";
     print $sf "tree $cafe_tree_str\n\n";
-    print $sf "load -p ${pval_lim} -i $cafe_table_file -t 1\n\n";
+    print $sf "load -p ${pval_lim} -i $cafe_table_file -t $num_threads\n\n";
     print $sf "lambda -l $lambda\n";
 #    print $sf $cafe_lambdas ? " -l $cafe_lambdas\n\n" : " -s\n\n";
 #    print $sf $cafe_lambdas ? "-l $cafe_lambdas -t $cafe_struct_tree\n\n" : " -s\n\n";


### PR DESCRIPTION
## Description

Enabling multi-core CAFE runs. 

**Related JIRA tickets:**
- [ENSCOMPARASW-6465](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-6465)

## Overview of changes

Default CAFE jobs are configured to use the `1Gb_8c_job` resource class, while highmem CAFE jobs use the `4Gb_48c_job` resource class.

## Testing
Not yet. The test will soon be performed with the plants' protein tree pipeline along with other code updates. 

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
