### PR TITLE
Fix MSA species-tree healthcheck for polyploid case

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/MSA/SqlHealthChecks.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/MSA/SqlHealthChecks.pm
@@ -51,8 +51,38 @@ our $config = {
                 query => 'SELECT stn.* FROM species_tree_node stn LEFT JOIN species_tree_node stnc ON stnc.parent_id = stn.node_id WHERE stn.root_id = #species_tree_root_id# AND stnc.node_id IS NULL AND stn.genome_db_id IS NULL'
             },
             {
-                description => 'All current genome_dbs (for the MLSS if specified) should be in the species tree',
-                query => 'SELECT gdb.* FROM genome_db gdb JOIN species_set ss USING(genome_db_id) JOIN method_link_species_set USING(species_set_id) LEFT JOIN species_tree_node stn ON gdb.genome_db_id = stn.genome_db_id AND stn.root_id = #species_tree_root_id# WHERE method_link_species_set_id = #mlss_id# AND gdb.name != "ancestral_sequences" AND stn.node_id IS NULL',
+                description => 'All current genome_dbs in the MLSS should be represented in the species tree',
+                query => q/
+                    SELECT
+                        mlss_gdb.name
+                    FROM
+                        genome_db mlss_gdb
+                    JOIN
+                        species_set
+                    USING
+                        (genome_db_id)
+                    JOIN
+                        method_link_species_set
+                    USING
+                        (species_set_id)
+                    WHERE
+                        method_link_species_set_id = #mlss_id#
+                    AND
+                        mlss_gdb.name != "ancestral_sequences"
+                    AND
+                        mlss_gdb.name NOT IN (
+                            SELECT DISTINCT
+                                node_gdb.name
+                            FROM
+                                species_tree_node stn
+                            JOIN
+                                genome_db node_gdb
+                            ON
+                                node_gdb.genome_db_id = stn.genome_db_id
+                            WHERE
+                                stn.root_id = #species_tree_root_id#
+                        )
+                /,
                 expected_size => '= #n_missing_species_in_tree#',
             },
             {


### PR DESCRIPTION
## Description

This PR fixes an edge case in the `MSA::SqlHealthChecks` module, such that a polyploid Cactus MLSS (e.g. Wheat Cactus) would fail one of the tests because some of its `GenomeDBs` were not in the Cactus MLSS species tree, though they were represented in the tree by `GenomeDBs` corresponding to their polyploid components.

## Testing
The updated healthcheck was tested against both the Wheat and Rice Cactus alignment MLSSes in `ensembl_compara_plants_59_112`, as well as the Wheat Cactus species tree in a copy of the Plants Compara database in which T. aestivum Mattis had been removed from the Wheat Cactus MLSS. As expected, the revised healthcheck passed on the Cactus alignments in the `ensembl_compara_plants_59_112`, but failed on the modified Wheat Cactus species tree lacking Mattis.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
