### PR TITLE
Fix awk substitution in buscoAnnot

### DIFF
--- a/pipelines/SpeciesTreeFromBusco/main.nf
+++ b/pipelines/SpeciesTreeFromBusco/main.nf
@@ -232,7 +232,7 @@ process buscoAnnot {
         fi
         ${params.miniprot_exe} \$SENS -t ${params.cores} -d genome.mpi $genome
         ${params.miniprot_exe} -N 0 -Iu -t ${params.cores} --gff genome.mpi $busco_prot | grep -v '##PAF' \
-        | awk -F "\t" '\$3=="mRNA" {match(\$9, /Target=([^; ]+)/, m)} {sub(/ID=[^; ]+/, sprintf("ID=%s", m[1]), \$9); print}' > annotation.gtf
+        | awk -F "\t" '\$3=="mRNA" {match(\$9, /Target=([^; ]+)/, m)} {attribs=gensub(/(ID|Parent)=[^; ]+/, sprintf("\\\\1=%s", m[1]), "g", \$9); \$9=attribs; print}' > annotation.gtf
         rm -f genome.mpi
     """
     else


### PR DESCRIPTION
## Description

A suggestion during review of PR #688 turned out to have a bug in it, which resulted in `Parent` attributes not being substituted.

This PR fixes that bug.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
