### PR TITLE
Update Slurm resource classes in Compara FTP dump pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
@@ -113,6 +113,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'factory_homology_range_dumps',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+            -rc_name   => '1Gb_168_hour_job',
             -parameters => {
                 'db_conn'               => '#rel_db#',
                 'inputquery'            => 'SELECT MIN(homology_id) AS min_hom_id, MAX(homology_id) AS max_hom_id FROM homology JOIN gene_tree_root ON gene_tree_root_id = root_id WHERE clusterset_id = "#clusterset_id#" AND member_type = "#member_type#"',
@@ -210,6 +211,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'fetch_exp_line_count_per_genome',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+            -rc_name   => '1Gb_168_hour_job',
             -parameters => {
                 'db_conn' => '#rel_db#',
                 'inputquery' => q/SELECT
@@ -242,6 +244,7 @@ sub pipeline_analyses_dump_trees {
 
           { -logic_name => 'dump_per_genome_homologies_tsv',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::DumpHomologiesTSV',
+            -rc_name   => '1Gb_168_hour_job',
             -parameters => {
                 'db_conn'       => '#rel_db#',
                 'output_file'   => '#tsv_dir#/#species_name#/#name_root#.homologies.tsv',


### PR DESCRIPTION
## Description

The resource classes of the Compara FTP dump pipeline have been updated to configure analyses with very long-running jobs.

**Related JIRA tickets:**
- ENSCOMPARASW-7128

## Testing
The changes were tested by initialising a vertebrates dump pipeline on the branch 111.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
