### PR TITLE
The intentions output is now in JSON format with included text summary

### DIFF
--- a/scripts/pipeline/populate_new_database.pl
+++ b/scripts/pipeline/populate_new_database.pl
@@ -182,6 +182,7 @@ use Bio::EnsEMBL::Utils::Exception qw(throw warning);
 use Bio::EnsEMBL::Utils::Scalar qw(:assert);
 use Bio::EnsEMBL::Compara::Utils::CopyData qw(:table_copy);
 use Getopt::Long;
+use JSON;
 
 my $help;
 
@@ -276,27 +277,59 @@ my $rerun_tag = 'rerun_in_'.software_version();
 $skipped_mlss_ids{$_->dbID} = 1 for grep {$_->has_tag($rerun_tag)} @$all_default_method_link_species_sets;
 
 if($only_show_intentions) {
-    print "GenomeDB entries to be copied:\n";
+    my $out;
+    $out .= "GenomeDB entries to be copied:\n";
+    my $copied_genome_db = {};
     foreach my $genome_db (@$all_default_genome_dbs) {
-        print "\t".$genome_db->dbID.": ".$genome_db->_get_unique_name."\n";
+        $out .= "\t".$genome_db->dbID.": ".$genome_db->_get_unique_name."\n";
+        $copied_genome_db->{$genome_db->dbID} = $genome_db->_get_unique_name;
     }
-    print "MethodLinkSpeciesSet entries to be copied:\n";
+    $out .= "MethodLinkSpeciesSet entries to be copied:\n";
+    my $copied_mlss = {};
+    my $copied_mlss_entry = {};
     my %counts;
     foreach my $mlss (sort {$a->method->dbID <=> $b->method->dbID} @$all_default_method_link_species_sets) {
         $counts{$mlss->method->type}++;
-        print "\t".$mlss->dbID.": ".$mlss->name;
-        print " (mlss entry only)" if $skipped_mlss_ids{$mlss->dbID};
-        print "\n";
+        $out .= "\t".$mlss->dbID.": ".$mlss->name;
+        $out .= " (mlss entry only)" if $skipped_mlss_ids{$mlss->dbID};
+        $out .= "\n";
+        if ($skipped_mlss_ids{$mlss->dbID}) {
+            $copied_mlss_entry->{$mlss->dbID} = $mlss->name;
+        } else {
+            $copied_mlss->{$mlss->dbID} = $mlss->name;
+        }
+
     }
-    print "Additional SpeciesSet entries to be copied:\n";
+    my $copied_mlss_all = {"copied" => $copied_mlss, "entry_only" => $copied_mlss_entry};
+    $out .= "Additional SpeciesSet entries to be copied:\n";
+    my $additional = {};
     foreach my $ss (@$all_default_species_sets) {
-        print "\t".$ss->dbID.": ".join(', ', map { $_->_get_unique_name} @{$ss->genome_dbs})."\n";
+        $out .= "\t".$ss->dbID.": ".join(', ', map { $_->_get_unique_name} @{$ss->genome_dbs})."\n";
+        $additional->{$ss->dbID} = [ map { $_->_get_unique_name} @{$ss->genome_dbs} ];
     }
-    print "\nSummary:\n";
-    print "\t", scalar(@$all_default_genome_dbs), " GenomeDBs\n";
-    print "\t", scalar(@$all_default_method_link_species_sets), " MethodLinkSpeciesSets\n";
-    printf("\t\t%5d %s\n", $counts{$_}, $_) for sort keys %counts;
-    print "\t", scalar(@$all_default_species_sets), " SpeciesSets\n";
+    $out .= "\nSummary:\n";
+    my $summary = {};
+    $out .= "\t" . scalar(@$all_default_genome_dbs) . " GenomeDBs\n";
+    $summary->{genome_dbs} = scalar(@$all_default_genome_dbs);
+    $out .= "\t" . scalar(@$all_default_method_link_species_sets) . " MethodLinkSpeciesSets\n";
+    $summary->{method_link_species_sets} = {};
+    $out .= sprintf("\t\t%5d %s\n", $counts{$_}, $_) for sort keys %counts;
+    foreach my $key (keys %counts) {
+        $summary->{method_link_species_sets}->{$key} = $counts{$key};
+    }
+    $out .= "\t" . scalar(@$all_default_species_sets) . " SpeciesSets\n";
+    $summary->{species_sets} = scalar(@$all_default_species_sets);
+
+    my $out_json = [ {"text_summary" => $out},
+            {"summary" => $summary, "additional_copied" => $additional,
+             "copied_mlss" => $copied_mlss_all, "copied_genome_db" => $copied_genome_db
+            }
+          ];
+
+    my $json = JSON->new->utf8;
+    my $encoded = $json->pretty->encode( $out_json );
+    print $encoded;
+
     exit 0;
 }
 


### PR DESCRIPTION
## Description
The intentions file created during the population of the new release databases should be generated in a human- and machine-readable format such as JSON or YAML, so that we have the option to load the release intentions using a mode of access (e.g. terminal, script or Jupyter notebook) that makes it feasible to focus on the relevant changes, and also to do checks in an automated or semi-automated way.

**Related JIRA tickets:**
- ENSCOMPARASW-7012

## Overview of changes

#### Change 1
The populate_new_database.pl intentions output is now in JSON format with included text summary.

## Testing
The changes were tested on a freshly created 113 plants release database.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
