### PR TITLE
Species tree pipeline: using miniprot as default annotation engine

### DIFF
--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -101,6 +101,8 @@ process dumpVersions {
     (java -jar $params.astral_jar 2>&1| grep "This is") >> $out
     echo "macse:" >> $out
     (java -jar $params.macse_jar -help 2>&1| grep "This is") >> $out
+    echo "miniprot:" >> $out
+    ${params.miniprot_exe} --version >> $out
     """
 
 }
@@ -132,7 +134,7 @@ process prepareGenome {
 *@output path to input genomes info csv
 */
 process prepareGenomeFromDb {
-    label 'retry_with_8gb_mem_c1'
+    label 'retry_with_16gb_mem_c1'
 
     publishDir "${params.results_dir}", pattern: "input_genomes.csv", mode: "copy", overwrite: true
 
@@ -211,7 +213,7 @@ process linkAnnoCache {
 *@output tuple of path to annotation GTF and genome fasta
 */
 process buscoAnnot {
-    label 'retry_with_32gb_mem_c32'
+    label 'retry_with_128gb_mem_c32'
 
     publishDir "${params.results_dir}/anno_cache/$genome", pattern: "annotation.gtf", mode: "copy",  overwrite: true
 
@@ -221,21 +223,35 @@ process buscoAnnot {
     output:
         tuple path("annotation.gtf"), path(genome), emit: busco_annot
     script:
+    if (params.use_anno == "")
     """
-    mkdir -p anno_res
-    export ENSCODE=$params.enscode
-    ln -s `which tblastn` .
-
-    python3 $params.anno_exe \
-    --output_dir anno_res \
-    --genome_file $genome \
-    --num_threads ${params.cores} \
-    --max_intron_length 100000 \
-    --run_busco \
-    --genblast_timeout  64800\
-    --busco_protein_file $busco_prot
-
-    mv anno_res/busco_output/annotation.gtf .
+        SENS=""
+        if [ "${params.sensitive}" != "" ];
+        then
+            SENS="-M0 -k5"
+        fi
+        ${params.miniprot_exe} \$SENS -t ${params.cores} -d genome.mpi $genome
+        ${params.miniprot_exe} -N 0 -Iu -t ${params.cores} --gff genome.mpi $busco_prot | grep -v '##PAF' \
+        | awk '/mRNA/{split(\$9,a,/ID=|;/); split(\$9,b,/Target=|\s/)}{sub(a[2], b[2]); print}' > annotation.gtf
+        rm -f genome.mpi
+    """
+    else
+    """
+        mkdir -p anno_res
+        export ENSCODE=$params.enscode
+        ln -s `which tblastn` .
+        
+        python3 $params.anno_exe \
+        --output_dir anno_res \
+        --genome_file $genome \
+        --num_threads ${params.cores} \
+        --max_intron_length 100000 \
+        --run_busco \
+        --genblast_timeout  64800\
+        --busco_protein_file $busco_prot
+        
+        mv anno_res/busco_output/annotation.gtf .
+    fi
     """
 }
 
@@ -252,7 +268,8 @@ process runGffread {
     script:
     """
     mkdir -p cdna
-    ${params.gffread_exe} -w cdna/$genome -g $genome $busco_annot
+    ${params.gffread_exe} $busco_annot > anno_clean.gtf
+    ${params.gffread_exe} --adj-stop -w cdna/$genome -g $genome anno_clean.gtf
     """
 }
 
@@ -305,7 +322,7 @@ process collateBusco {
 *@output path to cDNA fasta
 */
 process alignProt {
-    label 'retry_with_4gb_mem_c1'
+    label 'retry_with_8gb_mem_c1'
 
     input:
         val protFas

--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -232,7 +232,7 @@ process buscoAnnot {
         fi
         ${params.miniprot_exe} \$SENS -t ${params.cores} -d genome.mpi $genome
         ${params.miniprot_exe} -N 0 -Iu -t ${params.cores} --gff genome.mpi $busco_prot | grep -v '##PAF' \
-        | awk '/mRNA/{split(\$9,a,/ID=|;/); split(\$9,b,/Target=|\s/)}{sub(a[2], b[2]); print}' > annotation.gtf
+        | awk -F "\t" '$3=="mRNA" {match($9, /Target=([^; ]+)/, m)} {sub(/ID=[^; ]+/, sprintf("ID=%s", m[1]), $9); print}' > annotation.gtf
         rm -f genome.mpi
     """
     else
@@ -251,7 +251,6 @@ process buscoAnnot {
         --busco_protein_file $busco_prot
         
         mv anno_res/busco_output/annotation.gtf .
-    fi
     """
 }
 

--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -232,7 +232,7 @@ process buscoAnnot {
         fi
         ${params.miniprot_exe} \$SENS -t ${params.cores} -d genome.mpi $genome
         ${params.miniprot_exe} -N 0 -Iu -t ${params.cores} --gff genome.mpi $busco_prot | grep -v '##PAF' \
-        | awk -F "\t" '$3=="mRNA" {match($9, /Target=([^; ]+)/, m)} {sub(/ID=[^; ]+/, sprintf("ID=%s", m[1]), $9); print}' > annotation.gtf
+        | awk -F "\t" '\$3=="mRNA" {match(\$9, /Target=([^; ]+)/, m)} {sub(/ID=[^; ]+/, sprintf("ID=%s", m[1]), \$9); print}' > annotation.gtf
         rm -f genome.mpi
     """
     else

--- a/pipelines/SpeciesTreeFromBusco/nextflow.config
+++ b/pipelines/SpeciesTreeFromBusco/nextflow.config
@@ -45,9 +45,9 @@ params {
     min_taxa = 0.5
     // Name of outgroup taxon:
     outgroup = ""
-    // Use sensitive miniprot mode:
+    // If 'sensitive' is a nonempty string, use sensitive miniprot mode:
     sensitive = ""
-    // Use ensembl-anno/GenBlast instead of miniprot:
+    // If 'use_anno' is a nonempty string, use ensembl-anno/GenBlast instead of miniprot:
     use_anno = ""
 
     //

--- a/pipelines/SpeciesTreeFromBusco/nextflow.config
+++ b/pipelines/SpeciesTreeFromBusco/nextflow.config
@@ -45,6 +45,10 @@ params {
     min_taxa = 0.5
     // Name of outgroup taxon:
     outgroup = ""
+    // Use sensitive miniprot mode:
+    sensitive = ""
+    // Use ensembl-anno/GenBlast instead of miniprot:
+    use_anno = ""
 
     //
     // Software dependencies specifications:
@@ -71,6 +75,8 @@ params {
 
     // Path to gffread binary:
     gffread_exe = "$COMPARA_SOFTWARE/build/gffread/0.12.7/bin/gffread"
+    // Path to miniprot binary:
+    miniprot_exe = "$COMPARA_SOFTWARE/build/miniprot/0.12/bin/miniprot"
     // Path to mafft binary:
     mafft_exe = "$LINUXBREW_HOME/bin/mafft"
     // Path to iqtree2 binary:

--- a/pipelines/SpeciesTreeFromBusco/scripts/collate_busco_results.py
+++ b/pipelines/SpeciesTreeFromBusco/scripts/collate_busco_results.py
@@ -124,7 +124,7 @@ if __name__ == '__main__':
                 continue
             # Filter out sequences with multiple stop
             # codons:
-            if str(y.seq).count("*") > 1:
+            if y.seq.count("*") > 1:
                 continue
             y.id = x.id     # type: ignore
             y.description = ""

--- a/pipelines/SpeciesTreeFromBusco/scripts/collate_busco_results.py
+++ b/pipelines/SpeciesTreeFromBusco/scripts/collate_busco_results.py
@@ -119,11 +119,20 @@ if __name__ == '__main__':
             if (len(x.seq) % 3) != 0:
                 continue
             y = x.translate(stop_symbol='*', to_stop=False, cds=False)   # type: ignore
+            # Filter out if cDNA had too many Ns:
             if str(y.seq).count("X") > 10:
+                continue
+            # Filter out sequences with multiple stop
+            # codons:
+            if str(y.seq).count("*") > 1:
                 continue
             y.id = x.id     # type: ignore
             y.description = ""
             ts.append(y)
 
+        if len(ts) < 3:
+            continue
+        if len(ts) / len(taxa) < args.m:
+            continue
         with open(path.join(args.o, f"gene_prot_{g}.fas"), "w") as output_handle:
             SeqIO.write(ts, output_handle, "fasta")

--- a/pipelines/nextflow.config
+++ b/pipelines/nextflow.config
@@ -122,7 +122,7 @@ process {
        errorStrategy = { (task.exitStatus == 137) ? 'retry' : 'terminate' }
        memory = { 32.GB * task.attempt }
        time = 168.h
-       maxRetries = { (task.exitStatus == 137) ? 8 : 1 }
+       maxRetries = { (task.exitStatus == 137) ? 16 : 1 }
     }	
     withLabel: retry_with_128gb_mem_c32 {
        cpus = 32

--- a/src/python/tests/test_collate_busco_results.py
+++ b/src/python/tests/test_collate_busco_results.py
@@ -62,12 +62,8 @@ class TestCollateBusco:
                             / "collate_output_taxa.tsv")
         expected_gene1 = str(Path(__file__).parents[2] / 'test_data' / "flatfiles" / "SpeciesTreeFromBusco"
                              / "collate_gene_prot_gene1.fas")
-        expected_gene2 = str(Path(__file__).parents[2] / 'test_data' / "flatfiles" / "SpeciesTreeFromBusco"
-                             / "collate_gene_prot_gene2.fas")
         expected_gene3 = str(Path(__file__).parents[2] / 'test_data' / "flatfiles" / "SpeciesTreeFromBusco"
                              / "collate_gene_prot_gene3.fas")
-        expected_gene4 = str(Path(__file__).parents[2] / 'test_data' / "flatfiles" / "SpeciesTreeFromBusco"
-                             / "collate_gene_prot_gene4.fas")
 
         # Compare stats and taxa:
         assert file_cmp(output_stats, expected_stats)
@@ -75,9 +71,7 @@ class TestCollateBusco:
 
         # Compare per-gene output:
         assert file_cmp(str(tmp_dir / "gene_prot_gene1.fas"), expected_gene1)
-        assert file_cmp(str(tmp_dir / "gene_prot_gene2.fas"), expected_gene2)
         assert file_cmp(str(tmp_dir / "gene_prot_gene3.fas"), expected_gene3)
-        assert file_cmp(str(tmp_dir / "gene_prot_gene4.fas"), expected_gene4)
 
     def test_collate_for_empty_input(self, tmp_dir: Path) -> None:
         """Tests the `collate_busco_results.py` script when input is empty.


### PR DESCRIPTION
## Description

Certain genomes (e.g. ones with high levels of softmasking) cannot be annotated using GenBlast and ensembl-anno. Hence miniprot was added as a default annotation engine, which also has the benefit of being faster.

**Related JIRA tickets:**
- ENSCOMPARASW-7072

## Overview of changes

#### Change 1
Miniprot was added as default annotation engine.

#### Change 2
The filtering criteria when collating the annotation results are now stricter: multiple stop codons are disallowed and minimum taxa fraction filtering is performed again at the end of the filtering process.

#### Change 2
Some label and resource class definition updates.

## Testing
The pipeline was tested on the vertebrates and plants divisions with the vertebrates and viridiplantae BUSCO sets respecitively. A test run was performed using the eukaryotic BUSCO set as well.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
