### PR TITLE
Extend criteria for skipping reference-query pair

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DiamondAgainstQuery.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DiamondAgainstQuery.pm
@@ -32,6 +32,8 @@ package Bio::EnsEMBL::Compara::PipeConfig::Parts::DiamondAgainstQuery;
 use strict;
 use warnings;
 
+use File::Spec::Functions;
+
 use Bio::EnsEMBL::Hive::Version 2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf; # For WHEN and INPUT_PLUS
 
@@ -56,6 +58,10 @@ sub pipeline_analyses_diamond_against_query {
 
         {   -logic_name    => 'ref_from_fasta_factory',
             -module        => 'Bio::EnsEMBL::Compara::RunnableDB::HomologyAnnotation::RefFromFastaFactory',
+            -parameters    => {
+                'get_genebuild_id_exe' => $self->o('get_genebuild_id_exe'),
+                'ref_reg_conf'         => catfile($self->o('ensembl_root_dir'), 'ensembl-compara', 'conf', 'references', 'production_reg_conf.pl'),
+            },
             -priority      => 1,
             -flow_into     => {
                 '2' => { 'diamond_blastp_ref_to_query'  => INPUT_PLUS() },


### PR DESCRIPTION
## Description

There are two steps of the Compara homology annotation pipeline ([HomologyAnnotation::BlastFactory](https://github.com/Ensembl/ensembl-compara/blob/4f85763d0222ff6d8512721f4e2863e2661b3a8e/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/BlastFactory.pm) and [HomologyAnnotation::RefFromFastaFactory](https://github.com/Ensembl/ensembl-compara/blob/4f85763d0222ff6d8512721f4e2863e2661b3a8e/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/RefFromFastaFactory.pm)) in which Rapid-Release query genomes are checked against their reference genomes, so that query-reference pairings of a genome to itself can be skipped.

[Compara PR #605](https://github.com/Ensembl/ensembl-compara/pull/605) extended the criteria of the query-reference check in `HomologyAnnotation::BlastFactory`, ensuring that no homologies would be created between a genome and itself, even in the small number of cases where their production name does not match.

This PR extends the criteria of the reference-query check in `HomologyAnnotation::RefFromFastaFactory`, so that no reference-query BLAST results are generated for such cases.

**Related JIRA tickets:**
- ENSCOMPARASW-6709
- [ENSRR-574](https://www.ebi.ac.uk/panda/jira/browse/ENSRR-574)

## Overview of changes

This PR takes an existing supplementary check of key attributes of each query-reference pair, and additionally applies it to reference-query pairs, with the aim of ensuring that reciprocal DIAMOND BLAST is not run on a genome against itself.

## Testing

This PR was tested by running the homology annotation pipeline as far as the relevant analyses (`diamond_factory` and `ref_from_fasta_factory`) and checking their warning messages to confirm that the expected query-reference and reference-query pairs were being skipped. For more details on testing, see ENSCOMPARASW-6709.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
