### PR TITLE
Handle species tree with all nodes in same NCBI taxon

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/Utils/SpeciesTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/SpeciesTree.pm
@@ -224,7 +224,13 @@ sub create_species_tree {
                             throw("Could not find the leaf with taxon_id $taxon_id");
         my $new_node = $current_leaf->copy_node();
         $new_node->node_id($taxon_id);
-        $current_leaf->parent->add_child($new_node);
+
+        if (defined $current_leaf->parent) {
+          $current_leaf->parent->add_child($new_node);
+        } else {
+          $stn_root = $new_node;
+        }
+
         $new_node->add_child($current_leaf);
         $new_node->{'_genome_db_id'} = undef;
         $new_node->name($current_leaf->taxon->name);


### PR DESCRIPTION
## Description

In `Bio::EnsEMBL::Compara::Utils::SpeciesTree::create_species_tree`, GenomeDBs sharing the same NCBI Taxonomy ID may be grouped together under a parent node. If that parent node does not exist (e.g. in a case where all the GenomeDBs in the tree share the same NCBI Taxonomy ID), the following error occurs:
```bash
Can't call method "add_child" on an undefined value at /path/to/ensembl-compara/modules/Bio/EnsEMBL/Compara/Utils/SpeciesTree.pm line 227.
```

## Overview of changes

If the representative node for a given Taxonomy ID has no parent (i.e. it's the only node in the species tree), the new node that is intended to be the parent of that representative node will be set as the new root of the species tree.

## Testing
This change was tested using the following code, which obtained a GenomicAlignTree from an AlignSlice object for the LastZ alignment between the Wheat Chinese Spring and Jagger cultivars:
```perl
#!/usr/bin/env perl

use strict;
use warnings;

use JSON qw(encode_json);

use Bio::EnsEMBL::Registry;
use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;


Bio::EnsEMBL::Registry->load_registry_from_url("${core_host_url}/${curr_release}");
my $compara_dba = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba($compara_url);

my $mlss_id = 309620;
my $prod_name = 'triticum_aestivum';
my $seq_region_name = '6D';
my $start = 378_329_616;
my $end = 378_329_697;

my $slice_adaptor = Bio::EnsEMBL::Registry->get_adaptor($prod_name, 'core', 'slice');
my $slice = $slice_adaptor->fetch_by_region('toplevel', $seq_region_name, $start, $end);

my $mlss_adaptor = $compara_dba->get_MethodLinkSpeciesSetAdaptor();
my $method_link_species_set = $mlss_adaptor->fetch_by_dbID($mlss_id);

my $as_adaptor = $compara_dba->get_AlignSliceAdaptor();
my $align_slice = $as_adaptor->fetch_by_Slice_MethodLinkSpeciesSet($slice, $method_link_species_set, 'expanded', 'restrict');

my $ga_block = $align_slice->get_all_GenomicAlignBlocks->[0];
my $ga_tree = $ga_block->get_GenomicAlignTree();

print $ga_tree->newick_format . "\n";
```

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
