### PR TITLE
Exclude non-reference contigs from the number of genomic positions when calculating HAL stats

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HAL/AggregateHalGenomicCoverage.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HAL/AggregateHalGenomicCoverage.pm
@@ -69,6 +69,10 @@ sub run {
         # A dnafrag that is not in the HAL file cannot have alignment coverage,
         # but we still include its length in the total length of the genome.
         if (!exists $hal_sequence_names{$dnafrag_name}) {
+            # Exclude if it is not a reference:
+            if (!$dnafrag->is_reference()){
+                next;
+            }
             $num_positions_in_genome += $dnafrag_length;
             next;
         }


### PR DESCRIPTION
if they are not present in the cactus HAL file.

## Description
When calculating Cactus per-genome coverage stats, calculation of genome length by runnable HAL::AggregateHalGenomicCoverage includes dnafrags which are not in the Cactus alignment file. This is done to ensure an accurate coverage calculation even in cases where dnafrags may have been excluded from a Cactus alignment for any reason.
To ensure accurate Cactus coverage stats, the AggregateHalGenomicCoverage runnable should be updated so that non-reference dnafrags are excluded.

**Related JIRA tickets:**
- ENSCOMPARASW-7075

## Overview of changes

#### Change 1
Excluded the non-reference contigs from the number of genomic positions if they are not present in the cactus HAL file.

## Testing
The changes were tested on a copy of the 112 register HAL pipeline. The number of genomic positions was compared to the expected values for human and zebrafish.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
