### PR TITLE
Species tree pipeline: limit memory usage of branch length calculation

### DIFF
--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -405,7 +405,7 @@ process trimAlignments {
     id = (full_aln =~ /.*prot_(.*)\.fas$/)[0][1]
     """
     mkdir -p trimmed_alignments
-    trimal -gappyout -in $full_aln -out trimmed_alignments/trim_${id}.fas
+    trimal -keepseqs -in $full_aln -out trimmed_alignments/trim_${id}.fas
     """
 
 }
@@ -420,7 +420,7 @@ process trimAlignments {
 *@output path to RAXML style partition file
 */
 process mergeProtAlns {
-    label 'rc_4Gb'
+    label 'rc_8Gb'
 
     publishDir "${params.results_dir}/", pattern: "merged_protein_alns.fas", mode: "copy",  overwrite: true
     publishDir "${params.results_dir}/", pattern: "partitions.tsv", mode: "copy",  overwrite: true
@@ -453,7 +453,7 @@ process mergeProtAlns {
 *@output path to merged alignments fasta
 */
 process mergeCodonAlns {
-    label 'rc_4Gb'
+    label 'rc_8Gb'
 
     publishDir "${params.results_dir}/", pattern: "merged_codon_alns.fas", mode: "copy",  overwrite: true
 
@@ -654,7 +654,7 @@ process calcNeutralBranchesAstral {
     script:
     if (params.dir == "")
     """
-    ${params.iqtree_exe} -s $aln -m GTR+G -g $input_tree --fast -T ${params.cores}
+    ${params.iqtree_exe} -s $aln --mem 100G -m GTR+G -g $input_tree --fast -T ${params.cores}
     mv *.treefile astral_species_tree_neutral_bl.nwk
     mv *.iqtree astral_iqtree_report_neutral_bl.txt
     mv *.log astral_iqtree_log_neutral_bl.txt
@@ -663,7 +663,7 @@ process calcNeutralBranchesAstral {
     """
     else
     """
-    ${params.iqtree_exe} -s $aln -m GTR+G -g $input_tree --fast -T ${params.cores}
+    ${params.iqtree_exe} -s $aln --mem 100G -m GTR+G -g $input_tree --fast -T ${params.cores}
     mv *.treefile astral_species_tree_neutral_bl.nwk
     mv *.iqtree astral_iqtree_report_neutral_bl.txt
     mv *.log astral_iqtree_log_neutral_bl.txt
@@ -732,7 +732,7 @@ process calcProtBranchesAstral {
     script:
     if (params.dir == "")
     """
-    ${params.iqtree_exe} -s $aln -p $partitions -g $input_tree --fast -T ${params.cores}
+    ${params.iqtree_exe} -s $aln --mem 100G -m LG+F+G -g $input_tree --fast -T ${params.cores}
     mv *.treefile astral_species_tree_prot_bl.nwk
     mv *.iqtree astral_iqtree_report_prot_bl.txt
     mv *.log astral_iqtree_log_prot_bl.txt
@@ -741,7 +741,7 @@ process calcProtBranchesAstral {
     """
     else
     """
-    ${params.iqtree_exe} -s $aln -p $partitions -g $input_tree --fast -T ${params.cores}
+    ${params.iqtree_exe} -s $aln --mem 100G -m LG+F+G -g $input_tree --fast -T ${params.cores}
     mv *.treefile astral_species_tree_prot_bl.nwk
     mv *.iqtree astral_iqtree_report_prot_bl.txt
     mv *.log astral_iqtree_log_prot_bl.txt

--- a/pipelines/nextflow.config
+++ b/pipelines/nextflow.config
@@ -63,73 +63,72 @@ process {
     }
     withLabel: retry_with_4gb_mem_c1 {
        cpus = 1
-       errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
+       errorStrategy = { (task.exitStatus == 137) ? 'retry' : 'terminate' }
        memory = { 4.GB * task.attempt }
        time =  168.h
-       maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 10 : 1 }
+       maxRetries = { (task.exitStatus == 137) ? 10 : 1 }
     }
     withLabel: retry_with_8gb_mem_c5 {
        cpus = 5
-       errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
+       errorStrategy = { (task.exitStatus == 137) ? 'retry' : 'terminate' }
        memory = { 8.GB * task.attempt }
        time =  168.h 
-       maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 10 : 1 }
+       maxRetries = { (task.exitStatus == 137) ? 10 : 1 }
     }
     withLabel: retry_with_8gb_mem_c16 {
        cpus = 16
-       errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
+       errorStrategy = { (task.exitStatus == 137) ? 'retry' : 'terminate' }
        memory = { 8.GB * task.attempt }
        time = 168.h 
-       maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 10 : 1 }
+       maxRetries = { (task.exitStatus == 137) ? 10 : 1 }
     }
     withLabel: retry_with_8gb_mem_c32 {
        cpus = 32
-       errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
+       errorStrategy = { (task.exitStatus == 137) ? 'retry' : 'terminate' }
        memory = { 8.GB * task.attempt }
        time = 168.h 
-       maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 10 : 1 }
+       maxRetries = { (task.exitStatus == 137) ? 10 : 1 }
     }
     withLabel: retry_with_8gb_mem_c1 {
        cpus = 1
-       errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
+       errorStrategy = { (task.exitStatus == 137) ? 'retry' : 'terminate' }
        memory = { 8.GB * task.attempt }
        time = 168.h 
-       maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 10 : 1 }
+       maxRetries = { (task.exitStatus == 137) ? 10 : 1 }
     }
     withLabel: retry_with_16gb_mem_c1 {
        cpus = 1
-       errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
+       errorStrategy = { (task.exitStatus == 137) ? 'retry' : 'terminate' }
        memory = { 16.GB * task.attempt }
        time = 168.h
-       maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 16 : 1 }
+       maxRetries = { (task.exitStatus == 137) ? 16 : 1 }
     }
     withLabel: retry_with_16gb_mem_c16 {
        cpus = 16
-       errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
+       errorStrategy = { (task.exitStatus == 137) ? 'retry' : 'terminate' }
        memory = { 16.GB * task.attempt }
        time = 168.h
-       maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 10 : 1 }
+       maxRetries = { (task.exitStatus == 137) ? 10 : 1 }
     }
     withLabel: retry_with_16gb_mem_c32 {
        cpus = 32
-       errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
+       errorStrategy = { (task.exitStatus == 137) ? 'retry' : 'terminate' }
        memory = { 16.GB * task.attempt }
        time = 168.h
-       maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 10 : 1 }
+       maxRetries = { (task.exitStatus == 137) ? 10 : 1 }
     }
     withLabel: retry_with_32gb_mem_c32 {
        cpus = 32
-       errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
+       errorStrategy = { (task.exitStatus == 137) ? 'retry' : 'terminate' }
        memory = { 32.GB * task.attempt }
        time = 168.h
-       maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 8 : 1 }
+       maxRetries = { (task.exitStatus == 137) ? 8 : 1 }
     }	
     withLabel: retry_with_128gb_mem_c32 {
        cpus = 32
-       queue = { task.attempt >= 2 ? 'bigmem' : 'standard' }
-       errorStrategy = { (task.exitStatus == 140 || task.exitStatus == 130) ? 'retry' : 'terminate' }
+       errorStrategy = { (task.exitStatus == 137) ? 'retry' : 'terminate' }
        memory = { 128.GB * task.attempt }
        time = 168.h
-       maxRetries = { (task.exitStatus == 140 || task.exitStatus == 130) ? 4 : 1 }
+       maxRetries = { (task.exitStatus == 137) ? 4 : 1 }
     }
 }


### PR DESCRIPTION
## Description

The branch length calculations consumed too much memory and the slurmification of the pipeline was incomplete due to differences in error handling between LSF and Slurm.

**Related JIRA tickets:**
- ENSCOMPARASW-6853

## Overview of changes

#### Change 1
Corrected errors in slurmification.

#### Change 2
Limiting memory usage of the branch length calculation steps.

#### Change 2
Various other tweaks.

## Testing
The pipeline was tested on the 111 vertebrates division with the vertebrates BUSCO set.


For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
