### PR TITLE
ncRNA pipeline resource class updates to work with 1 hour default

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/CAFE.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/CAFE.pm
@@ -83,7 +83,7 @@ sub pipeline_analyses_cafe {
                              'cafe_species' => $self->o('cafe_species'),
                              'label'        => $self->o('full_species_tree_label')
                             },
-             -rc_name => '16Gb_1_hour_job',
+             -rc_name => '16Gb_job',
              -flow_into     => {
                  2 => [ 'hc_cafe_species_tree' ],
              }
@@ -160,7 +160,7 @@ sub pipeline_analyses_cafe {
             -module        => 'Bio::EnsEMBL::Compara::RunnableDB::ObjectStore::GeneTreeCAFE',
             -hive_capacity => $self->o('cafe_capacity'),
             -batch_size    => 20,
-            -rc_name       => '1Gb_1_hour_job',
+            -rc_name       => '1Gb_job',
             -flow_into  => {
                 -1 => [ 'CAFE_json_himem' ],
             }
@@ -170,7 +170,7 @@ sub pipeline_analyses_cafe {
             -module        => 'Bio::EnsEMBL::Compara::RunnableDB::ObjectStore::GeneTreeCAFE',
             -hive_capacity => $self->o('cafe_capacity'),
             -batch_size    => 20,
-            -rc_name       => '2Gb_1_hour_job',
+            -rc_name       => '2Gb_job',
         },
 
         {   -logic_name         => 'hc_cafe_results',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DataCheckFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DataCheckFactory.pm
@@ -56,7 +56,7 @@ sub pipeline_analyses_datacheck_factory {
             -analysis_capacity => 1,
             -batch_size        => 100,
             -max_retry_count   => 0,
-            -rc_name           => '2Gb_1_hour_job',
+            -rc_name           => '2Gb_job',
             -flow_into         => [ 'store_results' ],
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DataCheckFan.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DataCheckFan.pm
@@ -49,6 +49,7 @@ sub pipeline_analyses_datacheck_fan {
                     WHEN( '#do_jira_ticket_creation#' => 'jira_ticket_creation' )
                 ],
             },
+            -rc_name           => '1Gb_24_hour_job',
         },
 
         {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpHomologiesForPosttree.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpHomologiesForPosttree.pm
@@ -103,6 +103,7 @@ sub pipeline_analyses_split_homologies_posttree {
 
         { -logic_name => 'split_tree_homologies',
           -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::SplitOrthoTreeOutput',
+          -rc_name => '1Gb_24_hour_job',
         },
     ];
 }

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/GeneMemberHomologyStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/GeneMemberHomologyStats.pm
@@ -148,7 +148,7 @@ sub pipeline_analyses_hom_stats {
             -parameters => {
                 'member_type' => $self->o('member_type'),
             },
-            -rc_name => '4Gb_job',
+            -rc_name => '4Gb_24_hour_job',
         },
 
     ];

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/HighConfidenceOrthologs.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/HighConfidenceOrthologs.pm
@@ -159,7 +159,7 @@ sub pipeline_analyses_high_confidence {
                 homology_flatfile => '#homology_dumps_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.homologies.tsv',
                 replace      => 0,
             },
-            -rc_name         => '16Gb_job',
+            -rc_name         => '16Gb_24_hour_job',
             -hive_capacity   => $self->o('import_homologies_capacity'),
             -max_retry_count => 0,
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -707,7 +707,7 @@ sub core_pipeline_analyses {
                     1 => 'hc_epo_removed_members',
                     -1 => 'recover_epo_himem',
                 },
-                -rc_name => '2Gb_job',
+                -rc_name => '2Gb_24_hour_job',
             },
 
             {   -logic_name    => 'recover_epo_himem',
@@ -717,7 +717,7 @@ sub core_pipeline_analyses {
                     1 => 'hc_epo_removed_members',
                     -1 => 'recover_epo_hugemem',
                 },
-                -rc_name => '16Gb_job',
+                -rc_name => '16Gb_24_hour_job',
             },
 
             {   -logic_name    => 'recover_epo_hugemem',
@@ -763,7 +763,7 @@ sub core_pipeline_analyses {
                     1 => ['quick_tree_break' ],
                     -1 => [ 'aligner_for_tree_break_himem' ],
                 },
-                -rc_name => '2Gb_job',
+                -rc_name => '2Gb_24_hour_job',
             },
 
             {   -logic_name    => 'aligner_for_tree_break_himem',
@@ -786,7 +786,7 @@ sub core_pipeline_analyses {
                                 'treebreak_gene_count'  => $self->o('treebreak_gene_count'),
                                },
                 -analysis_capacity  => $self->o('quick_tree_break_capacity'),
-                -rc_name        => '2Gb_job',
+                -rc_name        => '2Gb_24_hour_job',
                 -priority       => 50,
                 -flow_into      => {
                    1   => ['other_paralogs', 'subcluster_factory'],
@@ -863,7 +863,7 @@ sub core_pipeline_analyses {
                                   -1 => [ 'infernal_himem' ],
                                    1 => [ 'pre_secondary_structure_decision', WHEN('#create_ss_picts#' => 'create_ss_picts' ) ],
                                   },
-                -rc_name       => '1Gb_job',
+                -rc_name       => '1Gb_24_hour_job',
             },
 
             {   -logic_name    => 'infernal_himem',
@@ -939,6 +939,7 @@ sub core_pipeline_analyses {
                             2 => [ 'secondary_structure_decision' ],
                             3 => [ 'pre_sec_struct_tree_2_cores' ], #After trying to restart RAxML we should escalate the capacity.
                            },
+              -rc_name       => '1Gb_24_hour_job',
         },
 
         {   -logic_name    => 'pre_sec_struct_tree_2_cores', ## pre_sec_struct_tree
@@ -1032,7 +1033,7 @@ sub core_pipeline_analyses {
                            -1 => [ 'sec_struct_model_tree_4_cores' ],   # This analysis has more cores *and* more memory
                             3 => [ 'sec_struct_model_tree_4_cores' ],
                        },
-            -rc_name => '1Gb_2c_job',
+            -rc_name => '1Gb_2c_24_hour_job',
         },
 
         {   -logic_name    => 'sec_struct_model_tree_4_cores', ## sec_struct_model_tree
@@ -1078,7 +1079,7 @@ sub core_pipeline_analyses {
                            3  => ['fast_trees'],
                            2  => ['genomic_tree'],
                           },
-            -rc_name => '2Gb_4c_job',
+            -rc_name => '2Gb_4c_24_hour_job',
             -priority      => $self->o('genomic_alignment_priority'),
         },
 
@@ -1110,7 +1111,7 @@ sub core_pipeline_analyses {
             -flow_into => {
                            -1 => ['fast_trees_hugemem'],
                           },
-             -rc_name => '16Gb_4c_mpi',
+             -rc_name => '16Gb_4c_24_hour_mpi',
             },
             {
              -logic_name => 'fast_trees_hugemem',
@@ -1138,7 +1139,7 @@ sub core_pipeline_analyses {
                             'genome_dumps_dir' => $self->o('genome_dumps_dir'),
                             'inhugemem' => 1,
                            },
-         -rc_name => '8Gb_8c_job',
+         -rc_name => '8Gb_8c_24_hour_job',
          -priority  => $self->o('genomic_alignment_himem_priority'),
          -flow_into => {
                         3 => [ 'fast_trees' ],
@@ -1176,7 +1177,7 @@ sub core_pipeline_analyses {
                 'inhugemem'             => 1,
             },
             -analysis_capacity => $self->o('genomic_alignment_capacity'),
-            -rc_name           => '96Gb_8c_job',
+            -rc_name           => '96Gb_8c_24_hour_job',
             -flow_into         => {
                 3 => [ 'fast_trees_himem' ],
                 2 => [ 'genomic_tree_himem' ],
@@ -1203,7 +1204,7 @@ sub core_pipeline_analyses {
              -parameters => {
                              'treebest_exe' => $self->o('treebest_exe'),
                             },
-             -rc_name => '1Gb_job',
+             -rc_name => '1Gb_24_hour_job',
             },
 
         {   -logic_name    => 'treebest_mmerge',
@@ -1247,7 +1248,7 @@ sub core_pipeline_analyses {
                             'treebest_exe'  => $self->o('treebest_exe'),
                             'ktreedist_exe' => $self->o('ktreedist_exe'),
                            },
-            -rc_name => '2Gb_job',
+            -rc_name => '2Gb_24_hour_job',
         },
 
         {   -logic_name     => 'consensus_cigar_line_prep',


### PR DESCRIPTION
## Description

**Related JIRA tickets:**
- ENSCOMPARASW-7145

## Overview of changes
Resource classes of ncRNA-tree pipeline have been updated on so that they can be used on Slurm with a 1-hour default time limit.

## Testing
The pipeline was initialised on the vertebrates division.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
