### PR TITLE
Add pairwise alignment and synteny between Human and Tasmanian devil

### DIFF
--- a/conf/vertebrates/mlss_conf.xml
+++ b/conf/vertebrates/mlss_conf.xml
@@ -122,6 +122,9 @@
     <!-- Chicken vs Human LastZ (on Human) -->
     <pairwise_alignment method="LASTZ_NET" ref_genome="homo_sapiens" target_genome="gallus_gallus"/>
 
+    <!-- Tasmanian devil vs Human LastZ (on Human) -->
+    <pairwise_alignment method="LASTZ_NET" ref_genome="homo_sapiens" target_genome="sarcophilus_harrisii"/>    
+
   </pairwise_alignments>
 
   <multiple_alignments>


### PR DESCRIPTION
## Description

Due to community interest, thie release (111) will perform LastZ and synteny between Human (GRCh38) and the new Tasmanian devil genome assembly (mSarHar1.11). 

**Related JIRA tickets:**
- ENSCOMPARASW-6404

## Overview of changes
Add `<pairwise_alignment method="LASTZ_NET" ref_genome="homo_sapiens" target_genome="sarcophilus_harrisii"/>` into `conf/vertebrates/mlss_conf.xml`


---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
