### PR TITLE
Enable listing of 'always-reuse' Metazoa species

### DIFF
--- a/scripts/production/list_must_reuse_species.py
+++ b/scripts/production/list_must_reuse_species.py
@@ -16,15 +16,26 @@
 
 Example::
 
+    # To list species that must be reused in release 111:
     ${ENSEMBL_ROOT_DIR}/ensembl-compara/scripts/production/list_must_reuse_species.py \
         --input-file ${ENSEMBL_ROOT_DIR}/ensembl-compara/conf/metazoa/must_reuse_collections.json \
         --mlss-conf-file ${ENSEMBL_ROOT_DIR}/ensembl-compara/conf/metazoa/mlss_conf.xml \
         --ensembl-release 111 \
         --output-file must_reuse_species.json
 
+    # To list species that must always be reused, assuming the
+    # current collections are updated in alternating releases:
+    ${ENSEMBL_ROOT_DIR}/ensembl-compara/scripts/production/list_must_reuse_species.py \
+        --input-file ${ENSEMBL_ROOT_DIR}/ensembl-compara/conf/metazoa/must_reuse_collections.json \
+        --mlss-conf-file ${ENSEMBL_ROOT_DIR}/ensembl-compara/conf/metazoa/mlss_conf.xml \
+        --ensembl-release all \
+        --output-file always_reuse_species.json
+
 """
 
 import argparse
+from collections import defaultdict
+import itertools
 import json
 
 from lxml import etree
@@ -33,34 +44,67 @@ from lxml import etree
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate list of must-reuse species.")
     parser.add_argument(
-        "-i", "--input-file", metavar="PATH", required=True, help="Input must-reuse collection file."
+        "-i",
+        "--input-file",
+        metavar="PATH",
+        required=True,
+        help="Input reused collection config file.",
     )
-    parser.add_argument("--mlss-conf-file", metavar="PATH", required=True, help="Input MLSS conf file.")
-    parser.add_argument("--ensembl-release", metavar="INT", required=True, type=int, help="Ensembl release.")
     parser.add_argument(
-        "-o", "--output-file", metavar="PATH", required=True, help="Output allowed-species JSON file."
+        "--mlss-conf-file",
+        metavar="PATH",
+        required=True,
+        help="Input MLSS conf file.",
+    )
+    parser.add_argument(
+        "--ensembl-release",
+        metavar="VALUE",
+        required=True,
+        help="Ensembl release, or 'all' to list 'always-reused' species.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-file",
+        metavar="PATH",
+        required=True,
+        help="Output JSON file listing must-reuse species.",
     )
 
     args = parser.parse_args()
 
     with open(args.input_file) as in_file_obj:
-        muse_reuse_config = json.load(in_file_obj)
+        reused_collection_conf = json.load(in_file_obj)
 
-    parity = "even" if args.ensembl_release % 2 == 0 else "odd"
-    must_reuse_collections = muse_reuse_config[parity]
+    reused_collection_names = sorted(itertools.chain.from_iterable(reused_collection_conf.values()))
 
     with open(args.mlss_conf_file) as in_file_obj:
         xml_tree = etree.parse(in_file_obj)
 
     xml_root = xml_tree.getroot()
 
-    must_reuse_genomes = set()
-    for collection_name in must_reuse_collections:
+    reused_collection_genomes = defaultdict(set)
+    for collection_name in reused_collection_names:
         collection = xml_root.find(f".//collection[@name='{collection_name}']")
         for genome in collection.findall("genome"):
             if genome.attrib.get("exclude", False):
                 continue
-            must_reuse_genomes.add(genome.attrib["name"])
+            reused_collection_genomes[collection_name].add(genome.attrib["name"])
+
+    reused_genomes_by_parity = {}
+    for parity in ["odd", "even"]:
+        reused_genomes_by_parity[parity] = set.union(
+            *[reused_collection_genomes[collection] for collection in reused_collection_conf[parity]]
+        )
+
+    if args.ensembl_release == "all":
+        must_reuse_genomes = reused_genomes_by_parity["odd"] & reused_genomes_by_parity["even"]
+    else:
+        try:
+            ensembl_release = int(args.ensembl_release)
+        except ValueError as exc:
+            raise ValueError(f"invalid/unsupported Ensembl release: {args.ensembl_release}") from exc
+        parity = "even" if ensembl_release % 2 == 0 else "odd"
+        must_reuse_genomes = reused_genomes_by_parity[parity]
 
     with open(args.output_file, "w") as out_file_obj:
         json.dump(sorted(must_reuse_genomes), out_file_obj)


### PR DESCRIPTION
## Description

The main Metazoa protein-trees collections are currently processed in a staggered manner, with `default` and `protostomes` protein-tree collections processed in even-numbered releases and the `insects` collection processed in odd-numbered releases.

[Compara PR #637](https://github.com/Ensembl/ensembl-compara/pull/637) updated the handling of must-reuse species with the aim of simplifying the configuration of the Metazoa protein-trees collections, as well as the automatic verification that gene sets which must be reused in member-loading and protein-trees pipelines are indeed reused in a given release.

As part of that PR, the utility script `list_must_reuse_species.py` was introduced, which generates a list of the 'must-reuse' species for a given Ensembl release, given the input `must_reuse_collections.json` and `mlss_conf.xml` configuration files.

This PR extends the functionality of `list_must_reuse_species.py` so that, if the Ensembl release is set to `all`, the output file contains the list of species which must _always_ be reused (assuming the currently configured collections are updated in alternating releases).

## Overview of changes

The `--ensembl-release` parameter of the `list_must_reuse_species.py` utility script accepts the special value `all`. If specified, the script outputs the list of species in the main Metazoa protein-tree collections which must always be reused, given the current configuration.

## Testing

The utility script `list_must_reuse_species.py` was tested with even- and odd-numbered Ensembl release numbers, as well as with the special Ensembl release value `all`, to confirm that it generated the expected output.


---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
