### PR TITLE
Update EPOwithExt resource classes for Slurm with 1-hour default time limit

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwithExt_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwithExt_conf.pm
@@ -234,6 +234,7 @@ sub core_pipeline_analyses {
             -parameters => {
                 method_link_species_set_id => '#ext_mlss_id#',
             },
+            -rc_name => '1Gb_24_hour_job',
             -flow_into => [ 'alignment_mlss_factory' ],
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOAlignment.pm
@@ -126,7 +126,7 @@ return
 	-parameters => {
                 'add_non_nuclear_alignments' => $self->o('add_non_nuclear_alignments'),
 	},
-        -rc_name   => '4Gb_job',
+        -rc_name   => '4Gb_24_hour_job',
         -flow_into => {
                 '2->A' => [ 'find_dnafrag_region_strand' ],
                 '3->A' => [ 'ortheus' ],
@@ -178,7 +178,7 @@ return
                 'semphy_exe'        => $self->o('semphy_exe'),
 	},
 	-module => 'Bio::EnsEMBL::Compara::RunnableDB::Ortheus',
-        -rc_name   => '2Gb_job',
+        -rc_name   => '2Gb_24_hour_job',
 	-hive_capacity => 2000,
 	-max_retry_count => 3,
 	-flow_into => {
@@ -200,7 +200,7 @@ return
                 'semphy_exe'        => $self->o('semphy_exe'),
 	},
 	-module => 'Bio::EnsEMBL::Compara::RunnableDB::Ortheus',
-	-rc_name => '8Gb_job',
+	-rc_name => '8Gb_24_hour_job',
 	-max_retry_count => 2,
 	-flow_into => { 
                 1 => WHEN( '#run_gerp#' => [ 'gerp' ] ),
@@ -220,7 +220,7 @@ return
                 'semphy_exe'        => $self->o('semphy_exe'),
         },  
         -module => 'Bio::EnsEMBL::Compara::RunnableDB::Ortheus',
-        -rc_name => '32Gb_job',
+        -rc_name => '32Gb_24_hour_job',
 	-max_retry_count => 1,
 	-flow_into => {
                 1 => WHEN( '#run_gerp#' => [ 'gerp' ] ),
@@ -233,7 +233,7 @@ return
                 -parameters => {
                                 'inputquery' => 'SELECT root_id FROM genomic_align_tree WHERE parent_id IS NULL',
                                },  
-                -rc_name => '2Gb_job',
+                -rc_name => '2Gb_24_hour_job',
                 -flow_into => {
                                '2->A' => [ 'set_neighbour_nodes' ],
                                'A->1' => [ 'update_max_alignment_length' ],
@@ -324,7 +324,7 @@ sub pipeline_analyses_healthcheck {
 
         {   -logic_name => 'conservation_score_healthcheck',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::HealthCheck',
-            -rc_name    => '4Gb_job',
+            -rc_name    => '4Gb_24_hour_job',
         },
 
         {   -logic_name  => 'end_pipeline',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOMapAnchors.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOMapAnchors.pm
@@ -267,7 +267,7 @@ sub pipeline_analyses_epo_anchor_mapping {
                 -flow_into => {
                                2 => { 'trim_anchor_align' => INPUT_PLUS() },
                               },  
-		-rc_name => '4Gb_job',
+		-rc_name => '4Gb_24_hour_job',
             },  
 
 	    {   -logic_name => 'trim_anchor_align',			

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EpoExtended.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EpoExtended.pm
@@ -252,7 +252,7 @@ sub pipeline_analyses_epo_ext_alignment {
                 2  => WHEN( '#run_gerp#' => [ 'gerp' ] ),
                 -1 => [ 'extended_genome_alignment_himem' ],
             },
-            -rc_name => '2Gb_job',
+            -rc_name => '2Gb_24_hour_job',
         },
         #If fail due to MEMLIMIT, probably due to memory leak, and rerunning with extra memory.
         {   -logic_name => 'extended_genome_alignment_himem',
@@ -269,7 +269,7 @@ sub pipeline_analyses_epo_ext_alignment {
                 2  => WHEN( '#run_gerp#' => [ 'gerp' ] ),
                 -1 => [ 'extended_genome_alignment_hugemem' ],
             },
-            -rc_name => '4Gb_job',
+            -rc_name => '4Gb_24_hour_job',
         },
 
         #Super MEM analysis, there is a small amount of jobs still failing with current RAM limits
@@ -286,7 +286,7 @@ sub pipeline_analyses_epo_ext_alignment {
             -flow_into => {
                 2 => WHEN( '#run_gerp#' => [ 'gerp' ] ),
             },
-            -rc_name => '8Gb_job',
+            -rc_name => '8Gb_24_hour_job',
         },
 
         # ---------------------------------------------------------------[Gerp]-------------------------------------------------------------------
@@ -349,7 +349,7 @@ sub pipeline_analyses_db_complete {
                 '2->A' => [ 'set_neighbour_nodes' ],
                 'A->1' => [ 'update_max_alignment_length' ],
             },
-            -rc_name => '2Gb_job',
+            -rc_name => '2Gb_24_hour_job',
         },
         {   -logic_name => 'set_neighbour_nodes',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::EpoExtended::SetNeighbourNodes',
@@ -404,6 +404,7 @@ sub pipeline_analyses_healthcheck {
 
         {   -logic_name => 'conservation_score_healthcheck',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::HealthCheck',
+            -rc_name => '2Gb_24_hour_job',
         },
 
         {   -logic_name  => 'end_pipeline',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/MultipleAlignerStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/MultipleAlignerStats.pm
@@ -55,12 +55,13 @@ sub pipeline_analyses_multiple_aligner_stats {
                 'ensembl_release'   => $self->o('ensembl_release'),
                 'output_dir'        => $self->o('output_dir'),
             },
-            -rc_name => '4Gb_job',
+            -rc_name => '4Gb_24_hour_job',
             -hive_capacity  => 100,
         },
 
         {   -logic_name => 'block_size_distribution',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomicAlignBlock::MultipleAlignerBlockSize',
+            -rc_name => '1Gb_24_hour_job',
             -flow_into  => [ 'generate_msa_stats_report' ],
         },
 
@@ -110,7 +111,7 @@ sub pipeline_analyses_multiple_aligner_stats {
 
         {   -logic_name =>  'per_block_stats',
             -module     =>  'Bio::EnsEMBL::Compara::RunnableDB::GenomicAlignBlock::CalculateBlockStats',
-            -rc_name    => '2Gb_job',
+            -rc_name    => '2Gb_24_hour_job',
             -flow_into  => {
                 2 => [
                     '?accu_name=num_of_positions&accu_address={genome_db_id}[]',


### PR DESCRIPTION
**Related JIRA tickets:**
- ENSCOMPARASW-7164

## Overview of changes
Resource classes of EPOwithExt pipeline analyses have been updated so that they can be used on Slurm with a 1-hour default time limit.

## Testing
The pipeline was initialised on the vertebrates division.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
