### PR TITLE
Reorder and add to Insect GOC threshold clade sets

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/InsectsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/InsectsProteinTrees_conf.pm
@@ -58,11 +58,11 @@ sub default_options {
         # In this structure, the "thresholds" are for resp. the GOC score, the WGA coverage and %identity
         'threshold_levels' => [
             {
-                'taxa'          => [ 'Aculeata', 'Anophelinae', 'Drosophila', 'Glossinidae', 'Ditrysia', 'Tephritidae', 'Aphididae', 'Bemisia', 'Orthoptera', 'Trichoptera' ],
+		'taxa'          => [ 'Aculeata', 'Anophelinae', 'Drosophila', 'Glossinidae', 'Ditrysia', 'Tephritidae', 'Aphididae', 'Bemisia', 'Culicinae', 'Acrididae' ],
                 'thresholds'    => [ 50, 50, 25 ],
             },
             {
-                'taxa'          => [ 'Brachycera', 'Culicinae', 'Hemiptera', 'Phlebotominae', 'Hymenoptera', 'Diptera' ],
+                'taxa'          => [ 'Brachycera', 'Hemiptera', 'Phlebotominae', 'Hymenoptera', 'Diptera', 'Orthoptera', 'Trichoptera' ],
                 'thresholds'    => [ 25, 25, 25 ],
             },
             {


### PR DESCRIPTION
## Description
Adjustments made to Insect GOC sets. Higher order clades (level = Order) of Orthopter and Trichoptera repositioned to lower GOC (25%) set. Culicidea repositioned to higher GOC set (50%). 

**Related JIRA tickets:**
- [ENSCOMPARASW-6402](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-6402)

## Overview of changes
Slight adjustments made to some clades which I felt were out of line with other clades of a particular taxa set. 

Context: 
_NCBI taxonomy insects species tree and GOC score heat maps were compared for both e110 insects protein tree pipeline and e109 release database. The heatmaps were compared to the existing GOC thresholds for the proposed new taxlevels and depending on whether the heatmap was a hotspot (red colour) or not (yellow colour) the thresholds were selected. The updated GOC taxlevels and thresholds are reflected in the InsectsProteinTrees_conf.pm file._

#### Change 1
- Restructure, placed Orthoptera and Trichoptera within the '25, 25, 25' taxon set. 

#### Change 2
- Restructure, placed Culicinae within the '50, 50, 25' taxon set. 

#### Change 3
- Added additional clade set of Acrididae (Family), relevant for locusts species (Orthoptera) added within the '50, 50, 25' taxon set.

## Testing
Not tested

## Notes

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
