### PR TITLE
Fix for handling of U-component gene  homologies in wheat cultivars

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/OrthoTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/OrthoTree.pm
@@ -514,7 +514,6 @@ sub store_gene_link_as_homology {
                (($gdb2->name =~ m/^(triticum_aestivum|triticum_turgidum).*$/) and ($gene2->genome_db->genome_component eq 'U')) ) {
               $mlss_type = 'ENSEMBL_PARALOGUES';
               $type      = 'within_species_paralog';
-          } else {
           }
           ####
       } else {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/OrthoTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/OrthoTree.pm
@@ -510,10 +510,11 @@ sub store_gene_link_as_homology {
           $type      =~ s/ortholog/homoeolog/;
           $gdbs      = [$gdb1];
           #### temp fix triticum_aestivum
-          if ( (($gdb1->name eq 'triticum_aestivum') and ($gene1->genome_db->genome_component eq 'U')) or
-               (($gdb2->name eq 'triticum_aestivum') and ($gene2->genome_db->genome_component eq 'U')) ) {
+          if ( (($gdb1->name =~ m/^(triticum_aestivum|triticum_turgidum).*$/) and ($gene1->genome_db->genome_component eq 'U')) or
+               (($gdb2->name =~ m/^(triticum_aestivum|triticum_turgidum).*$/) and ($gene2->genome_db->genome_component eq 'U')) ) {
               $mlss_type = 'ENSEMBL_PARALOGUES';
               $type      = 'within_species_paralog';
+          } else {
           }
           ####
       } else {


### PR DESCRIPTION
## Description

In [Compara commit 3837d83](https://github.com/Ensembl/ensembl-compara/commit/3837d83416bc1d0058c7660a9b43a392639c050e) a temporary fix was added to the OrthoTree runnable to convert homoeologues in the Triticum aestivum U component to within-species paralogues.

This behaviour was not extended to U-component genes in the Wheat cultivars when they were introduced in e106. As a result, homology-type inference is inconsistent between U-component genes in the Wheat reference genome and the Wheat cultivars. U-component genes in triticum_aestivum lack homoeologues, while those in other Wheat genomes have homoeologues.

**Related JIRA tickets:**
- ENSCOMPARASW-7050

## Overview of changes

Added a regular expression to convert the U-component homoeologues to within-species paralogs in all wheat cultivars.

## Testing

The pipeline was tested by running an orthotree job in a protein trees pipeline on a subset of wheat cultivars. The target U-component gene was TraesJAGUn03G04544200 with the input gene tree 2000084634.


## Notes


---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
