### PR TITLE
GOC taxlevel and threshold  updates for Metazoa-insects collection

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/InsectsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/InsectsProteinTrees_conf.pm
@@ -58,7 +58,7 @@ sub default_options {
         # In this structure, the "thresholds" are for resp. the GOC score, the WGA coverage and %identity
         'threshold_levels' => [
             {
-                'taxa'          => [ 'Aculeata', 'Anophelinae', 'Drosophila', 'Glossinidae', 'Ditrysia', 'Tephritidae', 'Aphididae', 'Bemisia' ],
+                'taxa'          => [ 'Aculeata', 'Anophelinae', 'Drosophila', 'Glossinidae', 'Ditrysia', 'Tephritidae', 'Aphididae', 'Bemisia', 'Orthoptera', 'Trichoptera' ],
                 'thresholds'    => [ 50, 50, 25 ],
             },
             {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/InsectsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/InsectsProteinTrees_conf.pm
@@ -50,6 +50,27 @@ sub default_options {
         'dbID_range_index'    => 20,
         'ref_collection_list'      => ['default','protostomes'],
         'label_prefix' => 'insects_',
+
+        #GOC parameters:
+        'goc_taxlevels' => ['Hymenoptera', 'Diptera', 'Ditrysia', 'Hemiptera'],
+
+        # HighConfidenceOrthologs parameters:
+        # In this structure, the "thresholds" are for resp. the GOC score, the WGA coverage and %identity
+        'threshold_levels' => [
+            {
+                'taxa'          => [ 'Aculeata', 'Anophelinae', 'Drosophila', 'Glossinidae', 'Ditrysia', 'Tephritidae', 'Aphididae', 'Bemisia' ],
+                'thresholds'    => [ 50, 50, 25 ],
+            },
+            {
+                'taxa'          => [ 'Brachycera', 'Culicinae', 'Hemiptera', 'Phlebotominae', 'Hymenoptera', 'Diptera' ],
+                'thresholds'    => [ 25, 25, 25 ],
+            },
+            {
+                'taxa'          => [ 'all' ],
+                'thresholds'    => [ undef, undef, 25 ],
+            },
+        ],
+
     };
 }
 


### PR DESCRIPTION
## Description

During the Metazoa-Compara production for release 110, there was a marked reduction in GOC scores in the default and protostomes protein-trees. It turned out that the GOC 'taxlevels' parameter was set to taxa that were not necessarily suited to the set of species in the new protostomes and default collections.
To avoid this issue for the insects collections for e111 the updated GOC taxlevels and thresholds  are proposed here. 

**Related JIRA tickets:**
- [ENSCOMPARASW-6402](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-6402) 

## Overview of changes
NCBI taxonomy insects species tree and GOC score heat maps were compared for both e110 insects protein tree pipeline and e109 release database. The heatmaps were compared to the existing GOC thresholds for the proposed new taxlevels and depending on whether the heatmap was a hotspot (red colour) or not (yellow colour) the thresholds were selected. The updated GOC taxlevels and thresholds are reflected in the InsectsProteinTrees_conf.pm file. 

## Testing

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
