### PR TITLE
fixing issue related to URL resolution inside DB

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
+++ b/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
@@ -269,6 +269,10 @@ sub url {
       my $data_dir = $self->adaptor->base_dir_location;
       my $url = $self->{'url'};
       #warn "<- $url";
+      
+      # store the original, non-resolved url
+      $self->{'original_url'} = $url;
+
       $url =~ s/#base_dir#/$data_dir/;
       $url =~ s/\/multi\/+multi\//\/multi\//;    # temporary hack for e88 production until the database has been updated
       #warn "-> $url";

--- a/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
+++ b/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
@@ -274,7 +274,6 @@ sub url {
       #warn "-> $url";
 
       if (-e $url) {
-          $self->{'original_url'} = $url;
           $self->{'url'} = $url;
       } else {
           die "'$url' does not exist on this machine\n";


### PR DESCRIPTION
## Description

 The HAL file URL is being resolved in the database, i.e., being set to the fully resolved absolute path. However, it should have been set to a value including a fixed string containing the base directory parameter (`#base_dir#`) plus a relative path containing  `multi/hal_files` plus the HAL filename (e.g. `#base_dir#/multi/hal_files/Rice_27-way_202208.hal`).

**Related JIRA tickets:**
- ENSCOMPARASW-6488

## Overview of changes
Move intruction`$self->{'original_url'} = $url;` before the modification `$url =~ s/#base_dir#/$data_dir/;`

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
