### PR TITLE
Made 1 hour the default resource class in ENV.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -591,7 +591,7 @@ sub _generate_resource_classes {
             }
 
             my $rc_name = $rc_key;
-            if ($time_limit_name ne '24_hour') {
+            if ($time_limit_name ne '1_hour') {
                 $rc_name =~ s/(?=_job|_mpi$)/_${time_limit_name}/;
             }
 


### PR DESCRIPTION
## Description

**Related JIRA tickets:**
- ENSCOMPARASW-7142

## Overview of changes

Made 1 hour the default resource class in ENV.pm

## Testing
The resource classes were dumped using `scripts/production/dump_hive_rc_config.pl` and a spot check was performed.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
