### PR TITLE
fixing bigmem slurm queue name

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -207,7 +207,7 @@ sub resource_classes_single_thread {
 
         '512Gb_job' => {
             'LSF'   => '-q bigmem -C0 -M512000 -R"select[mem>512000] rusage[mem=512000]"',
-            'SLURM' => '--partition=bigmem --mem=512g',
+            'SLURM' => '--partition=standard --mem=512g',
         },
     };
 


### PR DESCRIPTION
## Description

Fixing the Slurm queue name for `bigmem` jobs

Teste:
```bash
srun -t 1-00:00:0 --mem 512GB --cpus-per-task 1 --pty bash
┌─[thiagogenez@hl-codon-bm-18]─[○]                                                        
├─[~]
└─☻ echo $SLURM_MEM_PER_NODE
524288
```
---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
