### PR TITLE
Integrate the CheckNonMinimisedGATs datacheck in the UpdateMSA pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
@@ -140,7 +140,7 @@ sub pipeline_wide_parameters {
 sub core_pipeline_analyses {
     my $self = shift;
 
-    my %semaphore_check_params = (
+    my %dc_analysis_params = (
         'compara_db' => $self->pipeline_url(),
         'datacheck_names' => [ 'CheckNonMinimisedGATs' ],
         'db_type' => 'compara',
@@ -304,7 +304,7 @@ sub core_pipeline_analyses {
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::UpdateMSA::UpdateGABFactory',
             -flow_into  => {
                 '2->A' => [ 'update_gab' ],
-                'A->1' => [ { 'minimize_gab_check' => \%semaphore_check_params } ]
+                'A->1' => [ { 'minimize_gab_check' => \%dc_analysis_params } ]
             }
         },
         {   -logic_name        => 'minimize_gab_check',


### PR DESCRIPTION
## Description

During e112 production, the UpdateMSA pipeline was run on the Fish EPO.
The CheckNonMinimisedGATs ([ENSCOMPARASW-7110](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-7110)) datacheck subsequently failed on the updated Fish EPO alignment data.
These had failed because changes to EPO genomic-align trees in the 'update_gab' step had not completely cleaned up internal nodes.

The aim of this PR is to ensure that non-minimised GenomicAlignTrees are flagged as soon as possible during production.

**Related JIRA tickets:**
- ENSCOMPARASW-7122

## Overview of changes

#### Change 1

The CheckNonMinimisedGATs datacheck is integrated in the UpdateMSA
    pipeline after the UpdateGAB job.

## Testing
The pipeline was run on the fish EPO on the 112 branch. The datacheck failed as expected.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
