### PR TITLE
Integrate semaphore check into gene-tree pipelines

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ComplementaryProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ComplementaryProteinTrees_conf.pm
@@ -144,7 +144,7 @@ sub tweak_analyses {
         'A->1' => [ 'find_overlapping_genomes' ],
     };
 
-    push @{$analyses_by_name->{'backbone_pipeline_finished'}->{'-flow_into'}}, 'remove_overlapping_homologies';
+    push @{$analyses_by_name->{'final_semaphore_check'}->{'-flow_into'}}, 'remove_overlapping_homologies';
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/CultivarsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/CultivarsProteinTrees_conf.pm
@@ -129,7 +129,7 @@ sub tweak_analyses {
 
     # Wire up cultivar-specific analyses
     $analyses_by_name->{'remove_blocklisted_genes'}->{'-flow_into'} = ['find_overlapping_genomes'];
-    push @{$analyses_by_name->{'backbone_pipeline_finished'}->{'-flow_into'}}, 'remove_overlapping_homologies';
+    push @{$analyses_by_name->{'final_semaphore_check'}->{'-flow_into'}}, 'remove_overlapping_homologies';
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
@@ -135,7 +135,7 @@ sub tweak_analyses {
 
     # wire up strain-specific analyses
     $analyses_by_name->{'remove_blocklisted_genes'}->{'-flow_into'} = ['find_overlapping_genomes'];
-    push @{$analyses_by_name->{'backbone_pipeline_finished'}->{'-flow_into'}}, 'remove_overlapping_homologies';
+    push @{$analyses_by_name->{'final_semaphore_check'}->{'-flow_into'}}, 'remove_overlapping_homologies';
 }
 
 


### PR DESCRIPTION
## Description

Early semaphore release issues affected several pipelines in e111. Such issues have been reported before, but the impact of this issue in e111 has provided the impetus for measures to catch such issues as soon as possible.

A TimelySemaphoreRelease datacheck is currently under review ([ensembl-datacheck PR #557](https://github.com/Ensembl/ensembl-datacheck/pull/557)) which flags semaphored jobs whose timing appears to indicated premature release of the semaphore.

That datacheck is a member of the `compara_gene_tree_pipelines` datacheck group, so that it would be executed as part of existing integrated datachecks near the end of each gene-tree pipeline. This PR supplements that by integrating semaphore checks at several key points in the protein-trees pipeline and in the ncRNA-trees pipeline.

**Related JIRA tickets:**

- ENSCOMPARASW-6846
- ENSCOMPARASW-6847

## Overview of changes

In the `ProteinTrees` pipeline, semaphore checks are added immediately after the following pipeline steps:
- `backbone_fire_clustering`
- `backbone_fire_tree_building`
- `backbone_fire_homology_dumps`
- `backbone_fire_posttree`
- `backbone_pipeline_finished`

In the `ncRNAtrees` pipeline, semaphore checks are added after the following pipeline steps:
- `backbone_fire_tree_building`
- `backbone_fire_posttree`

Protein-tree pipeline tweaks involving analysis `backbone_pipeline_finished` are changed to flow instead from `final_semaphore_check`.

## Testing

With integrated semaphore checks set up in gene-tree pipeline configs, an ncRNAtrees pipeline was initialised, and a full protein-trees pipeline test run was done. Details about each can be found in their respective Jira tickets.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
