### PR TITLE
Species tree piepline: now using slurm executor

### DIFF
--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -453,7 +453,7 @@ process mergeProtAlns {
 *@output path to merged alignments fasta
 */
 process mergeCodonAlns {
-    label 'rc_4gb'
+    label 'rc_4Gb'
 
     publishDir "${params.results_dir}/", pattern: "merged_codon_alns.fas", mode: "copy",  overwrite: true
 
@@ -482,7 +482,7 @@ process mergeCodonAlns {
 *@output fasta alignment with every third site.
 */
 process pickThirdCodonSite {
-    label 'rc_4gb'
+    label 'rc_4Gb'
 
     publishDir "${params.results_dir}/", pattern: "merged_third_sites_alns.fas", mode: "copy",  overwrite: true
 
@@ -554,7 +554,7 @@ process calcGeneTrees {
 *@output path to tree in newick format
 */
 process calcProtTrees {
-    label 'retry_with_8gb_mem_c1'
+    label 'retry_with_8gb_mem_c32'
 
     input:
         path aln
@@ -602,7 +602,7 @@ process runAstral {
 *@output path to iqtree2 log file
 */
 process calcCodonBranchesIqtree {
-    label 'retry_with_16gb_mem_c1'
+    label 'retry_with_16gb_mem_c32'
 
     publishDir "${params.results_dir}/", pattern: "species_tree_codon_bl.nwk", mode: "copy",  overwrite: true
     publishDir "${params.results_dir}/", pattern: "iqtree_report_codon_bl.txt", mode: "copy",  overwrite: true

--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -252,7 +252,7 @@ process runGffread {
     script:
     """
     mkdir -p cdna
-    ${params.gffread_exe} -x cdna/$genome -g $genome $busco_annot
+    ${params.gffread_exe} -w cdna/$genome -g $genome $busco_annot
     """
 }
 

--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -244,7 +244,7 @@ process buscoAnnot {
 *@output path to cDNA fasta
 */
 process runGffread {
-    label 'rc_4gb'
+    label 'rc_4Gb'
     input:
         tuple path(busco_annot), path(genome)
     output:
@@ -266,7 +266,7 @@ process runGffread {
 *@output path to taxon list TSV
 */
 process collateBusco {
-    label 'rc_16gb'
+    label 'rc_16Gb'
 
     publishDir "${params.results_dir}/busco_genes", pattern: "cdnas_fofn.txt", mode: "copy", overwrite: true
     publishDir "${params.results_dir}/busco_genes/prot", pattern: "gene_prot_*.fas", mode: "copy",  overwrite: true
@@ -420,7 +420,7 @@ process trimAlignments {
 *@output path to RAXML style partition file
 */
 process mergeProtAlns {
-    label 'rc_4gb'
+    label 'rc_4Gb'
 
     publishDir "${params.results_dir}/", pattern: "merged_protein_alns.fas", mode: "copy",  overwrite: true
     publishDir "${params.results_dir}/", pattern: "partitions.tsv", mode: "copy",  overwrite: true

--- a/pipelines/nextflow.config
+++ b/pipelines/nextflow.config
@@ -77,6 +77,13 @@ process {
        time = 168.h 
        maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 10 : 1 }
     }
+    withLabel: retry_with_8gb_mem_c32 {
+       cpus = 32
+       errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
+       memory = { 8.GB * task.attempt }
+       time = 168.h 
+       maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 10 : 1 }
+    }
     withLabel: retry_with_8gb_mem_c1 {
        cpus = 1
        errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }

--- a/pipelines/nextflow.config
+++ b/pipelines/nextflow.config
@@ -24,95 +24,92 @@ params {
 }
 
 process {
-    executor = 'lsf'
+    executor = 'slurm'
     queue = 'standard'
     perJobMemLimit = true
-    withLabel: lsf_default {
-        clusterOptions = ' -C0 -M1000 '
-    }
-    withLabel: slurm_default {
-        executor = 'slurm'
-        queue = '1c2m20d'
+    perJobTimeLimit = true
+    withLabel: rc_1Gb {
+       memory = { 1.GB }
+       time = 168.h
     }
     withLabel: rc_2Gb {
-        clusterOptions = ' -C0 -M2000 '
+       memory = { 2.GB }
+       time = 168.h
     }
     withLabel: rc_4Gb {
-        clusterOptions = ' -C0 -M4000 '
+       memory =  { 4.GB }
+       time =  168.h
     }
     withLabel: rc_8Gb {
-        clusterOptions = ' -C0 -M8000 '
+       memory =  { 8.GB }
+       time =  168.h
     }
     withLabel: rc_16Gb {
-        clusterOptions = ' -C0 -M16000 '
+       memory =  { 16.GB }
+       time =  168.h
     }
     withLabel: rc_32Gb {
-        clusterOptions = ' -C0 -M32000 '
+       memory =  { 32.GB }
+       time =  168.h
     }
     withLabel: rc_64Gb {
-        clusterOptions = ' -C0 -M64000 '
-    }
-    withLabel: lsf_64Gb_32C {
-        clusterOptions = ' -n 32 -C0 -M64000 -R"span[hosts=1] rusage[mem=64000.00:duration=168h:decay=0]" '
-    }
-    withLabel: slurm_64Gb_32C {
-        executor = 'slurm'
-        queue = '32c128m60d'
+       memory =  { 64.GB }
+       time =  168.h
     }
     withLabel: retry_with_4gb_mem_c1 {
        cpus = 1
        errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
        memory = { 4.GB * task.attempt }
-       time = { 168.h }
+       time =  168.h
        maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 10 : 1 }
     }
     withLabel: retry_with_8gb_mem_c5 {
        cpus = 5
        errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
        memory = { 8.GB * task.attempt }
-       time = { 168.h }
+       time =  168.h 
        maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 10 : 1 }
     }
     withLabel: retry_with_8gb_mem_c16 {
        cpus = 16
        errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
        memory = { 8.GB * task.attempt }
-       time = { 168.h }
+       time = 168.h 
        maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 10 : 1 }
     }
     withLabel: retry_with_8gb_mem_c1 {
        cpus = 1
        errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
        memory = { 8.GB * task.attempt }
-       time = { 168.h }
+       time = 168.h 
        maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 10 : 1 }
     }
     withLabel: retry_with_16gb_mem_c1 {
        cpus = 1
        errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
        memory = { 16.GB * task.attempt }
-       time = { 168.h }
+       time = 168.h
        maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 16 : 1 }
     }
     withLabel: retry_with_16gb_mem_c16 {
        cpus = 16
        errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
        memory = { 16.GB * task.attempt }
-       time = { 168.h }
+       time = 168.h
        maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 10 : 1 }
     }
     withLabel: retry_with_16gb_mem_c32 {
        cpus = 32
        errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
        memory = { 16.GB * task.attempt }
-       time = { 168.h }
+       time = 168.h
        maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 10 : 1 }
     }
     withLabel: retry_with_32gb_mem_c32 {
        cpus = 32
        errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
        memory = { 32.GB * task.attempt }
-       time = { 168.h }
+       time = 168.h
        maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 8 : 1 }
     }	
     withLabel: retry_with_128gb_mem_c32 {
@@ -120,7 +117,7 @@ process {
        queue = { task.attempt >= 2 ? 'bigmem' : 'standard' }
        errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
        memory = { 128.GB * task.attempt }
-       time = { 168.h }
+       time = 168.h
        maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 4 : 1 }
     }
 }


### PR DESCRIPTION
## Description

This PR modifies the species tree pipeline to run on a SLURM cluster.

**Related JIRA tickets:**
- ENSCOMPARASW-ENSCOMPARASW-6117

## Overview of changes

#### Change 1

Made SLURM the default executor.

#### Change 2

Fixed resource classes so no job runs with default settings.

## Testing

The piepeline was run on 5 bird species and the vertebrates BUSCO set.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
