### PR TITLE
updated production_reg_conf.pl tp enable a env var to override defaul…

### DIFF
--- a/conf/homology_annotation/production_reg_conf.pl
+++ b/conf/homology_annotation/production_reg_conf.pl
@@ -33,12 +33,16 @@ my $curr_release = $ENV{'CURR_ENSEMBL_RELEASE'};
 
 Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-6:4695/$curr_release");
 
+
+
 #------------------------COMPARA DATABASE LOCATIONS----------------------------------
 
+#------------------------COMPARA DATABASE LOCATIONS----------------------------------
+my $homology_reference_host = $ENV{'homology_reference_host'} || 'mysql-ens-sta-6';
 # FORMAT: alias name => [ host, db_name ]
 my $compara_dbs = {
     # necessary compara dbs
-    'compara_references' => [ 'mysql-ens-sta-6', 'ensembl_compara_references_mvp' ],
+    'compara_references' => [ $homology_reference_host, 'ensembl_compara_references_mvp' ],
 
 };
 


### PR DESCRIPTION
…t compara reference host configuration.

## Description

The host for the reference DB is hard coded in the registry. Enable this ENV var to override it if necessary.

 
**Related JIRA tickets:**
[ENSMVP-271]

## Overview of changes
Updated configuration with ENV param enabled. Default to initial value. 

## Testing
Rerun for all Rapid species against new MVP reference set.

## Notes

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
