### PR TITLE
Add support for genomes without members

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/MemberAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/MemberAdaptor.pm
@@ -376,6 +376,38 @@ sub count_all_by_source_taxon {
     return $self->generic_count('source_name=? AND taxon_id=?');
 }
 
+=head2 count_all_by_GenomeDB
+
+  Arg [1]    : integer $genome_db_id or Bio::EnsEMBL::Compara::GenomeDB object
+  Example    : my $gdb_gene_count = $member_adaptor->count_all_by_GenomeDB($genome_db);
+  Description: Returns the number of members for the given GenomeDB
+  Returntype : int
+  Exceptions : argument undefined or of inappropriate type
+
+=cut
+
+sub count_all_by_GenomeDB {
+  my ($self,$genome_db) = @_;
+
+    if (!$genome_db) {
+        throw("MemberAdaptor::count_all_by_GenomeDB() must have a genome_db");
+    }
+
+    my $genome_db_id;
+    if ( $genome_db and ($genome_db =~ /^\d+$/) ) {
+        $genome_db_id = $genome_db;
+    }
+    else {
+        assert_ref($genome_db, 'Bio::EnsEMBL::Compara::GenomeDB', 'genome_db');
+        $genome_db_id = $genome_db->dbID;
+        if (!$genome_db_id) {
+            throw( "[$genome_db] does not have a dbID" );
+        }
+    }
+
+    $self->bind_param_generic_fetch($genome_db_id, SQL_INTEGER);
+    return $self->generic_count('genome_db_id=?');
+}
 
 =head2 get_source_breakdown_by_member_ids
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
@@ -204,7 +204,7 @@ sub core_pipeline_analyses {
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
             -parameters => {
                 'compara_db'        => '#master_db#',   # that's where genome_db_ids come from
-                'all_current'       => 1,
+                'all_in_current_gene_trees' => 1,
                 'extra_parameters'  => [ 'locator' ],
             },
             -rc_name => '2Gb_job',

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomeDBFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomeDBFactory.pm
@@ -124,6 +124,20 @@ sub fetch_input {
     } elsif ($self->param('all_current')) {
         $genome_dbs = $self->compara_dba->get_GenomeDBAdaptor->fetch_all_current();
 
+    } elsif ($self->param('all_in_current_gene_trees')) {
+        my %id_to_gdb;
+        my $mlss_adaptor = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor();
+        foreach my $method_type ('PROTEIN_TREES', 'NC_TREES') {
+            foreach my $mlss (@{$mlss_adaptor->fetch_all_by_method_link_type($method_type)}) {
+                next unless $mlss->is_current;
+                foreach my $genome_db (@{$mlss->species_set->genome_dbs}) {
+                    next unless $genome_db->is_current;
+                    $id_to_gdb{$genome_db->dbID} = $genome_db;
+                }
+            }
+        }
+        $genome_dbs = [values %id_to_gdb];
+
     } else {
         $genome_dbs = $self->compara_dba->get_GenomeDBAdaptor->fetch_all();
     }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/CheckMembersReusability.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/CheckMembersReusability.pm
@@ -57,6 +57,11 @@ sub run_comparison {
     my $self = shift @_;
 
     if ($self->comes_from_core_database($self->param('genome_db'))) {
+
+        # A core comparison is irrelevant if members have not previously been loaded for the given GenomeDB.
+        my $reuse_member_adaptor = $self->get_cached_compara_dba('reuse_db')->get_GeneMemberAdaptor();
+        return 0 unless( $reuse_member_adaptor->count_all_by_GenomeDB($self->param('genome_db')) > 0 );
+
         return $self->do_one_comparison('exons',
             $self->hash_all_exons_from_dba( $self->param('prev_core_dba') ),
             $self->hash_all_exons_from_dba( $self->param('curr_core_dba') ),


### PR DESCRIPTION
## Description

As currently implemented, Compara gene members are loaded for all GenomeDBs, even if a given GenomeDB is not in any gene-tree dataset. However, in recent Ensembl releases, an increasing number of Compara genomes have been excluded from gene-tree inference.

For example, 13 "Cactus-only" genomes were initially included in `ensembl_compara_111` and 34 further "Cactus-only" genomes were included in `ensembl_compara_112`, with a view to including these in the Mammals and Aves Cactus alignments, respectively. This unused member data took up ~1GB in `ensembl_compara_111`, and ~3GB in `ensembl_compara_112`. The size of this surplus data — and the time spent unnecessarily processing it — is likely to increase further in future.

At the same time, the core-based member reusability check currently assumes that it's unnecessary to load members of a genome for which the current and previous core databases have matching gene sets. However, this assumption would be violated in the case of a GenomeDB which is present in the previous Compara database, but being added to a gene-tree collection for the first time in the current Ensembl release. To enable a GenomeDB to lack members, the member reusability check must be updated in order to allow for such cases.

**Related JIRA tickets:**
- ENSCOMPARASW-7079

## Overview of changes

This PR has two main changes: member loading is only done for genomes which are in at least one gene-tree collection, and member loading is always done for a genome if there are no members for that genome in `reuse_member_db`.

### Loading members only for genomes in a gene-tree collection

- An `all_in_current_gene_trees` option is added to the `GenomeDBFactory` runnable. When used, the set of `$genome_dbs` includes all current GenomeDBs which are in at least one gene-tree collection.
- The `load_genomedb_factory` step of the LoadMembers pipeline uses `all_in_current_gene_trees` mode by default.

### Always loading members for genomes without reusable members

- API method `MemberAdaptor::count_all_by_GenomeDB` is added to enable the caller to count the number of gene members for a given GenomeDB.
- In `CheckMembersReusability`, method `MemberAdaptor::count_all_by_GenomeDB` is used to check whether there is a reusable gene set; if a GenomeDB had no gene members in `reuse_member_db`, then it cannot be reused.

### Adjusting expectations

- In `CompareNonReusedGenomeList`, the set of `expected_updated_gdbs` is filtered to include only those present in the member-loading pipeline (i.e. only GenomeDBs which are in at least one gene-tree collection); and a non-reused GenomeDB is not flagged if the `reuse_member_db` lacks members in that GenomeDB.

## Testing

Two test pipelines were used to test the two main changes in this PR. For more info, see ENSCOMPARASW-7079.


---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
