### PR TITLE
Allow for ADR of NCBI Taxonomy IDs in pairwise GAT

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/GenomicAlignBlock.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomicAlignBlock.pm
@@ -1509,6 +1509,7 @@ sub get_GenomicAlignTree {
         
         #Create species_tree in newick format. Do not get the branch lengths.
         $species_tree_string = Bio::EnsEMBL::Compara::Utils::SpeciesTree->create_species_tree(-compara_dba => $self->adaptor->db,
+                                                                                              -allow_subtaxa => 1,
                                                                                               -species_set => $species_set)->newick_format('ryo', '%{g}');
     } elsif ($self->method_link_species_set->dbID == 313160 && $self->method_link_species_set->name eq '16 wheat Cactus') {
         my ($volume, $dir_path) = splitpath(rel2abs(__FILE__));


### PR DESCRIPTION
## Description

Due to a bug in handling of pairwise alignments between genomes with NCBI Taxonomy IDs that have an ancestor-descendant relationship (ADR), an error occurs when accessing the GenomicAlignTree of GenomicAlignBlocks in some pairwise alignments in the Rice pangenome.

On the e111 website, that error is preventing visualisation of 22 of 325 pairwise alignments derived from the Rice pangenome Cactus alignment, as well as 4 Rice LastZ alignments.

This PR prevents the error from occurring.

**Related JIRA tickets:**
- ENSCOMPARASW-7149

## Overview of changes

The `-allow_subtaxa` option is set when creating the species tree for pairwise genomic alignments.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
