### PR TITLE
Revert Cactus code to e110

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/GenomicAlignBlockAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/GenomicAlignBlockAdaptor.pm
@@ -130,14 +130,9 @@ use Bio::EnsEMBL::Utils::Exception;
 use Bio::EnsEMBL::Utils::Scalar qw(assert_ref);
 use Bio::EnsEMBL::Compara::Utils::Cigars;
 use Bio::EnsEMBL::Compara::HAL::UCSCMapping;
-use Bio::EnsEMBL::Compara::Utils::Polyploid qw(map_dnafrag_to_genome_component);
 use Bio::EnsEMBL::Compara::Utils::Projection;
 
 use List::Util qw( max );
-
-use Bio::EnsEMBL::Utils::IO qw(slurp);
-use Bio::EnsEMBL::Compara::Graph::NewickParser;
-use File::Spec::Functions qw(catfile rel2abs splitdir splitpath);
 
 @ISA = qw(Bio::EnsEMBL::DBSQL::BaseAdaptor);
 
@@ -700,16 +695,6 @@ sub fetch_all_by_MethodLinkSpeciesSet_DnaFrag {
 
         my $ref = $dnafrag->genome_db;
         my @targets = grep { $_->dbID != $ref->dbID } @{ $method_link_species_set->species_set->genome_dbs };
-
-        # With a Cactus multiple alignment MLSS, we would miss homoeological alignments
-        # if we did not add here the other subgenome components of the reference genome.
-        if ($method_link_species_set->method->class eq 'GenomicAlignBlock.multiple_alignment' && $ref->is_polyploid()) {
-          my @all_ref_comp_gdbs = ($ref, @{$ref->component_genome_dbs()});
-          my $comp_dnafrag = map_dnafrag_to_genome_component($dnafrag);
-          my $ref_comp_gdb = defined $comp_dnafrag ? $comp_dnafrag->genome_db : $ref;
-          my @target_comp_gdbs = grep { $_->dbID != $ref_comp_gdb->dbID } @all_ref_comp_gdbs;
-          push(@targets, @target_comp_gdbs);
-        }
 
         my $block_start = defined $start ? $start : $dnafrag->slice->start;
         my $block_end   = defined $end ? $end : $dnafrag->slice->end;
@@ -1432,20 +1417,7 @@ sub _get_GenomicAlignBlocks_from_HAL {
           }
       }
 
-      my %mlss_sp_tree_gdb_ids;
-      if ($mlss_with_mapping->dbID == 313160 && $mlss_with_mapping->name eq '16 wheat Cactus') {
-          my ($volume, $dir_path) = splitpath(rel2abs(__FILE__));
-          my @path_parts = splitdir($dir_path);
-          pop @path_parts until $path_parts[$#path_parts] eq 'ensembl-compara';
-          my $species_tree_file_path = catfile(@path_parts, 'conf', 'plants', 'species_tree.wheat.placeholder.nw');
-          my $species_tree = Bio::EnsEMBL::Compara::Graph::NewickParser::parse_newick_into_tree(slurp($species_tree_file_path));
-          %mlss_sp_tree_gdb_ids = map { $_->name => 1 } @{$species_tree->get_all_sorted_leaves()};
-      } else {
-          %mlss_sp_tree_gdb_ids = map { $_ => 1 } keys %{$mlss_with_mapping->species_tree->get_genome_db_id_2_node_hash()};
-      }
-
       my %hal_species_map;
-      my %group_key_map;
       while (my ($map_gdb_id, $hal_genome_name) = each %{$species_map}) {
           my $genome_db = $genome_db_adaptor->fetch_by_dbID($map_gdb_id);
 
@@ -1453,43 +1425,23 @@ sub _get_GenomicAlignBlocks_from_HAL {
           # mapping back to the principal GenomeDB simplifies the reverse mapping process.
           my $principal = $genome_db->principal_genome_db();
           $hal_species_map{$hal_genome_name} = defined $principal ? $principal->dbID : $map_gdb_id;
-
-          # With the current implementation of a Cactus GenomicAlignBlock, only one aligned sequence can
-          # be included per species-tree node, so aligned sequences are grouped and the one that has the
-          # longest ungapped sequence is kept. The grouping key for this is the genome_db_id associated
-          # with the given HAL genome (as indicated by the HAL mapping). For polyploids we fall back to
-          # grouping by the principal GenomeDB if present in the MLSS species tree. Polypoid alignment
-          # sequences may therefore be grouped by principal or component GenomeDB, depending on whether
-          # they are represented at the genome or subgenome level (respectively) in the MLSS species tree.
-          # If the Cactus MLSS is pairwise, aligned sequences are always grouped by principal GenomeDB,
-          # to guarantee the resulting alignment is pairwise even if the initial alignment retrieved
-          # from the HAL file includes aligned sequences from multiple subgenomes of the target genome.
-          if ($mlss->method->class eq 'GenomicAlignBlock.pairwise_alignment' && defined $principal) {
-            $group_key_map{$hal_genome_name} = $principal->dbID;
-          } elsif (exists $mlss_sp_tree_gdb_ids{$map_gdb_id}) {
-            $group_key_map{$hal_genome_name} = $map_gdb_id;
-          } elsif (defined $principal && exists $mlss_sp_tree_gdb_ids{$principal->dbID}) {
-            $group_key_map{$hal_genome_name} = $principal->dbID;
-          } else {
-            throw(sprintf("Cannot find HAL genome '%s' in species tree of MLSS %d", $hal_genome_name, $mlss->dbID));
-          }
       }
 
       $mlss->{'_hal_species_name_mapping'} = $species_map;
       $mlss->{'_hal_species_name_mapping_reverse'} = \%hal_species_map;
-      $mlss->{'_hal_genome_name_to_group_key'} = \%group_key_map;
     }
 
     my ($linking_ref_gdb, $linking_dnafrag) = @{$self->_get_hal_linking_genome_dnafrag($dnafrag_adaptor, $ref_gdb, $dnafrag, $mlss->{'_hal_species_name_mapping'})};
     return [] if (!defined $linking_ref_gdb);
 
     my $hal_ref_name = $mlss->{'_hal_species_name_mapping'}->{ $linking_ref_gdb->dbID };
-    my $ref_group_key = $mlss->{'_hal_genome_name_to_group_key'}->{ $hal_ref_name };
 
     my $e2u_mappings = $Bio::EnsEMBL::Compara::HAL::UCSCMapping::e2u_mappings->{ $dnafrag->genome_db_id };
     my $hal_seq_reg = $e2u_mappings->{ $dnafrag->name } || $linking_dnafrag->name;
 
     my $num_targets  = scalar @$targets_gdb;
+    my $id_base      = $mlss->dbID * 10000000000;
+    my ($gab_id_count, $ga_id_count)  = (0, 0);
     my $min_gab_len = !$mlss->has_tag('no_filter_small_blocks') && int(abs($end-$start)/1000);
     my $min_ga_len  = !$mlss->has_tag('no_filter_small_blocks') && $min_gab_len/4;
 
@@ -1514,8 +1466,7 @@ sub _get_GenomicAlignBlocks_from_HAL {
 
         foreach my $hal_target_gdb (@hal_target_gdbs) {
           my $hal_target = $mlss->{'_hal_species_name_mapping'}->{ $hal_target_gdb->dbID };
-          my $target_group_key = $mlss->{'_hal_genome_name_to_group_key'}->{ $hal_target };
-          $hal_target_set{$hal_target} = 1 if (defined $hal_target && $target_group_key != $ref_group_key);
+          $hal_target_set{$hal_target} = 1 if (defined $hal_target);
         }
       }
 
@@ -1543,6 +1494,7 @@ sub _get_GenomicAlignBlocks_from_HAL {
       push(@hal_genome_names, $hal_ref_name) if (!exists $hal_target_set{$hal_ref_name});
 
       for my $aln_block ( @$maf_info ) {
+        my $duplicates_found = 0;
         my %species_found;
         my $block_len = length($aln_block->[0]->{seq});
 
@@ -1552,13 +1504,13 @@ sub _get_GenomicAlignBlocks_from_HAL {
           -length => $block_len,
           -method_link_species_set => $mlss,
           -adaptor => $self,
+          # -dbID => $id_base + $gab_id_count,
         );
         $gab->reference_slice_strand( $linking_dnafrag->slice->strand );
+        $gab_id_count++;
 
         my $ga_adaptor = $self->db->get_GenomicAlignAdaptor;
-        my $ref_genomic_align;
-        my @hal_ga_group_order;
-        my $grouped_genomic_aligns;
+        my (@genomic_align_array, $ref_genomic_align);
         foreach my $seq (@$aln_block) {
           # find dnafrag for the region
           my ( $species_id, $chr );
@@ -1569,12 +1521,12 @@ sub _get_GenomicAlignBlocks_from_HAL {
           # a dot in either the genome or sequence name (e.g. genome 'oryza_sativa.IRGSP-1.0', sequence 'KN549081.1').
           # So we check the MAF src against patterns prefixed by the names of the genomes known to be in the HAL file,
           # in order to allow the HAL genome and sequence names to be extracted.
-          my $genomic_align_group_key;
           my $maf_src_id = $seq->{display_id};
           my @matching_genome_names = grep { $maf_src_id =~ /^\Q$_\E[.].+/ } @hal_genome_names;
           if ( scalar(@matching_genome_names) == 1 ) {
-              $species_id = $matching_genome_names[0];
-              $chr = substr($maf_src_id, length($species_id) + 1);
+              my $matching_genome_name = $matching_genome_names[0];
+              $species_id = substr($maf_src_id, 0, length($matching_genome_name));
+              $chr = substr($maf_src_id, length($matching_genome_name) + 1);
           } elsif ( scalar(@matching_genome_names) == 0 ) {
               throw("Cannot map MAF src field '$maf_src_id' to any HAL genome name");
           } else {
@@ -1599,6 +1551,16 @@ sub _get_GenomicAlignBlocks_from_HAL {
           # check length of genomic align meets threshold
           next if abs( $seq->{end} - $seq->{start} + 1) < $min_ga_len;
 
+          if ( !$duplicates_found ){
+            my $species_name = $this_dnafrag->genome_db->name;
+            if ( $species_found{$species_name} ){
+                $duplicates_found = 1;
+            } else {
+                $species_found{$species_name} = 1;
+            }
+          }
+          
+
           # create cigar line
           my $this_cigar = Bio::EnsEMBL::Compara::Utils::Cigars::cigar_from_alignment_string($seq->{seq});
 
@@ -1610,6 +1572,7 @@ sub _get_GenomicAlignBlocks_from_HAL {
             -dnafrag_end => $seq->{end},
             -dnafrag_strand => $seq->{strand},
             -cigar_line => $this_cigar, 
+            # -dbID => $id_base + $ga_id_count,
             -visible => 1,
             -adaptor => $ga_adaptor,
           );
@@ -1618,24 +1581,10 @@ sub _get_GenomicAlignBlocks_from_HAL {
           $genomic_align->genomic_align_block( $gab );
           $genomic_align->method_link_species_set($mlss);
           $genomic_align->dbID( join('-', $this_dnafrag->genome_db->dbID, $this_dnafrag->dbID, $genomic_align->dnafrag_start, $genomic_align->dnafrag_end) );
-
-          my $ga_group_key = $mlss->{'_hal_genome_name_to_group_key'}{$species_id};
-          if (!exists $grouped_genomic_aligns->{$ga_group_key}) {
-            push(@hal_ga_group_order, $ga_group_key);
-          }
-          push(@{$grouped_genomic_aligns->{$ga_group_key}}, $genomic_align);
-
-          $ref_genomic_align = $genomic_align if ( $ga_group_key == $ref_group_key );
+          push( @genomic_align_array, $genomic_align );
+          $ref_genomic_align = $genomic_align if ( $this_gdb->dbID == $ref_gdb->dbID );
+          $ga_id_count++;
         }
-
-        # check for duplicates
-        my @genomic_align_counts = map { scalar(@{$_}) } values %{$grouped_genomic_aligns};
-        if (max(@genomic_align_counts) > 1) {
-            ## e87 HACK, updated for e110 ##
-            $grouped_genomic_aligns = $self->_resolve_duplicates($grouped_genomic_aligns);
-            ##############
-        }
-        my @genomic_align_array = map { $grouped_genomic_aligns->{$_}[0] } @hal_ga_group_order;
 
         next if ( scalar(@genomic_align_array) < 2 || !defined $ref_genomic_align );
 
@@ -1645,7 +1594,27 @@ sub _get_GenomicAlignBlocks_from_HAL {
         	$ga->genomic_align_block_id( $gab->dbID );
         }
         $gab->genomic_align_array(\@genomic_align_array);
-        push(@gabs, $gab);
+
+        # check for duplicate species
+        if ( $duplicates_found ) {
+            ## e87 HACK ##
+            my $resolved_gab = $self->_resolve_duplicates( $gab, $min_gab_len );
+            push( @gabs, $resolved_gab );
+            $gab_id_count++;
+            ##############
+
+            # my $split_gabs = $self->_split_genomic_aligns( $gab, $min_gab_len );
+
+            # foreach my $this_gab ( @$split_gabs ) {
+            #     $this_gab->adaptor($self);
+            #     $this_gab->dbID($id_base + $gab_id_count);
+
+            #     push( @gabs, $this_gab );
+            #     $gab_id_count++;
+            # }
+        } else {
+            push(@gabs, $gab);
+        }
       }
       undef $maf_file_str;
     }
@@ -1685,7 +1654,9 @@ sub _get_GenomicAlignBlocks_from_HAL {
                   -length => @$entry[3],
                   -method_link_species_set => $mlss,
                   -adaptor => $self,
+                  # -dbID => $id_base + $gab_id_count,
               );
+              $gab_id_count++;
   		
               my $ga_adaptor = $self->db->get_GenomicAlignAdaptor;
   		        # Create cigar strings
@@ -1711,13 +1682,16 @@ sub _get_GenomicAlignBlocks_from_HAL {
                   -dnafrag_end => @$entry[2] + @$entry[3] + (@$entry[4] eq '+' ? 0 : -1),
                   -dnafrag_strand => @$entry[4] eq '+' ? 1 : -1,
                   -cigar_line => $target_cigar,
+                  # -dbID => $id_base + $ga_id_count,
                   -visible => 1,
                   -adaptor => $ga_adaptor,
   	          );
               $genomic_align->cigar_line($target_cigar);
               $genomic_align->aligned_sequence( $target_aln_seq );
               $genomic_align->genomic_align_block( $gab );
+              # $genomic_align->dbID( $id_base + $ga_id_count );
               $genomic_align->dbID( join('-', $target_dnafrag->genome_db->dbID, $target_dnafrag->dbID, $genomic_align->dnafrag_start, $genomic_align->dnafrag_end) );
+              $ga_id_count+=1;
 
               $dnafrag->{'_slice'} = undef;
               my $ref_genomic_align = new Bio::EnsEMBL::Compara::GenomicAlign(
@@ -1728,6 +1702,7 @@ sub _get_GenomicAlignBlocks_from_HAL {
                 -dnafrag_end => @$entry[1] + @$entry[3],
                 -dnafrag_strand => 1,
                 -cigar_line => $ref_cigar,
+                # -dbID => $id_base + $ga_id_count,
                 -visible => 1,
                 -adaptor => $ga_adaptor,
   		        );
@@ -1735,6 +1710,7 @@ sub _get_GenomicAlignBlocks_from_HAL {
               $ref_genomic_align->aligned_sequence( $ref_aln_seq );
               $ref_genomic_align->genomic_align_block( $gab );
               $ref_genomic_align->dbID( join('-', $dnafrag->genome_db->dbID, $dnafrag->dbID, $ref_genomic_align->dnafrag_start, $ref_genomic_align->dnafrag_end) );
+              $ga_id_count++;
 
 
   		      $gab->genomic_align_array([$ref_genomic_align, $genomic_align]);
@@ -1750,10 +1726,9 @@ sub _get_GenomicAlignBlocks_from_HAL {
     return \@gabs;
 }
 
-# Get a 'linking' GenomeDB and DnaFrag, assuming the GenomeDB is present in the HAL mapping.
-# For accessing per-subgenome Cactus alignments, these may be the polyploid component GenomeDB
-# and DnaFrag corresponding to the input principal GenomeDB and DnaFrag. For cases where the
-# input GenomeDB is present in the HAL mapping, the input GenomeDB and DnaFrag are returned.
+# Get a 'linking' GenomeDB and DnaFrag. For accessing per-subgenome Cactus alignments, these are
+# are the polyploid component GenomeDB and DnaFrag corresponding to the input principal GenomeDB
+# and DnaFrag. Otherwise the input GenomeDB and DnaFrag are returned.
 sub _get_hal_linking_genome_dnafrag {
     my ($self, $dnafrag_adaptor, $genome_db, $dnafrag, $hal_species_map) = @_;
 
@@ -1767,15 +1742,29 @@ sub _get_hal_linking_genome_dnafrag {
 
     } elsif ($genome_db->is_polyploid()) {
 
-        my $comp_dnafrag = map_dnafrag_to_genome_component($dnafrag);
+        my $comp_gdbs = $genome_db->component_genome_dbs();
+        my @comp_dnafrags = grep { defined } map { $dnafrag_adaptor->fetch_by_GenomeDB_and_name($_, $dnafrag->name) } @{$comp_gdbs};
 
-        # It's possible for a DnaFrag to be present only in a principal GenomeDB, or for
-        # a polyploid subgenome GenomeDB to be excluded from a Cactus alignment, so we
-        # should only set a linking DnaFrag and GenomeDB if the given DnaFrag maps to a
-        # component GenomeDB and that component GenomeDB is present in the HAL mapping.
-        if (defined $comp_dnafrag && exists $hal_species_map->{ $comp_dnafrag->genome_db->dbID }) {
-            $linking_dnafrag = $comp_dnafrag;
-            $linking_genome_db = $comp_dnafrag->genome_db;
+        if (scalar(@comp_dnafrags) == 1) {
+
+            my $comp_dnafrag = $comp_dnafrags[0];
+            my $comp_gdb = $comp_dnafrag->genome_db;
+
+            # It's possible for a polyploid subgenome GenomeDB to be excluded from a Cactus alignment,
+            # so we should only set it as a linking GenomeDB if it is present in the HAL mapping.
+            if (exists $hal_species_map->{ $comp_gdb->dbID }) {
+                $linking_dnafrag = $comp_dnafrag;
+                $linking_genome_db = $comp_gdb;
+            }
+
+        } elsif (scalar(@comp_dnafrags) == 0) {
+            # If a dnafrag is present in the polyploid principal GenomeDB but not in any
+            # subgenome (e.g. scaffold_v5_108365 in triticum_aestivum_landmark), it will
+            # not be present in a per-component Cactus alignment, so there is no linking
+            # DnaFrag or GenomeDB.
+            warning('Cannot map dnafrag ' . $dnafrag->name . ' to any subgenome of ' . $genome_db->name);
+        } else {
+            throw('Cannot map dnafrag ' . $dnafrag->name . ' to a unique subgenome of ' . $genome_db->name);
         }
 
     } else {
@@ -1789,20 +1778,32 @@ sub _get_hal_linking_genome_dnafrag {
  # discard the smaller duplicated alignments for now
 
 sub _resolve_duplicates {
-    my ( $self, $grouped_genomic_aligns ) = @_;
+    my ( $self, $gab, $min_gab_len ) = @_;
+    my @ga_array = @{ $gab->genomic_align_array };
 
-    my %resolved_ga_for_hal_genomes;
-    for my $ga_group_key ( keys %{$grouped_genomic_aligns} ) {
+    # split genomic_aligns by species
+    # take note of species order   
+    my (%sort_gas, @species_order);
+    for my $ga ( @ga_array ) {
+        my $sp_name = $ga->genome_db->name;
+        push( @species_order, $sp_name ) unless ( defined $sort_gas{$sp_name} );
+        push( @{ $sort_gas{$sp_name} }, $ga );
+    }
+
+    my %resolved_ga_for_species;
+    for my $species ( keys %sort_gas ) {
         # if it's a duplicate, keep the longer alignment
         # if not, always keep it
-        if ( scalar( @{ $grouped_genomic_aligns->{$ga_group_key} } ) > 1 ) {
-            $resolved_ga_for_hal_genomes{$ga_group_key} = [$self->_longer_alignment($grouped_genomic_aligns->{$ga_group_key})];
+        if ( scalar( @{ $sort_gas{$species} } ) > 1 ) {
+            $resolved_ga_for_species{$species} = $self->_longer_alignment( $sort_gas{$species} );
         } else {
-            $resolved_ga_for_hal_genomes{$ga_group_key} = $grouped_genomic_aligns->{$ga_group_key};
+            $resolved_ga_for_species{$species} = $sort_gas{$species}->[0];
         }
     }
 
-    return \%resolved_ga_for_hal_genomes;
+    my @resolved_genomic_aligns = map { $resolved_ga_for_species{$_} } @species_order;
+    $gab->genomic_align_array( \@resolved_genomic_aligns );
+    return $gab;
 }
 
 sub _longer_alignment {
@@ -1819,6 +1820,77 @@ sub _longer_alignment {
     return $size{ $max_len };
 }
 ##################################
+
+sub _split_genomic_aligns {
+    my ( $self, $gab, $min_gab_len ) = @_;
+    my @ga_array = @{ $gab->genomic_align_array };
+
+    my @cigar_lines       = map { $_->cigar_line } @ga_array;
+    my $ref_genomic_align = shift @ga_array;
+    my $ref_cigar         = shift @cigar_lines;
+
+    my @non_matching_cigars = grep { $_ ne $ref_cigar } @cigar_lines;
+    my @m_end = grep { $_ =~ m/M$/ } @non_matching_cigars;
+    my @d_end = grep { $_ =~ m/D$/ } @non_matching_cigars;
+
+    my $max_end_match = 0;
+    foreach my $end_match ( @d_end ){
+        $end_match =~ m/(\d+)D$/;
+        $max_end_match = $1 if ( $1 > $max_end_match );
+    }
+
+    # check whether we can split the block in half(ish) or whether it's
+    # better to keep the main block intact and move the offending genomic_aligns
+    # to a new block
+    my ($can_split, $trim) = (1, 0);
+    foreach my $end_gap ( @d_end ) {
+        # if it also starts with a deletion, then the match is surrounded on each
+        # side and we can't just split the block down the middle. If the deletion
+        # is shorter than the matched region, we should just trim it off (we lose
+        # less data this way) and split in two as usual
+        if ( $end_gap =~ m/^(\d*)D(\d*)M/ ) {
+            my $d = $1 eq '' ? 1 : $1;
+            my $m = $2 eq '' ? 1 : $2;
+            if ( $d < $m ) {
+                $trim = $d if ( $d > $trim );
+            } else {
+                $can_split = 0;
+                last;
+            }
+        }
+        $end_gap =~ m/(\d+)D$/;
+        if ( $1 < $max_end_match ){
+            $can_split = 0;
+        }
+    }
+
+    if ( $trim > 0) {
+        my $new_gab = $gab->restrict_between_alignment_positions($trim+1, $gab->length, 1 );
+        $gab = $new_gab;
+        $can_split = 1;
+    }
+
+    my @split_blocks = ();
+    if ( $can_split ){ # restrict the block to create 2, non-overlapping ones
+        my $aln_length = $gab->length;
+        my $split_pos  = ($aln_length - $max_end_match);
+
+        if ( $split_pos > $min_gab_len ) {
+            my $block1 = $gab->restrict_between_alignment_positions(1, $split_pos, 1 );
+            push( @split_blocks, $block1 );
+        }
+
+        if ( $max_end_match > $min_gab_len ) {
+            my $block2 = $gab->restrict_between_alignment_positions($split_pos+1, $aln_length, 1 );
+            push( @split_blocks, $block2 );
+        }
+        return \@split_blocks if ( scalar @split_blocks > 1 );
+    }
+    # if the above method fails to split, or the block just can't be split
+    # then keep main block, but remove offending duplications
+    return [ $self->_resolve_duplicates($gab, $min_gab_len) ];
+}
+
 
 sub _parse_maf {
   my ($self, $maf_lines) = @_;

--- a/modules/Bio/EnsEMBL/Compara/GenomicAlignBlock.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomicAlignBlock.pm
@@ -166,7 +166,6 @@ use Bio::SimpleAlign;
 use Bio::EnsEMBL::Compara::BaseGenomicAlignSet;
 use Bio::EnsEMBL::Compara::GenomicAlignGroup;
 use Bio::EnsEMBL::Compara::GenomicAlignTree;
-use Bio::EnsEMBL::Compara::Utils::Polyploid qw(map_dnafrag_to_genome_component);
 use Bio::EnsEMBL::Compara::Utils::SpeciesTree;
 use Bio::EnsEMBL::Compara::Graph::NewickParser;
 
@@ -1414,8 +1413,7 @@ sub restrict_between_alignment_positions {
   Example    : $genomic_align_block->get_GenomicAlignTree
   Description: Return a Bio::EnsEMBL::Compara::GenomicAlignTree object either from a GenomicAlignTreeAdaptor, a SpeciesTreeAdaptor or from the species set.
   Returntype : Bio::EnsEMBL::Compara::GenomicAlignTree
-  Exceptions : throw if no GenomicAlignTree object in the database and either a duplicate species is found, or a
-               GenomicAlign maps to both its polyploid principal and component genome on the GenomicAlignTree
+  Exceptions : throw if duplicate species found but no GenomicAlignTree object in the database
   Status     : At risk
 
 =cut
@@ -1455,50 +1453,15 @@ sub get_GenomicAlignTree {
     }
 
     #Create lookup of names to GenomicAlign objects
+    my $leaf_names;
     my $genomic_aligns = $self->get_all_GenomicAligns();
-    my $gdb_id_to_ga;
-    my %gdb_id_to_gdb;
-    my %polyploid_gdb_id_map;
-    foreach my $genomic_align (@{$genomic_aligns}) {
 
-        my $ga_gdb = $genomic_align->genome_db;
-        $gdb_id_to_gdb{$ga_gdb->dbID} = $ga_gdb;
-
-        my $comp_gdb;
-        if ($ga_gdb->is_polyploid()) {
-
-            my $comp_dnafrag = map_dnafrag_to_genome_component($genomic_align->dnafrag);
-
-            # We don't have the species tree yet, so we don't know whether it represents polyploids as genomes
-            # or subgenomes. But to avoid a duplicate GenomicAlign error, we assume that they are represented
-            # as subgenomes and map each polyploid to its component GenomeDB if possible.
-            if (defined($comp_dnafrag)) {
-                $comp_gdb = $comp_dnafrag->genome_db;
-                $gdb_id_to_gdb{$comp_gdb->dbID} = $comp_gdb;
-                push(@{$polyploid_gdb_id_map{$ga_gdb->dbID}}, $comp_gdb->dbID);
-            }
-        }
-
-        my $ga_gdb_id = defined($comp_gdb) ? $comp_gdb->dbID : $ga_gdb->dbID;
-
+    foreach my $genomic_align (@$genomic_aligns) {
         #Throw if duplicates are found (and no GenomicAlignTree has been found)
-        if (defined($gdb_id_to_ga->{$ga_gdb_id})) {
-            throw("Duplicate genomic_align found for genome_db_id $ga_gdb_id");
+        if (defined  $leaf_names->{$genomic_align->genome_db->dbID}) {
+            throw ("Duplicate found for species " . $genomic_align->genome_db->dbID);
         }
-        $gdb_id_to_ga->{$ga_gdb_id} = $genomic_align;
-    }
-
-    while (my ($princ_gdb_id, $comp_gdb_ids) = each %polyploid_gdb_id_map) {
-        # We hedge our bets with polyploids whose GenomicAligns have been linked to their
-        # component GenomeDB, by also linking them to the principal GenomeDB, except where
-        # this would result in mapping multiple GenomicAligns to the same principal GenomeDB.
-        if (!defined($gdb_id_to_ga->{$princ_gdb_id}) && scalar(@{$comp_gdb_ids}) == 1) {
-            my $comp_gdb_id = $comp_gdb_ids->[0];
-            $polyploid_gdb_id_map{$princ_gdb_id} = $comp_gdb_id;
-            $gdb_id_to_ga->{$princ_gdb_id} = $gdb_id_to_ga->{$comp_gdb_id};
-        } else {
-            delete $polyploid_gdb_id_map{$princ_gdb_id};
-        }
+        $leaf_names->{$genomic_align->genome_db->dbID} = $genomic_align;
     }
 
     #Create a tree as a newick format string
@@ -1530,25 +1493,15 @@ sub get_GenomicAlignTree {
 
     #Prune the tree to just contain the species in this GenomicAlignBlock and add GenomicAlignGroup objects on the leaves
     my $all_leaves = $genomic_align_tree->get_all_leaves;
-    my %leaf_gdb_ids_seen;
     foreach my $this_leaf (@$all_leaves) {        
-        my $leaf_gdb_id = $this_leaf->name;
+        my $this_leaf_name = $this_leaf->name;
 
-        if ($gdb_id_to_ga->{$leaf_gdb_id}) {
-            $leaf_gdb_ids_seen{$leaf_gdb_id} = 1;
+        if ($leaf_names->{$this_leaf_name}) {
             #add GenomicAlignGroup populated with GenomicAlign to leaf
-            my $this_genomic_align = $gdb_id_to_ga->{$leaf_gdb_id};
-
-            my $leaf_gdb = $gdb_id_to_gdb{$leaf_gdb_id};
-            $this_leaf->name($leaf_gdb->get_distinct_name);
-            if ($leaf_gdb_id != $this_genomic_align->genome_db->dbID) {
-                # The leaf GenomeDB can differ from that of the GenomicAlign
-                # if, for example, it is a polyploid component GenomeDB.
-                $this_leaf->{_genome_db} = $leaf_gdb;
-            }
-
+	    my $this_genomic_align = $leaf_names->{$this_leaf_name};
+            $this_leaf->name($this_genomic_align->genome_db->name);
             my $genomic_align_group = new Bio::EnsEMBL::Compara::GenomicAlignGroup();
-            $genomic_align_group->add_GenomicAlign($this_genomic_align);
+            $genomic_align_group->add_GenomicAlign($leaf_names->{$this_leaf_name});
             $this_leaf->genomic_align_group($genomic_align_group);
 	    if ($this_genomic_align->genome_db->name eq $ref_genomic_align->genome_db->name and
 		$this_genomic_align->dnafrag->name eq $ref_genomic_align->dnafrag->name and
@@ -1566,13 +1519,6 @@ sub get_GenomicAlignTree {
     }
     $genomic_align_tree->root->reference_genomic_align($ref_genomic_align);
     $genomic_align_tree->root->reference_genomic_align_node($ref_genomic_align_node);
-
-    while (my ($princ_gdb_id, $comp_gdb_id) = each %polyploid_gdb_id_map) {
-        if (exists $leaf_gdb_ids_seen{$princ_gdb_id} && exists $leaf_gdb_ids_seen{$comp_gdb_id}) {
-            throw(sprintf('GenomicAlign %s mapped to both its polyploid principal and component genome on GenomicAlignTree',
-                          $gdb_id_to_ga->{$princ_gdb_id}->display_id));
-        }
-    }
 
     # Copy the adaptor if there is one
     $genomic_align_tree->adaptor( $self->adaptor->db->get_GenomicAlignTreeAdaptor ) if $self->adaptor;


### PR DESCRIPTION
This reverts Cactus-related code to be as it was on the `release/110` branch, except for the following:
* hotfix to use the Wheat Cactus placeholder tree;
* new Perl API methods; and
* bugfixes.

Further information to follow.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
