### PR TITLE
Dump unchanged data files as relative symlinks

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -136,6 +136,7 @@ sub executable_locations {
         'copy_ancestral_core_exe'           => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/copy_ancestral_core.pl'),
         'gene_tree_stats_report_exe'        => $self->check_exe_in_ensembl('ensembl-compara/scripts/production/gene_tree_stats.pl'),
         'hal_cov_one_seq_chunk_exe'         => $self->check_exe_in_ensembl('ensembl-compara/scripts/hal_alignment/hal_cov_one_seq_chunk.py'),
+        'symlink_prev_dump_exe'             => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/symlink_prev_dump.py'),
         'xmlschema_validate_exe'            => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/xmlschema_validate.py'),
 
         # Other dependencies (non executables)

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/DumpAllForRelease_conf.pm
@@ -47,8 +47,6 @@ sub default_options {
         'dump_dir'          => $self->o('dump_root') . '/release-' . $self->o('eg_release'),
 
         'division'          => 'fungi',
-
-        'prev_rel_ftp_root' => $self->o('ftp_root') . '/release-' . $self->o('prev_eg_release') . '/' . $self->o('division'),
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/DumpAllForRelease_conf.pm
@@ -50,8 +50,6 @@ sub default_options {
         'dump_dir'         => $self->o('dump_root') . '/release-' . $self->o('eg_release'),
 
         'division'         => 'metazoa',
-
-        'prev_rel_ftp_root' => $self->o('ftp_root') . '/release-' . $self->o('prev_eg_release') . '/' . $self->o('division'),
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/DumpAllForRelease_conf.pm
@@ -52,8 +52,6 @@ sub default_options {
         'dump_dir'         => $self->o('dump_root') . '/release-' . $self->o('eg_release'),
 
         'division'          => 'pan',
-
-        'prev_rel_ftp_root' => $self->o('ftp_root') . '/release-' . $self->o('prev_eg_release') . '/pan_ensembl',
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/DumpAllForRelease_conf.pm
@@ -54,8 +54,6 @@ sub default_options {
 
         'division'          => 'plants',
         'epo_reference_species' => ['oryza_sativa'],
-
-        'prev_rel_ftp_root' => $self->o('ftp_root') . '/release-' . $self->o('prev_eg_release') . '/' . $self->o('division'),
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/DumpAllForRelease_conf.pm
@@ -47,8 +47,6 @@ sub default_options {
         'dump_dir'         => $self->o('dump_root') . '/release-' . $self->o('eg_release'),
 
         'division'         => 'protists',
-
-        'prev_rel_ftp_root' => $self->o('ftp_root') . '/release-' . $self->o('prev_eg_release') . '/' . $self->o('division'),
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/FTPSkeleton.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/FTPSkeleton.pm
@@ -102,10 +102,22 @@ sub run {
 
 sub write_output {
 	my $self = shift;
-	$self->dataflow_output_id( { 
-		mlss_dump_dirs => $self->param('mlss_dump_dirs'),
-		archived_dumps => $self->param('archived_dumps'),
-	}, 1 );
+
+    while (my ($mlss_path, $mlss_id) = each %{$self->param('mlss_dump_dirs')}) {
+        $self->dataflow_output_id( {
+            mlss_path_type => 'directory',
+            mlss_path      => $mlss_path,
+            mlss_id        => $mlss_id,
+        }, 2 );
+    }
+
+    while (my ($mlss_path, $mlss_id) = each %{$self->param('archived_dumps')}) {
+        $self->dataflow_output_id( {
+            mlss_path_type => 'archive',
+            mlss_path      => $mlss_path,
+            mlss_id        => $mlss_id,
+        }, 2 );
+    }
 }
 
 sub _mlss_dirs {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/FlowAnyMissingMLSSes.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/FlowAnyMissingMLSSes.pm
@@ -1,0 +1,41 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::FlowAnyMissingMLSSes
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::FlowAnyMissingMLSSes;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+sub write_output {
+    my $self = shift;
+
+    my $missing_mlss_ids = $self->param('missing_mlss_id');
+
+    if (defined $missing_mlss_ids && scalar(@$missing_mlss_ids) > 0) {
+         $self->dataflow_output_id( { mlss_ids => $missing_mlss_ids, reuse_prev_rel => 0 }, 2 );
+    }
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/SymlinkPreviousDumps.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/SymlinkPreviousDumps.pm
@@ -85,6 +85,8 @@ sub fetch_input {
 sub run {
 	my $self = shift;
 
+    $self->warning("RunnableDB::FTPDumps::SymlinkPreviousDumps is deprecated");
+
 	my @symlink_cmds = @{ $self->param('symlink_cmds') };
 	foreach my $this_cmd ( @symlink_cmds ) {
 		print STDERR "$this_cmd\n";

--- a/scripts/pipeline/symlink_prev_dump.py
+++ b/scripts/pipeline/symlink_prev_dump.py
@@ -103,12 +103,12 @@ if __name__ == "__main__":
     if prev_mlss_file_paths:
         curr_to_prev_root_path = Path(os.path.relpath(prev_ftp_pub_root, start=curr_ftp_pub_root))
         curr_mlss_dir_path = curr_ftp_dump_root / root_to_mlss_dir_path
-        mlss_dir_to_root_parent = os.path.relpath(curr_ftp_dump_root, start=curr_mlss_dir_path)
+        mlss_dir_to_root_path = os.path.relpath(curr_ftp_dump_root, start=curr_mlss_dir_path)
 
         symlink_pairs = []
         for prev_mlss_file_path in prev_mlss_file_paths:
             root_to_mlss_file_path = root_to_mlss_dir_path / prev_mlss_file_path.name
-            new_symlink_target = mlss_dir_to_root_parent / curr_to_prev_root_path / root_to_mlss_file_path
+            new_symlink_target = mlss_dir_to_root_path / curr_to_prev_root_path / root_to_mlss_file_path
 
             if prev_mlss_file_path.is_symlink():
                 prev_symlink_target = Path(os.readlink(prev_mlss_file_path))

--- a/scripts/pipeline/symlink_prev_dump.py
+++ b/scripts/pipeline/symlink_prev_dump.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
             if prev_mlss_file_path.is_symlink():
                 prev_symlink_target = Path(os.readlink(prev_mlss_file_path))
                 if not prev_symlink_target.is_absolute():
-                    new_symlink_target = os.path.normpath(new_symlink_target.parent / prev_symlink_target)
+                    new_symlink_target = Path(os.path.normpath(new_symlink_target.parent / prev_symlink_target))
 
             curr_mlss_file_path = curr_ftp_dump_root / root_to_mlss_file_path
             symlink_pairs.append((new_symlink_target, curr_mlss_file_path))

--- a/scripts/pipeline/symlink_prev_dump.py
+++ b/scripts/pipeline/symlink_prev_dump.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Create symlinks to previously dumped Compara data files."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+from tempfile import TemporaryDirectory
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--curr_ftp_dump_root", required=True, help="Main dump root directory of the current Ensembl release."
+    )
+    parser.add_argument(
+        "--prev_ftp_dump_root", required=True, help="Main dump root directory of previous Ensembl release."
+    )
+    parser.add_argument(
+        "--curr_ftp_pub_root", required=True, help="FTP publication root directory of current release."
+    )
+    parser.add_argument(
+        "--prev_ftp_pub_root", required=True, help="FTP publication root directory of previous release."
+    )
+    parser.add_argument(
+        "--mlss_path_type", required=True, choices=["archive", "directory"], help="MLSS path type."
+    )
+    parser.add_argument(
+        "--mlss_path", required=True, help="MLSS dump path relative to the main dump root directory."
+    )
+    parser.add_argument("--mlss_id", required=True, help="MLSS ID of dumped data.")
+    parser.add_argument("--dataflow_file", required=True, help="Output JSON file to dataflow missing MLSSes.")
+
+    args = parser.parse_args()
+
+    curr_ftp_dump_root = Path(args.curr_ftp_dump_root)
+    prev_ftp_dump_root = Path(args.prev_ftp_dump_root)
+    curr_ftp_pub_root = Path(args.curr_ftp_pub_root)
+    prev_ftp_pub_root = Path(args.prev_ftp_pub_root)
+    mlss_path = Path(args.mlss_path)
+    dataflow_file = Path(args.dataflow_file)
+
+    known_standin_mlss_ids = ["ANCESTRAL_ALLELES"]
+    try:
+        mlss_id = int(args.mlss_id)
+    except ValueError as exc:
+        if args.mlss_id in known_standin_mlss_ids:
+            mlss_id = args.mlss_id
+        else:
+            raise ValueError(f"invalid MLSS ID: {args.mlss_id}") from exc
+
+    if not curr_ftp_dump_root.is_absolute():
+        raise ValueError(
+            f"value of --curr_ftp_dump_root must be an absolute path,"
+            f" but appears to be relative: {str(curr_ftp_dump_root)!r}"
+        )
+    if not prev_ftp_dump_root.is_absolute():
+        raise ValueError(
+            f"value of --prev_ftp_dump_root must be an absolute path,"
+            f" but appears to be relative: {str(prev_ftp_dump_root)!r}"
+        )
+    if not curr_ftp_pub_root.is_absolute():
+        raise ValueError(
+            f"value of --curr_ftp_pub_root must be an absolute path,"
+            f" but appears to be relative: {str(curr_ftp_pub_root)!r}"
+        )
+    if not prev_ftp_pub_root.is_absolute():
+        raise ValueError(
+            f"value of --prev_ftp_pub_root must be an absolute path,"
+            f" but appears to be relative: {str(prev_ftp_pub_root)!r}"
+        )
+
+    if args.mlss_path_type == "archive":
+        root_to_mlss_dir_path = mlss_path.parent
+        path_spec = f"{mlss_path.name}*"
+    elif args.mlss_path_type == "directory":
+        root_to_mlss_dir_path = mlss_path
+        path_spec = "*"
+
+    prev_mlss_dir_path = prev_ftp_dump_root / root_to_mlss_dir_path
+    prev_mlss_file_paths = list(prev_mlss_dir_path.glob(path_spec))
+
+    if args.mlss_path_type == "archive" and len(prev_mlss_file_paths) > 1:
+        raise RuntimeError(
+            f"path spec {path_spec!r} matches multiple archive files in directory {str(prev_mlss_dir_path)!r}"
+        )
+
+    dataflow_events = []
+    if prev_mlss_file_paths:
+        curr_to_prev_root_path = Path(os.path.relpath(prev_ftp_pub_root, start=curr_ftp_pub_root))
+        curr_mlss_dir_path = curr_ftp_dump_root / root_to_mlss_dir_path
+        mlss_dir_to_root_parent = os.path.relpath(curr_ftp_dump_root, start=curr_mlss_dir_path)
+
+        symlink_pairs = []
+        for prev_mlss_file_path in prev_mlss_file_paths:
+            root_to_mlss_file_path = root_to_mlss_dir_path / prev_mlss_file_path.name
+            new_symlink_target = mlss_dir_to_root_parent / curr_to_prev_root_path / root_to_mlss_file_path
+
+            if prev_mlss_file_path.is_symlink():
+                prev_symlink_target = Path(os.readlink(prev_mlss_file_path))
+                if not prev_symlink_target.is_absolute():
+                    new_symlink_target = os.path.normpath(new_symlink_target.parent / prev_symlink_target)
+
+            curr_mlss_file_path = curr_ftp_dump_root / root_to_mlss_file_path
+            symlink_pairs.append((new_symlink_target, curr_mlss_file_path))
+
+        with TemporaryDirectory(dir=curr_mlss_dir_path, prefix=".symlink_tmp_") as tmp_dir:
+            for new_symlink_target, curr_mlss_file_path in symlink_pairs:
+                tmp_mlss_file_path = os.path.join(tmp_dir, curr_mlss_file_path.name)
+                os.symlink(new_symlink_target, tmp_mlss_file_path)
+                shutil.move(tmp_mlss_file_path, curr_mlss_file_path)
+    else:
+        # We cannot currently dataflow standin MLSS IDs.
+        if mlss_id in known_standin_mlss_ids:
+            raise RuntimeError(
+                f"cannot symlink {mlss_id} data - file not found in"
+                f" previous release dump {str(prev_ftp_dump_root)!r}"
+            )
+        dataflow_branch = 2
+        dataflow_json = json.dumps({"missing_mlss_id": args.mlss_id})
+        dataflow_events.append(f"{dataflow_branch} {dataflow_json}")
+
+    os.makedirs(dataflow_file.parent, mode=0o775, exist_ok=True)
+    with open(dataflow_file, "w") as out_file_obj:
+        for dataflow_event in dataflow_events:
+            print(dataflow_event, file=out_file_obj)


### PR DESCRIPTION
## Description

To save redumping Compara data such as LastZ alignments, data files dumped in a previous release are currently initially symlinked, with those symlinks ultimately being resolved before the data file is copied to the Ensembl FTP.

The size of all these identical copies can add up to a significant amount of space. The aim of this PR is to save some space by creating symlinks which will not be resolved until they are in their final location in the Ensembl FTP space (i.e. relative symlinks from a data file in a given release to a corresponding data file in a previous release).

**Related JIRA tickets:**
- ENSCOMPARASW-7095

## Overview of changes
- In addition to the `prev_rel_ftp_root` parameter specifying the current root directory of the FTP dumps of the previous release, there are now two parameters to specify the final FTP publication root of the Compara data dumps
in the current and previous releases (`curr_ftp_pub_root` and `prev_ftp_pub_root`, respectively). All 3 parameters must be specified.
- The `RunnableDB::FTPDumps::SymlinkPreviousDumps` Perl module is replaced by a `symlink_prev_dump.py`
Python script, which generates inferred relative symlinks to the relevant previous data file(s).
- To facilitate the use of the Python script `symlink_prev_dump.py`, `FTPSkeleton` now dataflows parameters for each MLSS individually. A tiny runnable (`FlowAnyMissingMLSSes`) is added to enable dataflow of missing MLSS IDs (formerly handled by the `SymlinkPreviousDumps` runnable).
- The `SymlinkPreviousDumps` runnable is deprecated.

## Testing
These changes have been tested by a trial run of the `DumpAllForRelease` pipeline. See related ticket for more info.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
