### PR TITLE
Add Drosophila pangenome

### DIFF
--- a/conf/metazoa/jira_recurrent_tickets.json
+++ b/conf/metazoa/jira_recurrent_tickets.json
@@ -75,9 +75,21 @@
          },
          {
             "component": "Production tasks",
+            "description": "*GitHub*: [<Division>/DrosophilaProteinTrees_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/<Division>/DrosophilaProteinTrees_conf.pm]\n{code}ibsub init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::<Division>::DrosophilaProteinTrees_conf -host mysql-ens-compara-prod-X -port XXXX{code}",
+            "summary": "Run the Drosophila Protein-trees pipeline",
+            "name_on_graph": "Protein-trees:Drosophila"
+         },
+         {
+            "component": "Production tasks",
             "description": "Mark as done when all LastZs have been merged into the new release database.",
             "summary": "Merge all LastZ",
             "name_on_graph": "Merge all LastZ"
+         },
+         {
+            "component": "Production tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Add+CACTUS+HAL+Alignment+to+Compara",
+            "summary": "Register HAL alignment data",
+            "name_on_graph": "Register HAL alignment data"
          },
          {
             "component": "Production tasks",

--- a/conf/metazoa/production_reg_conf.pl
+++ b/conf/metazoa/production_reg_conf.pl
@@ -80,6 +80,7 @@ my $compara_dbs = {
     'compara_ptrees'   => [ 'mysql-ens-compara-prod-6', 'sbhurji_default_metazoa_protein_trees_110' ],
     'protostomes_ptrees' => [ 'mysql-ens-compara-prod-6', 'twalsh_protostomes_metazoa_protein_trees_20230209_110' ],
     'insects_ptrees'   => [ 'mysql-ens-compara-prod-8', 'twalsh_insects_metazoa_protein_trees_20230624_111' ],
+    #'drosophila_ptrees'  => [ 'mysql-ens-compara-prod-X', '' ],
 
     # LastZ dbs
     # 'lastz_batch_1' => [ 'mysql-ens-compara-prod-X', '' ],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/DrosophilaProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/DrosophilaProteinTrees_conf.pm
@@ -1,0 +1,78 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Metazoa::DrosophilaProteinTrees_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Metazoa::DrosophilaProteinTrees_conf \
+        -host mysql-ens-compara-prod-X -port XXXX
+
+=head1 DESCRIPTION
+
+The Drosophila PipeConfig file for ComplementaryProteinTrees pipeline.
+This automates relevant pre-execution tasks.
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Metazoa::DrosophilaProteinTrees_conf;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::ApiVersion ();
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::Metazoa::ComplementaryProteinTrees_conf');
+
+
+sub default_options {
+    my ($self) = @_;
+
+    return {
+        %{$self->SUPER::default_options},
+
+        'collection'          => 'drosophila',
+        'dbID_range_index'    => 30,
+        'ref_collection_list' => ['default', 'protostomes', 'insects'],
+        'label_prefix'        => 'drosophila_',
+
+        # GOC parameters:
+        'goc_taxlevels' => ['Diptera', 'Hemiptera'],
+
+        # HighConfidenceOrthologs parameters:
+        # In this structure, the "thresholds" are for resp. the GOC score, the WGA coverage and %identity
+        'threshold_levels' => [
+            {
+                'taxa'          => ['Drosophila'],
+                'thresholds'    => [50, 50, 25],
+            },
+            {
+                'taxa'          => ['Brachycera'],
+                'thresholds'    => [25, 25, 25],
+            },
+            {
+                'taxa'          => ['all'],
+                'thresholds'    => [undef, undef, 25],
+            },
+        ],
+    };
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/MergeDBsIntoRelease_conf.pm
@@ -55,6 +55,7 @@ sub default_options {
             'default_protein_db'        => 'compara_ptrees',
             'protostomes_protein_db'    => 'protostomes_ptrees',
             'insects_protein_db'        => 'insects_ptrees',
+            'drosophila_protein_db'     => 'drosophila_ptrees',
             'members_db'                => 'compara_members',
         },
 
@@ -81,6 +82,7 @@ sub default_options {
             'default_protein_db'        => [qw(ortholog_quality id_generator id_assignments datacheck_results)],
             'protostomes_protein_db'    => [qw(ortholog_quality id_generator id_assignments datacheck_results)],
             'insects_protein_db'        => [qw(ortholog_quality id_generator id_assignments datacheck_results)],
+            'drosophila_protein_db'     => [qw(ortholog_quality id_generator id_assignments datacheck_results)],
         }
     }
 }


### PR DESCRIPTION
## Description

A Drosophila pangenome is to be introduced to Metazoa Compara as soon as e112.

This PR adds the pipeline and config files to make that possible.

**Related JIRA tickets:**
- [ENSINT-1649](https://www.ebi.ac.uk/panda/jira/browse/ENSINT-1649)

## Overview of changes
- A `drosophila` protein-trees pipeline config file is added, placing the Drosophila collection below the 3 existing collections in order of homology merge precedence;
- the Metazoa `MergeDBsIntoRelease` pipeline config is updated to include the Drosophila protein-trees collection;
- a placeholder is added to the Metazoa Compara production registry for the Drosophila protein-trees collection;
- the Metazoa Jira config JSON file is updated with ticket for the planned Drosophila pangenome protein trees and Cactus alignment.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
