### PR TITLE
Configure alternating staging hosts dynamically

### DIFF
--- a/conf/fungi/production_reg_conf.pl
+++ b/conf/fungi/production_reg_conf.pl
@@ -36,6 +36,13 @@ my $prev_release = $curr_release - 1;
 my $curr_eg_release = $ENV{'CURR_EG_RELEASE'};
 my $prev_eg_release = $curr_eg_release - 1;
 
+# ---------------------- DATABASE HOSTS -----------------------------------------
+
+my $curr_nv_host = $curr_release % 2 == 0 ? 'mysql-ens-sta-3' : 'mysql-ens-sta-3-b';
+
+my ($prev_nv_host, $prev_nv_port) = $prev_release % 2 == 0
+    ? ('mysql-ens-sta-3', 4160)
+    : ('mysql-ens-sta-3-b', 4686);
 
 # ---------------------- CURRENT CORE DATABASES----------------------------------
 
@@ -62,7 +69,6 @@ Bio::EnsEMBL::Compara::Utils::Registry::remove_multi();
 my @overlap_species = qw(saccharomyces_cerevisiae);
 Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species);
 my $overlap_cores = {
-    #'saccharomyces_cerevisiae' => [ 'mysql-ens-sta-1-b', "saccharomyces_cerevisiae_core_${curr_eg_release}_${curr_release}_4" ],
     'saccharomyces_cerevisiae' => [ 'mysql-ens-vertannot-staging', "saccharomyces_cerevisiae_core_${curr_eg_release}_${curr_release}_4" ],
 };
 Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $overlap_cores );
@@ -83,8 +89,8 @@ foreach my $group ( @collection_groups ) {
 # previous release core databases will be required by PrepareMasterDatabaseForRelease and LoadMembers only
 *Bio::EnsEMBL::Compara::Utils::Registry::load_previous_core_databases = sub {
     Bio::EnsEMBL::Registry->load_registry_from_db(
-        -host           => 'mysql-ens-sta-3-b',
-        -port           => 4686,
+        -host           => $prev_nv_host,
+        -port           => $prev_nv_port,
         -user           => 'ensro',
         -pass           => '',
         -db_version     => $prev_release,
@@ -95,8 +101,8 @@ foreach my $group ( @collection_groups ) {
     # Fungi collection databases
     foreach my $group ( @collection_groups ) {
         Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
-            -host           => 'mysql-ens-sta-3-b',
-            -port           => 4686,
+            -host           => $prev_nv_host,
+            -port           => $prev_nv_port,
             -user           => 'ensro',
             -pass           => '',
             -dbname         => "fungi_${group}_collection_core_${prev_eg_release}_${prev_release}_1",
@@ -133,7 +139,7 @@ Bio::EnsEMBL::Compara::Utils::Registry::add_compara_dbas( $compara_dbs );
 
 # NCBI taxonomy database (also maintained by production team):
 Bio::EnsEMBL::Compara::Utils::Registry::add_taxonomy_dbas({
-    'ncbi_taxonomy' => [ 'mysql-ens-sta-3', "ncbi_taxonomy_${curr_release}" ],
+    'ncbi_taxonomy' => [ $curr_nv_host, "ncbi_taxonomy_${curr_release}" ],
 });
 
 # -------------------------------------------------------------------

--- a/conf/metazoa/production_reg_conf.pl
+++ b/conf/metazoa/production_reg_conf.pl
@@ -36,13 +36,18 @@ my $prev_release = $curr_release - 1;
 my $curr_eg_release = $curr_release - 53;
 my $prev_eg_release = $curr_eg_release - 1;
 
+# ---------------------- DATABASE HOSTS -----------------------------------------
+
+my $curr_nv_host = $curr_release % 2 == 0 ? 'mysql-ens-sta-3' : 'mysql-ens-sta-3-b';
+
+my ($prev_nv_host, $prev_nv_port) = $prev_release % 2 == 0
+    ? ('mysql-ens-sta-3', 4160)
+    : ('mysql-ens-sta-3-b', 4686);
+
 # ---------------------- CURRENT CORE DATABASES----------------------------------
 
 # Use our mirror (which has all the databases)
 Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertannot-staging:4573/$curr_release");
-
-# Or use the official staging servers
-#Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-sta-3:4160/$curr_release");
 
 # Ensure we are using the correct cores for species that overlap with vertebrates
 my @overlap_species = qw(caenorhabditis_elegans drosophila_melanogaster);
@@ -58,8 +63,8 @@ Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $overlap_cores );
 # previous release core databases will be required by PrepareMasterDatabaseForRelease and LoadMembers only
 *Bio::EnsEMBL::Compara::Utils::Registry::load_previous_core_databases = sub {
     Bio::EnsEMBL::Registry->load_registry_from_db(
-        -host   => 'mysql-ens-sta-3',
-        -port   => 4160,
+        -host   => $prev_nv_host,
+        -port   => $prev_nv_port,
         -user   => 'ensro',
         -pass   => '',
         -db_version     => $prev_release,
@@ -95,7 +100,7 @@ Bio::EnsEMBL::Compara::Utils::Registry::add_compara_dbas( $compara_dbs );
 # ----------------------NON-COMPARA DATABASES------------------------
 # NCBI taxonomy database (maintained by production team):
 Bio::EnsEMBL::Compara::Utils::Registry::add_taxonomy_dbas({
-    'ncbi_taxonomy' => [ 'mysql-ens-sta-3-b', "ncbi_taxonomy_$curr_release" ],
+    'ncbi_taxonomy' => [ $curr_nv_host, "ncbi_taxonomy_$curr_release" ],
 });
 
 # -------------------------------------------------------------------

--- a/conf/pan/production_reg_conf.pl
+++ b/conf/pan/production_reg_conf.pl
@@ -38,6 +38,16 @@ my $prev_eg_release = $curr_eg_release - 1;
 # Species found on both vertebrates and non-vertebrates servers
 my @overlap_species = qw(saccharomyces_cerevisiae drosophila_melanogaster caenorhabditis_elegans);
 
+# ---------------------- DATABASE HOSTS -----------------------------------------
+
+my ($prev_vert_host, $prev_vert_port) = $prev_release % 2 == 0
+    ? ('mysql-ens-sta-1', 4519)
+    : ('mysql-ens-sta-1-b', 4685);
+
+my ($prev_nv_host, $prev_nv_port) = $prev_release % 2 == 0
+    ? ('mysql-ens-sta-3', 4160)
+    : ('mysql-ens-sta-3-b', 4686);
+
 # ---------------------- CURRENT CORE DATABASES----------------------------------
 
 Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertannot-staging:4573/$curr_release");
@@ -65,8 +75,8 @@ Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
 # previous release core databases will be required by PrepareMasterDatabaseForRelease and LoadMembers only
 *Bio::EnsEMBL::Compara::Utils::Registry::load_previous_core_databases = sub {
     Bio::EnsEMBL::Registry->load_registry_from_db(
-        -host   => 'mysql-ens-sta-1-b',
-        -port   => 4685,
+        -host   => $prev_vert_host,
+        -port   => $prev_vert_port,
         -user   => 'ensro',
         -pass   => '',
         -db_version     => $prev_release,
@@ -75,8 +85,8 @@ Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
     Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species, Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX);
     Bio::EnsEMBL::Compara::Utils::Registry::remove_multi(undef, Bio::EnsEMBL::Compara::Utils::Registry::PREVIOUS_DATABASE_SUFFIX);
     Bio::EnsEMBL::Registry->load_registry_from_db(
-        -host   => 'mysql-ens-sta-3-b',
-        -port   => 4686,
+        -host   => $prev_nv_host,
+        -port   => $prev_nv_port,
         -user   => 'ensro',
         -pass   => '',
         -db_version     => $prev_release,
@@ -84,8 +94,8 @@ Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
     );
     # Bacteria server: all species used in Pan happen to be in this database
     Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
-        -host   => 'mysql-ens-sta-4',
-        -port   => 4494,
+        -host   => 'mysql-ens-mirror-4',
+        -port   => 4495,
         -user   => 'ensro',
         -pass   => '',
         -dbname => "bacteria_0_collection_core_${prev_eg_release}_${prev_release}_1",

--- a/conf/protists/production_reg_conf.pl
+++ b/conf/protists/production_reg_conf.pl
@@ -35,6 +35,13 @@ my $prev_release = $curr_release - 1;
 my $curr_eg_release = $ENV{'CURR_EG_RELEASE'};
 my $prev_eg_release = $curr_eg_release - 1;
 
+# ---------------------- DATABASE HOSTS -----------------------------------------
+
+my $curr_nv_host = $curr_release % 2 == 0 ? 'mysql-ens-sta-3' : 'mysql-ens-sta-3-b';
+
+my ($prev_nv_host, $prev_nv_port) = $prev_release % 2 == 0
+    ? ('mysql-ens-sta-3', 4160)
+    : ('mysql-ens-sta-3-b', 4686);
 
 # ---------------------- CURRENT CORE DATABASES----------------------------------
 
@@ -72,8 +79,8 @@ foreach my $group ( @collection_groups ) {
 # previous release core databases will be required by PrepareMasterDatabaseForRelease and LoadMembers only
 *Bio::EnsEMBL::Compara::Utils::Registry::load_previous_core_databases = sub {
     Bio::EnsEMBL::Registry->load_registry_from_db(
-        -host   => 'mysql-ens-sta-3',
-        -port   => 4160,
+        -host   => $prev_nv_host,
+        -port   => $prev_nv_port,
         -user   => 'ensro',
         -pass   => '',
         -db_version     => $prev_release,
@@ -82,8 +89,8 @@ foreach my $group ( @collection_groups ) {
     # Protist Collections
     foreach my $group ( @collection_groups ) {
         Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
-            -host   => 'mysql-ens-sta-3',
-            -port   => 4160,
+            -host   => $prev_nv_host,
+            -port   => $prev_nv_port,
             -user   => 'ensro',
             -pass   => '',
             -dbname => "protists_${group}_collection_core_${prev_eg_release}_${prev_release}_1",
@@ -119,7 +126,7 @@ Bio::EnsEMBL::Compara::Utils::Registry::add_compara_dbas( $compara_dbs );
 
 # NCBI taxonomy database (also maintained by production team):
 Bio::EnsEMBL::Compara::Utils::Registry::add_taxonomy_dbas({
-    'ncbi_taxonomy' => [ 'mysql-ens-sta-3-b', "ncbi_taxonomy_${curr_release}" ],
+    'ncbi_taxonomy' => [ $curr_nv_host, "ncbi_taxonomy_${curr_release}" ],
 });
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
## Description

Staging hosts currently alternate in every Ensembl release, with for example, `mysql-ens-sta-1` being used for Vertebrates in even-numbered releases and `mysql-ens-sta-1-b` being used in odd-numbered releases.

This PR updates Compara production registry files to configure those alternating staging hosts dynamically.

**Related JIRA tickets:**

- ENSCOMPARASW-7067

## Overview of changes

- Staging hosts are configured dynamically based on the `$curr_release` and `$prev_release` variables.
- Some commented-out configuration has been removed.

## Testing

The `production_reg_conf.pl` script of each division was executed from the command line.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
