### PR TITLE
Update jira_recurrent_tickets.json to include BUSCO species tree

### DIFF
--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -57,8 +57,8 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
-            "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+setup#Productionsetup-Species-tree\n*GitHub*: [CreateSpeciesTree_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateSpeciesTree_conf.pm]\n{code}ibsub init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::CreateSpeciesTree_conf -host mysql-ens-compara-prod-X -port XXXX -division plants -output_file $ENSEMBL_ROOT_DIR/ensembl-compara/conf/plants/species_tree.rice.branch_len.nw -species_set_id XXXXXX{code}\n(!) Only needs to be recomputed if there is a change to the rice {{species_set}}",
-            "summary": "Import the species-tree",
+            "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+setup#Productionsetup-Species-tree\n*GitHub*: [SpeciesTreeFromBusco|https://github.com/Ensembl/ensembl-compara/tree/main/pipelines/SpeciesTreeFromBusco](!) Only needs to be recomputed if there is a change to the rice {{species_set}}",
+            "summary": "Run BUSCO species-tree pipeline",
             "name_on_graph": "Species-tree"
          }
       ],

--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -57,7 +57,7 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
-            "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+setup#Productionsetup-Species-tree\n*GitHub*: [SpeciesTreeFromBusco|https://github.com/Ensembl/ensembl-compara/tree/main/pipelines/SpeciesTreeFromBusco](!) Only needs to be recomputed if there is a change to the rice {{species_set}}",
+            "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+setup#Productionsetup-Species-tree\n*GitHub*: [SpeciesTreeFromBusco|https://github.com/Ensembl/ensembl-compara/tree/main/pipelines/SpeciesTreeFromBusco]",
             "summary": "Run BUSCO species-tree pipeline",
             "name_on_graph": "Species-tree"
          }

--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -57,7 +57,7 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
-            "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+setup#Productionsetup-Species-tree\n*GitHub*: [SpeciesTreeFromBusco|https://github.com/Ensembl/ensembl-compara/tree/main/pipelines/SpeciesTreeFromBusco]",
+            "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+setup#Productionsetup-Species-tree\n*GitHub*: [SpeciesTreeFromBusco|https://github.com/Ensembl/ensembl-compara/tree/release/<version>/pipelines/SpeciesTreeFromBusco]",
             "summary": "Run BUSCO species-tree pipeline",
             "name_on_graph": "Species-tree"
          }

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -57,8 +57,8 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
-            "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+setup#Productionsetup-Species-tree\n*GitHub*: [CreateSpeciesTree_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateSpeciesTree_conf.pm]\n{code}ibsub init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::CreateSpeciesTree_conf -host mysql-ens-compara-prod-X -port XXXX -output_file $ENSEMBL_ROOT_DIR/ensembl-compara/conf/<division>/species_tree.branch_len.nw -division <division>{code}",
-            "summary": "Run Create Species Tree pipeline",
+            "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+setup#Productionsetup-Species-tree\n*GitHub*: [SpeciesTreeFromBusco|https://github.com/Ensembl/ensembl-compara/tree/main/pipelines/SpeciesTreeFromBusco]",
+            "summary": "Run BUSCO Species Tree pipeline",
             "name_on_graph": "Species-tree"
          }
       ],

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -57,7 +57,7 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
-            "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+setup#Productionsetup-Species-tree\n*GitHub*: [SpeciesTreeFromBusco|https://github.com/Ensembl/ensembl-compara/tree/main/pipelines/SpeciesTreeFromBusco]",
+            "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Production+setup#Productionsetup-Species-tree\n*GitHub*: [SpeciesTreeFromBusco|https://github.com/Ensembl/ensembl-compara/tree/release/<version>/pipelines/SpeciesTreeFromBusco]",
             "summary": "Run BUSCO Species Tree pipeline",
             "name_on_graph": "Species-tree"
          }


### PR DESCRIPTION
## Description

Updated the jira_recurrent_tickets.json to include the SOP for BUSCO species tree replacing the existing one. 

**Related JIRA tickets:**
- [ENSCOMPARASW-6476](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-6476)

## Overview of changes
Updated the description and summary of the Species-Tree step in the json file.

## Testing
Validated the json file.

---
For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
