### PR TITLE
Curb output of semaphore checks

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ComplementaryProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ComplementaryProteinTrees_conf.pm
@@ -144,7 +144,7 @@ sub tweak_analyses {
         'A->1' => [ 'find_overlapping_genomes' ],
     };
 
-    push @{$analyses_by_name->{'final_semaphore_check'}->{'-flow_into'}}, 'remove_overlapping_homologies';
+    push @{$analyses_by_name->{'fire_final_analyses'}->{'-flow_into'}}, 'remove_overlapping_homologies';
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/CultivarsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/CultivarsProteinTrees_conf.pm
@@ -129,7 +129,7 @@ sub tweak_analyses {
 
     # Wire up cultivar-specific analyses
     $analyses_by_name->{'remove_blocklisted_genes'}->{'-flow_into'} = ['find_overlapping_genomes'];
-    push @{$analyses_by_name->{'final_semaphore_check'}->{'-flow_into'}}, 'remove_overlapping_homologies';
+    push @{$analyses_by_name->{'fire_final_analyses'}->{'-flow_into'}}, 'remove_overlapping_homologies';
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -662,6 +662,11 @@ sub core_pipeline_analyses {
         {   -logic_name        => 'pre_clustering_semaphore_check',
             -module            => 'Bio::EnsEMBL::Compara::RunnableDB::DataCheckFan',
             -max_retry_count   => 0,
+            -flow_into         => [ { 'fire_clustering_analyses' => '{}' } ],
+        },
+
+        {   -logic_name => 'fire_clustering_analyses',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => {
                 '1->A'  => WHEN(
                     '#are_all_species_reused# and (#reuse_level# eq "clusters")' => 'copy_clusters',
@@ -684,6 +689,11 @@ sub core_pipeline_analyses {
         {   -logic_name        => 'pre_tree_building_semaphore_check',
             -module            => 'Bio::EnsEMBL::Compara::RunnableDB::DataCheckFan',
             -max_retry_count   => 0,
+            -flow_into         => [ { 'fire_tree_building_analyses' => '{}' } ],
+        },
+
+        {   -logic_name => 'fire_tree_building_analyses',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => {
                 '1->A'  => [ 'cluster_factory' ],
                 'A->1'  => [ 'backbone_fire_homology_dumps' ],
@@ -698,6 +708,11 @@ sub core_pipeline_analyses {
         {   -logic_name        => 'pre_homology_dump_semaphore_check',
             -module            => 'Bio::EnsEMBL::Compara::RunnableDB::DataCheckFan',
             -max_retry_count   => 0,
+            -flow_into         => [ { 'fire_homology_dump_analyses' => '{}' } ],
+        },
+
+        {   -logic_name => 'fire_homology_dump_analyses',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => {
                 '1->A' => [ 'snapshot_posttree', 'homology_dumps_mlss_id_factory', 'gene_dumps_genome_db_factory' ],
                 'A->1' => [ 'backbone_fire_posttree' ],
@@ -712,6 +727,11 @@ sub core_pipeline_analyses {
         {   -logic_name        => 'posttree_semaphore_check',
             -module            => 'Bio::EnsEMBL::Compara::RunnableDB::DataCheckFan',
             -max_retry_count   => 0,
+            -flow_into         => [ { 'fire_posttree_analyses' => '{}' } ],
+        },
+
+        {   -logic_name => 'fire_posttree_analyses',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => {
                 '1->A'  => [ 'rib_group_1' ],
                 'A->1'  => [ 'backbone_pipeline_finished' ],
@@ -731,6 +751,11 @@ sub core_pipeline_analyses {
         {   -logic_name        => 'final_semaphore_check',
             -module            => 'Bio::EnsEMBL::Compara::RunnableDB::DataCheckFan',
             -max_retry_count   => 0,
+            -flow_into         => [ { 'fire_final_analyses' => '{}' } ],
+        },
+
+        {   -logic_name => 'fire_final_analyses',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => [
                 WHEN( '#gene_tree_stats_shared_dir#' => 'generate_tree_stats_report' ),
                 'wga_expected_dumps',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
@@ -135,7 +135,7 @@ sub tweak_analyses {
 
     # wire up strain-specific analyses
     $analyses_by_name->{'remove_blocklisted_genes'}->{'-flow_into'} = ['find_overlapping_genomes'];
-    push @{$analyses_by_name->{'final_semaphore_check'}->{'-flow_into'}}, 'remove_overlapping_homologies';
+    push @{$analyses_by_name->{'fire_final_analyses'}->{'-flow_into'}}, 'remove_overlapping_homologies';
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -368,6 +368,11 @@ sub core_pipeline_analyses {
             {   -logic_name => 'pre_tree_building_semaphore_check',
                 -module     => 'Bio::EnsEMBL::Compara::RunnableDB::DataCheckFan',
                 -max_retry_count => 0,
+                -flow_into  => [ { 'fire_tree_building_analyses' => '{}' } ],
+            },
+
+            {   -logic_name => 'fire_tree_building_analyses',
+                -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
                 -flow_into  => {
                                 '1->A'  => [ 'clusters_factory' ],
                                 'A->1'  => [ 'backbone_fire_posttree' ],
@@ -383,8 +388,8 @@ sub core_pipeline_analyses {
                 -module     => 'Bio::EnsEMBL::Compara::RunnableDB::DataCheckFan',
                 -max_retry_count => 0,
                 -flow_into  => {
-                    '1->A' => ['rib_fire_posttree_processing'],
-                    'A->1' => ['backbone_pipeline_finished'],
+                    '1->A' => [ { 'rib_fire_posttree_processing' => '{}' } ],
+                    'A->1' => [ { 'backbone_pipeline_finished' => '{}' } ],
                 },
             },
 


### PR DESCRIPTION
## Description

The integration of the `TimelySemaphoreRelease` datacheck in gene-tree pipelines (ENSCOMPARASW-6846, ENSCOMPARASW-6847) used `DatacheckFan` jobs, which dataflow the datacheck results to downstream analyses. This has caused issues for at least one downstream analysis (the `cluster_factory` `JobFactory` in the ProteinTrees pipeline) and has required manual intervention.

One way to address this would be to put the relevant `DatacheckFan` in a Hive fan, but that would depend on the semaphores whose failure this datacheck was intended to catch.

Instead, this PR effectively silences the dataflow output of each semaphore-check `DatacheckFan` in the gene-tree pipelines.

**Related JIRA tickets:**
- ENSCOMPARASW-7071

## Overview of changes

Each integrated semaphore-check `DatacheckFan` is rewired so that it does not send output to downstream analyses.

## Testing

A test pipeline was run with the rewired semaphore-check `DatacheckFan` analyses. See ENSCOMPARASW-7071 for more info on testing.


---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
