### PR TITLE
Limit lifecycle of schema interoperability tests

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/Utils/Test.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Test.pm
@@ -37,6 +37,7 @@ use Test::More;
 
 use Bio::EnsEMBL::Utils::IO qw/work_with_file/;
 use Bio::EnsEMBL::Test::MultiTestDB;
+use Bio::EnsEMBL::Compara::Utils::RunCommand;
 
 =head2 GLOBAL VARIABLES
 
@@ -51,7 +52,24 @@ to "compute" it again and again.
 
 =cut
 
+my $repository_branch;
 my $repository_root;
+
+=head2 get_repository_branch
+
+  Description : Return name of the active branch of the repository.
+
+=cut
+
+sub get_repository_branch {
+    return $repository_branch if $repository_branch;
+    my $cmd_args = ['git', '-C', dirname(__FILE__), 'branch', '--show-current'];
+    my $cmd_opts = { die_on_failure => 1 };
+    my $run_cmd = Bio::EnsEMBL::Compara::Utils::RunCommand->new_and_exec($cmd_args, $cmd_opts);
+    $repository_branch = $run_cmd->out;
+    chomp $repository_branch;
+    return $repository_branch;
+}
 
 =head2 get_repository_root
 

--- a/scripts/pipeline/init_dump_registry.pl
+++ b/scripts/pipeline/init_dump_registry.pl
@@ -85,6 +85,7 @@ use Bio::EnsEMBL::Utils::Exception qw(throw);
 use Bio::EnsEMBL::Utils::IO qw(slurp spurt);
 use Bio::EnsEMBL::Compara::Utils::Registry;
 use Bio::EnsEMBL::Compara::Utils::RunCommand;
+use Bio::EnsEMBL::Compara::Utils::Test;
 
 
 sub get_adaptor_init_text {
@@ -102,15 +103,6 @@ sub get_adaptor_init_text {
     $text .= ");\n\n";
 
     return $text;
-}
-
-sub get_compara_branch {
-    my $cmd_args = ["git", "-C", dirname(__FILE__), "branch", "--show-current"];
-    my $cmd_opts = { die_on_failure => 1 };
-    my $run_cmd = Bio::EnsEMBL::Compara::Utils::RunCommand->new_and_exec($cmd_args, $cmd_opts);
-    my $compara_branch = $run_cmd->out;
-    chomp $compara_branch;
-    return $compara_branch;
 }
 
 sub get_host_name {
@@ -186,7 +178,7 @@ if ($software_version != $release) {
     throw("Ensembl software version ($software_version) does not match Ensembl release ($release)");
 }
 
-my $compara_branch = get_compara_branch();
+my $compara_branch = Bio::EnsEMBL::Compara::Utils::Test::get_repository_branch();
 my $branch_version;
 if ($compara_branch =~ m|^release/(?<ensembl_version>[0-9]+)$|) {
     $branch_version = $+{ensembl_version};

--- a/travisci/sql-unittest/test_core_dbs_up_to_date.t
+++ b/travisci/sql-unittest/test_core_dbs_up_to_date.t
@@ -1,0 +1,72 @@
+#!/usr/bin/env perl
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use strict;
+use warnings;
+
+use HTTP::Tiny;
+use JSON qw(decode_json);
+use Test::More;
+
+use Bio::EnsEMBL::ApiVersion qw(software_version);
+use Bio::EnsEMBL::Compara::Utils::Test;
+
+
+my $compara_branch = Bio::EnsEMBL::Compara::Utils::Test::get_repository_branch();
+unless ($compara_branch =~ m|^release/[0-9]+$|) {
+    plan skip_all => 'test core database schema update check is only run on Ensembl release branches';
+}
+
+my $response = HTTP::Tiny->new->get('https://api.github.com/repos/Ensembl/ensembl-compara');
+if ($response->{'success'}) {
+    my $content = decode_json($response->{'content'});
+    if ($content->{'default_branch'} =~ m|^release/(?<live_version>[0-9]+)$|) {
+        if (software_version() <= $+{'live_version'}) {
+            plan skip_all => 'test core database schema update check is not run on an Ensembl version after it has been released';
+        }
+    }
+}
+
+
+## Check that the test core database schemas are up to date
+
+my $compara_dir = Bio::EnsEMBL::Compara::Utils::Test::get_repository_root();
+my $multitestdb = Bio::EnsEMBL::Compara::Utils::Test::create_multitestdb();
+
+# Load the Core schema for reference
+my $core_db_name = $multitestdb->create_db_name('core_schema');
+my $core_statements = Bio::EnsEMBL::Compara::Utils::Test::read_sqls("$ENV{ENSEMBL_ROOT_DIR}/ensembl/sql/table.sql");
+my $core_db = Bio::EnsEMBL::Compara::Utils::Test::load_statements($multitestdb, $core_db_name, $core_statements, 'Can load the reference Core schema');
+my $core_schema = Bio::EnsEMBL::Compara::Utils::Test::get_schema_from_database($core_db, $core_db_name);
+Bio::EnsEMBL::Compara::Utils::Test::drop_database($multitestdb, $core_db_name);
+
+my $test_db_name = $multitestdb->create_db_name('test_schema');
+
+my $db_dir = "${compara_dir}/src/test_data/databases/core";
+foreach my $test_file_name (glob "${db_dir}/*/table.sql") {
+    my $short_name = $test_file_name;
+    $short_name =~ s{${db_dir}/}{};
+    subtest $short_name, sub {
+        my $test_statements = Bio::EnsEMBL::Compara::Utils::Test::read_sqls($test_file_name);
+        my $test_db = Bio::EnsEMBL::Compara::Utils::Test::load_statements($multitestdb, $test_db_name, $test_statements, 'Can load the test schema');
+        my $test_schema = Bio::EnsEMBL::Compara::Utils::Test::get_schema_from_database($test_db, $test_db_name);
+        is_deeply($test_schema, $core_schema, 'Test schema identical to the Core schema');
+    };
+}
+
+Bio::EnsEMBL::Compara::Utils::Test::drop_database($multitestdb, $test_db_name);
+
+done_testing();


### PR DESCRIPTION
## Description

This PR limits the lifecycle of SQL schema interoperability unit tests so that they are only run on a release branch prior to release of the given Ensembl version, in consequence avoiding unnecessary checks and false alarms.

## Overview of changes

- Function `get_compara_branch` in script `init_dump_registry.pl` is refactored into module `Bio::EnsEMBL::Compara::Utils::Test` and renamed to `get_repository_branch`.
- SQL unit test `test_core_dbs_up_to_date.t` is split into two tests: `test_compara_dbs_up_to_date.t` for test Compara databases and `test_core_dbs_up_to_date.t` for test core databases.
- Tests `ncbi_taxa_schema_consistency.t` and `test_core_dbs_up_to_date.t` are restricted so that tests are only run on release branches with a release version greater than the default branch of the `ensembl-compara` repo (i.e. on Ensembl release branches prior to release).

## Testing

The updated unit tests were trialled on 3 branches of the `ensembl-compara` repo: `release/111`, `release/112` and `main`.

Output of `test_core_dbs_up_to_date.t` on `release/111`:
```
test_core_dbs_up_to_date.t .. skipped: test core database schema update check is not run on an Ensembl version after it has been released
Files=1, Tests=0,  1 wallclock secs ( 0.01 usr  0.01 sys +  0.20 cusr  0.06 csys =  0.28 CPU)
Result: NOTESTS
```

Output of `test_core_dbs_up_to_date.t` on `release/112`:
```
test_core_dbs_up_to_date.t .. ok   
All tests successful.
Files=1, Tests=6,  3 wallclock secs ( 0.02 usr  0.01 sys +  0.78 cusr  0.08 csys =  0.89 CPU)
Result: PASS
```
Output of `test_core_dbs_up_to_date.t` on `main`:
```
test_core_dbs_up_to_date.t .. skipped: test core database schema update check is only run on Ensembl release branches
Files=1, Tests=0,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.12 cusr  0.04 csys =  0.19 CPU)
Result: NOTESTS
```

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
