### PR TITLE
Fix handling of polyploid Cactus alignment and tree

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/AlignSlice.pm
+++ b/modules/Bio/EnsEMBL/Compara/AlignSlice.pm
@@ -1088,27 +1088,20 @@ sub _create_underlying_Slices {
 
   my %ga_tree_gdb_id_set;
   my %ga_id_to_slice_gdb;
-  if ($species_order) {
-    foreach my $species_def (@{$species_order}) {
-      $ga_tree_gdb_id_set{$species_def->{genome_db}->dbID} = 1;
-      foreach my $genomic_align_id (@{$species_def->{genomic_align_ids}}) {
-        $ga_id_to_slice_gdb{$genomic_align_id} = $species_def->{genome_db};
-      }
-    }
-  } else {
-    foreach my $ga_block (@$sorted_genomic_align_blocks) {
-      my $is_genomic_align_tree = UNIVERSAL::isa($ga_block, "Bio::EnsEMBL::Compara::GenomicAlignTree");
-      my $ga_tree = $is_genomic_align_tree ? $ga_block : $ga_block->get_GenomicAlignTree();
-      foreach my $ga_node (@{$ga_tree->get_all_nodes}) {
-        my @genomic_aligns = @{$ga_node->get_all_genomic_aligns_for_node};
-        if (@genomic_aligns) {
-          my $genome_db = $ga_node->get_genome_db_for_node;
-          $ga_tree_gdb_id_set{$genome_db->dbID} = 1;
-          foreach my $genomic_align (@genomic_aligns) {
-            my $ga_id = $genomic_align->dbID ? $genomic_align->dbID : $genomic_align->original_dbID;
-            $ga_id_to_slice_gdb{$ga_id} = $genome_db;
-          }
+  foreach my $ga_block (@$sorted_genomic_align_blocks) {
+    my $is_genomic_align_tree = UNIVERSAL::isa($ga_block, "Bio::EnsEMBL::Compara::GenomicAlignTree");
+    my $ga_tree = $is_genomic_align_tree ? $ga_block : $ga_block->get_GenomicAlignTree();
+    foreach my $ga_node (@{$ga_tree->get_all_nodes}) {
+      my @genomic_aligns = @{$ga_node->get_all_genomic_aligns_for_node};
+      if (@genomic_aligns) {
+
+        my $genome_db = $ga_node->get_genome_db_for_node;
+        foreach my $genomic_align (@genomic_aligns) {
+          my $ga_id = $genomic_align->dbID ? $genomic_align->dbID : $genomic_align->original_dbID;
+          $ga_id_to_slice_gdb{$ga_id} = $genome_db;
         }
+
+        $ga_tree_gdb_id_set{$genome_db->dbID} = 1;
       }
     }
   }

--- a/modules/Bio/EnsEMBL/Compara/AlignSlice.pm
+++ b/modules/Bio/EnsEMBL/Compara/AlignSlice.pm
@@ -1118,9 +1118,8 @@ sub _create_underlying_Slices {
   my $ref_genome_db = $temp_dnafrag->genome_db;
   if ($ref_genome_db->is_polyploid()) {
     my $comp_dnafrag = map_dnafrag_to_genome_component($temp_dnafrag);
-    my $ref_comp_gdb = $comp_dnafrag->genome_db if defined($comp_dnafrag);
-    if (exists $ga_tree_gdb_id_set{$ref_comp_gdb->dbID}) {
-      $ref_genome_db = $ref_comp_gdb;
+    if (defined($comp_dnafrag) && exists $ga_tree_gdb_id_set{$comp_dnafrag->genome_db->dbID}) {
+      $ref_genome_db = $comp_dnafrag->genome_db;
     }
   }
 

--- a/modules/Bio/EnsEMBL/Compara/AlignSlice.pm
+++ b/modules/Bio/EnsEMBL/Compara/AlignSlice.pm
@@ -658,7 +658,7 @@ sub get_SimpleAlign {
   my $genome_db_name_counter;
 
   foreach my $slice (@{$self->get_all_Slices(@species)}) {
-    my $slice_gdb_name = $slice->display_Slice_name;
+    my $slice_gdb_name = lcfirst $slice->distinct_Slice_name;
     my $seq = Bio::LocatableSeq->new(
             -SEQ    => $slice->seq,
             -START  => $slice->start,

--- a/modules/Bio/EnsEMBL/Compara/AlignSlice/Slice.pm
+++ b/modules/Bio/EnsEMBL/Compara/AlignSlice/Slice.pm
@@ -143,7 +143,7 @@ sub new {
   $self->{adaptor} = undef;
   $self->{coord_system} = $coord_system;
   $self->genome_db($genome_db) if (defined($genome_db));
-  $self->{seq_region_name} = (eval{$genome_db->name} or "FakeAlignSlice");
+  $self->{seq_region_name} = (eval{$genome_db->get_distinct_name} or "FakeAlignSlice");
   $self->{display_Slice_name} = $self->{seq_region_name};
   $self->{display_Slice_name} =~ s/ /_/g;
   $self->{seq_region_length} = $length;
@@ -194,6 +194,12 @@ sub genome_db {
   if (defined($genome_db)) {
     throw("[$genome_db] must bu a Bio::EnsEMBL::Compara::GenomeDB object")
       unless ($genome_db and ref($genome_db) and $genome_db->isa("Bio::EnsEMBL::Compara::GenomeDB"));
+
+    if(defined($genome_db->genome_component)) {
+      $self->{_genome_component} = $genome_db->genome_component;
+      $genome_db = $genome_db->principal_genome_db;
+    }
+
     $self->{genome_db} = $genome_db;
   }
 
@@ -1235,6 +1241,25 @@ sub _sort_Exons {
 #
 # WARNING - WARNING - WARNING - WARNING - WARNING - WARNING - WARNING
 #
+
+=head2 get_genome_component
+
+  Arg []     : none
+  Example    : my $genome_component = $slice->get_genome_component();
+  Description: Returns the name of the genome component of the slice
+  Returntype : string containing the name of the genome component of the slice,
+               or undef if the slice is not on a polyploid genome component
+  Exceptions : none
+  Caller     : general
+  Status     : Experimental
+
+=cut
+
+sub get_genome_component {
+    my $self = shift;
+    return $self->{_genome_component};
+}
+
 
 =head2 invert (not supported)
 

--- a/modules/Bio/EnsEMBL/Compara/AlignSlice/Slice.pm
+++ b/modules/Bio/EnsEMBL/Compara/AlignSlice/Slice.pm
@@ -143,7 +143,7 @@ sub new {
   $self->{adaptor} = undef;
   $self->{coord_system} = $coord_system;
   $self->genome_db($genome_db) if (defined($genome_db));
-  $self->{seq_region_name} = (eval{$genome_db->get_distinct_name} or "FakeAlignSlice");
+  $self->{seq_region_name} = (eval{$genome_db->name} or "FakeAlignSlice");
   $self->{display_Slice_name} = $self->{seq_region_name};
   $self->{display_Slice_name} =~ s/ /_/g;
   $self->{seq_region_length} = $length;
@@ -195,6 +195,8 @@ sub genome_db {
     throw("[$genome_db] must bu a Bio::EnsEMBL::Compara::GenomeDB object")
       unless ($genome_db and ref($genome_db) and $genome_db->isa("Bio::EnsEMBL::Compara::GenomeDB"));
 
+    $self->{distinct_Slice_name} = ucfirst($genome_db->get_distinct_name) || "FakeAlignSlice";
+
     if(defined($genome_db->genome_component)) {
       $self->{_genome_component} = $genome_db->genome_component;
       $genome_db = $genome_db->principal_genome_db;
@@ -224,6 +226,22 @@ sub display_Slice_name {
   }
 
   return ucfirst $self->{display_Slice_name};
+}
+
+
+=head2 distinct_Slice_name
+
+  Arg[1]     : string $name
+  Example    : $slice->distinct_Slice_name("triticum_aestivum_A");
+  Description: getter for the attribute distinct_Slice_name
+  Returntype : string
+
+=cut
+
+sub distinct_Slice_name {
+  my ($self) = @_;
+
+  return $self->{distinct_Slice_name};
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/AlignSliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/AlignSliceAdaptor.pm
@@ -308,8 +308,8 @@ sub _get_species_order {
   my $species_order;
   foreach my $this_genomic_align_node (@{$genomic_align_tree->get_all_sorted_genomic_align_nodes}) {
     next if (!@{$this_genomic_align_node->get_all_genomic_aligns_for_node});
-    my $this_genomic_align = $this_genomic_align_node->get_all_genomic_aligns_for_node->[0];
-    my $genome_db = $this_genomic_align->genome_db;
+    my $genome_db = $this_genomic_align_node->get_genome_db_for_node;
+
     my $this_node_id = $this_genomic_align_node->node_id;
     my $right_node_id = _get_right_node_id($this_genomic_align_node);
     my $genomic_align_ids = [];
@@ -356,7 +356,7 @@ sub _combine_genomic_align_trees {
   while (my ($index, $species_def) = each @$species_order) {
     my $right_node_id = $species_def->{right_node_id};
     $existing_right_node_ids{$right_node_id} = 1 if ($right_node_id);
-    my $genome_db_name = $species_def->{genome_db}->name;
+    my $genome_db_name = $species_def->{genome_db}->get_distinct_name;
     $existing_species_names{$genome_db_name} = $index if ($genome_db_name ne "ancestral_sequences");
   }
 
@@ -368,8 +368,8 @@ sub _combine_genomic_align_trees {
   ## it in the right place, if possible, or append the node to the end of $species_order.
   foreach my $this_genomic_align_node (@{$next_tree->get_all_sorted_genomic_align_nodes}) {
     next if (!@{$this_genomic_align_node->get_all_genomic_aligns_for_node});
-    my $this_genomic_align = $this_genomic_align_node->get_all_genomic_aligns_for_node->[0];
-    my $this_genome_db = $this_genomic_align->genome_db;
+    my $this_genome_db = $this_genomic_align_node->get_genome_db_for_node;
+
     my $this_node_id = $this_genomic_align_node->node_id;
     my $this_right_node_id = _get_right_node_id($this_genomic_align_node);
     my $these_genomic_align_ids = [];
@@ -377,7 +377,7 @@ sub _combine_genomic_align_trees {
       push (@$these_genomic_align_ids, $each_genomic_align->dbID);
     }
     ## DEBUG info
-    # print "Inserting ", $this_genome_db->name, " into the species_order\n";
+    # print "Inserting ", $this_genome_db->get_distinct_name, " into the species_order\n";
 
     my $match = 0;
     ## SECONDARY LOOP. Note that the $species_counter is not reset at the end of the loop.
@@ -404,9 +404,9 @@ sub _combine_genomic_align_trees {
 
       ## 2. If there is no info about right node or this points to a node not found in next tree,
       ## rely on the species name
-      } elsif (defined $species_genome_db and ($species_genome_db->name eq $this_genome_db->name)) {
+      } elsif (defined $species_genome_db and ($species_genome_db->get_distinct_name eq $this_genome_db->get_distinct_name)) {
         my $debug_msg = "MATCH";
-        if ($this_genome_db->name eq "ancestral_sequences") {
+        if ($this_genome_db->get_distinct_name eq "ancestral_sequences") {
           $pending_ancestral_species = {
             genome_db         => $this_genome_db,
             right_node_id     => $this_right_node_id,
@@ -427,8 +427,8 @@ sub _combine_genomic_align_trees {
 
       ## 3. If the species is in $species_order but next tree has a different order, link the node
       ## information disregarding the next tree's species order
-      } elsif (exists $existing_species_names{$this_genome_db->name}) {
-        $species_counter = $existing_species_names{$this_genome_db->name};
+      } elsif (exists $existing_species_names{$this_genome_db->get_distinct_name}) {
+        $species_counter = $existing_species_names{$this_genome_db->get_distinct_name};
         $species_order->[$species_counter]->{right_node_id} = $this_right_node_id;
         push (@{$species_order->[$species_counter]->{genomic_align_ids}}, @$these_genomic_align_ids);
         if (defined $pending_ancestral_species) {
@@ -440,10 +440,10 @@ sub _combine_genomic_align_trees {
         # _debug_info("OUT-OF-ORDER NODE LINK", $species_order, $species_counter);
 
       ## 4. Insert/append this species if not found in $species_order
-      } elsif ( (!exists $existing_right_node_ids{$this_node_id} and !exists $existing_species_names{$this_genome_db->name})
+      } elsif ( (!exists $existing_right_node_ids{$this_node_id} and !exists $existing_species_names{$this_genome_db->get_distinct_name})
                 || $species_counter >= scalar(@$species_order) ) {
         my $debug_msg = "APPEND";
-        if ($this_genome_db->name eq "ancestral_sequences") {
+        if ($this_genome_db->get_distinct_name eq "ancestral_sequences") {
           $pending_ancestral_species = {
             genome_db         => $this_genome_db,
             right_node_id     => $this_right_node_id,
@@ -462,7 +462,7 @@ sub _combine_genomic_align_trees {
             genomic_align_ids => [ @$these_genomic_align_ids ],
           });
           # Update the existing species names
-          $existing_species_names{$this_genome_db->name} = $species_counter;
+          $existing_species_names{$this_genome_db->get_distinct_name} = $species_counter;
         }
         # _debug_info($debug_msg, $species_order, $species_counter);
       } else {

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/GenomicAlignBlockAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/GenomicAlignBlockAdaptor.pm
@@ -1430,6 +1430,13 @@ sub _get_GenomicAlignBlocks_from_HAL {
           my $principal = $genome_db->principal_genome_db();
           $hal_species_map{$hal_genome_name} = defined $principal ? $principal->dbID : $map_gdb_id;
 
+          # With the current implementation of a Cactus GenomicAlignBlock, only one aligned sequence can
+          # be included per species-tree node, so aligned sequences are grouped and the one that has the
+          # longest ungapped sequence is kept. The grouping key for this is the genome_db_id associated
+          # with the given HAL genome (as indicated by the HAL mapping). For polyploids we fall back to
+          # grouping by the principal GenomeDB if present in the MLSS species tree. Polypoid alignment
+          # sequences may therefore be grouped by principal or component GenomeDB, depending on whether
+          # they are represented at the genome or subgenome level (respectively) in the MLSS species tree.
           if (exists $mlss_sp_tree_gdb_ids{$map_gdb_id}) {
             $group_key_map{$hal_genome_name} = $map_gdb_id;
           } elsif (defined $principal && exists $mlss_sp_tree_gdb_ids{$principal->dbID}) {

--- a/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
@@ -268,6 +268,21 @@ sub name{
   return $self->{'name'};
 }
 
+=head2 get_distinct_name
+
+  Example     : print $genome_db->get_distinct_name();
+  Description : Returns the name of the GenomeDB, with additional information
+                (e.g. genome component) appended if relevant to allow it to be
+                distinguished from other GenomeDBs with the same name.
+  Returntype  : String
+  Exceptions  : none
+
+=cut
+
+sub get_distinct_name {
+    my $self = shift;
+    return $self->genome_component ? $self->name . '_' . $self->genome_component : $self->name;
+}
 
 =head2 get_short_name
 

--- a/modules/Bio/EnsEMBL/Compara/GenomicAlignTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomicAlignTree.pm
@@ -1396,6 +1396,19 @@ sub annotate_node_type {
     }
 }
 
+sub get_genome_db_for_node {
+    my ($self) = @_;
+
+    my $genome_db;
+    if (defined $self->{_genome_db}) {
+        $genome_db = $self->{_genome_db};
+    } elsif (defined $self->genomic_align_group) {
+        $genome_db = $self->genomic_align_group->genome_db;
+    }
+
+    return $genome_db;
+}
+
 #sub DESTROY {
 #    my ($self) = @_;
 #

--- a/modules/Bio/EnsEMBL/Compara/GenomicAlignTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomicAlignTree.pm
@@ -1396,6 +1396,19 @@ sub annotate_node_type {
     }
 }
 
+=head2 get_genome_db_for_node
+
+  Arg []     : none
+  Example    : my $genome_db = $genomic_align_tree->get_genome_db_for_node();
+  Description: Returns the GenomeDB associated with this genomic align tree or node.
+  Returntype : GenomeDB associated with the given GenomicAlignTree or node,
+               or undef if there is no associated GenomeDB.
+  Exceptions : none
+  Caller     : general
+  Status     : Experimental
+
+=cut
+
 sub get_genome_db_for_node {
     my ($self) = @_;
 

--- a/modules/Bio/EnsEMBL/Compara/Utils/Polyploid.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Polyploid.pm
@@ -1,0 +1,88 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::Utils::Polyploid
+
+=head1 DESCRIPTION
+
+Utility module for handling polyploid genomes.
+
+=cut
+
+package Bio::EnsEMBL::Compara::Utils::Polyploid;
+
+use strict;
+use warnings;
+
+use base qw(Exporter);
+
+
+our @EXPORT_OK = qw(
+    map_dnafrag_to_genome_component
+);
+
+
+=head2 map_dnafrag_to_genome_component
+
+  Arg [1]     : Bio::EnsEMBL::Compara::DnaFrag $dnafrag
+  Example     : my $component_dnafrag = map_dnafrag_to_genome_component($principal_dnafrag);
+  Description : Given a DnaFrag in a polyploid principal GenomeDB, this method returns
+                the equivalent DnaFrag on its corresponding component GenomeDB,
+                or undef if the DnaFrag is not present on any component GenomeDB.
+  Returntype  : Bio::EnsEMBL::Compara::DnaFrag or undef
+  Exceptions  : none
+  Caller      : general
+  Status      : Experimental
+
+=cut
+
+sub map_dnafrag_to_genome_component {
+    my ($principal_dnafrag) = @_;
+
+    if(!defined($principal_dnafrag->adaptor)) {
+        throw('cannot map dnafrag ' . $principal_dnafrag->name . ' without an adaptor');
+    }
+
+    my $principal_gdb = $principal_dnafrag->genome_db;
+    if (!defined $principal_gdb) {
+        throw('cannot map dnafrag ' . $principal_dnafrag->name . ' to a subgenome - no genome defined');
+    } elsif (!$principal_gdb->is_polyploid()) {
+        throw('cannot map dnafrag ' . $principal_dnafrag->name . ' to a subgenome from non-polyploid genome' . $principal_gdb->name);
+    }
+
+    my @component_dnafrags = grep { defined } map {
+        $principal_dnafrag->adaptor->fetch_by_GenomeDB_and_name($_, $principal_dnafrag->name)
+    } @{$principal_gdb->component_genome_dbs()};
+
+    my $component_dnafrag;
+    if (scalar(@component_dnafrags) == 1) {
+        $component_dnafrag = $component_dnafrags[0];
+    } elsif (scalar(@component_dnafrags) == 0) {
+        # A DnaFrag may be present in a polyploid principal GenomeDB but not in any of its subgenomes
+        # (e.g. scaffold_v5_108365 in triticum_aestivum_landmark), so we let it off with a warning.
+        warning('cannot map dnafrag ' . $principal_dnafrag->name . ' to any subgenome of ' . $principal_gdb->name);
+    } else {
+        throw('cannot map dnafrag ' . $principal_dnafrag->name . ' to a unique subgenome of ' . $principal_gdb->name);
+    }
+
+    return $component_dnafrag;
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/Utils/Polyploid.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Polyploid.pm
@@ -30,6 +30,8 @@ package Bio::EnsEMBL::Compara::Utils::Polyploid;
 use strict;
 use warnings;
 
+use Bio::EnsEMBL::Utils::Exception qw(throw warning);
+
 use base qw(Exporter);
 
 

--- a/scripts/dumps/DumpAlignedGenes.pl
+++ b/scripts/dumps/DumpAlignedGenes.pl
@@ -479,8 +479,8 @@ my $align_slice = $align_slice_adaptor->fetch_by_Slice_MethodLinkSpeciesSet(
 # Get all the genes from the source species and map them on the query genome
 
 die "no alignments available in $species chr$seq_region:$seq_region_start-$seq_region_end which contain sequences from $source_species" 
- unless $align_slice->{slices}->{$source_genome_db->name}->[0];
-my $mapped_genes = $align_slice->{slices}->{$source_genome_db->name}->[0]->get_all_Genes($logic_name, $dbtype, undef,
+ unless $align_slice->{slices}->{$source_genome_db->get_distinct_name}->[0];
+my $mapped_genes = $align_slice->{slices}->{$source_genome_db->get_distinct_name}->[0]->get_all_Genes($logic_name, $dbtype, undef,
         -MAX_REPETITION_LENGTH => 100,
         -MAX_GAP_LENGTH => 100,
         -MAX_INTRON_LENGTH => 100000,
@@ -529,7 +529,7 @@ foreach my $gene (sort {$a->stable_id cmp $b->stable_id} @$mapped_genes) {
         $seq = ("." x 50).$exon->seq->revcom->seq.("." x 50);
       }
 
-      my $aseq = $align_slice->{slices}->{$query_genome_db->name}->[0]->subseq($exon->start-50, $exon->end+50);
+      my $aseq = $align_slice->{slices}->{$query_genome_db->get_distinct_name}->[0]->subseq($exon->start-50, $exon->end+50);
       $seq =~ s/(.{80})/$1\n/g;
       $aseq =~ s/(.{80})/$1\n/g;
       $seq =~ s/(.{20})/$1 /g;


### PR DESCRIPTION
## Description

The 37-Wheat Cactus alignment being introduced in Ensembl Plants 110 includes 11 polyploid genomes. In the species tree used to generate this Cactus alignment, the subgenome components of these polyploid genomes are represented by different nodes of the tree.

Like most Compara data types, Wheat Cactus genomic alignments are associated with the principal `GenomeDB`. However, in the associated species tree (and therefore `GenomicAlignTree`), each node representing a polyploid subgenome is associated with the corresponding component `GenomeDB`. Getting a Cactus alignment on the principal genome to work with a species tree containing genome components requires some changes to the code.

**Related JIRA tickets:**
- ENSCOMPARASW-6478

## Overview of changes

This PR enables a Cactus alignment containing a polyploid genome to have an MLSS species tree (and therefore `GenomicAlignTree`) in which its subgenomes are associated with different nodes of the species tree.

#### Deduplicating Cactus GenomicAlignBlock sequences by genome component

The HAL alignment duplicate resolution code in `GenomicAlignBlockAdaptor` is simplified and adapted so that it can resolve duplicates per subgenome iff the configured Cactus alignment and its species tree contain subgenomes, or per genome otherwise.

#### Including homoeologous genomic alignments in HAL GenomicAlignBlock

When fetching HAL MSA blocks for a `DnaFrag` from a polyploid genome, the set of target `GenomeDBs` is expanded to include polyploid components other than the one containing the specified `DnaFrag`. For example, when specifying a region on T. aestivum Jagger 6D, the returned `GenomicAlignBlock` may include an aligned genomic sequence from Jagger 6B.

#### Adding method GenomeDB::get_distinct_name

A method `get_distinct_name` is added to the `GenomeDB` class, which returns the name of the `GenomeDB`, with additional information if relevant. For the T. aestivum principal `GenomeDB`, the return value would be `triticum_aestivum`, while for the `GenomeDB` representing its 'A' subgenome, the value returned would be `triticum_aestivum_A`. This makes it possible to distinguish genomic alignments and slices from different components of the same genome.

#### Connecting a polyploid Cactus GenomicAlignBlock to its species tree

The `GenomicAlignTree` of a Cactus `GenomicAlignBlock` is derived from the MLSS species tree by matching each GenomicAlign in the `GenomicAlignBlock` to its corresponding node in the species tree. This assumes a one-to-one correspondence between `GenomeAlign` and species-tree node, which is made possible by the deduplication of Cactus `GenomicAlignBlock` sequences per species-tree node. In the Wheat Cactus tree, a node may be associated with a genome or with a subgenome, so the method `GenomicAlignBlock::get_GenomicAlignTree` is updated to match each GenomicAlign to a node of the species tree, which may be linked to a principal `GenomeDB` (e.g. `triticum_aestivum`) or a component `GenomeDB` (e.g. `triticum_aestivum_A`).

#### Adding method GenomicAlignTree::get_genome_db_for_node

A method `get_genome_db_for_node` is added to the ``GenomicAlignTree`` class, which retrieves the `GenomeDB` associated with the given `GenomicAlignTree` node, if any. In most cases this will be the same as the `GenomeDB` associated with the `GenomicAligns` on that node, but if the node represents a polyploid subgenome, the corresponding component `GenomeDB` is returned. This makes it possible to determine from the `GenomicAlignTree` of a Cactus alignment whether its aligned sequences can be grouped by subgenome.

#### Adding get_genome_component and distinct_Slice_name methods to AlignSlice::Slice

A genome component attribute is added to the `Compara::AlignSlice::Slice` class. This is set indirectly: if a component `GenomeDB` is passed to the `genome_db` method, the genome component name of the slice is set to match that of the component `GenomeDB`.

This can then be retrieved via the method `get_genome_component`, which is analogous to the `Bio::EnsEMBL::Slice` method of the same name, and preserves information about whether a given slice is associated with a principal or component `GenomeDB`.

Method `distinct_Slice_name` is added to the `Compara::AlignSlice::Slice` class, and is also set from the `GenomeDB` passed to the `genome_db` method (e.g. `Triticum_aestivum` if a principal `GenomeDB` is passed, `Triticum_aestivum_A` if a component `GenomeDB`). It can be used to get a name that is distinct for slices of interest (except in cases such as `ancestral_sequences`).

#### Grouping AlignSlice slices by genome or subgenome

When accessing a Cactus `AlignSlice`, the `GenomicAlignTree` (and by implication the MLSS species tree) acts as a sort of switch to determine whether Slices are grouped by genome or subgenome. If components of a genome are present in different nodes of the tree, aligned sequences from that genome are grouped by subgenome; otherwise they are grouped per genome.

#### Housekeeping changes

Module `Bio::EnsEMBL::Compara::Utils::Polyploid` is added, containing a single method — `map_dnafrag_to_genome_component` — which can be used to convert a given `DnaFrag` associated with its principal `GenomeDB` to the corresponding `DnaFrag` on the component `GenomeDB`.

Some unused code is removed, and the script `DumpAlignedGenes.pl` is updated to use method `GenomeDB::get_distinct_name` when directly accessing the `AlignSlice` internal `slices` data.

## Testing

Tests were done by dumping examples of `AlignSlice` data for `EPO`, `EPO_EXTENDED`, `LASTZ_NET` and `CACTUS_HAL` genomic alignments in Vertebrates and Plants, using the versions of the code before and after the changes in this PR, followed by comparison of the output files to check for issues introduced by the update.

Ticket ENSCOMPARASW-6478 has example files of alignments generated with a per-genome species tree (`jagger_per_genome.fa` and `jagger_per_genome.phyloxml.xml`) and with a per-subgenome species tree (`jagger_per_subgenome.fa` and `jagger_per_subgenome.phyloxml.xml`).

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
