### PR TITLE
A deprecation notice has been added to dN/dS-related Compara Perl API methods.

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/HomologyAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/HomologyAdaptor.pm
@@ -26,7 +26,7 @@ use Bio::EnsEMBL::Compara::Homology;
 use Bio::EnsEMBL::Compara::DBSQL::BaseRelationAdaptor;
 use Bio::EnsEMBL::Compara::Utils::Scalar qw(:assert);
 
-use Bio::EnsEMBL::Utils::Exception qw(throw);
+use Bio::EnsEMBL::Utils::Exception qw(throw deprecate);
 use Bio::EnsEMBL::Utils::Argument qw(rearrange);
 use Bio::EnsEMBL::Utils::Scalar qw(:assert :check);
 

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/HomologyAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/HomologyAdaptor.pm
@@ -644,9 +644,10 @@ sub store {
 
 =cut
 
-sub update_genetic_distance {
+sub update_genetic_distance { ## DEPRECATED
   my $self = shift;
   my $hom = shift;
+  deprecate("DBSQL::HomologyAdaptor::update_genetic_distance() is deprecated and will be removed in e115.");
 
   assert_ref($hom, 'Bio::EnsEMBL::Compara::Homology', 'hom');
 

--- a/modules/Bio/EnsEMBL/Compara/Homology.pm
+++ b/modules/Bio/EnsEMBL/Compara/Homology.pm
@@ -80,7 +80,7 @@ use warnings;
 
 use JSON;
 
-use Bio::EnsEMBL::Utils::Exception qw(throw warning);
+use Bio::EnsEMBL::Utils::Exception qw(throw warning deprecate);
 
 use base ('Bio::EnsEMBL::Compara::AlignedMemberSet');
 

--- a/modules/Bio/EnsEMBL/Compara/Homology.pm
+++ b/modules/Bio/EnsEMBL/Compara/Homology.pm
@@ -214,8 +214,9 @@ sub is_high_confidence {
 
 =cut
 
-sub n {
+sub n { ## DEPRECATED
   my $self = shift;
+  deprecate("Homology::n() is deprecated and will be removed in e115.");
   $self->{'_n'} = shift if(@_);
   return $self->{'_n'};
 }
@@ -233,8 +234,9 @@ sub n {
 
 =cut
 
-sub s {
+sub s { ## DEPRECATED
   my $self = shift;
+  deprecate("Homology::s() is deprecated and will be removed in e115.");
   $self->{'_s'} = shift if(@_);
   return $self->{'_s'};
 }
@@ -252,8 +254,9 @@ sub s {
 
 =cut
 
-sub lnl {
+sub lnl { ## DEPRECATED
   my $self = shift;
+  deprecate("Homology::lnl() is deprecated and will be removed in e115.");
   $self->{'_lnl'} = shift if(@_);
   return $self->{'_lnl'};
 }
@@ -272,8 +275,9 @@ sub lnl {
 
 =cut
 
-sub threshold_on_ds {
+sub threshold_on_ds { ## DEPRECATED
   my $self = shift;
+  deprecate("Homology::threshold_on_ds() is deprecated and will be removed in e115.");
   return $self->method_link_species_set->_getter_setter_for_tag('threshold_on_ds', @_);
 }
 
@@ -293,8 +297,9 @@ sub threshold_on_ds {
 =cut
 
 
-sub dn {
+sub dn { ## DEPRECATED
   my ($self, $dn, $apply_threshold_on_ds) = @_;
+  deprecate("Homology::dn() is deprecated and will be removed in e115.");
 
   if (defined $dn) {
       $self->{'_dn'} = $dn;
@@ -325,8 +330,9 @@ sub dn {
 =cut
 
 
-sub ds {
+sub ds { ## DEPRECATED
   my ($self, $ds, $apply_threshold_on_ds) = @_;
+  deprecate("Homology::ds() is deprecated and will be removed in e115.");
 
   if (defined $ds) {
       $self->{'_ds'} = $ds;
@@ -363,8 +369,9 @@ sub ds {
 =cut
 
 
-sub dnds_ratio {
+sub dnds_ratio { ## DEPRECATED
   my $self = shift;
+  deprecate("Homology::dnds_ratio() is deprecated and will be removed in e115.");
   my $apply_threshold_on_ds = shift;
   
   $apply_threshold_on_ds = 1 unless (defined $apply_threshold_on_ds);


### PR DESCRIPTION
dN/dS-related statistics are to be removed from Compara code, so a deprecation message had to be added to the following Compara Perl API methods, and any others related to dN/dS stats.

## Description


**Related JIRA tickets:**
- ENSCOMPARASW-7009

## Overview of changes

#### Change 1
A deprecation notice has been added to dN/dS-related Compara Perl API methods, in accordance with the relevant SOP.

## Testing
The changes were tested for correct syntax.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
