### PR TITLE
The create MLSS script to output full JSON with included summary

### DIFF
--- a/scripts/pipeline/create_all_mlss.pl
+++ b/scripts/pipeline/create_all_mlss.pl
@@ -596,16 +596,16 @@ my $current_version = software_version();
 my %methods_not_worth_reporting = map {$_ => 1} qw(SYNTENY ENSEMBL_ORTHOLOGUES ENSEMBL_PARALOGUES ENSEMBL_HOMOEOLOGUES ENSEMBL_PROJECTIONS CACTUS_HAL_PW GERP_CONSTRAINED_ELEMENT GERP_CONSERVATION_SCORE);
 
 sub mlss2hash {
-    my $self = shift;
+    my $mlss = shift;
     my $res = {
-        db_id            => $self->dbID,
-        name             => ($self->name ? $self->name : '(unnamed)'),
-        method_type      => $self->method->type,
-        species_set_name => $self->species_set->name,
-        species_set_id   => $self->species_set->dbID
+        db_id            => $mlss->dbID,
+        name             => ($mlss->name ? $mlss->name : '(unnamed)'),
+        method_type      => $mlss->method->type,
+        species_set_name => $mlss->species_set->name,
+        species_set_id   => $mlss->species_set->dbID
     };
-    if ($self->{'url'}) {
-        $res->{url} = $self->{'url'};
+    if ($mlss->{url}) {
+        $res->{url} = $mlss->{url};
     }
     return $res;
 }


### PR DESCRIPTION
## Description

The MLSS report file should be generated in a human- and machine-readable format such as JSON or YAML, so that it can be loaded and checked in whatever mode of access works for us (e.g. terminal, script or Jupyter notebook).

**Related JIRA tickets:**
- ENSCOMPARASW-7013

## Overview of changes

#### Change 1
create_all_mlss.pl now produces a full JSON output with included summary.

## Testing
The script was run on the 112 vertebrates master database using the dry run flag.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
