### PR TITLE
Remove dump_hash at last possible moment

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
@@ -439,16 +439,12 @@ sub core_pipeline_analyses {
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -rc_name    => '1Gb_1_hour_job',
             -flow_into  => {
-                1 => WHEN('#clean_intermediate_files#' => [ 'clean_dump_hash' ])
+                1 => WHEN('#clean_intermediate_files#' => [ 'start_file_cleanup' ])
             },
         },
 
-        {   -logic_name     => 'clean_dump_hash',
-            -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name        => '1Gb_job',
-            -parameters     => {
-                'cmd' => 'rm -rf #work_dir#',
-            },
+        {   -logic_name => 'start_file_cleanup',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into =>  {
                 1 => WHEN(
                     '#division# eq "vertebrates"' => 'move_uniprot_file',
@@ -470,14 +466,24 @@ sub core_pipeline_analyses {
                 ))
             },
             -rc_name       => '1Gb_datamover_job',
+            -flow_into  => [ 'clean_dump_hash' ],
         },
 
         {   -logic_name     => 'remove_uniprot_file',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name        => '1Gb_1_hour_job',
+            -rc_name        => '1Gb_job',
             -parameters     => {
                 'clusterset_id' => 'default',
                 'cmd'           => 'rm #dump_root#/#division#.#uniprot_file#.gz',
+            },
+            -flow_into  => [ 'clean_dump_hash' ],
+        },
+
+        {   -logic_name     => 'clean_dump_hash',
+            -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -rc_name        => '1Gb_job',
+            -parameters     => {
+                'cmd' => 'rm -rf #work_dir#',
             },
         },
 


### PR DESCRIPTION
## Description

The `clean_dump_hash` step of the Compara FTP dump pipeline removes the dump registry file, but this creates issues for downstream analyses `move_uniprot_file` and `remove_uniprot_file`.

This PR moves `clean_dump_hash` so that it is the final step of the pipeline, after `move_uniprot_file` and `remove_uniprot_file` have completed, ensuring that removal of the dump registry does not impact the final stages of the pipeline.

**Related JIRA tickets:**
- ENSCOMPARASW-7222

## Testing
A test pipeline was initialised to confirm that the new pipeline structure would work as expected.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
