### PR TITLE
Updating the jira tickets to include backup reminder

### DIFF
--- a/conf/fungi/jira_recurrent_tickets.json
+++ b/conf/fungi/jira_recurrent_tickets.json
@@ -103,6 +103,13 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines#Mergethehomologypipelines-Preliminaries",
+            "summary": "Backup release database",
+            "name_on_graph": "Backup the release database before merging the homology data"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines",
             "summary": "Merge the homology pipelines"
          },

--- a/conf/metazoa/jira_recurrent_tickets.json
+++ b/conf/metazoa/jira_recurrent_tickets.json
@@ -121,6 +121,13 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines#Mergethehomologypipelines-Preliminaries",
+            "summary": "Backup release database",
+            "name_on_graph": "Backup the release database before merging the homology data"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines",
             "summary": "Merge the homology pipelines"
          },

--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -135,6 +135,13 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines#Mergethehomologypipelines-Preliminaries",
+            "summary": "Backup release database",
+            "name_on_graph": "Backup the release database before merging the homology data"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Creation+of+a+new+ancestral+database",
             "summary": "Build a new ancestral sequence core database"
          },

--- a/conf/protists/jira_recurrent_tickets.json
+++ b/conf/protists/jira_recurrent_tickets.json
@@ -103,6 +103,13 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines#Mergethehomologypipelines-Preliminaries",
+            "summary": "Backup release database",
+            "name_on_graph": "Backup the release database before merging the homology data"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines",
             "summary": "Merge the homology pipelines"
          },

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -260,6 +260,13 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines#Mergethehomologypipelines-Preliminaries",
+            "summary": "Backup release database",
+            "name_on_graph": "Backup the release database before merging the homology data"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Creation+of+a+new+ancestral+database",
             "summary": "Build a new ancestral sequence core database"
          },


### PR DESCRIPTION
## Reminder to backup release database

Adding a new ticket in the jira avalanche of all divisions to remind to backup release database before merging the homology data. Not added in pan division. 

**Related JIRA tickets:**
- ENSCOMPARASW-6793

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
