### PR TITLE
DumpGenomes resurce class update to 1 hour default

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpGenomes_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpGenomes_conf.pm
@@ -146,7 +146,7 @@ sub pipeline_analyses {
                 'force_redump'  => $self->o('force_redump'),
             },
             -flow_into  => [ 'build_faidx_index', WHEN('#methods#->{"EPO"}' => [ 'build_exonerate_esd_index' ]), ],
-            -rc_name    => '4Gb_job',
+            -rc_name    => '4Gb_24_hour_job',
             -priority   => 10,
             -hive_capacity  => $self->o('dump_capacity'),
         },
@@ -159,7 +159,7 @@ sub pipeline_analyses {
             -flow_into  => {
                 2 => [ 'build_faidx_index' ],
             },
-            -rc_name    => '4Gb_job',
+            -rc_name    => '4Gb_24_hour_job',
             -hive_capacity  => $self->o('dump_capacity'),
         },
 


### PR DESCRIPTION
## Description

**Related JIRA tickets:**
- ENSCOMPARASW-7159

## Overview of changes

Resource classes of DumpGenomes pipeline analyses have been update so that they can be used on Slurm with a 1-hour default time limit.

## Testing
The pipeline was initialised on the vertebrates division.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
