### PR TITLE
Feature/url hal mlss conf

### DIFF
--- a/conf/vertebrates/mlss_conf.xml
+++ b/conf/vertebrates/mlss_conf.xml
@@ -421,7 +421,7 @@
       </species_set>
     </multiple_alignment>
 
-    <multiple_alignment method="CACTUS_HAL">
+    <multiple_alignment method="CACTUS_HAL" url="#base_dir#/multi/hal_files/Mammals-100-way_20230606.hal">
       <species_set name="mammals">
         <genome name="anolis_carolinensis"/>
         <genome name="aotus_nancymaae"/>

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
@@ -237,7 +237,7 @@ sub pipeline_analyses_prep_master_db_for_release {
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::DbCmd',
             -parameters => {
                 'db_conn'     => '#master_db#',
-                'input_query' => 'UPDATE method_link_species_set SET url = "" WHERE source = "ensembl"',
+                'input_query' => 'UPDATE method_link_species_set SET url = "" WHERE source = "ensembl" AND method_link_id != 22 AND method_link_id != 23',
             },
             -flow_into  => [ 'dc_master' ],
         },

--- a/scripts/pipeline/compara_db_config.rng
+++ b/scripts/pipeline/compara_db_config.rng
@@ -228,6 +228,9 @@
                   </choice>
                 </attribute>
               </optional>
+              <optional>
+                <attribute name="url" blockly:blockName="URL field for CACTUS_HAL"/>
+              </optional>
             </element>
           </oneOrMore>
         </element>

--- a/scripts/pipeline/create_all_mlss.pl
+++ b/scripts/pipeline/create_all_mlss.pl
@@ -424,7 +424,7 @@ foreach my $xml_msa (@{$division_node->findnodes('multiple_alignments/multiple_a
     }
     my $method = $compara_dba->get_MethodAdaptor->fetch_by_type($xml_msa->getAttribute('method'));
     my $species_set = make_named_species_set_from_XML_node($xml_msa, $method, $division_genome_dbs);
-    push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_multiple_wga_mlsss($compara_dba, $method, $species_set, ($xml_msa->getAttribute('gerp') // 0), $no_release) };
+    push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_multiple_wga_mlsss($compara_dba, $method, $species_set, ($xml_msa->getAttribute('gerp') // 0), $no_release), undef, ($xml_msa->getAttribute('url') // 0), $no_release) };
 }
 
 foreach my $xml_self_aln (@{$division_node->findnodes('self_alignments/genome')}) {

--- a/scripts/pipeline/create_all_mlss.pl
+++ b/scripts/pipeline/create_all_mlss.pl
@@ -424,7 +424,7 @@ foreach my $xml_msa (@{$division_node->findnodes('multiple_alignments/multiple_a
     }
     my $method = $compara_dba->get_MethodAdaptor->fetch_by_type($xml_msa->getAttribute('method'));
     my $species_set = make_named_species_set_from_XML_node($xml_msa, $method, $division_genome_dbs);
-    push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_multiple_wga_mlsss($compara_dba, $method, $species_set, ($xml_msa->getAttribute('gerp') // 0), $no_release, undef, ($xml_msa->getAttribute('url') // 0), $no_release) };
+    push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_multiple_wga_mlsss($compara_dba, $method, $species_set, ($xml_msa->getAttribute('gerp') // 0), $no_release, undef, $xml_msa->getAttribute('url')) };
 }
 
 foreach my $xml_self_aln (@{$division_node->findnodes('self_alignments/genome')}) {

--- a/scripts/pipeline/create_all_mlss.pl
+++ b/scripts/pipeline/create_all_mlss.pl
@@ -424,7 +424,7 @@ foreach my $xml_msa (@{$division_node->findnodes('multiple_alignments/multiple_a
     }
     my $method = $compara_dba->get_MethodAdaptor->fetch_by_type($xml_msa->getAttribute('method'));
     my $species_set = make_named_species_set_from_XML_node($xml_msa, $method, $division_genome_dbs);
-    push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_multiple_wga_mlsss($compara_dba, $method, $species_set, ($xml_msa->getAttribute('gerp') // 0), $no_release), undef, ($xml_msa->getAttribute('url') // 0), $no_release) };
+    push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_multiple_wga_mlsss($compara_dba, $method, $species_set, ($xml_msa->getAttribute('gerp') // 0), $no_release, undef, ($xml_msa->getAttribute('url') // 0), $no_release) };
 }
 
 foreach my $xml_self_aln (@{$division_node->findnodes('self_alignments/genome')}) {


### PR DESCRIPTION
## Description

This PR allows the inclusion of the `URL` field in the `mlss.conf` file for Cactus HAL file alignments and stores the URL in the URL column of the MLSS table. 

It also prevent of the Cactus-related URL content to be erased by the task `add_mlss_to_master` of the `PrepareMasterDatabaseForRelease` pipeline. 

**Related JIRA tickets:**
- ENSCOMPARASW-6772
- ENSCOMPARASW-6773

## Overview of changes

#### Change 1
-  add support for a 'url' attribute to the MLSS config '`multiple_alignment`' element, to enable the URL of Cactus MLSSes to be set during the `add_mlss_to_master` step of the `PrepareMasterDatabaseForRelease` pipeline. 

#### Change 2
- avoid the `reset_master_urls` step to reset the 'url' column

## Testing
Yes, it has been tested using a copy of the `ensembl_compara_master` with `pre_111` data. 

after running the script below
```bash
perl /hps/software/users/ensembl/repositories/compara/thiagogenez/dev-e111/ensembl-compara/scripts/pipeline/create_all_mlss.pl --reg_conf /hps/software/users/ensembl/repositories/compara/thiagogenez/dev-e111/ensembl-compara/conf/vertebrates/production_reg_conf.pl --compara compara_master -xml /hps/software/users/ensembl/repositories/compara/thiagogenez/dev-e111/ensembl-compara/conf/vertebrates/mlss_conf.xml --release --output_file /homes/thiagogenez/mlss_ids_vertebrates.list --verbose
```
and un-retiring 13 species because they are presented in the 100-mammals HAL file
```bash
'castor_canadensis'
'cavia_aperea'
'colobus_angolensis_palliatus'
'cricetulus_griseus_picr'
'fukomys_damarensis'
'lynx_canadensis'
'meriones_unguiculatus'
'piliocolobus_tephrosceles'
'spermophilus_dauricus'
'suricata_suricatta'
'theropithecus_gelada'
'ursus_thibetanus_thibetanus'
'zalophus_californianus'
```
, we have the following results

```sql
mysql> SELECT method_link_species_set_id,method_link_id,species_set_id,name,url FROM method_link_species_set WHERE name LIKE '%mammals Cactus%';
+----------------------------+----------------+----------------+--------------------+---------------------------------------------------------+
| method_link_species_set_id | method_link_id | species_set_id | name               | url                                                     |
+----------------------------+----------------+----------------+--------------------+---------------------------------------------------------+
|                       5798 |             22 |          86244 | 100 mammals Cactus | #base_dir#/multi/hal_files/Mammals-100-way_20230606.hal |
+----------------------------+----------------+----------------+--------------------+---------------------------------------------------------+
1 row in set (0.02 sec)
```

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
