### PR TITLE
Fix homology XML validation in FTP dump pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -136,6 +136,7 @@ sub executable_locations {
         'copy_ancestral_core_exe'           => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/copy_ancestral_core.pl'),
         'gene_tree_stats_report_exe'        => $self->check_exe_in_ensembl('ensembl-compara/scripts/production/gene_tree_stats.pl'),
         'hal_cov_one_seq_chunk_exe'         => $self->check_exe_in_ensembl('ensembl-compara/scripts/hal_alignment/hal_cov_one_seq_chunk.py'),
+        'xmlschema_validate_exe'            => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/xmlschema_validate.py'),
 
         # Other dependencies (non executables)
         'core_schema_sql'                   => $self->check_file_in_ensembl('ensembl/sql/table.sql'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
@@ -294,17 +294,11 @@ sub pipeline_analyses_dump_trees {
             -parameters    => {
                 'dump_script'       => $self->o('dump_gene_tree_exe'),
                 'tree_args'         => '-nh 1 -a 1 -nhx 1 -f 1 -fc 1 -oxml 1 -pxml 1 -cafe 1',
-                'base_filename'     => '#hash_dir#/#hashed_id#/#tree_id#',
-                'cmd'               => '#dump_script# --reg_conf #reg_conf# --reg_alias #rel_db# --dirpath #hash_dir#/#hashed_id# --tree_id #tree_id# #tree_args#',
+                'dataflow_file'     => '#hash_dir#/#hashed_id#/tree.#tree_id#.dataflow.json',
+                'cmd'               => '#dump_script# --reg_conf #reg_conf# --reg_alias #rel_db# --dirpath #hash_dir#/#hashed_id# --tree_id #tree_id# --dataflow_file #dataflow_file# #tree_args#',
             },
             -flow_into     => {
-                1 => {
-                    'validate_xml' => [
-                        { 'schema' => 'orthoxml', 'filename' => '#base_filename#.orthoxml.xml' },
-                        { 'schema' => 'phyloxml', 'filename' => '#base_filename#.phyloxml.xml' },
-                        { 'schema' => 'phyloxml', 'filename' => '#base_filename#.cafe_phyloxml.xml' },
-                    ],
-                },
+                1  => [ 'validate_xml' ],
                 -1 => [ 'dump_a_tree_himem' ],
             },
             -hive_capacity => $self->o('dump_trees_capacity'),       # allow several workers to perform identical tasks in parallel
@@ -317,17 +311,11 @@ sub pipeline_analyses_dump_trees {
             -parameters    => {
                 'dump_script'       => $self->o('dump_gene_tree_exe'),
                 'tree_args'         => '-nh 1 -a 1 -nhx 1 -f 1 -fc 1 -oxml 1 -pxml 1 -cafe 1',
-                'base_filename'     => '#hash_dir#/#hashed_id#/#tree_id#',
-                'cmd'               => '#dump_script# --reg_conf #reg_conf# --reg_alias #rel_db# --dirpath #hash_dir#/#hashed_id# --tree_id #tree_id# #tree_args#',
+                'dataflow_file'     => '#hash_dir#/#hashed_id#/tree.#tree_id#.dataflow.json',
+                'cmd'               => '#dump_script# --reg_conf #reg_conf# --reg_alias #rel_db# --dirpath #hash_dir#/#hashed_id# --tree_id #tree_id# --dataflow_file #dataflow_file# #tree_args#',
             },
             -flow_into     => {
-                1 => {
-                    'validate_xml' => [
-                        { 'schema' => 'orthoxml', 'filename' => '#base_filename#.orthoxml.xml' },
-                        { 'schema' => 'phyloxml', 'filename' => '#base_filename#.phyloxml.xml' },
-                        { 'schema' => 'phyloxml', 'filename' => '#base_filename#.cafe_phyloxml.xml' },
-                    ],
-                },
+                1  => [ 'validate_xml' ],
             },
             -hive_capacity => $self->o('dump_trees_capacity'),       # allow several workers to perform identical tasks in parallel
             -rc_name       => '16Gb_1_hour_job',
@@ -336,8 +324,9 @@ sub pipeline_analyses_dump_trees {
         {   -logic_name    => 'validate_xml',
             -module        => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
             -parameters    => {
-                'xmllint_exe'   => $self->o('xmllint_exe'),
-                'cmd'           => '[[ ! -e #filename# ]] || #xmllint_exe# --noout --schema /homes/compara_ensembl/warehouse/xml_schema/#schema#.xsd #filename#',
+                'xmllint_exe'   => $self->o('xmlschema_validate_exe'),
+                'cmd'           => '#xmllint_exe# --noout --schema #schema_file# #filename#',
+                'schema_file'   => $self->o('shared_hps_dir') . '/xml_schema/#schema#.xsd',
             },
             -batch_size    => $self->o('batch_size'),
             -analysis_capacity => $self->o('dump_trees_capacity'),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "pandas>=0.24.2",
     "pybedtools==0.8.2",
     "sqlalchemy>=1.4.0",
+    "xmlschema>=2.5.1",
 ]
 
 [project.optional-dependencies]

--- a/scripts/dumps/dumpTreeMSA_id.pl
+++ b/scripts/dumps/dumpTreeMSA_id.pl
@@ -20,9 +20,10 @@ use warnings;
 use Bio::AlignIO;
 use File::Spec;
 use Getopt::Long;
+use JSON qw (encode_json);
 use Bio::EnsEMBL::ApiVersion;
 use Bio::EnsEMBL::Registry;
-use Bio::EnsEMBL::Utils::IO qw (slurp);
+use Bio::EnsEMBL::Utils::IO qw (slurp spurt);
 use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
 use Bio::EnsEMBL::Compara::Graph::OrthoXMLWriter;
 use Bio::EnsEMBL::Compara::Graph::GeneTreePhyloXMLWriter;
@@ -31,6 +32,7 @@ use Bio::EnsEMBL::Compara::Utils::Preloader;
 
 my $tree_id_file;
 my $one_tree_id;
+my $dataflow_file;
 my $url;
 my $help = 0;
 my $aln_out;
@@ -51,6 +53,7 @@ $| = 1;
 GetOptions('help'           => \$help,
            'tree_id_file|infile=s' => \$tree_id_file,
            'tree_id=i'      => \$one_tree_id,
+           'dataflow_file=s' => \$dataflow_file,
 
            'reg_conf=s'     => \$reg_conf,
            'reg_alias=s'    => \$reg_alias,
@@ -74,6 +77,7 @@ $0 [--tree_id id | --tree_id_file file.txt] [--url mysql://ensro\@compara1:3306/
 
 --tree_id         the root_id of the tree to be dumped
 --tree_id_file    a file with a list of tree_ids
+--dataflow_file   a JSONL file with a list of dataflow events, one per line
 --url string      database url location of the form,
                   mysql://username[:password]\@host[:port]/[release_version]
 --aa              dump alignment in amino acid (default is in DNA)
@@ -145,7 +149,7 @@ sub dump_if_wanted {
     my $default_name = shift;
 
     my $filename = ($param =~ /^\// ? sprintf('%s.%s', $param, $tree_id) : sprintf('%s/%s.%s', $dirpath, $tree_id, $param eq 1 ? $default_name : $param));
-    return if -s $filename;
+    return $filename if -s $filename;  # ensures validation of pre-existing file, if using dataflow file to flow to validation step
 
     my $fh;
     open $fh, '>', $filename or die "couldnt open $filename:$!\n";
@@ -155,8 +159,11 @@ sub dump_if_wanted {
     my $extra = shift;
     &$sub($root, $fh, @$extra);
     close $fh;
+
+    return $filename;
 }
 
+my @dataflow_events;
 foreach my $tree_id (@tree_ids) {
 
   system("mkdir -p $dirpath") && die "Could not make directory '$dirpath: $!";
@@ -173,16 +180,41 @@ foreach my $tree_id (@tree_ids) {
       Bio::EnsEMBL::Compara::Utils::Preloader::load_all_DnaFrags($dba->get_DnaFragAdaptor, $tree->get_all_Members);
   }
 
+  my $orthoxml_compatible = 1;
+  if ($orthoxml) {
+      my $tree_num_dup_nodes = $tree->get_value_for_tag('tree_num_dup_nodes');
+      my $tree_num_leaves = $tree->get_value_for_tag('tree_num_leaves');
+      if (defined $tree_num_dup_nodes && defined $tree_num_leaves) {
+          # If all the internal nodes of the binary tree are duplications,
+          # then the tree is not currently expressible in OrthoXML format.
+          $orthoxml_compatible = 0 if ($tree_num_dup_nodes == ($tree_num_leaves - 1));
+      }
+  }
+
   dump_if_wanted($aln_out, $tree_id, 'aln.emf', \&dumpTreeMultipleAlignment, $tree, []);
   dump_if_wanted($nh_out, $tree_id, 'nh.emf', \&dumpNewickTree, $root, [0]);
   dump_if_wanted($nhx_out, $tree_id, 'nhx.emf', \&dumpNewickTree, $root, [1]);
   dump_if_wanted($fasta_out, $tree_id, $fasta_names{$tree->member_type}, \&dumpTreeFasta, $root, [0]);
   dump_if_wanted($fasta_cds_out, $tree_id, 'cds.fasta', \&dumpTreeFasta, $root, [1]) if $tree->member_type eq 'protein';
-  dump_if_wanted($orthoxml, $tree_id, 'orthoxml.xml', \&dumpTreeOrthoXML, $tree);
-  dump_if_wanted($phyloxml, $tree_id, 'phyloxml.xml', \&dumpTreePhyloXML, $tree);
-  dump_if_wanted($cafe_phyloxml, $tree_id, 'cafe_phyloxml.xml', \&dumpCafeTreePhyloXML, $cafe_tree) if $cafe_tree;
+
+  my ($orthoxml_file_path, $phyloxml_file_path, $cafe_file_path);
+  $orthoxml_file_path = dump_if_wanted($orthoxml, $tree_id, 'orthoxml.xml', \&dumpTreeOrthoXML, $tree) if $orthoxml_compatible;
+  $phyloxml_file_path = dump_if_wanted($phyloxml, $tree_id, 'phyloxml.xml', \&dumpTreePhyloXML, $tree);
+  $cafe_file_path = dump_if_wanted($cafe_phyloxml, $tree_id, 'cafe_phyloxml.xml', \&dumpCafeTreePhyloXML, $cafe_tree) if $cafe_tree;
 
   $root->release_tree;
+
+  if ($dataflow_file) {
+      push(@dataflow_events, { 'schema' => 'orthoxml', 'filename' => $orthoxml_file_path }) if $orthoxml_file_path;
+      push(@dataflow_events, { 'schema' => 'phyloxml', 'filename' => $phyloxml_file_path }) if $phyloxml_file_path;
+      push(@dataflow_events, { 'schema' => 'phyloxml', 'filename' => $cafe_file_path }) if $cafe_file_path;
+  }
+}
+
+if ($dataflow_file) {
+    my @dataflow_lines = map { encode_json($_) } @dataflow_events;
+    my $dataflow_text = join("\n", @dataflow_lines) . "\n";
+    spurt($dataflow_file, $dataflow_text);
 }
 
 sub dumpTreeMultipleAlignment {

--- a/scripts/pipeline/xmlschema_validate.py
+++ b/scripts/pipeline/xmlschema_validate.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Script to validate XML data file against the given schema.
+
+Unknown options are ignored.
+"""
+
+import argparse
+import xmlschema
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--schema", dest="schema_file", metavar="schema_file", required=True,
+                        help="Schema file against which to validate.")
+    parser.add_argument("data_file", help="XML data file to be validated against the schema.")
+
+    known_args, other_args = parser.parse_known_args()
+
+    schema = xmlschema.XMLSchema(known_args.schema_file)
+    schema.validate(known_args.data_file)


### PR DESCRIPTION
## Description

Several issues affect homology XML validation in the Compara `DumpAllForRelease` pipeline:
- OrthoXML and PhyloXML schemata are hard-coded to a path which does not exist in the Codon cluster currently being used for Compara production.
- Expected filenames being dataflowed from `dump_a_tree` to `validate_xml` are incorrect, since they lack the prefix (i.e. `tree.`) used in the actual filenames. For example, given an OrthoXML file with basename `tree.243431.orthoxml.xml`, the expected file basename is currently `243431.orthoxml.xml`. As a result, XML validation is not currently being done.
- When XML validation is done, a significant subset of Compara gene trees (~10%) fail OrthoXML validation because they cannot currently be represented in OrthoXML format. As the OrthoXML format currently allows only `orthologGroup` elements at the top level of the `groups` element, Compara gene trees are represented in OrthoXML format by subtrees rooted at the speciation nodes closest to the gene-tree root. If a gene tree lacks a speciation node, it is represented in an OrthoXML file with an empty `groups` element, causing it to fail OrthoXML validation.
- A very small subset of Compara gene trees can be represented in OrthoXML format, but when `xmllint` validates them (successfully), it then fails with a segmentation fault. See the related Jira ticket (ENSCOMPARASW-7138) for an example of an XML file for which this issue is encountered.
- Gene trees lacking corresponding CAFE trees, which therefore can't have `cafe_phyloxml.xml`, are unnecessarily being dataflowed to the `validate_xml` step.

**Related JIRA tickets:**
- ENSCOMPARASW-7133
- ENSCOMPARASW-7135
- ENSCOMPARASW-7138

## Overview of changes

- A `schema_file` parameter is added to the `validate_xml` step of the `DumpAllForRelease` pipeline, and updated to reflect the current location of the relevant schema file. This addresses ENSCOMPARASW-7133.
- Dataflow of expected homology XML filenames is now handled by the `dumpTreeMSA_id.pl` script, which outputs a dataflow JSON file with the files which the script itself has output. The `dumpTreeMSA_id.pl` script has also been updated to determine whether a given gene tree can be output in OrthoXML format, so that OrthoXML files with empty `group` elements are not generated, and their expected file names are not dataflowed to `validate_xml`. This addresses ENSCOMPARASW-7135.
- With the dataflow changes to `dumpTreeMSA_id.pl`, CAFE file names are now dataflowed by `dump_a_tree` only if a CAFE tree exists for the given gene tree.
- A Python script (`xmlschema_validate.py`) is added which uses the `xmlschema` package to validate OrthoXML and PhyloXML files in the `validate_xml` step of the `DumpAllForRelease` pipeline. This addresses ENSCOMPARASW-7138.

## Testing

The various fixes implemented in this PR were tested as part of a trial run of the `DumpAllForRelease` pipeline. For more info, see the related Jira tickets.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)