### PR TITLE
Make further FTP dump resource class updates

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
@@ -291,29 +291,36 @@ sub core_pipeline_analyses {
         {	-logic_name => 'DumpMultiAlign_start',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
         	-flow_into  => [ 'DumpMultiAlign_MLSSJobFactory' ],
+            -rc_name    => '1Gb_1_hour_job',
         },
         {	-logic_name => 'DumpTrees_start',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
         	-flow_into => [ 'dump_trees_pipeline_start' ],
+            -rc_name    => '1Gb_1_hour_job',
         },
         {	-logic_name => 'DumpConstrainedElements_start',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
         	-flow_into  => [ 'mkdir_constrained_elems' ],
+            -rc_name    => '1Gb_1_hour_job',
         },
         {	-logic_name => 'DumpConservationScores_start',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
         	-flow_into => [ 'mkdir_conservation_scores' ],
+            -rc_name    => '1Gb_1_hour_job',
         },
         {	-logic_name => 'DumpSpeciesTrees_start',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
         	-flow_into  => ['mk_species_trees_dump_dir' ],
+            -rc_name    => '1Gb_1_hour_job',
         },
         {	-logic_name => 'DumpAncestralAlleles_start',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
         	-flow_into  => [ 'mk_ancestral_dump_dir' ],
+            -rc_name    => '1Gb_1_hour_job',
         },
         {	-logic_name => 'DumpMultiAlignPatches_start',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -rc_name    => '1Gb_1_hour_job',
         	-flow_into  => {
         		'1->A' => [ 'DumpMultiAlign_MLSSJobFactory' ],
                         'A->1' => [ 'patch_lastz_dump' ],
@@ -325,16 +332,19 @@ sub core_pipeline_analyses {
 
         {	-logic_name => 'create_ftp_skeleton',
         	-module     => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::FTPSkeleton',
+            -rc_name    => '1Gb_1_hour_job',
         	-flow_into => [ 'symlink_prev_dumps' ],
         },
 
         {	-logic_name => 'symlink_prev_dumps',
         	-module     => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::SymlinkPreviousDumps',
+            -rc_name    => '1Gb_1_hour_job',
                 -flow_into => { 2 => 'create_all_dump_jobs' }, # to top up any missing dumps
         },
 
         {   -logic_name => 'patch_lastz_dump',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::PatchLastzDump',
+            -rc_name    => '1Gb_1_hour_job',
             -parameters => {
             	'lastz_dump_path' => $self->o('lastz_dump_path'),
             },
@@ -342,6 +352,7 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'add_hmm_lib',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::AddHMMLib',
+            -rc_name    => '1Gb_1_hour_job',
             -parameters => {
                 'ref_tar_path_templ' => '#warehouse_dir#/hmms/treefam/multi_division_hmm_lib.%s.tar.gz',
                 'tar_ftp_path'       => '#dump_dir#/compara/multi_division_hmm_lib.tar.gz',
@@ -350,6 +361,7 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'clean_files_decision',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -rc_name    => '1Gb_1_hour_job',
             -flow_into  => {
                 1 => WHEN('#clean_intermediate_files#' => [ 'clean_dump_hash' ])
             },
@@ -357,6 +369,7 @@ sub core_pipeline_analyses {
 
         {   -logic_name     => 'clean_dump_hash',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -rc_name        => '1Gb_job',
             -parameters     => {
                 'cmd' => 'rm -rf #work_dir#',
             },
@@ -385,6 +398,7 @@ sub core_pipeline_analyses {
 
         {   -logic_name     => 'remove_uniprot_file',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -rc_name        => '1Gb_1_hour_job',
             -parameters     => {
                 'clusterset_id' => 'default',
                 'cmd'           => 'rm #dump_root#/#division#.#uniprot_file#.gz',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpAncestralAlleles.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpAncestralAlleles.pm
@@ -42,6 +42,7 @@ sub pipeline_analyses_dump_anc_alleles {
 
     	{	-logic_name => 'mk_ancestral_dump_dir',
     		-module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -rc_name    => '1Gb_1_hour_job',
     		-parameters => {
                     cmd => 'mkdir -p #anc_output_dir# #anc_tmp_dir#'
     		},
@@ -51,6 +52,7 @@ sub pipeline_analyses_dump_anc_alleles {
 
         {   -logic_name     => 'fetch_genome_dbs',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::DumpAncestralAlleles::GenomeDBFactory',
+            -rc_name        => '1Gb_1_hour_job',
             -parameters     => {
                 compara_db => $self->o('compara_db'),
                 reg_conf   => $self->o('reg_conf'),
@@ -84,6 +86,7 @@ sub pipeline_analyses_dump_anc_alleles {
 
         {   -logic_name => 'remove_empty_files',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -rc_name    => '1Gb_1_hour_job',
             -parameters => {
                 species_outdir  => '#anc_tmp_dir#/#species_dir#',
                 cmd             => 'find #species_outdir# -empty -type f -delete',
@@ -93,6 +96,7 @@ sub pipeline_analyses_dump_anc_alleles {
 
         {   -logic_name => 'generate_anc_stats',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -rc_name    => '1Gb_1_hour_job',
             -parameters => {
                 species_outdir  => '#anc_tmp_dir#/#species_dir#',
                 cmd             => 'cd #species_outdir#; perl #ancestral_stats_program# > summary.txt',
@@ -102,6 +106,7 @@ sub pipeline_analyses_dump_anc_alleles {
 
         {	-logic_name => 'tar',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -rc_name    => '1Gb_1_hour_job',
         	-parameters => {
         		cmd => join( '; ',
                                     'cd #anc_tmp_dir#',
@@ -112,6 +117,7 @@ sub pipeline_analyses_dump_anc_alleles {
 
         {	-logic_name => 'md5sum',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -rc_name    => '1Gb_1_hour_job',
         	-parameters => {
         		cmd => join( '; ',
         			'cd #anc_output_dir#',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConservationScores.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConservationScores.pm
@@ -42,11 +42,13 @@ sub pipeline_analyses_dump_conservation_scores {
 
         {   -logic_name     => 'mkdir_conservation_scores',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::DumpMultiAlign::MkDirConservationScores',
+            -rc_name        => '1Gb_1_hour_job',
             -flow_into      => [ 'genomedb_factory_cs' ],
         },
 
         {   -logic_name     => 'genomedb_factory_cs',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
+            -rc_name        => '1Gb_1_hour_job',
             -parameters     => {
                 'extra_parameters'      => [ 'name', 'assembly' ],
             },
@@ -79,6 +81,7 @@ sub pipeline_analyses_dump_conservation_scores {
 
         {   -logic_name     => 'concatenate_bedgraph_files',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::ConcatenateBedGraphFiles',
+            -rc_name        => '1Gb_job',
             -flow_into      => 'convert_to_bigwig',
         },
 
@@ -92,6 +95,7 @@ sub pipeline_analyses_dump_conservation_scores {
 
         {   -logic_name     => 'md5sum_cs',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -rc_name        => '1Gb_job',
             -parameters     => {
                 'cmd'   => 'cd #cs_output_dir#; md5sum *.bw > MD5SUM',
             },
@@ -100,6 +104,7 @@ sub pipeline_analyses_dump_conservation_scores {
 
         {   -logic_name     => 'readme_cs',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -rc_name        => '1Gb_1_hour_job',
             -parameters     => {
                 'cmd'   => [qw(cp -af #cs_readme# #cs_output_dir#/README)],
             },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConstrainedElements.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConstrainedElements.pm
@@ -42,11 +42,13 @@ sub pipeline_analyses_dump_constrained_elems {
 
         {   -logic_name     => 'mkdir_constrained_elems',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::DumpMultiAlign::MkDirConstrainedElements',
+            -rc_name        => '1Gb_1_hour_job',
             -flow_into      => [ 'genomedb_factory_ce' ],
         },
 
         {   -logic_name     => 'genomedb_factory_ce',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
+            -rc_name        => '1Gb_1_hour_job',
             -parameters     => {
                 'extra_parameters'      => [ 'name' ],
             },
@@ -68,6 +70,7 @@ sub pipeline_analyses_dump_constrained_elems {
 
         {   -logic_name     => 'check_not_empty',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::CheckNotEmpty',
+            -rc_name        => '1Gb_1_hour_job',
             -parameters     => {
                 'min_number_of_lines'   => 1,   # The header is always present
                 'filename'              => '#bed_file#',
@@ -77,6 +80,7 @@ sub pipeline_analyses_dump_constrained_elems {
 
         {   -logic_name     => 'convert_to_bigbed',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::ConvertToBigBed',
+            -rc_name        => '1Gb_1_hour_job',
             -parameters     => {
                 'big_bed_exe'   => $self->o('big_bed_exe'),
                 'autosql_file'  => $self->o('bigbed_autosql'),
@@ -86,6 +90,7 @@ sub pipeline_analyses_dump_constrained_elems {
 
         {   -logic_name     => 'md5sum_ce',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -rc_name        => '1Gb_1_hour_job',
             -parameters     => {
                 'cmd'   => 'cd #ce_output_dir#; md5sum *.bb > MD5SUM',
             },
@@ -94,6 +99,7 @@ sub pipeline_analyses_dump_constrained_elems {
 
         {   -logic_name     => 'readme_ce',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -rc_name        => '1Gb_1_hour_job',
             -parameters     => {
                 'cmd'   => [qw(cp -af #ce_readme# #ce_output_dir#/README)],
             },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpSpeciesTrees.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpSpeciesTrees.pm
@@ -42,6 +42,7 @@ sub pipeline_analyses_dump_species_trees {
     return [
         {   -logic_name => 'mk_species_trees_dump_dir',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -rc_name    => '1Gb_1_hour_job',
             -parameters => {
                 'cmd'           => ['mkdir', '-p', '#dump_dir#'],
             },
@@ -51,6 +52,7 @@ sub pipeline_analyses_dump_species_trees {
 
         {   -logic_name => 'dump_factory',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+            -rc_name    => '1Gb_1_hour_job',
             -parameters => {
                 'db_conn'       => '#compara_db#',
                 'inputquery'    => 'SELECT root_id, label, method_link_id, replace(name, " ", "_") as name FROM species_tree_root JOIN method_link_species_set USING (method_link_species_set_id)',
@@ -64,6 +66,7 @@ sub pipeline_analyses_dump_species_trees {
 
         {   -logic_name => 'dump_one_tree_with_distances',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -rc_name    => '1Gb_1_hour_job',
             -parameters => {
                 'cmd'           => '#dump_species_tree_exe# -compara_db #compara_db# -reg_conf #reg_conf# --stn_root_id #root_id# -with_distances > "#dump_dir#/#name#_#label#.nh"',
             },
@@ -72,6 +75,7 @@ sub pipeline_analyses_dump_species_trees {
 
         {   -logic_name => 'dump_one_tree_without_distances',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -rc_name    => '1Gb_1_hour_job',
             -parameters => {
                 'cmd'           => '#dump_species_tree_exe# -compara_db #compara_db# -reg_conf #reg_conf# --stn_root_id #root_id# > "#dump_dir#/#name#_#label#.nh"',
             },
@@ -80,6 +84,7 @@ sub pipeline_analyses_dump_species_trees {
 
         {   -logic_name => 'sanitize_file',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -rc_name    => '1Gb_1_hour_job',
             -parameters => {
                 'cmd'           => ['sed', '-i', 's/  */_/g', '#dump_dir#/#name#_#label#.nh'],
             },


### PR DESCRIPTION
## Description

The default Hive Slurm walltime limit on `release/112` branch of `ensembl-compara` is 24 hours. This is expected to be changed to 1 hour in `release/113`.

In the meantime, this PR makes the 1-hour walltime limit the effective default for the Compara FTP dump pipeline, in line with expected production needs.

**Related JIRA tickets:**
- ENSCOMPARASW-7132

## Overview of changes

The resource classes of all Compara FTP dump pipeline analyses have been updated as needed to make the effective default walltime limit 1 hour (as opposed to the 24-hour default walltime currently used more generally).

Some resource classes have additionally been updated in light of historical pipeline data.

## Testing

A test pipeline was initialised to confirm that the resource classes were set correctly. See the related ticket for details.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
