### PR TITLE
Simplify dumping of updated Compara data

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/MLSSJobFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/MLSSJobFactory.pm
@@ -54,12 +54,19 @@ sub run {
         return;
     }
 
+    my $updated_mlss_ids = $self->param('updated_mlss_ids');
     foreach my $ml_typ (split /[,:]/, $self->param_required('method_link_types')){
         # Get MethodLinkSpeciesSet Objects for required method_link_type
         my $mlss_listref = $mlssa->fetch_all_by_method_link_type($ml_typ);
         foreach my $mlss (@$mlss_listref) {
             my $from_first_release = $self->param('from_first_release');
-            next if ( defined $from_first_release && !($mlss->first_release == $from_first_release || $mlss->has_tag("rerun_in_${from_first_release}")) );
+            if ( defined $from_first_release ) {
+                my $mlss_dump_wanted = ($mlss->first_release == $from_first_release
+                                        || $mlss->has_tag("patched_in_${from_first_release}")
+                                        || $mlss->has_tag("rerun_in_${from_first_release}")
+                                        || grep { $mlss->dbID eq $_ } @$updated_mlss_ids);
+                next unless $mlss_dump_wanted;
+            }
             $self->_process_mlss($mlss);
         }
     }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/PatchLastzDump.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/PatchLastzDump.pm
@@ -70,6 +70,8 @@ sub fetch_input {
 sub run {
 	my $self = shift;
 
+    $self->warning("RunnableDB::FTPDumps::PatchLastzDump is deprecated");
+
 	my $prev_rel_tarball = $self->param('prev_rel_tarball');
 	my $patch_dump_dir = $self->param('patch_dump_dir');
 	my $mlss_filename = $self->param('mlss_filename');


### PR DESCRIPTION
## Description

To save redumping Compara data such as LastZ alignments, data files dumped in a given release may be symlinks to the corresponding file in a previous release.

Sometimes a LastZ alignment file needs to be redumped, such as when genome patches have been updated in one of the species in the alignment. Currently this can be signalled in several ways, such as setting an `updated_mlss_ids` parameter when initialising the `DumpAllForRelease` pipeline; setting a `rerun_in_<release>` MLSS tag, where `<release>` is set to the current Ensembl release; or configuring the relevant LastZ databases with the `lastz_patch_dbs` parameter, triggering a dedicated branch of the pipeline to `DumpMultiAlignPatches`.

This process could be simplified/automated to ensure that LastZ alignments involving patched genomes can be redumped as needed, while avoiding the level of manual intervention that has in the past been required to handle genome patches when the Compara FTP dump pipelines are run.

**Related JIRA tickets:**
- ENSCOMPARASW-6824

## Overview of changes

- The `lastz_patch_dbs` parameter and `DumpMultiAlignPatches` pipeline branch are removed from the `DumpAllForRelease` pipeline.
- In their place has been added the `patched_in_<release>` MLSS tag, which signals to the dump pipeline that the given alignment has been patched and should be redumped.
- In addition to being used to trigger redumps of data for specified MLSSes in the `CreateDumpJobs` pipeline step, the `updated_mlss_ids` parameter now also ensures that the updated MLSSes are handled correctly in `MLSSJobFactory`.
- The `PatchLastzDump` runnable is deprecated.

## Testing
These changes were tested by a trial run of the `DumpAllForRelease` pipeline. See related ticket for more info.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
