### PR TITLE
not ready yet for examl_48_cores

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -2486,7 +2486,7 @@ sub core_pipeline_analyses {
                     # examl can handle ~4x more patterns
                     '(#raxml_cores# >  16) && (#raxml_cores# <= 32)'    => 'examl_8_cores',
                     '(#raxml_cores# >  32) && (#raxml_cores# <= 48)'    => 'examl_16_cores',
-                    '(#raxml_cores# >  48) && (#raxml_cores# <= 96)'    => 'examl_32_cores',
+                    '(#raxml_cores# >  48) && (#raxml_cores# <= 128)'   => 'examl_32_cores',
                     '(#raxml_cores# >  96)'                             => 'examl_64_cores',
                 ),
             },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -2487,7 +2487,7 @@ sub core_pipeline_analyses {
                     '(#raxml_cores# >  16) && (#raxml_cores# <= 32)'    => 'examl_8_cores',
                     '(#raxml_cores# >  32) && (#raxml_cores# <= 48)'    => 'examl_16_cores',
                     '(#raxml_cores# >  48) && (#raxml_cores# <= 128)'   => 'examl_32_cores',
-                    '(#raxml_cores# >  96)'                             => 'examl_64_cores',
+                    '(#raxml_cores# >  128)'                            => 'examl_64_cores',
                 ),
             },
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -2487,7 +2487,7 @@ sub core_pipeline_analyses {
                     '(#raxml_cores# >  16) && (#raxml_cores# <= 32)'    => 'examl_8_cores',
                     '(#raxml_cores# >  32) && (#raxml_cores# <= 48)'    => 'examl_16_cores',
                     '(#raxml_cores# >  48) && (#raxml_cores# <= 96)'    => 'examl_32_cores',
-                    '(#raxml_cores# >  96)'                             => 'examl_48_cores',
+                    '(#raxml_cores# >  96)'                             => 'examl_64_cores',
                 ),
             },
         },
@@ -2550,7 +2550,7 @@ sub core_pipeline_analyses {
             -rc_name => '8Gb_32c_mpi',
             -flow_into => {
                -1 => [ 'examl_32_cores_himem' ],  # MEMLIMIT
-               -2 => [ 'examl_48_cores' ],  	  # RUNTIME
+               -2 => [ 'examl_64_cores' ],  	  # RUNTIME
             }
         },
 


### PR DESCRIPTION
## Description

During the test of the protein-tree pipeline, the following message comes up from the `beekeeper`

```bash
Could not find a local analysis named 'examl_48_cores' (dataflow from analysis 'raxml_decision')
Could not find a local analysis named 'examl_48_cores' (dataflow from analysis 'examl_32_cores')
```

Indeed, there is no analysis named `examl_48_cores`. I believe this might be an error from the SLURM configuration. Perhaps, we should enforce the LSF meadow for these analyses.  Just reverting this temporary

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
