### PR TITLE
adding SLURM configuration for mpi jobs

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -475,7 +475,7 @@ sub resource_classes_multi_thread {
 
         '16Gb_32c_mpi' => {
             'LSF'    => '-q mpi -n 32 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=16]"',
-            'SLURM'  => '--partition=standard --cpus-per-task=3 --mem=16g',
+            'SLURM'  => '--partition=standard --cpus-per-task=32 --mem=16g',
         },
 
         '32Gb_4c_mpi' => {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -425,22 +425,27 @@ sub resource_classes_multi_thread {
 
         '8Gb_4c_mpi' => {
             'LSF'   => '-q mpi -n 4 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=4]"',
+            'SLURM' => '--partition=standard --cpus-per-task=4 --mem=8g',
         },
 
         '8Gb_8c_mpi' => {
             'LSF'    => '-q mpi -n 8 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=8]"',
+            'SLURM'  => '--partition=standard --cpus-per-task=8 --mem=8g',
         },
 
         '8Gb_16c_mpi' => {
             'LSF'    => '-q mpi -n 16 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=16]"',
+            'SLURM'  => '--partition=standard --cpus-per-task=16 --mem=8g',
         },
 
         '8Gb_24c_mpi' => {
             'LSF'    => '-q mpi -n 24 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=12]"',
+            'SLURM'  => '--partition=standard --cpus-per-task=24 --mem=8g',
         },
 
         '8Gb_32c_mpi' => {
             'LSF'    => '-q mpi -n 32 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=16]"',
+            'SLURM'  => '--partition=standard --cpus-per-task=32 --mem=8g',
         },
 
         '8Gb_64c_mpi' => {
@@ -449,42 +454,52 @@ sub resource_classes_multi_thread {
 
         '16Gb_4c_mpi' => {
             'LSF'    => '-q mpi -n 4 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=4]"',
+            'SLURM'  => '--partition=standard --cpus-per-task=4 --mem=16g',
         },
 
         '16Gb_8c_mpi' => {
-            'LSF' => '-q mpi -n 8 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=8]"',
+            'LSF'    => '-q mpi -n 8 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=8]"',
+            'SLURM'  => '--partition=standard --cpus-per-task=8 --mem=16g',
         },
 
         '16Gb_16c_mpi' => {
             'LSF'    => '-q mpi -n 16 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=16]"',
+            'SLURM'  => '--partition=standard --cpus-per-task=16 --mem=16g',
         },
 
         '16Gb_24c_mpi' => {
             'LSF'    => '-q mpi -n 24 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=12]"',
+            'SLURM'  => '--partition=standard --cpus-per-task=24 --mem=16g',
         },
 
         '16Gb_32c_mpi' => {
             'LSF'    => '-q mpi -n 32 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=16]"',
+            'SLURM'  => '--partition=standard --cpus-per-task=3 --mem=16g',
         },
 
         '32Gb_4c_mpi' => {
             'LSF'    => '-q mpi -n 4 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=4]"',
+            'SLURM'  => '--partition=standard --cpus-per-task=4 --mem=32g',
         },
 
         '32Gb_8c_mpi' => {
             'LSF'    => '-q mpi -n 8 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=8]"',
+            'SLURM'  => '--partition=standard --cpus-per-task=8 --mem=32g',
         },
 
         '32Gb_16c_mpi' => {
             'LSF'    => '-q mpi -n 16 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=16]"',
+            'SLURM'  => '--partition=standard --cpus-per-task=16 --mem=32g',
         },
 
         '32Gb_24c_mpi' => {
             'LSF'    => '-q mpi -n 24 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=12]"',
+            'SLURM'  => '--partition=standard --cpus-per-task=24 --mem=32g',
         },
 
         '32Gb_32c_mpi' => {
             'LSF'    => '-q mpi -n 32 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=16]"',
+            'SLURM'  => '--partition=standard --cpus-per-task=32 --mem=32g',
         },
 
         '32Gb_64c_mpi' => {
@@ -493,6 +508,7 @@ sub resource_classes_multi_thread {
 
         '64Gb_4c_mpi' => {
             'LSF'    => '-q mpi -n 4 -M64000 -R"select[mem>64000] rusage[mem=64000] same[model] span[ptile=4]"',
+            'SLURM'  => '--partition=standard --cpus-per-task=4 --mem=64g',
         },
     };
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -448,8 +448,9 @@ sub resource_classes_multi_thread {
             'SLURM'  => '--partition=standard --cpus-per-task=32 --mem=8g',
         },
 
-        '8Gb_64c_mpi' => {
-            'LSF'    => '-q mpi -n 64 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=16]"',
+        '8Gb_48c_mpi' => {
+            'LSF'    => '-q mpi -n 48 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=16]"',
+            'SLURM'  => '--partition=standard --cpus-per-task=48 --mem=8g',
         },
 
         '16Gb_4c_mpi' => {
@@ -502,8 +503,9 @@ sub resource_classes_multi_thread {
             'SLURM'  => '--partition=standard --cpus-per-task=32 --mem=32g',
         },
 
-        '32Gb_64c_mpi' => {
-            'LSF'    => '-q mpi -n 64 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=16]"',
+        '32Gb_48c_mpi' => {
+            'LSF'    => '-q mpi -n 48 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=16]"',
+            'SLURM'  => '--partition=standard --cpus-per-task=48 --mem=32g',
         },
 
         '64Gb_4c_mpi' => {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -2593,7 +2593,7 @@ sub core_pipeline_analyses {
             },
             -hive_capacity        => $self->o('examl_capacity'),
             -rc_name => '32Gb_48c_mpi',
-            -max_retry_count => 3, #We restart this jobs 3 times then they will run in FastTree. After 18 days (3*518400) of ExaML 64 cores. It will probably not converge.
+            -max_retry_count => 3, #We restart this jobs 3 times then they will run in FastTree. After 18 days (3*518400) of ExaML 48 cores. It will probably not converge.
             -flow_into => {
                -2 => [ 'fasttree' ],  # RUNLIMIT
             }

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -2491,7 +2491,7 @@ sub core_pipeline_analyses {
                     '(#raxml_cores# >  16) && (#raxml_cores# <= 32)'    => 'examl_8_cores',
                     '(#raxml_cores# >  32) && (#raxml_cores# <= 48)'    => 'examl_16_cores',
                     '(#raxml_cores# >  48) && (#raxml_cores# <= 128)'   => 'examl_32_cores',
-                    '(#raxml_cores# >  128)'                            => 'examl_64_cores',
+                    '(#raxml_cores# >  128)'                            => 'examl_48_cores',
                 ),
             },
         },
@@ -2554,7 +2554,7 @@ sub core_pipeline_analyses {
             -rc_name => '8Gb_32c_mpi',
             -flow_into => {
                -1 => [ 'examl_32_cores_himem' ],  # MEMLIMIT
-               -2 => [ 'examl_64_cores' ],  	  # RUNTIME
+               -2 => [ 'examl_48_cores' ],  	  # RUNTIME
             }
         },
 
@@ -2568,7 +2568,7 @@ sub core_pipeline_analyses {
             -rc_name => '32Gb_32c_mpi',
         },
 
-        {   -logic_name => 'examl_64_cores',
+        {   -logic_name => 'examl_48_cores',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::ExaML',
             -parameters => {
                 %examl_parameters,
@@ -2576,15 +2576,15 @@ sub core_pipeline_analyses {
                 'escape_branch'         => -2,
             },
             -hive_capacity        => $self->o('examl_capacity'),
-            -rc_name => '8Gb_64c_mpi',
-            -max_retry_count => 3, #We restart this jobs 3 times then they will run in FastTree. After 18 days (3*518400) of ExaML 64 cores. It will probably not converge.
+            -rc_name => '8Gb_48c_mpi',
+            -max_retry_count => 3, #We restart this jobs 3 times then they will run in FastTree. After 18 days (3*518400) of ExaML 48 cores. It will probably not converge.
             -flow_into => {
-               -1 => [ 'examl_64_cores_himem' ],  # MEMLIMIT
+               -1 => [ 'examl_48_cores_himem' ],  # MEMLIMIT
                -2 => [ 'fasttree' ],  # RUNLIMIT
             }
         },
 
-        {   -logic_name => 'examl_64_cores_himem',
+        {   -logic_name => 'examl_48_cores_himem',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::ExaML',
             -parameters => {
                 %examl_parameters,
@@ -2592,7 +2592,7 @@ sub core_pipeline_analyses {
                 'escape_branch'         => -2,
             },
             -hive_capacity        => $self->o('examl_capacity'),
-            -rc_name => '32Gb_64c_mpi',
+            -rc_name => '32Gb_48c_mpi',
             -max_retry_count => 3, #We restart this jobs 3 times then they will run in FastTree. After 18 days (3*518400) of ExaML 64 cores. It will probably not converge.
             -flow_into => {
                -2 => [ 'fasttree' ],  # RUNLIMIT


### PR DESCRIPTION
## Description

Addin SLURM resource class configuration for MPI jobs

**Related JIRA tickets:**
- ENSCOMPARASW-6472

## Overview of changes
Adding SLURM configuration for resource class `[8|16|32]Gb_XXc_mpi`

## Testing
No tested

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
