### PR TITLE
Validate taxonomy ID metadata in flag_core_issues.pl

### DIFF
--- a/scripts/production/flag_core_issues.pl
+++ b/scripts/production/flag_core_issues.pl
@@ -303,7 +303,6 @@ foreach my $division (@divisions) {
 
         done_testing();
     };
-
 }
 
 done_testing();


### PR DESCRIPTION
## Description

NCBI Taxonomy metadata updates are applied to core databases during the production process, but a small number of Taxonomy metadata changes slip through the net. This PR adds a test to the existing `flag_core_issues.pl` script to check for these by testing that Taxonomy ID metadata is current.

## Testing

The new test was used in Protists Compara 111 production, flagging the Taxonomy metadata of 2 Protists genomes with the following output:
```bash
not ok 131 - core meta entry 'species.taxonomy_id' is current for 'phytomonas_sp_isolate_em1_gca_000582765' (protists_euglenozoa1_collection_core_58_111_1)
#   Failed test 'core meta entry 'species.taxonomy_id' is current for 'phytomonas_sp_isolate_em1_gca_000582765' (protists_euglenozoa1_collection_core_58_111_1)'
#   at /hps/software/users/ensembl/repositories/compara/twalsh/e111/ensembl-compara/scripts/production/flag_core_issues.pl line 277.
not ok 132 - core meta entry 'species.species_taxonomy_id' is current for phytomonas_sp_isolate_em1_gca_000582765
#   Failed test 'core meta entry 'species.species_taxonomy_id' is current for phytomonas_sp_isolate_em1_gca_000582765'
#   at /hps/software/users/ensembl/repositories/compara/twalsh/e111/ensembl-compara/scripts/production/flag_core_issues.pl line 282.
not ok 133 - core meta entry 'species.taxonomy_id' is current for 'phytomonas_sp_isolate_hart1_gca_000982615' (protists_euglenozoa1_collection_core_58_111_1)
#   Failed test 'core meta entry 'species.taxonomy_id' is current for 'phytomonas_sp_isolate_hart1_gca_000982615' (protists_euglenozoa1_collection_core_58_111_1)'
#   at /hps/software/users/ensembl/repositories/compara/twalsh/e111/ensembl-compara/scripts/production/flag_core_issues.pl line 277.
not ok 134 - core meta entry 'species.species_taxonomy_id' is current for phytomonas_sp_isolate_hart1_gca_000982615
#   Failed test 'core meta entry 'species.species_taxonomy_id' is current for phytomonas_sp_isolate_hart1_gca_000982615'
#   at /hps/software/users/ensembl/repositories/compara/twalsh/e111/ensembl-compara/scripts/production/flag_core_issues.pl line 282.
```

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
