### PR TITLE
Species tree pipeline: make it work with the vertebrata BUSCO set

### DIFF
--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -211,7 +211,7 @@ process linkAnnoCache {
 *@output tuple of path to annotation GTF and genome fasta
 */
 process buscoAnnot {
-    label 'retry_with_8gb_mem_c1'
+    label 'retry_with_32gb_mem_c32'
 
     publishDir "${params.results_dir}/anno_cache/$genome", pattern: "annotation.gtf", mode: "copy",  overwrite: true
 
@@ -559,7 +559,10 @@ process calcProtTrees {
         path "prot_aln_*.treefile", emit: tree
     script:
     """
-    ${params.iqtree_exe} -s $aln -m LG+F+G --fast -T ${params.cores}
+    # Remove taxa with gaps and stop codons only:
+    ${params.seqkit_exe} grep -v -s -r -p "^[*-]*\$" $aln > ${aln}.proc
+    # Run iqtree:
+    ${params.iqtree_exe} -s ${aln}.proc -m LG+F+G --fast -T ${params.cores}
     """
 }
 

--- a/pipelines/SpeciesTreeFromBusco/nextflow.config
+++ b/pipelines/SpeciesTreeFromBusco/nextflow.config
@@ -36,7 +36,7 @@ params {
 
     anno_cache = ""
     // Path to unzipped BUSCO protein set:
-    busco_proteins = "$COMPARA_SOFTWARE/dataset/busco/v4/eukaryota_odb10/refseq_db.faa"
+    busco_proteins = "$COMPARA_SOFTWARE/dataset/busco/v5/eukaryota_odb10/refseq_db.faa"
     // Directory for storing results:
     results_dir = "./SpeciesTreeRes"
     // Number of cores to use:


### PR DESCRIPTION
## Description

The BUSCO-based species tree pipeline was failing on the 110 vertebrates species set when using the vertebrata set.

**Related JIRA tickets:**
- ENSCOMPARASW-6463

## Overview of changes

#### Change 1
Tweaked the resource class for the buscoAnnot process to start with more memory and cores.

#### Change 2
Removing taxa from input alignemnts with gaps and stop codons only before running iqtree.

#### Change 3
Switched the default BUSCO protein set to v5 eukaryota set.

## Testing
The pipeline was successfully run on the e110 vertrebrates collection with the vertebrata BUSCO set.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
