### PR TITLE
Updated resource classes in the FTP dump pipeline so that they can be used with 1 hour as default

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
@@ -291,36 +291,36 @@ sub core_pipeline_analyses {
         {	-logic_name => 'DumpMultiAlign_start',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
         	-flow_into  => [ 'DumpMultiAlign_MLSSJobFactory' ],
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
         },
         {	-logic_name => 'DumpTrees_start',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
         	-flow_into => [ 'dump_trees_pipeline_start' ],
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
         },
         {	-logic_name => 'DumpConstrainedElements_start',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
         	-flow_into  => [ 'mkdir_constrained_elems' ],
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
         },
         {	-logic_name => 'DumpConservationScores_start',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
         	-flow_into => [ 'mkdir_conservation_scores' ],
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
         },
         {	-logic_name => 'DumpSpeciesTrees_start',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
         	-flow_into  => ['mk_species_trees_dump_dir' ],
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
         },
         {	-logic_name => 'DumpAncestralAlleles_start',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
         	-flow_into  => [ 'mk_ancestral_dump_dir' ],
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
         },
         {	-logic_name => 'DumpMultiAlignPatches_start',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
         	-flow_into  => {
         		'1->A' => [ 'DumpMultiAlign_MLSSJobFactory' ],
                         'A->1' => [ 'patch_lastz_dump' ],
@@ -332,19 +332,19 @@ sub core_pipeline_analyses {
 
         {	-logic_name => 'create_ftp_skeleton',
         	-module     => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::FTPSkeleton',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
         	-flow_into => [ 'symlink_prev_dumps' ],
         },
 
         {	-logic_name => 'symlink_prev_dumps',
         	-module     => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::SymlinkPreviousDumps',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
                 -flow_into => { 2 => 'create_all_dump_jobs' }, # to top up any missing dumps
         },
 
         {   -logic_name => 'patch_lastz_dump',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::PatchLastzDump',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
             	'lastz_dump_path' => $self->o('lastz_dump_path'),
             },
@@ -352,7 +352,7 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'add_hmm_lib',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::AddHMMLib',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 'ref_tar_path_templ' => '#warehouse_dir#/hmms/treefam/multi_division_hmm_lib.%s.tar.gz',
                 'tar_ftp_path'       => '#dump_dir#/compara/multi_division_hmm_lib.tar.gz',
@@ -361,7 +361,7 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'clean_files_decision',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -flow_into  => {
                 1 => WHEN('#clean_intermediate_files#' => [ 'clean_dump_hash' ])
             },
@@ -369,7 +369,7 @@ sub core_pipeline_analyses {
 
         {   -logic_name     => 'clean_dump_hash',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name        => '1Gb_job',
+            -rc_name        => '1Gb_24_hour_job',
             -parameters     => {
                 'cmd' => 'rm -rf #work_dir#',
             },
@@ -398,7 +398,7 @@ sub core_pipeline_analyses {
 
         {   -logic_name     => 'remove_uniprot_file',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name        => '1Gb_1_hour_job',
+            -rc_name        => '1Gb_job',
             -parameters     => {
                 'clusterset_id' => 'default',
                 'cmd'           => 'rm #dump_root#/#division#.#uniprot_file#.gz',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpAncestralAlleles.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpAncestralAlleles.pm
@@ -42,7 +42,7 @@ sub pipeline_analyses_dump_anc_alleles {
 
     	{	-logic_name => 'mk_ancestral_dump_dir',
     		-module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
     		-parameters => {
                     cmd => 'mkdir -p #anc_output_dir# #anc_tmp_dir#'
     		},
@@ -52,7 +52,7 @@ sub pipeline_analyses_dump_anc_alleles {
 
         {   -logic_name     => 'fetch_genome_dbs',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::DumpAncestralAlleles::GenomeDBFactory',
-            -rc_name        => '1Gb_1_hour_job',
+            -rc_name        => '1Gb_job',
             -parameters     => {
                 compara_db => $self->o('compara_db'),
                 reg_conf   => $self->o('reg_conf'),
@@ -86,7 +86,7 @@ sub pipeline_analyses_dump_anc_alleles {
 
         {   -logic_name => 'remove_empty_files',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 species_outdir  => '#anc_tmp_dir#/#species_dir#',
                 cmd             => 'find #species_outdir# -empty -type f -delete',
@@ -96,7 +96,7 @@ sub pipeline_analyses_dump_anc_alleles {
 
         {   -logic_name => 'generate_anc_stats',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 species_outdir  => '#anc_tmp_dir#/#species_dir#',
                 cmd             => 'cd #species_outdir#; perl #ancestral_stats_program# > summary.txt',
@@ -106,7 +106,7 @@ sub pipeline_analyses_dump_anc_alleles {
 
         {	-logic_name => 'tar',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
         	-parameters => {
         		cmd => join( '; ',
                                     'cd #anc_tmp_dir#',
@@ -117,7 +117,7 @@ sub pipeline_analyses_dump_anc_alleles {
 
         {	-logic_name => 'md5sum',
         	-module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
         	-parameters => {
         		cmd => join( '; ',
         			'cd #anc_output_dir#',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpAncestralAlleles.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpAncestralAlleles.pm
@@ -79,7 +79,7 @@ sub pipeline_analyses_dump_anc_alleles {
                     '--step #step_size#'
                 ),
             },
-            -rc_name            => '2Gb_job',
+            -rc_name            => '2Gb_24_hour_job',
             -flow_into => [ 'remove_empty_files' ],
             -hive_capacity => 400,
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConservationScores.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConservationScores.pm
@@ -73,7 +73,7 @@ sub pipeline_analyses_dump_conservation_scores {
         {   -logic_name        => 'dump_conservation_scores',
             -module            => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::DumpConservationScores',
             -hive_capacity     => $self->o('dump_cs_capacity'),
-            -rc_name           => '2Gb_job',
+            -rc_name           => '2Gb_24_hour_job',
             -flow_into         => {
                 1 => '?accu_name=all_bedgraph_files&accu_address=[chunkset_id]&accu_input_variable=this_bedgraph',
             },
@@ -90,7 +90,7 @@ sub pipeline_analyses_dump_conservation_scores {
             -parameters     => {
                 'cmd'   => [ $self->o('big_wig_exe'), '#bedgraph_file#', '#chromsize_file#', '#bigwig_file#' ],
             },
-            -rc_name        => '16Gb_job',
+            -rc_name        => '16Gb_24_hour_job',
         },
 
         {   -logic_name     => 'md5sum_cs',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConservationScores.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConservationScores.pm
@@ -42,13 +42,13 @@ sub pipeline_analyses_dump_conservation_scores {
 
         {   -logic_name     => 'mkdir_conservation_scores',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::DumpMultiAlign::MkDirConservationScores',
-            -rc_name        => '1Gb_1_hour_job',
+            -rc_name        => '1Gb_job',
             -flow_into      => [ 'genomedb_factory_cs' ],
         },
 
         {   -logic_name     => 'genomedb_factory_cs',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
-            -rc_name        => '1Gb_1_hour_job',
+            -rc_name        => '1Gb_job',
             -parameters     => {
                 'extra_parameters'      => [ 'name', 'assembly' ],
             },
@@ -81,7 +81,7 @@ sub pipeline_analyses_dump_conservation_scores {
 
         {   -logic_name     => 'concatenate_bedgraph_files',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::ConcatenateBedGraphFiles',
-            -rc_name        => '1Gb_job',
+            -rc_name        => '1Gb_24_hour_job',
             -flow_into      => 'convert_to_bigwig',
         },
 
@@ -95,7 +95,7 @@ sub pipeline_analyses_dump_conservation_scores {
 
         {   -logic_name     => 'md5sum_cs',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name        => '1Gb_job',
+            -rc_name        => '1Gb_24_hour_job',
             -parameters     => {
                 'cmd'   => 'cd #cs_output_dir#; md5sum *.bw > MD5SUM',
             },
@@ -104,7 +104,7 @@ sub pipeline_analyses_dump_conservation_scores {
 
         {   -logic_name     => 'readme_cs',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name        => '1Gb_1_hour_job',
+            -rc_name        => '1Gb_job',
             -parameters     => {
                 'cmd'   => [qw(cp -af #cs_readme# #cs_output_dir#/README)],
             },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConstrainedElements.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConstrainedElements.pm
@@ -42,13 +42,13 @@ sub pipeline_analyses_dump_constrained_elems {
 
         {   -logic_name     => 'mkdir_constrained_elems',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::DumpMultiAlign::MkDirConstrainedElements',
-            -rc_name        => '1Gb_1_hour_job',
+            -rc_name        => '1Gb_job',
             -flow_into      => [ 'genomedb_factory_ce' ],
         },
 
         {   -logic_name     => 'genomedb_factory_ce',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
-            -rc_name        => '1Gb_1_hour_job',
+            -rc_name        => '1Gb_job',
             -parameters     => {
                 'extra_parameters'      => [ 'name' ],
             },
@@ -63,14 +63,14 @@ sub pipeline_analyses_dump_constrained_elems {
             -parameters     => {
                 'cmd'   => '#dump_features_exe# --feature ce_#mlss_id# --compara_db #compara_db# --species #name# --lex_sort --reg_conf "#registry#" | tail -n+2 > #bed_file#',
             },
-            -rc_name        => '1Gb_job',
+            -rc_name        => '1Gb_24_hour_job',
             -hive_capacity => $self->o('dump_ce_capacity'),
             -flow_into      => [ 'check_not_empty' ],
         },
 
         {   -logic_name     => 'check_not_empty',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::CheckNotEmpty',
-            -rc_name        => '1Gb_1_hour_job',
+            -rc_name        => '1Gb_job',
             -parameters     => {
                 'min_number_of_lines'   => 1,   # The header is always present
                 'filename'              => '#bed_file#',
@@ -80,7 +80,7 @@ sub pipeline_analyses_dump_constrained_elems {
 
         {   -logic_name     => 'convert_to_bigbed',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::ConvertToBigBed',
-            -rc_name        => '1Gb_1_hour_job',
+            -rc_name        => '1Gb_job',
             -parameters     => {
                 'big_bed_exe'   => $self->o('big_bed_exe'),
                 'autosql_file'  => $self->o('bigbed_autosql'),
@@ -90,7 +90,7 @@ sub pipeline_analyses_dump_constrained_elems {
 
         {   -logic_name     => 'md5sum_ce',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name        => '1Gb_1_hour_job',
+            -rc_name        => '1Gb_job',
             -parameters     => {
                 'cmd'   => 'cd #ce_output_dir#; md5sum *.bb > MD5SUM',
             },
@@ -99,7 +99,7 @@ sub pipeline_analyses_dump_constrained_elems {
 
         {   -logic_name     => 'readme_ce',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name        => '1Gb_1_hour_job',
+            -rc_name        => '1Gb_job',
             -parameters     => {
                 'cmd'   => [qw(cp -af #ce_readme# #ce_output_dir#/README)],
             },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpMultiAlign.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpMultiAlign.pm
@@ -45,7 +45,7 @@ sub pipeline_analyses_dump_multi_align {
                 'from_first_release' => $self->o('ensembl_release'),
                 'species_priority'   => $self->o('epo_reference_species'),
             },
-            -rc_name        => '1Gb_1_hour_job',
+            -rc_name        => '1Gb_job',
             -flow_into      => {
                 '2->A' => [ 'count_blocks' ],
                 'A->2' => [ 'md5sum_aln_factory' ],
@@ -54,7 +54,7 @@ sub pipeline_analyses_dump_multi_align {
 
         {  -logic_name  => 'count_blocks',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 'db_conn'       => '#compara_db#',
                 'inputquery'    => 'SELECT COUNT(*) AS num_blocks FROM genomic_align_block WHERE method_link_species_set_id = #mlss_id#',
@@ -70,7 +70,7 @@ sub pipeline_analyses_dump_multi_align {
 
         {  -logic_name  => 'initJobs',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::DumpMultiAlign::InitJobs',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -hive_capacity => $self->o('dump_aln_capacity'),
             -flow_into => {
                 2 => [ 'createChrJobs' ],
@@ -85,12 +85,12 @@ sub pipeline_analyses_dump_multi_align {
             -flow_into => {
                 2 => [ 'dumpMultiAlign' ]
             },
-            -rc_name => '1Gb_1_hour_job',
+            -rc_name => '1Gb_job',
         },
         # Generates DumpMultiAlign jobs from genomic_align_blocks on supercontigs (1 job per coordinate-system)
         {  -logic_name    => 'createSuperJobs',
             -module        => 'Bio::EnsEMBL::Compara::RunnableDB::DumpMultiAlign::CreateSuperJobs',
-            -rc_name       => '1Gb_1_hour_job',
+            -rc_name       => '1Gb_job',
             -hive_capacity => $self->o('dump_aln_capacity'),
             -flow_into => {
                 2 => [ 'dumpMultiAlign' ]
@@ -139,7 +139,7 @@ sub pipeline_analyses_dump_multi_align {
         },
         {   -logic_name     => 'compress_aln',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name        => '1Gb_1_hour_job',
+            -rc_name        => '1Gb_job',
             -parameters     => {
                 'cmd'           => 'gzip -f -9 #output_file#',
             },
@@ -147,12 +147,12 @@ sub pipeline_analyses_dump_multi_align {
 
         {   -logic_name     => 'md5sum_aln_factory',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::DumpMultiAlign::MD5SUMFactory',
-            -rc_name        => '1Gb_1_hour_job',
+            -rc_name        => '1Gb_job',
             -flow_into     => [ 'md5sum_aln' ],
         },
         {   -logic_name     => 'md5sum_aln',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name        => '1Gb_job',
+            -rc_name        => '1Gb_24_hour_job',
             -parameters     => {
                 'cmd'           => 'cd #output_dir#; md5sum *.#format#* > MD5SUM',
             },
@@ -163,7 +163,7 @@ sub pipeline_analyses_dump_multi_align {
             -parameters    => {
                 'readme_file' => '#output_dir#/README.#base_filename#',
             },
-            -rc_name       => '1Gb_1_hour_job',
+            -rc_name       => '1Gb_job',
             -flow_into     => WHEN( '#make_tar_archive#' => [ 'targz' ] ),
         },
         {   -logic_name     => 'targz',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpMultiAlign.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpMultiAlign.pm
@@ -103,7 +103,7 @@ sub pipeline_analyses_dump_multi_align {
             -flow_into => {
                 2 => [ 'dumpMultiAlign' ]
             },
-            -rc_name => '2Gb_job',
+            -rc_name => '2Gb_24_hour_job',
         },
         {  -logic_name    => 'dumpMultiAlign',
             -module        => 'Bio::EnsEMBL::Compara::RunnableDB::DumpMultiAlign::DumpMultiAlign',
@@ -132,7 +132,7 @@ sub pipeline_analyses_dump_multi_align {
         },
         {   -logic_name     => 'emf2maf',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::DumpMultiAlign::Emf2Maf',
-            -rc_name        => '2Gb_job',
+            -rc_name        => '2Gb_24_hour_job',
             -flow_into => [
                 WHEN( '!#make_tar_archive#' => { 'compress_aln' => [ undef, { 'format' => 'maf'} ] } ),
             ],
@@ -168,7 +168,7 @@ sub pipeline_analyses_dump_multi_align {
         },
         {   -logic_name     => 'targz',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name        => '1Gb_job',
+            -rc_name        => '1Gb_24_hour_job',
             -parameters     => {
                 'cmd'           => 'cd #export_dir#; tar czf #base_filename#.tar.gz #base_filename#; rm -r #base_filename#',
             },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpSpeciesTrees.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpSpeciesTrees.pm
@@ -42,7 +42,7 @@ sub pipeline_analyses_dump_species_trees {
     return [
         {   -logic_name => 'mk_species_trees_dump_dir',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 'cmd'           => ['mkdir', '-p', '#dump_dir#'],
             },
@@ -52,7 +52,7 @@ sub pipeline_analyses_dump_species_trees {
 
         {   -logic_name => 'dump_factory',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 'db_conn'       => '#compara_db#',
                 'inputquery'    => 'SELECT root_id, label, method_link_id, replace(name, " ", "_") as name FROM species_tree_root JOIN method_link_species_set USING (method_link_species_set_id)',
@@ -66,7 +66,7 @@ sub pipeline_analyses_dump_species_trees {
 
         {   -logic_name => 'dump_one_tree_with_distances',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 'cmd'           => '#dump_species_tree_exe# -compara_db #compara_db# -reg_conf #reg_conf# --stn_root_id #root_id# -with_distances > "#dump_dir#/#name#_#label#.nh"',
             },
@@ -75,7 +75,7 @@ sub pipeline_analyses_dump_species_trees {
 
         {   -logic_name => 'dump_one_tree_without_distances',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 'cmd'           => '#dump_species_tree_exe# -compara_db #compara_db# -reg_conf #reg_conf# --stn_root_id #root_id# > "#dump_dir#/#name#_#label#.nh"',
             },
@@ -84,7 +84,7 @@ sub pipeline_analyses_dump_species_trees {
 
         {   -logic_name => 'sanitize_file',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 'cmd'           => ['sed', '-i', 's/  */_/g', '#dump_dir#/#name#_#label#.nh'],
             },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
@@ -328,7 +328,7 @@ sub pipeline_analyses_dump_trees {
             },
             -batch_size    => $self->o('batch_size'),
             # -hive_capacity => $self->o('dump_aln_capacity'),
-            -rc_name       => '2Gb_job',
+            -rc_name       => '2Gb_24_hour_job',
         },
 
         {   -logic_name => 'generate_collations',
@@ -424,7 +424,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'archive_long_files',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_job',
+            -rc_name    => '1Gb_24_hour_job',
             -parameters => {
                 'cmd'         => 'gzip -f #full_name#',
             },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
@@ -42,7 +42,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'dump_trees_pipeline_start',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 'readme_dir'    => $self->o('readme_dir'),
                 'cmd'           => join('; ',
@@ -58,7 +58,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'collection_factory',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -flow_into => {
                 '2->A' => [ 'mk_work_dir' ],
                 'A->1' => [ 'md5sum_tree_factory' ],
@@ -67,7 +67,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'mk_work_dir',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 'cmd'         => 'mkdir -p #hash_dir#/tar',
             },
@@ -134,7 +134,7 @@ sub pipeline_analyses_dump_trees {
                 'inputquery'            => 'SELECT DISTINCT genome_db_id FROM gene_tree_root JOIN gene_tree_node USING (root_id) JOIN seq_member USING (seq_member_id) WHERE clusterset_id = "#clusterset_id#" AND member_type = "#member_type#"',
             },
             -hive_capacity => $self->o('dump_trees_capacity'),
-            -rc_name       => '1Gb_job',
+            -rc_name       => '1Gb_24_hour_job',
             -flow_into => {
                 '2->A' => [ 'fetch_exp_line_count_per_genome' ],
                 'A->1' => [ 'concatenate_genome_homologies_tsv' ],
@@ -171,7 +171,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'concatenate_genome_homologies_tsv',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_job',
+            -rc_name    => '1Gb_24_hour_job',
             -parameters => {
                 'cmd'         => q{rm #output_file#; for filename in $(find #tsv_dir# -name #name_root#.homologies.tsv); do if [ ! -e #output_file# ]; then head -1 $filename > #output_file#; fi; tail -n +2 $filename >> #output_file#; done},
                 'output_file' => '#tsv_dir#/#name_root#.homologies.tsv',
@@ -194,7 +194,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'archive_per_genome_homologies_tsv_factory',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 'inputcmd'      => 'find #tsv_dir# -mindepth 2 -name #name_root#.homologies.tsv',
                 'column_names'  => [ 'full_name' ],
@@ -269,7 +269,7 @@ sub pipeline_analyses_dump_trees {
                 'inputquery'            => 'SELECT root_id AS tree_id FROM gene_tree_root WHERE tree_type = "tree" AND clusterset_id = "#clusterset_id#" AND member_type = "#member_type#"',
             },
             -hive_capacity => $self->o('dump_trees_capacity'),
-            -rc_name   => '1Gb_1_hour_job',
+            -rc_name   => '1Gb_job',
             -flow_into => {
                 'A->1' => 'generate_collations',
                 '2->A' => { 'dump_a_tree'  => { 'tree_id' => '#tree_id#', 'hashed_id' => '#expr(dir_revhash(#tree_id#))expr#' } },
@@ -317,7 +317,7 @@ sub pipeline_analyses_dump_trees {
                 },
             },
             -hive_capacity => $self->o('dump_trees_capacity'),       # allow several workers to perform identical tasks in parallel
-            -rc_name       => '16Gb_1_hour_job',
+            -rc_name       => '16Gb_job',
         },
 
         {   -logic_name    => 'validate_xml',
@@ -333,7 +333,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'generate_collations',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 'inputlist'         => [ 'aln.emf', 'nh.emf', 'nhx.emf', 'aa.fasta', 'cds.fasta', 'nt.fasta' ],
                 'column_names'      => [ 'extension' ],
@@ -346,7 +346,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name    => 'collate_dumps',
             -module        => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name       => '1Gb_job',
+            -rc_name       => '1Gb_24_hour_job',
             -parameters    => {
                 'collated_file' => '#emf_dir#/#dump_file_name#',
                 'cmd'           => 'find #hash_dir# -name "tree.*.#extension#" | sort -t . -k2 -n | xargs cat > #collated_file#',
@@ -361,7 +361,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'generate_tarjobs',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 'inputlist'         => [ 'orthoxml.xml', 'phyloxml.xml', 'cafe_phyloxml.xml' ],
                 'column_names'      => [ 'extension' ],
@@ -373,7 +373,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'tar_dumps_factory',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
-            -rc_name    => '1Gb_job',
+            -rc_name    => '1Gb_24_hour_job',
             -parameters => {
                 'step'          => $self->o('max_files_per_tar'),
                 'contiguous'    => 0,
@@ -387,7 +387,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'tar_dumps',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_job',
+            -rc_name    => '1Gb_24_hour_job',
             -parameters => {
                 'file_list'     => '#expr( join("\n", @{ #_range_list# }) )expr#',   # Assumes no whitespace in the filenames
                 'min_tree_id'   => '#expr( ($_ = #_range_start#) and $_ =~ s/^.*tree\.(\d+)\..*$/$1/ and $_ )expr#',
@@ -402,7 +402,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'tar_list',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 'file_list'     => '#hash_dir#/tar/#dump_file_name#.list',
                 'cmd'           => 'find #hash_dir#/tar -name "#dump_file_name#.*-*.tar.gz" | sort > #file_list#',
@@ -414,7 +414,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'tar_tar_dumps',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_job',
+            -rc_name    => '1Gb_24_hour_job',
             -parameters => {
                 'file_list'     => '#hash_dir#/tar/#dump_file_name#.list',
                 'tar_tar_path'  => '#xml_dir#/#dump_file_name#.tar',
@@ -432,7 +432,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'remove_empty_file',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 'cmd'         => 'rm #full_name#',
             },
@@ -440,7 +440,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'md5sum_tree_factory',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 'inputlist'     => [ [ '#emf_dir#' ], [ '#xml_dir#' ], [ '#tsv_dir#' ] ],
                 'column_names'  => [ 'directory' ],
@@ -452,7 +452,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'md5sum_tree',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name    => '1Gb_1_hour_job',
+            -rc_name    => '1Gb_job',
             -parameters => {
                 'cmd' => 'cd #directory# ; md5sum *.gz >MD5SUM',
             },

--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -232,7 +232,7 @@ process buscoAnnot {
         fi
         ${params.miniprot_exe} \$SENS -t ${params.cores} -d genome.mpi $genome
         ${params.miniprot_exe} -N 0 -Iu -t ${params.cores} --gff genome.mpi $busco_prot | grep -v '##PAF' \
-        | awk -F "\t" '\$3=="mRNA" {match(\$9, /Target=([^; ]+)/, m)} {sub(/ID=[^; ]+/, sprintf("ID=%s", m[1]), \$9); print}' > annotation.gtf
+        | awk -F "\t" '\$3=="mRNA" {match(\$9, /Target=([^; ]+)/, m)} {attribs=gensub(/(ID|Parent)=[^; ]+/, sprintf("\\\\1=%s", m[1]), "g", \$9); \$9=attribs; print}' > annotation.gtf
         rm -f genome.mpi
     """
     else


### PR DESCRIPTION
## Description

**Related JIRA tickets:**
- ENSCOMPARASW-7143

## Overview of changes
Resource classes of FTP dump pipeline analyses have been updated on the Compara main branch so that they can be used on Slurm with a 1-hour default time limit.

## Testing
A vertebrates FTP dump pipeline was initialised.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
