### PR TITLE
Ensure release-history objects are made current

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/BaseReleaseHistoryAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/BaseReleaseHistoryAdaptor.pm
@@ -162,9 +162,9 @@ sub retire_object {
 
 sub make_object_current {
     my ($self, $object) = @_;
-    return if $object->is_current;
-    $object->first_release(software_version()) unless $object->first_release;   # The object may already be current
-    $object->last_release(undef);
+    # The object may already be current; only modify as needed.
+    $object->first_release(software_version()) unless $object->first_release && $object->first_release <= software_version();
+    $object->last_release(undef) unless $object->last_release && $object->last_release >= software_version();
     return $self->update_first_last_release($object);
 }
 


### PR DESCRIPTION
## Description

In recent Ensembl releases the CheckHomologyMLSS datacheck has failed, in Metazoa in releases [110](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-6370) and [111](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-6674), and in [Vertebrates in release 111](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-6767).

This has manifested in one of two ways: failure to retire homology MLSSes that are no longer needed, and failure to bring out of retirement homology MLSSes which had been retired in a previous release.

The failure to retire homology MLSSes is due to the fact that the `create_all_mlss.pl` script does not retire unmatched homology MLSSes by default. This can be addressed by an SOP update to make appropriate use of that script's `--retire_unmatched` option to identify and retire homology MLSSes as needed.

The failure to unretire homology MLSSes is due to a bug in the method `BaseReleaseHistoryAdaptor::make_object_current` affecting release-history objects which are themselves current, but which have previously been retired in the Compara database.

As implemented at the moment, current objects (e.g. MLSSes) are returned unmodified if they are already current, but the database is not updated to reflect this. This PR aims to address that by making the minimum changes necessary to the input object to ensure it is current, and by updating the release status of the object in the database regardless of whether it is current or not.

**Related JIRA tickets:**
- ENSCOMPARASW-6776

## Testing

As the updated method is critical to correct handling of MLSSes, species sets etc., the bugfix was tested by running the `PrepareMasterDatabaseForRelease` pipeline on a restored copy of a backup of the Vertebrates master database made immediately prior to its update for release 111, and verifying that homology MLSSes involving the unretired genome `xiphophorus_couchianus` had also been unretired correctly.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)