### PR TITLE
Add production task to check gene-tree stats

### DIFF
--- a/conf/fungi/jira_recurrent_tickets.json
+++ b/conf/fungi/jira_recurrent_tickets.json
@@ -69,6 +69,12 @@
          },
          {
             "component": "Production tasks",
+            "description": "Review the gene-tree stats for each gene-tree pipeline, and address any issues.",
+            "summary": "Check gene-tree stats",
+            "name_on_graph": "Check gene-tree stats"
+         },
+         {
+            "component": "Production tasks",
             "description": "Mark as done when all LastZs have been merged into the new release database.",
             "summary": "Merge all LastZ",
             "name_on_graph": "Merge all LastZ"

--- a/conf/metazoa/jira_recurrent_tickets.json
+++ b/conf/metazoa/jira_recurrent_tickets.json
@@ -81,6 +81,12 @@
          },
          {
             "component": "Production tasks",
+            "description": "Review the gene-tree stats for each gene-tree pipeline, and address any issues.",
+            "summary": "Check gene-tree stats",
+            "name_on_graph": "Check gene-tree stats"
+         },
+         {
+            "component": "Production tasks",
             "description": "Mark as done when all LastZs have been merged into the new release database.",
             "summary": "Merge all LastZ",
             "name_on_graph": "Merge all LastZ"

--- a/conf/pan/jira_recurrent_tickets.json
+++ b/conf/pan/jira_recurrent_tickets.json
@@ -53,6 +53,12 @@
             "description": "*GitHub*: [<Division>/ProteinTrees_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/<Division>/ProteinTrees_conf.pm]\n{code}ibsub init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::<Division>::ProteinTrees_conf -host mysql-ens-compara-prod-X -port XXXX{code}",
             "summary": "Run the Protein-trees pipeline",
             "name_on_graph": "Protein-trees"
+         },
+         {
+            "component": "Production tasks",
+            "description": "Review the gene-tree stats for each gene-tree pipeline, and address any issues.",
+            "summary": "Check gene-tree stats",
+            "name_on_graph": "Check gene-tree stats"
          }
       ],
       "labels": ["Production_anchor"],

--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -86,7 +86,12 @@
             "summary": "Run the rice cultivars Protein-trees pipeline",
             "name_on_graph": "Protein-trees:Rice cultivars"
          },
-         
+         {
+            "component": "Production tasks",
+            "description": "Review the gene-tree stats for each gene-tree pipeline, and address any issues.",
+            "summary": "Check gene-tree stats",
+            "name_on_graph": "Check gene-tree stats"
+         },
          {
             "component": "Production tasks",
             "description": "Mark as done when all LastZs have been merged into the new release database.",

--- a/conf/protists/jira_recurrent_tickets.json
+++ b/conf/protists/jira_recurrent_tickets.json
@@ -69,6 +69,12 @@
          },
          {
             "component": "Production tasks",
+            "description": "Review the gene-tree stats for each gene-tree pipeline, and address any issues.",
+            "summary": "Check gene-tree stats",
+            "name_on_graph": "Check gene-tree stats"
+         },
+         {
+            "component": "Production tasks",
             "description": "Mark as done when all LastZs have been merged into the new release database.",
             "summary": "Merge all LastZ",
             "name_on_graph": "Merge all LastZ"

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -106,6 +106,12 @@
          },
          {
             "component": "Production tasks",
+            "description": "Review the gene-tree stats for each gene-tree pipeline, and address any issues.",
+            "summary": "Check gene-tree stats",
+            "name_on_graph": "Check gene-tree stats"
+         },
+         {
+            "component": "Production tasks",
             "description": "*GitHub*: [StrainsReindexMembers_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsReindexMembers_conf.pm]\n{code}ibsub init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::StrainsReindexMembers_conf -host mysql-ens-compara-prod-X -port XXXX -collection murinae -member_type protein{code}\n{code}ibsub init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::StrainsReindexMembers_conf -host mysql-ens-compara-prod-X -port XXXX -collection murinae -member_type ncrna{code}",
             "summary": "Reindex murinae gene trees",
             "name_on_graph": "Gene-tree reindexing:Murinae"

--- a/scripts/jira_tickets/compara_merged.dot
+++ b/scripts/jira_tickets/compara_merged.dot
@@ -12,6 +12,10 @@ digraph {
     "Merge all alignments for WGA Orthology QC" -> "ncRNA-trees" [fontsize="8", label="Orthologues\nonly"];
     "LastZ" -> "Merge all LastZ" -> "Synteny";
 
+    { "Protein-trees", "ncRNA-trees" } -> "Check gene-tree stats";
+    { "Check gene-tree stats", "Gene-tree reindexing", "Alt-alleles import" } -> "Backup the release database before merging the homology data";
+    "Backup the release database before merging the homology data" -> "Merge the homology pipelines";
+
     "Gene-tree reindexing" -> "ncRNA-trees" [style="dashed", dir=none, fontsize="8", label="XOR"];
     "Gene-tree reindexing" -> "Protein-trees" [style="dashed", dir=none, fontsize="8", label="XOR"];
     "EPOwithExt" -> "EPOwithExt" [style="dashed", fontsize="8", label="Anchor\nmapping\nonly", headport="Primates:e", tailport="Mammals:e"];


### PR DESCRIPTION
## Description

Add a production task to remind us to check the gene-tree stats for each gene-tree pipeline.

## Overview of changes

- A Jira production task is added as a reminder to check the gene-tree stats for each gene-tree pipeline.
- The Compara release graph is updated to include this production task.

## Testing

To confirm that the relevant part of the Compara release graph looked as expected, a PNG image was generated from the `compara_merged.dot` file using a command like the following:
```bash
dot -Tpng ensembl-compara/scripts/jira_tickets/compara_merged.dot \
    > ensembl-compara/scripts/jira_tickets/compara_merged.png
```

Here is the relevant part of the Compara release graph:
![compara_merged](https://github.com/Ensembl/ensembl-compara/assets/84317604/0f834df3-7989-4e45-adc4-22464f1fc64e)

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
