### PR TITLE
Update overlap core config in registry files

### DIFF
--- a/conf/fungi/production_reg_conf.pl
+++ b/conf/fungi/production_reg_conf.pl
@@ -58,6 +58,15 @@ my @curr_collection_groups = qw(
 Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertannot-staging:4573/$curr_release");
 Bio::EnsEMBL::Compara::Utils::Registry::remove_multi();
 
+# Ensure we're using the correct cores for species that overlap with other divisions
+my @overlap_species = qw(saccharomyces_cerevisiae);
+Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species);
+my $overlap_cores = {
+    #'saccharomyces_cerevisiae' => [ 'mysql-ens-sta-1-b', "saccharomyces_cerevisiae_core_${curr_eg_release}_${curr_release}_4" ],
+    'saccharomyces_cerevisiae' => [ 'mysql-ens-vertannot-staging', "saccharomyces_cerevisiae_core_${curr_eg_release}_${curr_release}_4" ],
+};
+Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $overlap_cores );
+
 foreach my $group ( @curr_collection_groups ) {
     Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
         -host   => 'mysql-ens-vertannot-staging',

--- a/conf/plants/production_reg_conf.pl
+++ b/conf/plants/production_reg_conf.pl
@@ -51,14 +51,15 @@ Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertann
 # before loading the Vertebrates version
 #Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-1:4519/$curr_release");
 
-# Ensure we're using the correct cores for species that overlap with metazoa
-my @metazoa_overlap_species = qw(drosophila_melanogaster caenorhabditis_elegans);
-Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@metazoa_overlap_species);
-my $metazoa_overlap_cores = {
+# Ensure we're using the correct cores for species that overlap with other divisions
+Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species);
+my $overlap_cores = {
     'drosophila_melanogaster' => [ 'mysql-ens-vertannot-staging', "drosophila_melanogaster_core_110_10" ],
     'caenorhabditis_elegans'  => [ 'mysql-ens-vertannot-staging', "caenorhabditis_elegans_core_110_282" ],
+    'saccharomyces_cerevisiae' => [ 'mysql-ens-vertannot-staging', "saccharomyces_cerevisiae_core_110_4" ],
 };
-Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $metazoa_overlap_cores );
+Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $overlap_cores );
+
 
 # ---------------------- PREVIOUS CORE DATABASES---------------------------------
 

--- a/conf/protists/production_reg_conf.pl
+++ b/conf/protists/production_reg_conf.pl
@@ -39,7 +39,7 @@ my $prev_eg_release = $curr_eg_release - 1;
 # ---------------------- CURRENT CORE DATABASES----------------------------------
 
 # Non-Vertebrates server
-Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-3-b:4686/$curr_release");
+Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertannot-staging:4573/$curr_release");
 # Protist collections
 my @collection_groups = qw(
     alveolata1
@@ -59,14 +59,14 @@ my @collection_groups = qw(
 my @overlap_species = qw(hyaloperonospora_arabidopsidis);
 Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species);
 my $overlap_cores = {
-    'hyaloperonospora_arabidopsidis'  => [ 'mysql-ens-sta-3-b', "hyaloperonospora_arabidopsidis_core_${curr_eg_release}_${curr_release}_1"],
+    'hyaloperonospora_arabidopsidis'  => [ 'mysql-ens-vertannot-staging', "hyaloperonospora_arabidopsidis_core_${curr_eg_release}_${curr_release}_1"],
 };
 Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $overlap_cores );
 
 foreach my $group ( @collection_groups ) {
     Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
-        -host   => 'mysql-ens-sta-3-b',
-        -port   => 4686,
+        -host   => 'mysql-ens-vertannot-staging',
+        -port   => 4573,
         -user   => 'ensro',
         -pass   => '',
         -dbname => "protists_${group}_collection_core_${curr_eg_release}_${curr_release}_1",

--- a/conf/vertebrates/production_reg_conf.pl
+++ b/conf/vertebrates/production_reg_conf.pl
@@ -39,16 +39,18 @@ my $prev_release = $curr_release - 1;
 #Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-1-b:4685/$curr_release");
 Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertannot-staging:4573/$curr_release");
 
-# Ensure we're using the correct cores for species that overlap with metazoa
-my @metazoa_overlap_species = qw(drosophila_melanogaster caenorhabditis_elegans);
-Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@metazoa_overlap_species);
-my $metazoa_overlap_cores = {
+# Ensure we're using the correct cores for species that overlap with other divisions
+my @overlap_species = qw(drosophila_melanogaster caenorhabditis_elegans saccharomyces_cerevisiae);
+Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species);
+my $overlap_cores = {
     #'drosophila_melanogaster' => [ 'mysql-ens-sta-1-b', "drosophila_melanogaster_core_" . $curr_release . "_10" ],
     #'caenorhabditis_elegans'  => [ 'mysql-ens-sta-1-b', "caenorhabditis_elegans_core_" . $curr_release . "_282" ],
+    #'saccharomyces_cerevisiae' => [ 'mysql-ens-sta-1-b', "saccharomyces_cerevisiae_core_" . $curr_release . "_4" ],
     'drosophila_melanogaster' => [ 'mysql-ens-vertannot-staging', "drosophila_melanogaster_core_" . $curr_release . "_10" ],
     'caenorhabditis_elegans'  => [ 'mysql-ens-vertannot-staging', "caenorhabditis_elegans_core_" . $curr_release . "_282" ],
+    'saccharomyces_cerevisiae' => [ 'mysql-ens-vertannot-staging', "saccharomyces_cerevisiae_core_" . $curr_release . "_4" ],
 };
-Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $metazoa_overlap_cores );
+Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $overlap_cores );
 
 # ---------------------- PREVIOUS CORE DATABASES---------------------------------
 


### PR DESCRIPTION
## Description

In the course of working on ticket ENSCOMPARASW-6473, several Compara registry files were flagged as needing to be updated. This PR would update those registry files.

**Related JIRA tickets:**
- ENSCOMPARASW-6473

## Overview of changes

- The Fungi, Plants and Vertebrates registry files are updated to configure _S. cerevisiae_ as an overlap species.
- The Protists registry is updated to configure current core databases on `mysql-ens-vertannot-staging`.

## Testing
The script being developed as part of ENSCOMPARASW-6473 was used to confirm that the registry updates had achieved the desired outcome.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
