### PR TITLE
Group post-handover tasks, add pipeline dir move task

### DIFF
--- a/conf/fungi/jira_recurrent_tickets.json
+++ b/conf/fungi/jira_recurrent_tickets.json
@@ -168,22 +168,35 @@
             "description": "[https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Handover+the+database+and+the+Age+of+Base+file#HandoverthedatabaseandtheAgeofBasefile-Non-vertebratesdivisionswithoutanancestraldatabase(e.g.Pan,Metazoa)]",
             "labels": ["Handover_anchor"],
             "summary": "Handover of release DB"
+         }
+      ],
+      "labels": ["Merge_anchor"],
+      "summary": "<Division> Release <version> Database merge and handover"
+   },
+   {
+      "assignee": "<RelCo>",
+      "component": "Relco tasks",
+      "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks",
+      "subtasks": [{
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "Clean up any <division> database backups that are no longer needed",
+            "summary": "Clean up unneeded <division> database backups"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks#Posthandovertasks-MovepipelinedirectoriestoNFS",
+            "summary": "Move pipeline directories to NFS"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "Update the jira_recurrent_tickets.json with any changes to the release process or tasks that has taken during the current release",
             "summary": "Update conf/<division>/jira_recurrent_tickets.json"
-         },
-         {
-            "assignee": "<RelCo>",
-            "component": "Relco tasks",
-            "description": "Clean up any <division> database backups that are no longer needed",
-            "summary": "Clean up unneeded <division> database backups"
          }
       ],
-      "labels": ["Merge_anchor"],
-      "summary": "<Division> Release <version> Database merge and handover"
+      "summary": "<Division> Release <version> Post-handover tasks"
    },
    {
       "assignee": "<RelCo>",

--- a/conf/metazoa/jira_recurrent_tickets.json
+++ b/conf/metazoa/jira_recurrent_tickets.json
@@ -186,22 +186,35 @@
             "description": "[https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Handover+the+database+and+the+Age+of+Base+file#HandoverthedatabaseandtheAgeofBasefile-Non-vertebratesdivisionswithoutanancestraldatabase(e.g.Pan,Metazoa)]",
             "labels": ["Handover_anchor"],
             "summary": "Handover of release DB"
+         }
+      ],
+      "labels": ["Merge_anchor"],
+      "summary": "<Division> Release <version> Database merge and handover"
+   },
+   {
+      "assignee": "<RelCo>",
+      "component": "Relco tasks",
+      "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks",
+      "subtasks": [{
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "Clean up any <division> database backups that are no longer needed",
+            "summary": "Clean up unneeded <division> database backups"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks#Posthandovertasks-MovepipelinedirectoriestoNFS",
+            "summary": "Move pipeline directories to NFS"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "Update the jira_recurrent_tickets.json with any changes to the release process or tasks that has taken during the current release",
             "summary": "Update conf/<division>/jira_recurrent_tickets.json"
-         },
-         {
-            "assignee": "<RelCo>",
-            "component": "Relco tasks",
-            "description": "Clean up any <division> database backups that are no longer needed",
-            "summary": "Clean up unneeded <division> database backups"
          }
       ],
-      "labels": ["Merge_anchor"],
-      "summary": "<Division> Release <version> Database merge and handover"
+      "summary": "<Division> Release <version> Post-handover tasks"
    },
    {
       "assignee": "<RelCo>",

--- a/conf/pan/jira_recurrent_tickets.json
+++ b/conf/pan/jira_recurrent_tickets.json
@@ -108,22 +108,35 @@
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Handover+the+database+and+the+Age+of+Base+file#HandoverthedatabaseandtheAgeofBasefile-Non-vertebratesdivisionswithoutanancestraldatabase(e.g.Pan,Metazoa)",
             "labels": ["Handover_anchor"],
             "summary": "Handover of release DB"
+         }
+      ],
+      "labels": ["Merge_anchor"],
+      "summary": "<Division> Release <version> Database merge and handover"
+   },
+   {
+      "assignee": "<RelCo>",
+      "component": "Relco tasks",
+      "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks",
+      "subtasks": [{
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "Clean up any <division> database backups that are no longer needed",
+            "summary": "Clean up unneeded <division> database backups"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks#Posthandovertasks-MovepipelinedirectoriestoNFS",
+            "summary": "Move pipeline directories to NFS"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "Update the jira_recurrent_tickets.json with any changes to the release process or tasks that has taken during the current release",
             "summary": "Update conf/<division>/jira_recurrent_tickets.json"
-         },
-         {
-            "assignee": "<RelCo>",
-            "component": "Relco tasks",
-            "description": "Clean up any <division> database backups that are no longer needed",
-            "summary": "Clean up unneeded <division> database backups"
          }
       ],
-      "labels": ["Merge_anchor"],
-      "summary": "<Division> Release <version> Database merge and handover"
+      "summary": "<Division> Release <version> Post-handover tasks"
    },
    {
       "assignee": "<RelCo>",

--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -217,22 +217,35 @@
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Handover+the+database+and+the+Age+of+Base+file#HandoverthedatabaseandtheAgeofBasefile-Non-vertebratesdivisionswithanancestraldatabase(e.g.Plants)",
             "summary": "Handover of ancestral DB"
+         }
+      ],
+      "labels": ["Merge_anchor"],
+      "summary": "<Division> Release <version> Database merge and handover"
+   },
+   {
+      "assignee": "<RelCo>",
+      "component": "Relco tasks",
+      "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks",
+      "subtasks": [{
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "Clean up any <division> database backups that are no longer needed",
+            "summary": "Clean up unneeded <division> database backups"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks#Posthandovertasks-MovepipelinedirectoriestoNFS",
+            "summary": "Move pipeline directories to NFS"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "Update the jira_recurrent_tickets.json with any changes to the release process or tasks that has taken during the current release",
             "summary": "Update conf/<division>/jira_recurrent_tickets.json"
-         },
-         {
-            "assignee": "<RelCo>",
-            "component": "Relco tasks",
-            "description": "Clean up any <division> database backups that are no longer needed",
-            "summary": "Clean up unneeded <division> database backups"
          }
       ],
-      "labels": ["Merge_anchor"],
-      "summary": "<Division> Release <version> Database merge and handover"
+      "summary": "<Division> Release <version> Post-handover tasks"
    },
    {
       "assignee": "<RelCo>",

--- a/conf/protists/jira_recurrent_tickets.json
+++ b/conf/protists/jira_recurrent_tickets.json
@@ -168,22 +168,35 @@
             "description": "[https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Handover+the+database+and+the+Age+of+Base+file#HandoverthedatabaseandtheAgeofBasefile-Non-vertebratesdivisionswithoutanancestraldatabase(e.g.Pan,Metazoa)]",
             "labels": ["Handover_anchor"],
             "summary": "Handover of release DB"
+         }
+      ],
+      "labels": ["Merge_anchor"],
+      "summary": "<Division> Release <version> Database merge and handover"
+   },
+   {
+      "assignee": "<RelCo>",
+      "component": "Relco tasks",
+      "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks",
+      "subtasks": [{
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "Clean up any <division> database backups that are no longer needed",
+            "summary": "Clean up unneeded <division> database backups"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks#Posthandovertasks-MovepipelinedirectoriestoNFS",
+            "summary": "Move pipeline directories to NFS"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "Update the jira_recurrent_tickets.json with any changes to the release process or tasks that has taken during the current release",
             "summary": "Update conf/<division>/jira_recurrent_tickets.json"
-         },
-         {
-            "assignee": "<RelCo>",
-            "component": "Relco tasks",
-            "description": "Clean up any <division> database backups that are no longer needed",
-            "summary": "Clean up unneeded <division> database backups"
          }
       ],
-      "labels": ["Merge_anchor"],
-      "summary": "<Division> Release <version> Database merge and handover"
+      "summary": "<Division> Release <version> Post-handover tasks"
    },
    {
       "assignee": "<RelCo>",

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -338,22 +338,35 @@
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Handover+the+database+and+the+Age+of+Base+file#HandoverthedatabaseandtheAgeofBasefile-Vertebrates",
             "summary": "Handover of ancestral DB"
+         }
+      ],
+      "labels": ["Merge_anchor"],
+      "summary": "<Division> Release <version> Database merge and handover"
+   },
+   {
+      "assignee": "<RelCo>",
+      "component": "Relco tasks",
+      "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks",
+      "subtasks": [{
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "Clean up any <division> database backups that are no longer needed",
+            "summary": "Clean up unneeded <division> database backups"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks#Posthandovertasks-MovepipelinedirectoriestoNFS",
+            "summary": "Move pipeline directories to NFS"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "Update the jira_recurrent_tickets.json with any changes to the release process or tasks that has taken during the current release",
             "summary": "Update conf/<division>/jira_recurrent_tickets.json"
-         },
-         {
-            "assignee": "<RelCo>",
-            "component": "Relco tasks",
-            "description": "Clean up any <division> database backups that are no longer needed",
-            "summary": "Clean up unneeded <division> database backups"
          }
       ],
-      "labels": ["Merge_anchor"],
-      "summary": "<Division> Release <version> Database merge and handover"
+      "summary": "<Division> Release <version> Post-handover tasks"
    },
    {
       "assignee": "<RelCo>",


### PR DESCRIPTION
## Description

To reduce our footprint on `/hps/nobackup`, we are adding a post-handover task to move pipeline directories to NFS after Compara handover.

With this task, there are now 3 post-handover tasks, so this PR also groups those tasks together.

## Testing

Changes to the `jira_recurrent_tickets.json` files were tested successfully with a dry run of `create_compara_release_JIRA_tickets.pl` on the Pan division.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
