### PR TITLE
Add funnel checks to FTP dump pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpAncestralAlleles.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpAncestralAlleles.pm
@@ -34,7 +34,7 @@ use strict;
 use warnings;
 
 use Bio::EnsEMBL::Hive::Version 2.4;
-use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;           # Allow this particular config to use conditional dataflow
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;  # Allow this particular config to use conditional dataflow and INPUT_PLUS
 
 sub pipeline_analyses_dump_anc_alleles {
     my ($self) = @_;
@@ -59,8 +59,14 @@ sub pipeline_analyses_dump_anc_alleles {
             },
             -flow_into => {
             	'2->A' => [ 'get_ancestral_sequence' ],
-            	'A->1' => [ 'md5sum' ],
+                'A->1' => [ 'anc_funnel_check' ],
             }
+        },
+
+        {   -logic_name => 'anc_funnel_check',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
+            -rc_name    => '1Gb_1_hour_job',
+            -flow_into  => [ { 'md5sum' => INPUT_PLUS() } ],
         },
 
         {   -logic_name => 'get_ancestral_sequence',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConservationScores.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConservationScores.pm
@@ -54,8 +54,14 @@ sub pipeline_analyses_dump_conservation_scores {
             },
             -flow_into      => {
                 '2->A' => { 'region_factory' => INPUT_PLUS() },
-                'A->1' => [ 'md5sum_cs' ],
+                'A->1' => [ 'md5sum_cs_funnel_check' ],
             },
+        },
+
+        {   -logic_name => 'md5sum_cs_funnel_check',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
+            -rc_name    => '1Gb_1_hour_job',
+            -flow_into  => [ { 'md5sum_cs' => INPUT_PLUS() } ],
         },
 
         {   -logic_name     => 'region_factory',
@@ -66,8 +72,14 @@ sub pipeline_analyses_dump_conservation_scores {
             -rc_name           => '2Gb_job',
             -flow_into      => {
                 '2->A' => { 'dump_conservation_scores' => INPUT_PLUS() },
-                'A->1' => [ 'concatenate_bedgraph_files' ],
+                'A->1' => [ 'cs_funnel_check' ],
             },
+        },
+
+        {   -logic_name => 'cs_funnel_check',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
+            -rc_name    => '1Gb_1_hour_job',
+            -flow_into  => [ { 'concatenate_bedgraph_files' => INPUT_PLUS() } ],
         },
 
         {   -logic_name        => 'dump_conservation_scores',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConstrainedElements.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConstrainedElements.pm
@@ -35,6 +35,7 @@ use warnings;
 no warnings 'qw';
 
 use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;  # For INPUT_PLUS
 
 sub pipeline_analyses_dump_constrained_elems {
     my ($self) = @_;
@@ -54,8 +55,14 @@ sub pipeline_analyses_dump_constrained_elems {
             },
             -flow_into      => {
                 '2->A' => [ 'dump_constrained_elements' ],
-                'A->1' => [ 'md5sum_ce' ],
+                'A->1' => [ 'ce_funnel_check' ],
             },
+        },
+
+        {   -logic_name => 'ce_funnel_check',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
+            -rc_name    => '1Gb_1_hour_job',
+            -flow_into  => [ { 'md5sum_ce' => INPUT_PLUS() } ],
         },
 
         {   -logic_name     => 'dump_constrained_elements',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpMultiAlign.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpMultiAlign.pm
@@ -33,7 +33,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpMultiAlign;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;           # Allow this particular config to use conditional dataflow
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;  # Allow this particular config to use conditional dataflow and INPUT_PLUS
 
 sub pipeline_analyses_dump_multi_align {
     my ($self) = @_;
@@ -48,8 +48,14 @@ sub pipeline_analyses_dump_multi_align {
             -rc_name        => '1Gb_1_hour_job',
             -flow_into      => {
                 '2->A' => [ 'count_blocks' ],
-                'A->2' => [ 'md5sum_aln_factory' ],
+                'A->2' => [ 'aln_funnel_check' ],
             },
+        },
+
+        {   -logic_name => 'aln_funnel_check',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
+            -rc_name    => '1Gb_1_hour_job',
+            -flow_into  => [ { 'md5sum_aln_factory' => INPUT_PLUS() } ],
         },
 
         {  -logic_name  => 'count_blocks',


### PR DESCRIPTION
## Description

Semaphore issues have been encountered in recent runs of the `DumpAllForRelease` pipeline.

This PR addresses those issues by integrating the `FunnelCheck` runnable (see PR #711) into the `DumpAllForRelease` pipeline, so that if a semaphore is released prematurely, the funnel job will fail.

**Related JIRA tickets:**

- ENSCOMPARASW-7063

## Overview of changes

Every funnel analysis in the `DumpAllForRelease` pipeline is replaced with a `FunnelCheck` step. The funnel-checks all dataflow to the original funnel analysis; almost all of these dataflow with `INPUT_PLUS`, to make the intent clear that the input parameters of the `FunnelCheck` should be passed to the next step of the pipeline.

## Testing

Integration of the new runnable was tested as part of a trial run of the `DumpAllForRelease` pipeline. For more info, see the related Jira ticket.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
