### PR TITLE
Add option to omit genome components from collection

### DIFF
--- a/conf/plants/mlss_conf.xml
+++ b/conf/plants/mlss_conf.xml
@@ -66,7 +66,7 @@
     </collection>
 
     <!-- Wheat CACTUS collection -->
-    <collection name="wheat">
+    <collection name="wheat" no_components="1">
       <genome name="aegilops_tauschii"/>
       <genome name="brachypodium_distachyon"/>
       <genome name="hordeum_vulgare"/>

--- a/scripts/pipeline/compara_db_config.rng
+++ b/scripts/pipeline/compara_db_config.rng
@@ -134,6 +134,14 @@
                 </attribute>
               </optional>
               <optional>
+                <attribute name="no_components" blockly:blockName="Omit polyploid subgenome components">
+                  <choice>
+                    <value blockly:blockName="Yes">1</value>
+                    <value blockly:blockName="No">0</value>
+                  </choice>
+                </attribute>
+              </optional>
+              <optional>
                   <element name="base_collection" blockly:blockName="Include collection as base">
                     <attribute name="name" blockly:blockName="Collection name"/>
                   </element>

--- a/scripts/pipeline/create_all_mlss.pl
+++ b/scripts/pipeline/create_all_mlss.pl
@@ -237,8 +237,7 @@ sub make_species_set_from_XML_node {
 
     if ($xml_ss->hasAttribute('in_collection')) {
         my $collection = find_collection_from_xml_node_attribute($xml_ss, 'in_collection', 'species-set');
-        # Exclude genome components from the pool
-        $pool = [grep { !$_->genome_component } @{$collection->genome_dbs}];
+        $pool = $collection->genome_dbs;
     }
 
     my @selected_gdbs;
@@ -271,7 +270,9 @@ sub make_species_set_from_XML_node {
         my $gdb = find_genome_from_xml_node_attribute($child, 'name', 'assembly');
         # If the genome is not current, warn the user and do not add it to the species set
         warn "The genome matching '" . $gdb->name . "' (assembly " . $gdb->assembly . ") is not current. Skipped" unless $gdb->is_current;
-        $some_genome_dbs = ($gdb->is_current) ? [$gdb] : [];
+        next unless $gdb->is_current;
+        # Matching GenomeDB by name ensures we draw its genome components from the pool.
+        $some_genome_dbs = [grep {$_->name eq $gdb->name} @$pool];
       } elsif ($child->nodeName =~ /^#(comment|text)$/) {
         next;
       } elsif ($child->nodeName eq 'base_collection') {
@@ -292,11 +293,17 @@ sub make_species_set_from_XML_node {
 }
 
 sub make_named_species_set_from_XML_node {
-    my ($xml_ss_parent, $method, $pool) = @_;
+    my ($xml_ss_parent, $method, $pool, $allow_components) = @_;
 
     if ($xml_ss_parent->hasAttribute('collection')) {
         my $collection_name = $xml_ss_parent->getAttribute('collection');
         my $species_set = find_collection_from_xml_node_attribute($xml_ss_parent, 'collection', $method->type);
+
+        if (!$allow_components && grep {$_->genome_component} @{$species_set->genome_dbs}) {
+            throw(sprintf("Cannot use the collection named '%s' because it contains component GenomeDBs, which are not allowed for %s",
+                          $collection_name, $method->type));
+        }
+
         return $species_set;
 
     } else {
@@ -306,6 +313,10 @@ sub make_named_species_set_from_XML_node {
             $collection = find_collection_from_xml_node_attribute($xml_species_set, 'in_collection', $method->type);
         }
         my $genome_dbs = make_species_set_from_XML_node($xml_species_set, $collection ? $collection->genome_dbs : $pool);
+
+        if (!$allow_components) {
+            $genome_dbs = [grep {!$_->genome_component} @$genome_dbs];
+        }
 
         my $species_set = Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_species_set($genome_dbs, $xml_species_set->getAttribute('name'));
         $species_set->add_tag('display_name', $xml_species_set->getAttribute('display_name')) if $xml_species_set->hasAttribute('display_name');
@@ -332,6 +343,12 @@ my $division_genome_dbs = [sort {$a->dbID <=> $b->dbID} @{$division_species_set-
 foreach my $collection_node (@{$division_node->findnodes('collections/collection')}) {
     my $no_release = $collection_node->getAttribute('no_release') || 0;
     my $genome_dbs = make_species_set_from_XML_node($collection_node, $division_genome_dbs);
+
+    my $no_components = $collection_node->getAttribute('no_components') // 0;
+    if ($no_components) {
+        $genome_dbs = [grep {!$_->genome_component} @$genome_dbs];
+    }
+
     my $collection_name = $collection_node->getAttribute('name');
     $collections{$collection_name} = Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_species_set($genome_dbs, "collection-$collection_name", $no_release);
 
@@ -340,8 +357,6 @@ foreach my $collection_node (@{$division_node->findnodes('collections/collection
         $unstored_collection_names{$collection_name} = 1;
     }
 }
-# Do not create MLSSs for genome components (polyploids will be handled by each pipeline accordingly)
-@{$division_genome_dbs} = grep {!$_->genome_component} @{$division_genome_dbs};
 
 foreach my $xml_one_vs_all_node (@{$division_node->findnodes('pairwise_alignments/pairwise_alignment')}) {
     my $ref_gdb = find_genome_from_xml_node_attribute($xml_one_vs_all_node, 'ref_genome');
@@ -362,7 +377,7 @@ foreach my $xml_one_vs_all_node (@{$division_node->findnodes('pairwise_alignment
     } else {
         $genome_dbs = make_species_set_from_XML_node($xml_one_vs_all_node->getChildrenByTagName('species_set')->[0], $division_genome_dbs);
     }
-    $genome_dbs = [grep {$_->dbID ne $ref_gdb->dbID} @$genome_dbs];
+    $genome_dbs = [grep {$_->dbID ne $ref_gdb->dbID && !$_->genome_component} @$genome_dbs];
     push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_pairwise_wga_mlsss($compara_dba, $method, $ref_gdb, $_) } for @$genome_dbs;
     my $target_ref_gdbs;
     if ($xml_one_vs_all_node->hasAttribute('ref_amongst')) {
@@ -371,6 +386,7 @@ foreach my $xml_one_vs_all_node (@{$division_node->findnodes('pairwise_alignment
     } elsif (my ($xml_ref_set) = $xml_one_vs_all_node->getChildrenByTagName('ref_genome_set')) {
         $target_ref_gdbs = make_species_set_from_XML_node($xml_ref_set, $division_genome_dbs);
     }
+    $target_ref_gdbs = [grep {!$_->genome_component} @$target_ref_gdbs];
     if ($target_ref_gdbs and scalar(@$target_ref_gdbs)) {
         push @refs, [$ref_gdb, $method, {map {$_->dbID => 1} @$target_ref_gdbs}];
     }
@@ -380,13 +396,14 @@ foreach my $xml_all_vs_one_node (@{$division_node->findnodes('pairwise_alignment
     my $target_gdb = find_genome_from_xml_node_attribute($xml_all_vs_one_node, 'target_genome');
     my $method = $compara_dba->get_MethodAdaptor->fetch_by_type( $xml_all_vs_one_node->getAttribute('method') );
     my $genome_dbs = make_species_set_from_XML_node($xml_all_vs_one_node->getChildrenByTagName('species_set')->[0], $division_genome_dbs);
-    $genome_dbs = [grep {$_->dbID ne $target_gdb->dbID} @$genome_dbs];
+    $genome_dbs = [grep {$_->dbID ne $target_gdb->dbID && !$_->genome_component} @$genome_dbs];
     push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_pairwise_wga_mlsss($compara_dba, $method, $_, $target_gdb) } for @$genome_dbs;
 }
 
 foreach my $xml_all_vs_all_node (@{$division_node->findnodes('pairwise_alignments/all_vs_all')}) {
     my $method = $compara_dba->get_MethodAdaptor->fetch_by_type( $xml_all_vs_all_node->getAttribute('method') );
     my $genome_dbs = make_species_set_from_XML_node($xml_all_vs_all_node->getChildrenByTagName('species_set')->[0], $division_genome_dbs);
+    $genome_dbs = [grep {!$_->genome_component} @$genome_dbs];
     while (my $ref_gdb = shift @$genome_dbs) {
         push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_pairwise_wga_mlsss($compara_dba, $method, $ref_gdb, $_) } for @$genome_dbs;
     }
@@ -410,7 +427,7 @@ foreach my $xml_msa (@{$division_node->findnodes('multiple_alignments/multiple_a
         # Assume we combine two pipelines (presumably EPO and EPO_EXTENDED)
         my $method1 = $compara_dba->get_MethodAdaptor->fetch_by_type($1);
         my $method2 = $compara_dba->get_MethodAdaptor->fetch_by_type($2);
-        my $species_set2 = make_named_species_set_from_XML_node($xml_msa, $method2, $division_genome_dbs);
+        my $species_set2 = make_named_species_set_from_XML_node($xml_msa, $method2, $division_genome_dbs, 0);
         my @good_gdbs = grep {$_->is_good_for_alignment} @{$species_set2->genome_dbs};
         if (scalar(@good_gdbs) < 3) {
             throw(sprintf('Only %d "good for alignment" genomes in the "%s" set. Need 3 or more for %s.', scalar(@good_gdbs), $species_set2->name, $method1->type));
@@ -439,28 +456,29 @@ foreach my $xml_asm_patch (@{$division_node->findnodes('assembly_patches/genome'
 
 my $fam_method = $compara_dba->get_MethodAdaptor->fetch_by_type('FAMILY');
 foreach my $fam_node (@{$division_node->findnodes('families/family')}) {
-    my $species_set = make_named_species_set_from_XML_node($fam_node, $fam_method, $division_genome_dbs);
+    my $species_set = make_named_species_set_from_XML_node($fam_node, $fam_method, $division_genome_dbs, 0);
     push @mlsss, Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_mlss($fam_method, $species_set);
 }
 
 foreach my $gt (qw(protein nc)) {
     my $gt_method = $compara_dba->get_MethodAdaptor->fetch_by_type((uc $gt).'_TREES');
-    my @genome_db_with_comp = Bio::EnsEMBL::Compara::Utils::MasterDatabase::_expand_components($division_genome_dbs);
     foreach my $gt_node (@{$division_node->findnodes("gene_trees/${gt}_trees")}) {
-        my $species_set = make_named_species_set_from_XML_node($gt_node, $gt_method, \@genome_db_with_comp);
+        my $allow_components = $gt eq 'protein';
+        my $species_set = make_named_species_set_from_XML_node($gt_node, $gt_method, $division_genome_dbs, $allow_components);
         push @mlsss, @{ Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_homology_mlsss($compara_dba, $gt_method, $species_set) }
     }
 }
 
 my $st_method = $compara_dba->get_MethodAdaptor->fetch_by_type('SPECIES_TREE');
 foreach my $st_node (@{$division_node->findnodes('species_trees/species_tree')}) {
-    my $species_set = make_named_species_set_from_XML_node($st_node, $st_method, $division_genome_dbs);
+    my $species_set = make_named_species_set_from_XML_node($st_node, $st_method, $division_genome_dbs, 1);
     push @mlsss, Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_mlss($st_method, $species_set);
 }
 
 my $method_adaptor = $compara_dba->get_MethodAdaptor;
 my $mlss_adaptor = $compara_dba->get_MethodLinkSpeciesSetAdaptor;
 my %mlss_ids_to_find = map {$_->dbID => $_} @{$mlss_adaptor->fetch_all_current};
+my @genome_db_without_comp = grep {!$_->genome_component} @{$division_genome_dbs};
 
 my @mlsss_created;
 my @mlsss_existing;
@@ -471,8 +489,8 @@ $compara_dba->dbc->sql_helper->transaction( -CALLBACK => sub {
         if ($verbose) {
             print "\n0. Division:\n\n" if $verbose;
             print "DIVISION: ", $division_name, "\n";
-            print $_->toString, "\n" for sort {$a->dbID <=> $b->dbID} @{$division_genome_dbs};
-            print "=", scalar(@{$division_genome_dbs}), " genomes\n\n";
+            print $_->toString, "\n" for sort {$a->dbID <=> $b->dbID} @genome_db_without_comp;
+            print "=", scalar(@genome_db_without_comp), " genomes\n\n";
             print "1. Collections that need to be created:\n\n";
         }
 


### PR DESCRIPTION
## Description

During preparation of the Plants master database for e111, the Wheat cultivars MLSS was regenerated with 16 GenomeDBs (excluding subgenome components), different from the previous Wheat cultivar collection which had contained 55 GenomeDBs (including subgenome components). This was flagged by Plants Compara datachecks, with the remedy being to remove the 16-Wheat-cultivar protein-tree MLSS and collection, and to unretire its predecessor.

This happened because elements that specify genomes by NCBI Taxonomy info (e.g. [taxonomic_group](https://github.com/Ensembl/ensembl-compara/blob/a426722c3798c14c1c992b2f175742df12c3f509/scripts/pipeline/create_all_mlss.pl#L249-L255), [ref_for_taxon](https://github.com/Ensembl/ensembl-compara/blob/a426722c3798c14c1c992b2f175742df12c3f509/scripts/pipeline/create_all_mlss.pl#L264-L269)) draw GenomeDBs matching the taxonomic criteria from a pool of GenomeDBs which in practice include the component GenomeDBs (though note that these component GenomeDBs are currently filtered out if either of these elements is in a species set which has an `in_collection` attribute). The [genome](https://github.com/Ensembl/ensembl-compara/blob/a426722c3798c14c1c992b2f175742df12c3f509/scripts/pipeline/create_all_mlss.pl#L270-L271) element, on the other hand, fetches a single GenomeDB by name and assembly, and does not currently fetch the subgenome component GenomeDBs.

This PR changes that, making the configuration of collections/species-sets more consistent with respect to handling of component GenomeDBs, and allowing for genomes configured by a `genome` element to include its component `GenomeDBs` in the resulting collection.

**Related JIRA tickets:**
- ENSCOMPARASW-6789

## Overview of changes

The effect of the following changes is to enable the `wheat` (Cactus) and `wheat_cultivars` (protein-trees) collections to be configured in the Plants `mlss_conf.xml` with an explicit list of `genome` elements, with the only additional configuration requirement being a `no_components` attribute in the `wheat` collection to indicate that component GenomeDBs are not included in the collection.

#### scripts/pipeline/compara_db_config.rng

The `collection` element has a new optional `no_components` attribute; if this is present and evaluates to true, it indicates that component GenomeDBs should not be included in the given collection.

#### conf/plants/mlss_conf.xml

The `wheat` Cactus collection is assigned a `no_components` attribute, set to `1`.

#### scripts/pipeline/create_all_mlss.pl

Handling of component GenomeDBs in `create_all_mlss.pl` has been updated to take the following general approach:

- By default, collections specified by a `compara_db` or `collection` element include genome components.
- If a `no_components` attribute is present in a `collection` element and evaluates to true, the given collection does not include genome components.
- The inclusion of genome components in a given species set or collection depends on the MLSS config element in which it is found:
  * If a species set or collection is used in a `protein_trees` or `species_tree` MLSS config element, that species-set/collection can include genome components.
  * If a species set or collection is in any other MLSS config element, that species-set/collection must not include genome components.

## Testing

Test pipelines were run to prepare the master database of Plants and Protists divisions, to check that the code worked as expected both for a division with polyploid genomes (Plants) and for another division for comparison (Protists). For more info on testing, see the related Jira ticket.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
