### PR TITLE
Recalibrate Hive capacity of Compara FTP dump analyses

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
@@ -86,11 +86,10 @@ sub default_options {
         # the following options should remain largely unchanged #
         # ----------------------------------------------------- #
         # capacities for heavy-hitting jobs
-        'dump_aln_capacity'   => 400,
+        'dump_aln_capacity'   => 150,
 		'dump_trees_capacity' => 10,
 		'dump_ce_capacity'    => 10,
     	'dump_cs_capacity'    => 20,
-        'dump_hom_capacity'   => 10,
         'dump_per_genome_cap' => 10,
 
 
@@ -198,7 +197,6 @@ sub pipeline_wide_parameters {
 
         # tree params
         'dump_trees_capacity' => $self->o('dump_trees_capacity'),
-        'dump_hom_capacity'   => $self->o('dump_hom_capacity'),
         'dump_per_genome_cap' => $self->o('dump_per_genome_cap'),
         'basename'            => '#member_type#_#clusterset_id#',
         'name_root'           => 'Compara.#curr_release#.#basename#',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
@@ -324,7 +324,7 @@ sub pipeline_analyses_dump_trees {
                 'cmd'           => '[[ ! -e #filename# ]] || #xmllint_exe# --noout --schema /homes/compara_ensembl/warehouse/xml_schema/#schema#.xsd #filename#',
             },
             -batch_size    => $self->o('batch_size'),
-            # -hive_capacity => $self->o('dump_aln_capacity'),
+            -analysis_capacity => $self->o('dump_trees_capacity'),
             -rc_name       => '2Gb_job',
         },
 


### PR DESCRIPTION
## Description

There have been some capacity issues in recent runs of the Compara FTP dump pipeline.

This PR recalibrates the capacity of some analyses, with a view to addressing those capacity issues.

**Related JIRA tickets:**
- ENSCOMPARASW-7127

## Testing
The updated Hive capacity settings were tested as part of a trial run of the `DumpAllForRelease` pipeline. For more info, see the related Jira ticket.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
