### PR TITLE
Fix patch of master DB updated every second release

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/PrepareMasterDatabaseForRelease_conf.pm
@@ -57,4 +57,14 @@ sub default_options {
     };
 }
 
+sub tweak_analyses {
+    my $self = shift;
+
+    $self->SUPER::tweak_analyses(@_);
+
+    my $analyses_by_name = shift;
+
+    $analyses_by_name->{'patch_master_db'}->{'-parameters'}{'oldest_patch_release'} = $self->o('prev_release');
+}
+
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
@@ -44,7 +44,8 @@ sub pipeline_analyses_prep_master_db_for_release {
         {   -logic_name => 'patch_master_db',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
             -parameters => {
-                'cmd' => [$self->o('patch_db_exe'), '--reg_conf', $self->o('reg_conf'), '--reg_alias', '#master_db#', '--fixlast', '--nointeractive'],
+                'cmd' => [$self->o('patch_db_exe'), '--reg_conf', $self->o('reg_conf'), '--reg_alias', '#master_db#', '--fix', '--oldest', '#oldest_patch_release#', '--nointeractive'],
+                'oldest_patch_release' => $self->o('rel_with_suffix'),
             },
             -flow_into  => ['load_ncbi_node'],
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/PrepareMasterDatabaseForRelease_conf.pm
@@ -63,10 +63,7 @@ sub tweak_analyses {
 
     my $analyses_by_name = shift;
 
-    $analyses_by_name->{'patch_master_db'}->{'-parameters'}{'cmd'} = [
-        $self->o('patch_db_exe'), '--reg_conf', $self->o('reg_conf'), '--reg_alias', '#master_db#',
-        '--fix', '--oldest', $self->o('prev_release'), '--nointeractive'
-    ];
+    $analyses_by_name->{'patch_master_db'}->{'-parameters'}{'oldest_patch_release'} = $self->o('prev_release');
 }
 
 1;


### PR DESCRIPTION
## Description

As part of the process of preparing a Compara master database, SQL patches are applied to bring the schema up to date. Currently the `--fixlast` schema patcher option is used, but this cannot be used for divisions updated every second release, so this PR instead uses the schema patcher options `--fix` and `--oldest` to facilitate patching of a master database updated every second release.

**Related JIRA tickets:**
- ENSCOMPARASW-6453

## Testing

Test pipelines were run to prepare the master database of the Protists and Plants divisions, to check that the code worked for both divisions current updated every second release and in every release, respectively. For more info on testing, see the related Jira ticket.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
