### PR TITLE
Updating Protostomes and Default GOC configs

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
@@ -58,7 +58,7 @@ sub default_options {
 
         'threshold_levels' => [
             {
-                'taxa'          => [ 'Penaeus', 'Thoracicalcarea', 'Dhapnia', 'Apinae', 'Haliotis', 'Echinacea', 'Asteroidea', 'Anthozoa', 'Scleractinia' ],
+                'taxa'          => [ 'Penaeus', 'Thoracicalcarea', 'Daphnia', 'Apinae', 'Haliotis', 'Echinacea', 'Asteroidea', 'Anthozoa', 'Scleractinia' ],
                 'thresholds'    => [ 50, 50, 25 ],
             },
             {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
@@ -48,21 +48,20 @@ sub default_options {
         'division'   => 'metazoa',
 
         # homology_dnds parameters:
-        'taxlevels' => ['Eukaryota'],
+        'taxlevels' => ['Drosophila' ,'Hymenoptera', 'Nematoda'],
 
         # GOC parameters:
-        'goc_taxlevels' => ['Eukaryota'],
+        'goc_taxlevels' => ['Decapoda', 'Daphnia', 'Thoracicalcarea', 'Neoptera', 'Mollusca', 'Deuterostomia', 'Anthozoa'],
 
         # HighConfidenceOrthologs parameters:
         # In this structure, the "thresholds" are for resp. the GOC score, the WGA coverage and %identity
-
         'threshold_levels' => [
             {
-                'taxa'          => [ 'Penaeus', 'Thoracicalcarea', 'Daphnia', 'Apinae', 'Haliotis', 'Echinacea', 'Asteroidea', 'Anthozoa', 'Scleractinia' ],
+                'taxa'          => [ 'Anthozoa', 'Apinae', 'Asteroidea', 'Daphnia', 'Echinozoa', 'Haliotis', 'Penaeus', 'Scleractinia', 'Thoracicalcarea' ],
                 'thresholds'    => [ 50, 50, 25 ],
             },
             {
-                'taxa'          => ['Decapoda', 'Neoptera', 'Deuterostomia', 'Mollusca' ],
+                'taxa'          => [ 'Decapoda', 'Deuterostomia', 'Mollusca', 'Neoptera' ],
                 'thresholds'    => [ 25, 25, 25 ],
             },
             {
@@ -70,6 +69,7 @@ sub default_options {
                 'thresholds'    => [ undef, undef, 25 ],
             },
         ],
+        
         # Extra analyses:
         # Gain/loss analysis?
         'do_cafe'                => 0,

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
@@ -51,7 +51,7 @@ sub default_options {
         'taxlevels' => ['Drosophila' ,'Hymenoptera', 'Nematoda'],
 
         # GOC parameters:
-        'goc_taxlevels' => ['Decapoda', 'Daphnia', 'Thoracicalcarea', 'Neoptera', 'Mollusca', 'Deuterostomia', 'Anthozoa'],
+        'goc_taxlevels' => ['Decapoda', 'Daphnia','Parachela', 'Thoracicalcarea', 'Neoptera', 'Mollusca', 'Deuterostomia', 'Anthozoa'],
 
         # HighConfidenceOrthologs parameters:
         # In this structure, the "thresholds" are for resp. the GOC score, the WGA coverage and %identity

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
@@ -57,11 +57,11 @@ sub default_options {
         # In this structure, the "thresholds" are for resp. the GOC score, the WGA coverage and %identity
         'threshold_levels' => [
             {
-                'taxa'          => [ 'Anthozoa', 'Apinae', 'Asteroidea', 'Daphnia', 'Echinozoa', 'Haliotis', 'Penaeus', 'Scleractinia', 'Thoracicalcarea' ],
+                'taxa'          => [ 'Apinae', 'Asteroidea', 'Daphnia', 'Echinozoa', 'Haliotis', 'Parachela', 'Penaeus', 'Scleractinia', 'Thoracicalcarea' ],
                 'thresholds'    => [ 50, 50, 25 ],
             },
             {
-                'taxa'          => [ 'Decapoda', 'Deuterostomia', 'Mollusca', 'Neoptera' ],
+                'taxa'          => [ 'Anthozoa', 'Decapoda', 'Deuterostomia', 'Mollusca', 'Neoptera' ],
                 'thresholds'    => [ 25, 25, 25 ],
             },
             {
@@ -69,7 +69,7 @@ sub default_options {
                 'thresholds'    => [ undef, undef, 25 ],
             },
         ],
-        
+
         # Extra analyses:
         # Gain/loss analysis?
         'do_cafe'                => 0,

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
@@ -48,36 +48,24 @@ sub default_options {
         'division'   => 'metazoa',
 
         # homology_dnds parameters:
-        'taxlevels' => ['Drosophila' ,'Hymenoptera', 'Nematoda'],
+        'taxlevels' => ['Eukaryota'],
 
         # GOC parameters:
-        'goc_taxlevels' => ['Diptera', 'Hymenoptera', 'Nematoda'],
+        'goc_taxlevels' => ['Eukaryota'],
 
         # HighConfidenceOrthologs parameters:
         # In this structure, the "thresholds" are for resp. the GOC score, the WGA coverage and %identity
+
         'threshold_levels' => [
             {
-                'taxa'          => [ 'Euteleostomi', 'Ciona' ],
+        'taxa'          => [ 'Penaeus', 'Thoracicalcarea', 'Dhapnia', 'Apinae', 'Haliotis', 'Echinacea', 'Asteroidea', 'Anthozoa', 'Scleractinia' ],
                 'thresholds'    => [ 50, 50, 25 ],
             },
             {
-                'taxa'          => [ 'Aculeata', 'Anophelinae', 'Caenorhabditis', 'Drosophila', 'Glossinidae', 'Onchocercidae' ],
-                'thresholds'    => [ 50, 50, 25 ],
-            },
-            {
-                'taxa'          => [ 'Brachycera', 'Culicinae', 'Hemiptera', 'Phlebotominae' ],
+                'taxa'          => ['Decapoda', 'Neoptera', 'Deuterostomia', 'Mollusca' ],
                 'thresholds'    => [ 25, 25, 25 ],
             },
-            {
-                'taxa'          => [ 'Chelicerata', 'Diptera', 'Hymenoptera', 'Nematoda' ],
-                'thresholds'    => [ undef, undef, 25 ],
-            },
-            {
-                'taxa'          => [ 'all' ],
-                'thresholds'    => [ undef, undef, 25 ],
-            },
         ],
-
         # Extra analyses:
         # Gain/loss analysis?
         'do_cafe'                => 0,

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
@@ -58,12 +58,16 @@ sub default_options {
 
         'threshold_levels' => [
             {
-        'taxa'          => [ 'Penaeus', 'Thoracicalcarea', 'Dhapnia', 'Apinae', 'Haliotis', 'Echinacea', 'Asteroidea', 'Anthozoa', 'Scleractinia' ],
+                'taxa'          => [ 'Penaeus', 'Thoracicalcarea', 'Dhapnia', 'Apinae', 'Haliotis', 'Echinacea', 'Asteroidea', 'Anthozoa', 'Scleractinia' ],
                 'thresholds'    => [ 50, 50, 25 ],
             },
             {
                 'taxa'          => ['Decapoda', 'Neoptera', 'Deuterostomia', 'Mollusca' ],
                 'thresholds'    => [ 25, 25, 25 ],
+            },
+            {
+                'taxa'          => [ 'all' ],
+                'thresholds'    => [ undef, undef, 25 ],
             },
         ],
         # Extra analyses:

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProtostomesProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProtostomesProteinTrees_conf.pm
@@ -50,8 +50,31 @@ sub default_options {
         'dbID_range_index'    => 10,
         'ref_collection_list' => ['default'],
         'label_prefix' => 'protostomes_',
+
+        #GOC parameters:
+        'goc_taxlevels' => ['Eukaryota'],
+
+        'threshold_levels' => [
+            {
+		        'taxa'          => [ 'Rhipicephalinae', 'Caenorhabditis', 'Spirurina', 'Haliotis', 'Crassostrea', 'Octopus', 'Cyclophyllidea', 'Schistosoma' ],
+                'thresholds'    => [ 50, 50, 25 ],
+            },
+            {
+                'taxa'          => [ 'Ixoididae' , 'Entelegynae' , 'Neoptera' , 'Mollusca' ],
+                'thresholds'    => [ 25, 25, 25 ],
+            },
+            {
+                'taxa'          => [ 'Nematoda' ],
+                'thresholds'    => [ undef, undef, 25 ],
+            }, 
+            {
+                'taxa'          => [ 'all' ],
+                'thresholds'    => [ undef, undef, 25 ],
+            },
+        ],
     };
 }
+
 
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProtostomesProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProtostomesProteinTrees_conf.pm
@@ -52,7 +52,7 @@ sub default_options {
         'label_prefix' => 'protostomes_',
 
         #GOC parameters:
-        'goc_taxlevels' => [ 'Cyclophyllidea', 'Entelegynae' , 'Ixoididae' ,'Mollusca' ,'Nematoda' ,'Neoptera', 'Schistosoma' ],
+        'goc_taxlevels' => [ 'Cyclophyllidea', 'Entelegynae' , 'Ixodidae' ,'Mollusca' ,'Nematoda' ,'Neoptera', 'Schistosoma' ],
 
         'threshold_levels' => [
             {
@@ -60,7 +60,7 @@ sub default_options {
                 'thresholds'    => [ 50, 50, 25 ],
             },
             {
-                'taxa'          => [ 'Entelegynae' , 'Ixoididae' ,'Mollusca' ,'Neoptera' ],
+                'taxa'          => [ 'Entelegynae' , 'Ixodidae' ,'Mollusca' ,'Neoptera' ],
                 'thresholds'    => [ 25, 25, 25 ],
             },
             {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProtostomesProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProtostomesProteinTrees_conf.pm
@@ -52,15 +52,15 @@ sub default_options {
         'label_prefix' => 'protostomes_',
 
         #GOC parameters:
-        'goc_taxlevels' => ['Eukaryota'],
+        'goc_taxlevels' => [ 'Cyclophyllidea', 'Entelegynae' , 'Ixoididae' ,'Mollusca' ,'Nematoda' ,'Neoptera', 'Schistosoma' ],
 
         'threshold_levels' => [
             {
-		        'taxa'          => [ 'Rhipicephalinae', 'Caenorhabditis', 'Spirurina', 'Haliotis', 'Crassostrea', 'Octopus', 'Cyclophyllidea', 'Schistosoma' ],
+		        'taxa'          => [ 'Caenorhabditis', 'Crassostrea', 'Cyclophyllidea', 'Haliotis', 'Octopus', 'Rhipicephalinae', 'Schistosoma', 'Spirurina' ],
                 'thresholds'    => [ 50, 50, 25 ],
             },
             {
-                'taxa'          => [ 'Ixoididae' , 'Entelegynae' , 'Neoptera' , 'Mollusca' ],
+                'taxa'          => [ 'Entelegynae' , 'Ixoididae' ,'Mollusca' ,'Neoptera' ],
                 'thresholds'    => [ 25, 25, 25 ],
             },
             {
@@ -74,7 +74,6 @@ sub default_options {
         ],
     };
 }
-
 
 
 1;


### PR DESCRIPTION
Created Protostomes GOC configs and updated default GOC configs. GOC heat plots and grid plots were created and compared to identify the GOC taxlevels, thresholds for Protostomes and Default collections. GOC configuration has been updated for protostomes and default Metazoa collections with values appropriate to the species in those collections.

ENSCOMPARASW-6368 


---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
