### PR TITLE
Add post-handover task to update production registry

### DIFF
--- a/conf/fungi/jira_recurrent_tickets.json
+++ b/conf/fungi/jira_recurrent_tickets.json
@@ -192,6 +192,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "Ensure that the division production_reg_conf.pl is up to date on GitHub",
+            "summary": "Update conf/<division>/production_reg_conf.pl"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "Update the jira_recurrent_tickets.json with any changes to the release process or tasks that has taken during the current release",
             "summary": "Update conf/<division>/jira_recurrent_tickets.json"
          }

--- a/conf/metazoa/jira_recurrent_tickets.json
+++ b/conf/metazoa/jira_recurrent_tickets.json
@@ -210,6 +210,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "Ensure that the division production_reg_conf.pl is up to date on GitHub",
+            "summary": "Update conf/<division>/production_reg_conf.pl"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "Update the jira_recurrent_tickets.json with any changes to the release process or tasks that has taken during the current release",
             "summary": "Update conf/<division>/jira_recurrent_tickets.json"
          }

--- a/conf/pan/jira_recurrent_tickets.json
+++ b/conf/pan/jira_recurrent_tickets.json
@@ -132,6 +132,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "Ensure that the division production_reg_conf.pl is up to date on GitHub",
+            "summary": "Update conf/<division>/production_reg_conf.pl"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "Update the jira_recurrent_tickets.json with any changes to the release process or tasks that has taken during the current release",
             "summary": "Update conf/<division>/jira_recurrent_tickets.json"
          }

--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -241,6 +241,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "Ensure that the division production_reg_conf.pl is up to date on GitHub",
+            "summary": "Update conf/<division>/production_reg_conf.pl"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "Update the jira_recurrent_tickets.json with any changes to the release process or tasks that has taken during the current release",
             "summary": "Update conf/<division>/jira_recurrent_tickets.json"
          }

--- a/conf/protists/jira_recurrent_tickets.json
+++ b/conf/protists/jira_recurrent_tickets.json
@@ -192,6 +192,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "Ensure that the division production_reg_conf.pl is up to date on GitHub",
+            "summary": "Update conf/<division>/production_reg_conf.pl"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "Update the jira_recurrent_tickets.json with any changes to the release process or tasks that has taken during the current release",
             "summary": "Update conf/<division>/jira_recurrent_tickets.json"
          }

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -362,6 +362,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "Ensure that the division production_reg_conf.pl is up to date on GitHub",
+            "summary": "Update conf/<division>/production_reg_conf.pl"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "Update the jira_recurrent_tickets.json with any changes to the release process or tasks that has taken during the current release",
             "summary": "Update conf/<division>/jira_recurrent_tickets.json"
          }


### PR DESCRIPTION
## Description

This PR adds a post-handover production task to ensure the registry is up to date on GitHub at the time immediately following Compara handover for the given division.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
