### PR TITLE
Resource class update in LoadMembers to accomodate 1 hour default time

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
@@ -489,7 +489,7 @@ sub core_pipeline_analyses {
                 'store_others'                  => $self->o('store_others'),
             },
             -hive_capacity => $self->o('loadmembers_capacity'),
-            -rc_name => '4Gb_job',
+            -rc_name => '4Gb_24_hour_job',
             -flow_into => [ 'hc_members_per_genome' ],
         },
 


### PR DESCRIPTION

**Related JIRA tickets:**
- ENSCOMPARASW-7161

## Overview of changes
Resource classes of LoadMembers pipeline analyses have been updated on so that they can be used on Slurm with a 1-hour default time limit.

## Testing
The pipeline was initialised on the vertebrates division.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
