### PR TITLE
Update Python package config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,8 +144,7 @@ jobs:
       python: 3.8
       name: "Python unit tests on the minimum version"
       install:
-        - pip install -r requirements.txt -r requirements-test.txt
-        - pip install .
+        - pip install .[test]
       script:
         - pytest --server=mysql://travis@127.0.0.1:3306/
 
@@ -154,8 +153,7 @@ jobs:
       name: "Python unit tests on the latest version, with code coverage"
       install:
         - pip install codecov
-        - pip install -r requirements.txt -r requirements-test.txt
-        - pip install .
+        - pip install .[test]
       script:
         # yamllint disable rule:line-length
         - pytest --cov=./ --cov-report=term-missing --server=mysql://travis@127.0.0.1:3306/
@@ -167,8 +165,6 @@ jobs:
       python: 3.9
       name: "Python linter"
       install:
-        - pip freeze | grep -v -f requirements.txt - | grep -v '^#' | xargs pip uninstall -y
         - pip install pylint mypy
-        - pip install -r requirements.txt
         - pip install .
       script: ./travisci/python-linter_harness.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,88 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [build-system]
 requires = [
     "setuptools",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "ensembl-compara"
+description = "Ensembl Compara's Python library"
+requires-python = ">= 3.8"
+dynamic = [
+    "readme",
+    "version",
+]
+authors = [
+    {name = "Ensembl Compara", email = "dev@ensembl.org"},
+]
+license = {text = "Apache License 2.0"}
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.8",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "ensembl-py@git+https://github.com/Ensembl/ensembl-py.git@1.0.0#egg=ensembl-py",
+    "biopython>=1.76",
+    "ete3>=3.1.1",
+    "lxml>=4.9.2",
+    "pandas>=0.24.2",
+    "pybedtools==0.8.2",
+    "sqlalchemy>=1.4.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "coverage[toml]",
+    "pylint",
+    "mock",
+    "mypy",
+    "pytest-cov",
+    "Sphinx",
+    "sphinx-rtd-theme",
+    "yamllint",
+]
+doc = [
+    "mock",
+    "Sphinx",
+    "sphinx-rtd-theme",
+]
+test = [
+    "coverage[toml]",
+    "pytest-cov",
+]
+
+[project.urls]
+homepage = "https://www.ensembl.org"
+repository = "https://github.com/Ensembl/ensembl-compara"
+
+[tool.setuptools]
+package-dir = {"" = "src/python/lib"}
+
+[tool.setuptools.dynamic]
+readme = {file = ["README.md"]}
+version = {file = ["PIP_VERSION"]}
 
 [tool.pytest.ini_options]
 # CITest project is on hold and it needs to be updated before resuming its unit tests
@@ -18,7 +97,7 @@ ignore_missing_imports = true
 show_error_codes = true
 warn_unused_configs = true
 
-[tool.pylint.messages_control]
+[tool.pylint.main]
 max-line-length = 110
 disable = [
     "invalid-name",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,0 @@
--r requirements.txt
--r requirements-test.txt
--r requirements-doc.txt
-pylint
-mypy
-yamllint

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,3 +1,0 @@
-mock
-Sphinx
-sphinx-rtd-theme

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,0 @@
-coverage[toml]
-pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-ensembl-py@git+https://github.com/Ensembl/ensembl-py.git@1.0.0#egg=ensembl-py
-biopython>=1.76
-ete3>=3.1.1
-lxml>=4.9.2
-pandas>=0.24.2
-pybedtools==0.8.2
-sqlalchemy>=1.4.0

--- a/setup.py
+++ b/setup.py
@@ -12,48 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Build script for setuptools."""
+"""setuptools-based stub for editable installs"""
 
-from setuptools import setup, find_namespace_packages
-
-
-with open('README.md') as f:
-    readme = f.read()
-
-with open('PIP_VERSION') as f:
-    version = f.read()
+from setuptools import setup
 
 
-def import_requirements(requirements_path):
-    """Import file located at the root of the repository."""
-    with open(requirements_path) as file:
-        return [line.rstrip() for line in file.readlines()]
-
-
-setup(
-    name='ensembl-compara',
-    version=version,
-    packages=find_namespace_packages(where='src/python/lib'),
-    package_dir={"": "src/python/lib"},
-    description="Ensembl Compara's Python library",
-    include_package_data=True,
-    install_requires=import_requirements('requirements.txt'),
-    tests_require=import_requirements('requirements-test.txt'),
-    long_description=readme,
-    author='Ensembl Compara',
-    author_email='dev@ensembl.org',
-    url='https://www.ensembl.org',
-    download_url='https://github.com/Ensembl/ensembl-compara',
-    license="Apache License 2.0",
-    python_requires=">=3.8",
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Environment :: Console",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
-        "Natural Language :: English",
-        "Programming Language :: Python :: 3.8",
-        "Topic :: Scientific/Engineering :: Bio-Informatics",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-    ]
-)
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
## Description

This PR updates `ensembl-compara` Python package config.

## Overview of changes

- The `setup.py` script has been simplified to serve as a setuptools-based stub for editable installs, and its package configuration moved to the `pyproject.toml` file.
- The package `requirements*.txt` files have been removed, and their dependency information added to the `pyproject.toml` file.
- A copy of the Ensembl software license has been added to the `pyproject.toml` file, and the `[tool.pylint.messages_control]` header of the `pyproject.toml` file has been changed to `[tool.pylint.main]`.
- The `.travis.yml` file has been updated to: use the `test` dependency group instead of the `requirements.txt` and `requirements-test.txt` files; and remove the environment cleanup command which had been added previously ( in #482 ), as the issue which motivated it appears to have been resolved.

## Testing

The `ensembl-compara` Python package was installed locally.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
