### PR TITLE
Species tree pipeline: fix memory usage in branch length calculation step

### DIFF
--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -631,7 +631,7 @@ process calcCodonBranchesIqtree {
 *@output path to iqtree2 log file
 */
 process calcNeutralBranchesAstral {
-    label 'retry_with_16gb_mem_c1'
+    label 'retry_with_128gb_mem_c32'
 
     publishDir "${params.results_dir}/", pattern: "astral_species_tree_neutral_bl.nwk", mode: "copy",  overwrite: true
     publishDir "${params.results_dir}/", pattern: "astral_iqtree_report_neutral_bl.txt", mode: "copy",  overwrite: true
@@ -708,7 +708,7 @@ process calcCodonBranchesAstral {
 *@output path to iqtree2 log file
 */
 process calcProtBranchesAstral {
-    label 'retry_with_16gb_mem_c1'
+    label 'retry_with_128gb_mem_c32'
 
     publishDir "${params.results_dir}/", pattern: "astral_species_tree_prot_bl.nwk", mode: "copy",  overwrite: true
     publishDir "${params.results_dir}/", pattern: "astral_iqtree_report_prot_bl.txt", mode: "copy",  overwrite: true

--- a/pipelines/nextflow.config
+++ b/pipelines/nextflow.config
@@ -115,4 +115,12 @@ process {
        time = { 168.h }
        maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 8 : 1 }
     }	
+    withLabel: retry_with_128gb_mem_c32 {
+       cpus = 32
+       queue = { task.attempt >= 2 ? 'bigmem' : 'standard' }
+       errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
+       memory = { 128.GB * task.attempt }
+       time = { 168.h }
+       maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 4 : 1 }
+    }
 }


### PR DESCRIPTION
## Description

During 111 vertebrates production there were issues with the branch length calculation step using more than 500gb of memory. In order to accomodate this, @twalsh-ebi patched the pipeline to submit jobs to the bigmem queue.
This PR adds a solution which dynamically determines the queue based on the amount of requested memory.

**Related JIRA tickets:**
- ENSCOMPARASW-6735

## Overview of changes
_Give details of what changes were required to solve the problem. Break into sections if applicable._

#### Change 1
- Added resource class: retry_with_128gb_mem_c32

#### Change 2
- Using the resource class above for branch length calculations.

## Testing
The pipeline was run with the 111 vertebrates division.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
