### PR TITLE
Add format_mode option to species-tree example script

### DIFF
--- a/scripts/examples/species_getSpeciesTree.pl
+++ b/scripts/examples/species_getSpeciesTree.pl
@@ -34,6 +34,7 @@ my $method = 'PROTEIN_TREES';
 my $ss_name;
 my $label = 'default';
 my $stn_root_id;
+my $format_mode;
 my $with_distances;
 my $ascii_scale;
 my ($reg_conf, $compara_db);
@@ -45,6 +46,7 @@ GetOptions(
        'ss_name=s'      => \$ss_name,
        'label=s'        => \$label,
        'stn_root_id=i'  => \$stn_root_id,
+       'format_mode=s'  => \$format_mode,
        'with_distances' => \$with_distances,
        'ascii_scale=f'  => \$ascii_scale,
        'reg_conf=s'     => \$reg_conf,
@@ -80,6 +82,17 @@ if ($stn_root_id) {
 
 if ($ascii_scale) {
     $species_tree->root->print_tree($ascii_scale);
+} elsif ($format_mode) {
+
+    my @format_args;
+    if ($format_mode =~ /^ryo\s+(?<ryo_string>.+)$/) {
+        push(@format_args, ('ryo', $+{'ryo_string'}));
+    } else {
+        push(@format_args, $format_mode);
+    }
+
+    print $species_tree->root->newick_format( @format_args ), "\n";
+
 } else {
     print $species_tree->root->newick_format( 'ryo', $with_distances ? '%{n}:%{d}' : '%{n}' ), "\n";
 }


### PR DESCRIPTION
## Description

When used to print the Newick format string of a species tree, the Compara species-tree example script (`species_getSpeciesTree.pl`) currently only supports printing gene-tree node names. Adding support for printing Newick format strings with other node labels would increase the usefulness of this example script.

An immediate application of this would be to use this script to generate a Newick file for input to the `plotGocData.r` script used to plot GOC score data, as part of efforts to update GOC score config for the Metazoa protein-tree collections.

## Overview of changes

This PR adds a `format_mode` option to the species-tree example script, enabling printing of a species tree in Newick format using a wider variety of node label types (e.g. species production names).

## Testing

The updated script was tested on Ensembl Metazoa Compara 110 with `-format_mode` set to `species`:
```bash
perl species_getSpeciesTree.pl \
    -url mysql://anonymous@mysql-eg-publicsql.ebi.ac.uk:4157/ensembl_compara_metazoa_57_110 \
    -method PROTEIN_TREES \
    -ss_name collection-protostomes \
    -label default \
    -format_mode species
```

The output was a Newick string representing the Protosomes species tree with node labels set from species production names:
```
(((((hymenolepis_microstoma,echinococcus_granulosus_gca000524195v1rs),(schistosoma_mansoni,schistosoma_haematobium_gca000699445v2rs)),(((capitella_teleta,owenia_fusiformis_gca903813345v1),dimorphilus_gyrociliatus_gca904063045v1),helobdella_robusta),((((crassostrea_virginica_gca002022765v4,crassostrea_gigas),mizuhopecten_yessoensis_gca002113885v2),mercenaria_mercenaria_gca014805675v2),(octopus_bimaculoides,octopus_sinensis_gca006345805v1),((biomphalaria_glabrata,aplysia_californica_gca000002075v2),(haliotis_rubra_gca003918875v1rs,haliotis_rufescens_gca023055435v1rs),gigantopelta_aegis_gca016097555v1,pomacea_canaliculata_gca003073045v1,lottia_gigantea)),lingula_anatina_gca001039355v2,pomphorhynchus_laevis_gca012934845v2gb),adineta_vaga),((((((zootermopsis_nevadensis,schistocerca_americana_gca021461395v2rs),((anopheles_gambiae,drosophila_melanogaster),(tribolium_castaneum,diabrotica_virgifera_gca917563875v2rs),bombyx_mori,apis_mellifera),acyrthosiphon_pisum_gca005508785v2rs),strigamia_maritima),(((stegodyphus_dumicola_gca010614865v2rs,stegodyphus_mimosarum),parasteatoda_tepidariorum_gca000365465v3),((dermatophagoides_pteronyssinus_gca001901225v2,tetranychus_urticae),((rhipicephalus_sanguineus_gca013339695v1,dermacentor_andersoni_gca023375885v2rs),haemaphysalis_longicornis_gca013339765v1,ixodes_scapularis_gca016920785v2)),centruroides_sculpturatus_gca000671375v2)),hypsibius_exemplaris_gca002082055v1),(((((caenorhabditis_remanei,caenorhabditis_japonica,caenorhabditis_brenneri,caenorhabditis_briggsae,caenorhabditis_elegans),pristionchus_pacificus),((brugia_malayi,loa_loa,onchocerca_volvulus),ascaris_suum),strongyloides_ratti),necator_americanus),(trichinella_spiralis,trichuris_muris)),priapulus_caudatus_gca000485595v2));
```

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
