### PR TITLE
Add vertebrate_species collection to Vertebrates

### DIFF
--- a/conf/vertebrates/mlss_conf.xml
+++ b/conf/vertebrates/mlss_conf.xml
@@ -6,7 +6,7 @@
 
     <!-- All chordates except the mouse strains, pig breeds and the three outgroups -->
     <!-- NB: we have several genomes of the same species, e.g. CHO, NMR -->
-    <collection name="default">
+    <collection name="vertebrate_species" no_store="1">
       <taxonomic_group taxon_name="Chordata">
         <!-- But exclude everything below mus_musculus and sus_scrofa -->
         <ref_for_taxon name="mus_musculus"/>
@@ -15,6 +15,11 @@
       <genome name="caenorhabditis_elegans"/>
       <genome name="drosophila_melanogaster"/>
       <genome name="saccharomyces_cerevisiae"/>
+    </collection>
+
+    <!-- Default gene-tree collection -->
+    <collection name="default">
+      <base_collection name="vertebrate_species"/>
     </collection>
 
     <!-- Mouse-strains analyses, i.e. incl. the closely relative -->
@@ -35,10 +40,10 @@
   <pairwise_alignments>
 
     <!-- Mammals -->
-    <!-- Use of "default" collection excludes the mouse strains and the pig breeds -->
+    <!-- Use of "vertebrate_species" collection excludes the mouse strains and the pig breeds -->
     <!-- NB: we have an EPO alignment for mouse strains and an EPO Extended MSA for pig breeds -->
     <one_vs_all method="LASTZ_NET" ref_genome="homo_sapiens">
-      <species_set in_collection="default">
+      <species_set in_collection="vertebrate_species">
         <taxonomic_group taxon_name="Eutheria"/>
         <!-- Remove all the taxa that have a better reference than human -->
         <taxonomic_group taxon_name="Rodentia" exclude="1"/>
@@ -49,7 +54,7 @@
     </one_vs_all>
 
     <one_vs_all method="LASTZ_NET" ref_genome="mus_musculus">
-      <species_set in_collection="default">
+      <species_set in_collection="vertebrate_species">
         <taxonomic_group taxon_name="Rodentia"/>
       </species_set>
     </one_vs_all>
@@ -57,7 +62,7 @@
     <one_vs_all method="LASTZ_NET" ref_genome="canis_lupus_familiaris" against="Carnivora"/>
 
     <one_vs_all method="LASTZ_NET" ref_genome="bos_taurus">
-      <species_set in_collection="default">
+      <species_set in_collection="vertebrate_species">
         <taxonomic_group taxon_name="Artiodactyla"/>
       </species_set>
     </one_vs_all>
@@ -68,7 +73,7 @@
     <one_vs_all method="LASTZ_NET" ref_genome="sus_scrofa" against="Sus"/>
 
     <one_vs_all method="LASTZ_NET" ref_genome="monodelphis_domestica">
-      <species_set in_collection="default">
+      <species_set in_collection="vertebrate_species">
         <taxonomic_group taxon_name="Metatheria"/>
         <taxonomic_group taxon_name="Prototheria"/>
       </species_set>
@@ -193,7 +198,7 @@
       </species_set>
     </multiple_alignment>
     <multiple_alignment method="EPO_EXTENDED" gerp="1">
-      <species_set name="mammals" display_name="eutherian mammals" in_collection="default">
+      <species_set name="mammals" display_name="eutherian mammals" in_collection="vertebrate_species">
         <taxonomic_group taxon_name="Eutheria"/>
       </species_set>
     </multiple_alignment>

--- a/scripts/pipeline/compara_db_config.rng
+++ b/scripts/pipeline/compara_db_config.rng
@@ -126,6 +126,14 @@
                 </attribute>
               </optional>
               <optional>
+                <attribute name="no_store" blockly:blockName="Do not store this collection">
+                  <choice>
+                    <value blockly:blockName="Yes">1</value>
+                    <value blockly:blockName="No">0</value>
+                  </choice>
+                </attribute>
+              </optional>
+              <optional>
                   <element name="base_collection" blockly:blockName="Include collection as base">
                     <attribute name="name" blockly:blockName="Collection name"/>
                   </element>


### PR DESCRIPTION
## Description

In Ensembl 111, the `default` Vertebrates gene-trees collection will not contain all species-level genomes in the division.

Currently, this `default` collection serves a secondary role in several places in the Vertebrates `mlss_conf.xml` file as a way of excluding strains and breeds from specific comparative analyses.

Adding support for unstored collections to the the Compara MLSS config schema, combined with adding an unstored `vertebrates_species` collection to the Vertebrates `mlss_conf.xml` to fulfil that secondary role, would decouple the two current roles of the `default` gene-trees collection, allowing it to be configured as needed for Ensembl 111 production.

## Overview of changes

- The Compara MLSS config schema file `compara_db_config.rng` is updated to add support for a `no_store` collection attribute.
- The script `create_all_mlss.pl` is updated so that collections having the `no_store` attribute are not stored.
- The Vertebrates `mlss_conf.xml` file is updated to add an unstored `vertebrate_species` collection — currently identical to the `default` collection — which is used to exclude strains and breeds from genomic alignment MLSSes.

## Testing

The script `create_all_mlss.pl` was run with the updated MLSS config schema and XML file against a test copy of the Vertebrates Compara master database.

In addition to the changes in this PR, the `default` collection was modified to exclude one genome:
```
    <!-- Default gene-tree collection -->
    <collection name="default">
      <base_collection name="vertebrate_species"/>
      <genome name="sinocyclocheilus_grahami" exclude="1"/>
    </collection>
```
After running `create_all_mlss.pl`, the test master database contained a new `default` collection that excluded the genome `sinocyclocheilus_grahami`, confirming that the changes in this PR would allow for separate `vertebrate_species` and `default` collections, each of which could fulfil one of the two previous roles of the `default` collection.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
