### PR TITLE
Move species tree check to relevant pipelines

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOAnchors_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOAnchors_conf.pm
@@ -138,9 +138,21 @@ return [
  -parameters    => {
    'species_tree_input_file' => $self->o('binary_species_tree'),
  },
- -flow_into     => [ 'set_gerp_neutral_rate' ],
+ -flow_into => {
+   2 => { 'hc_species_tree' => { 'mlss_id' => '#mlss_id#', 'species_tree_root_id' => '#species_tree_root_id#' } },
+ },
 },
 
+{
+ -logic_name => 'hc_species_tree',
+ -module     => 'Bio::EnsEMBL::Compara::RunnableDB::MSA::SqlHealthChecks',
+ -parameters => {
+  'mode'                      => 'species_tree',
+  'binary'                    => 0,
+  'n_missing_species_in_tree' => 0,
+ },
+ -flow_into     => [ 'set_gerp_neutral_rate' ],
+},
 
         {   -logic_name => 'set_gerp_neutral_rate',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomicAlignBlock::SetGerpNeutralRate',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EPO_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EPO_conf.pm
@@ -181,9 +181,9 @@ sub tweak_analyses {
     my $self = shift;
     my $analyses_by_name = shift;
 
-    # Move "make_species_tree" right after "create_mlss_ss" and disconnect it from "dump_mappings_to_file"
+    # Move "make_species_tree" right after "create_mlss_ss" and disconnect "hc_species_tree" from "dump_mappings_to_file"
     $analyses_by_name->{'create_mlss_ss'}->{'-flow_into'} = [ 'make_species_tree' ];
-    $analyses_by_name->{'make_species_tree'}->{'-flow_into'} = WHEN( '#run_gerp#' => [ 'set_gerp_neutral_rate' ] );
+    $analyses_by_name->{'hc_species_tree'}->{'-flow_into'} = WHEN( '#run_gerp#' => [ 'set_gerp_neutral_rate' ] );
     delete $analyses_by_name->{'set_gerp_neutral_rate'}->{'-flow_into'}->{1};
 
     # Do "dump_mappings_to_file" after having trimmed the anchors

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwithExt_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwithExt_conf.pm
@@ -272,7 +272,7 @@ sub tweak_analyses {
     # flow 2 "make_species_tree" jobs and add semaphore
     $analyses_by_name->{'create_mlss_ss'}->{'-flow_into'} = 'make_species_tree';
     delete $analyses_by_name->{'create_mlss_ss'}->{'-parameters'};
-    delete $analyses_by_name->{'make_species_tree'}->{'-flow_into'};
+    delete $analyses_by_name->{'hc_species_tree'}->{'-flow_into'};
 
     # Rewire "create_default_pairwise_mlss" and "dump_mappings_to_file" after having trimmed the anchors
     $analyses_by_name->{'trim_anchor_align_factory'}->{'-flow_into'} = {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MercatorPecan_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MercatorPecan_conf.pm
@@ -255,8 +255,20 @@ sub pipeline_analyses {
                                'species_tree_input_file' => $self->o('binary_species_tree'),
                               },
             -flow_into => {
-                           1 => [ 'set_gerp_neutral_rate' ],
+                           2 => [ 'hc_species_tree' ],
                           },
+        },
+
+        {   -logic_name => 'hc_species_tree',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::MSA::SqlHealthChecks',
+            -parameters => {
+                'mode'                      => 'species_tree',
+                'binary'                    => 0,
+                'n_missing_species_in_tree' => 0,
+            },
+            -flow_into  => {
+                1 => [ 'set_gerp_neutral_rate' ],
+            },
         },
 
         {   -logic_name => 'set_gerp_neutral_rate',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOAlignment.pm
@@ -93,8 +93,20 @@ return
 	-parameters    => {
 			'species_tree_input_file' => $self->o('binary_species_tree'),
 	},
-        -flow_into     => WHEN( '#run_gerp#' => [ 'set_gerp_neutral_rate' ],
-                                ELSE [ 'dump_mappings_to_file' ] ),
+    -flow_into     => {
+        2 => { 'hc_species_tree' => { 'mlss_id' => '#mlss_id#', 'species_tree_root_id' => '#species_tree_root_id#' } },
+    },
+},
+{
+    -logic_name => 'hc_species_tree',
+    -module     => 'Bio::EnsEMBL::Compara::RunnableDB::MSA::SqlHealthChecks',
+    -parameters => {
+        'mode'                      => 'species_tree',
+        'binary'                    => 0,
+        'n_missing_species_in_tree' => 0,
+    },
+    -flow_into  => WHEN( '#run_gerp#' => [ 'set_gerp_neutral_rate' ],
+                         ELSE [ 'dump_mappings_to_file' ] ),
 },
 # ------------------------------------- run enredo
 {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EpoExtended.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EpoExtended.pm
@@ -168,6 +168,18 @@ sub pipeline_analyses_db_prepare{
                 'species_tree_input_file' => $self->o('binary_species_tree'),
             },
             -rc_name => '1Gb_job',
+            -flow_into => {
+                2 => { 'hc_species_tree' => { 'mlss_id' => '#mlss_id#', 'species_tree_root_id' => '#species_tree_root_id#' } },
+            },
+        },
+
+        {   -logic_name => 'hc_species_tree',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::MSA::SqlHealthChecks',
+            -parameters => {
+                'mode'                      => 'species_tree',
+                'binary'                    => 0,
+                'n_missing_species_in_tree' => 0,
+            },
             -flow_into => 'create_default_pairwise_mlss',
         },
     ];

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
@@ -222,6 +222,17 @@ sub core_pipeline_analyses {
             -parameters => {
                 'species_tree_input_file' => $self->o('binary_species_tree'),
             },
+            -flow_into  => {
+                2 => { 'hc_species_tree' => { 'mlss_id' => '#mlss_id#', 'species_tree_root_id' => '#species_tree_root_id#' } },
+            },
+        },
+        {   -logic_name => 'hc_species_tree',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::MSA::SqlHealthChecks',
+            -parameters => {
+                'mode'                      => 'species_tree',
+                'binary'                    => 0,
+                'n_missing_species_in_tree' => 0,
+            },
         },
         # Copy data from the previous ancestral core database and update the ancestor names with new MLSS id
         {   -logic_name => 'copy_ancestral_data',

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/MSA/SqlHealthChecks.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/MSA/SqlHealthChecks.pm
@@ -52,7 +52,7 @@ our $config = {
             },
             {
                 description => 'All current genome_dbs (for the MLSS if specified) should be in the species tree',
-                query => 'SELECT gdb.* FROM genome_db gdb JOIN species_set ss USING(genome_db_id) JOIN method_link_species_set USING(species_set_id) LEFT JOIN species_tree_node stn ON gdb.genome_db_id = stn.genome_db_id AND stn.root_id = #species_tree_root_id# WHERE (method_link_species_set_id = #mlss_id# OR NOT #mlss_id#) AND gdb.name != "ancestral_sequences" AND stn.node_id IS NULL',
+                query => 'SELECT gdb.* FROM genome_db gdb JOIN species_set ss USING(genome_db_id) JOIN method_link_species_set USING(species_set_id) LEFT JOIN species_tree_node stn ON gdb.genome_db_id = stn.genome_db_id AND stn.root_id = #species_tree_root_id# WHERE method_link_species_set_id = #mlss_id# AND gdb.name != "ancestral_sequences" AND stn.node_id IS NULL',
                 expected_size => '= #n_missing_species_in_tree#',
             },
             {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/MSA/SqlHealthChecks.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/MSA/SqlHealthChecks.pm
@@ -1,0 +1,86 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::MSA::SqlHealthChecks
+
+=head1 DESCRIPTION
+
+This runnable offers one or more groups of healthchecks to
+verify the integrity of MSA-related data in a database.
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::MSA::SqlHealthChecks;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Hive::RunnableDB::SqlHealthcheck');
+
+
+our $config = {
+
+    ### Species Tree
+    #################
+
+    species_tree => {
+        params => [ 'species_tree_root_id', 'mlss_id', 'binary', 'n_missing_species_in_tree' ],
+        tests => [
+            {
+                description => 'genome_db_id can only be populated on leaves',
+                query => 'SELECT stn.*, COUNT(*) AS n_children FROM species_tree_node stn JOIN species_tree_node stnc ON stnc.parent_id = stn.node_id WHERE stn.root_id = #species_tree_root_id# AND stn.genome_db_id IS NOT NULL GROUP BY stn.node_id'
+            },
+            {
+                description => 'All the leaves of the species tree should have a genome_db',
+                query => 'SELECT stn.* FROM species_tree_node stn LEFT JOIN species_tree_node stnc ON stnc.parent_id = stn.node_id WHERE stn.root_id = #species_tree_root_id# AND stnc.node_id IS NULL AND stn.genome_db_id IS NULL'
+            },
+            {
+                description => 'All current genome_dbs (for the MLSS if specified) should be in the species tree',
+                query => 'SELECT gdb.* FROM genome_db gdb JOIN species_set ss USING(genome_db_id) JOIN method_link_species_set USING(species_set_id) LEFT JOIN species_tree_node stn ON gdb.genome_db_id = stn.genome_db_id AND stn.root_id = #species_tree_root_id# WHERE (method_link_species_set_id = #mlss_id# OR NOT #mlss_id#) AND gdb.name != "ancestral_sequences" AND stn.node_id IS NULL',
+                expected_size => '= #n_missing_species_in_tree#',
+            },
+            {
+                description => 'Checks that the species tree is minimized (i.e. nodes cannot have a single child)',
+                query => 'SELECT stn1.node_id FROM species_tree_node stn1 JOIN species_tree_node stn2 ON stn1.node_id = stn2.parent_id WHERE stn1.root_id = #species_tree_root_id# GROUP BY stn1.node_id HAVING COUNT(*) = 1',
+            },
+            {
+                description => 'Checks that the species tree is binary',
+                query => 'SELECT stn1.node_id FROM species_tree_node stn1 JOIN species_tree_node stn2 ON stn1.node_id = stn2.parent_id WHERE stn1.root_id = #species_tree_root_id# GROUP BY stn1.node_id HAVING COUNT(*) > 2 AND #binary#',
+            },
+        ],
+    },
+};
+
+
+sub fetch_input {
+    my $self = shift;
+
+    my $mode = $self->param_required('mode');
+    die unless exists $config->{$mode};
+    my $this_config = $config->{$mode};
+
+    foreach my $param_name (@{$this_config->{params}}) {
+        $self->param_required($param_name);
+    }
+    $self->param('tests', $this_config->{tests});
+    $self->_validate_tests;
+}
+
+
+1;

--- a/travisci/all-housekeeping/division_config.t
+++ b/travisci/all-housekeeping/division_config.t
@@ -59,7 +59,7 @@ sub test_division {
     # Load the species-tree if there is one
     my %species_in_tree;
     my $species_tree_file;
-    foreach my $tree_type (qw(topology branch_len)) {
+    foreach my $tree_type (qw(topology)) {
         $species_tree_file = File::Spec->catfile($division_dir, "species_tree.$tree_type.nw");
         if ($species_tree_file && -e $species_tree_file) {
             my $content = slurp($species_tree_file);


### PR DESCRIPTION
## Description

The `division_config.t` Travis test currently checks genome names in the `allowed_species.json` and `mlss_conf.xml` files against the division species tree, whether with branch lengths (`species_tree.branch_len.nw`) or topology only (`species_tree.topology.nw`).

This has caused some false alarms in the case of the `branch_len` tree, because `allowed_species.json` and `mlss_conf.xml` files are typically updated in advance of Compara branching for a given Ensembl release, while the `branch_len` species tree is typically updated some weeks later in the initial stages of Compara production.

These false alarms have been circumvented in the past by a temporary "fix" of the `branch_len` species tree, but a more effective solution would move any species-tree checks to a time during or after the point when the species tree is updated for a given release.

**Related JIRA tickets:**
- ENSCOMPARASW-6477

## Overview of changes

In the `division_config.t` Travis unit test, the `branch_len` species-tree check is dropped.

The rest of the changes aim to ensure that equivalent checks are done as needed. No changes were made to the gene-tree pipelines (as these already include a `hc_species_tree` step) or to the BUSCO species-tree workflow (as the SOP for generating the Vertebrates and Plants BUSCO species tree takes as input the relevant division collection, so it should include all current genomes by default). 

#### New MSA:: SqlHealthChecks runnable

A new `MSA:: SqlHealthChecks` runnable is implemented with a `species_tree` mode, which is based on the `species_tree` mode of the `GeneTrees:: SqlHealthChecks` runnable, with the added constraint of the `mlss_id` of the species tree to be checked in addition to its `species_tree_root_id`. Every `GenomeDB` in the MLSS referred to by `mlss_id` must be in the corresponding species tree.

#### New 'hc_species_tree' step in MSA pipelines

The following MSA pipelines have a `make_species_tree` or `load_species_tree` step, which is now immediately followed by a `hc_species_tree` step:

- Mercator-Pecan
- EPOAnchors
- EPO
- EPO-Extended
- EPOwithExt
- UpdateMSA
- RegisterHALFile

## Testing

The new MSA `hc_species_tree` analysis has been checked by a test run of every pipeline which includes it. See the related Jira ticket for more info on testing.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
