### PR TITLE
Improvements/python linter harness

### DIFF
--- a/travisci/python-linter_harness.sh
+++ b/travisci/python-linter_harness.sh
@@ -27,9 +27,9 @@ run_pylint() {
 
   # Run pylint, excluding specific files and directories
   find "${PYTHON_SOURCE_LOCATIONS[@]}" -type f -name "*.py" \
-    ! -name "Ortheus.py" \
-    ! -name "*citest*.py" \
-    ! -path "*/citest/*" -print0 |
+    \! -name "Ortheus.py" \
+    \! -name "*citest*.py" \
+    \! -path "*/citest/*" -print0 |
     xargs -0 pylint --rcfile=pyproject.toml --verbose \
       --msg-template='COMPARA_PYLINT_MSG:{path}:{line}:{column}: {msg_id}: {msg} ({symbol})' |
     tee "$pylint_output_file"

--- a/travisci/python-linter_harness.sh
+++ b/travisci/python-linter_harness.sh
@@ -36,6 +36,7 @@ run_pylint() {
     tee "$pylint_output_file"
 
   # Return 1 if pylint messages were found, otherwise 0
+  #  -c option counts the number of matches, -m 1 stops after the first match to optimize performance,
   local result=$(grep -c -m 1 -E '^COMPARA_PYLINT_MSG:' "$pylint_output_file")
 
   # Cleanup

--- a/travisci/python-linter_harness.sh
+++ b/travisci/python-linter_harness.sh
@@ -39,7 +39,6 @@ run_pylint() {
   grep -E '^.+:[0-9]+:[0-9]+: [A-Z]+[0-9]+: .+ (\(.*\))?$' "$pylint_output_file" >"$pylint_errors"
 
   # Return 1 if errors were found, otherwise 0
-  ! [ -s "$pylint_errors" ]
   local result=$(
     ! [ -s "$pylint_errors" ]
     echo $?

--- a/travisci/python-linter_harness.sh
+++ b/travisci/python-linter_harness.sh
@@ -24,7 +24,6 @@ export MYPYPATH=$MYPYPATH:src/python/lib
 # Function to run pylint
 run_pylint() {
   local pylint_output_file=$(mktemp)
-  local pylint_errors=$(mktemp)
 
   # Run pylint, excluding specific files and directories
   find "${PYTHON_SOURCE_LOCATIONS[@]}" -type f -name "*.py" \
@@ -40,7 +39,7 @@ run_pylint() {
   local result=$(grep -c -m 1 -E '^COMPARA_PYLINT_MSG:' "$pylint_output_file")
 
   # Cleanup
-  rm "$pylint_output_file" "$pylint_errors"
+  rm "$pylint_output_file"
 
   return "$result"
 }

--- a/travisci/python-linter_harness.sh
+++ b/travisci/python-linter_harness.sh
@@ -57,9 +57,6 @@ run_mypy() {
     \! -name "*citest*.py" \
     \! -path "*/citest/*" -print0 |
     xargs -0 mypy --config-file pyproject.toml --namespace-packages --explicit-package-bases
-
-  # Return the exit status of mypy
-  return $?
 }
 
 # Define Python source locations

--- a/travisci/python-linter_harness.sh
+++ b/travisci/python-linter_harness.sh
@@ -35,14 +35,8 @@ run_pylint() {
       --msg-template='COMPARA_PYLINT_MSG:{path}:{line}:{column}: {msg_id}: {msg} ({symbol})' |
     tee "$pylint_output_file"
 
-  # Keep only lines with pylint messages
-  grep -E '^.+:[0-9]+:[0-9]+: [A-Z]+[0-9]+: .+ (\(.*\))?$' "$pylint_output_file" >"$pylint_errors"
-
-  # Return 1 if errors were found, otherwise 0
-  local result=$(
-    ! [ -s "$pylint_errors" ]
-    echo $?
-  )
+  # Return 1 if pylint messages were found, otherwise 0
+  local result=$(grep -c -m 1 -E '^COMPARA_PYLINT_MSG:' "$pylint_output_file")
 
   # Cleanup
   rm "$pylint_output_file" "$pylint_errors"

--- a/travisci/python-linter_harness.sh
+++ b/travisci/python-linter_harness.sh
@@ -2,13 +2,13 @@
 
 # See the NOTICE file distributed with this work for additional information
 # regarding copyright ownership.
-#
+# 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#
+# 
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+# 
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/travisci/python-linter_harness.sh
+++ b/travisci/python-linter_harness.sh
@@ -48,7 +48,7 @@ run_pylint() {
   # Cleanup
   rm "$pylint_output_file" "$pylint_errors"
 
-  return $result
+  return "$result"
 }
 
 # Function to run mypy, excluding certain files and paths, and capturing the outcome

--- a/travisci/python-linter_harness.sh
+++ b/travisci/python-linter_harness.sh
@@ -2,20 +2,18 @@
 
 # See the NOTICE file distributed with this work for additional information
 # regarding copyright ownership.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-PYTHON_SOURCE_LOCATIONS=('scripts' 'src/python')
 
 # Setup the environment variables
 # shellcheck disable=SC2155
@@ -23,21 +21,65 @@ export PYTHONPATH=$PYTHONPATH:$(python -c 'import sysconfig; print(sysconfig.get
 # more info: https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules
 export MYPYPATH=$MYPYPATH:src/python/lib
 
-PYLINT_OUTPUT_FILE=$(mktemp)
-PYLINT_ERRORS=$(mktemp)
-# CITest project is on hold and it needs to be updated before resuming its linter checker
-find "${PYTHON_SOURCE_LOCATIONS[@]}" -type f -name "*.py" \! -name "Ortheus.py" \! -name "*citest*.py" \! -path "*/citest/*" -print0 | xargs -0 pylint --rcfile pyproject.toml --verbose | tee "$PYLINT_OUTPUT_FILE"
-grep -v "\-\-\-\-\-\-\-\-\-" "$PYLINT_OUTPUT_FILE" | grep -v "Your code has been rated" | grep -v "\n\n" | sed '/^$/d' > "$PYLINT_ERRORS"
-! [ -s "$PYLINT_ERRORS" ]
-rt1=$?
-rm "$PYLINT_OUTPUT_FILE" "$PYLINT_ERRORS"
+# Function to run pylint
+run_pylint() {
+  local pylint_output_file=$(mktemp)
+  local pylint_errors=$(mktemp)
 
-# CITest project is on hold and it needs to be updated before resuming its static type checker
-find "${PYTHON_SOURCE_LOCATIONS[@]}" -type f -name "*.py" \! -name "Ortheus.py" \! -name "*citest*.py" \! -path "*/citest/*" -print0 | xargs -0 mypy --config-file pyproject.toml --namespace-packages --explicit-package-bases
+  # Run pylint, excluding specific files and directories
+  find "${PYTHON_SOURCE_LOCATIONS[@]}" -type f -name "*.py" \
+    ! -name "Ortheus.py" \
+    ! -name "*citest*.py" \
+    ! -path "*/citest/*" -print0 |
+    xargs -0 pylint --rcfile=pyproject.toml --verbose \
+      --msg-template='{path}:{line}:{column}: {msg_id}: {msg} ({symbol})' |
+    tee "$pylint_output_file"
+
+  # Keep only lines with pylint messages
+  grep -E '^.+:[0-9]+:[0-9]+: [A-Z]+[0-9]+: .+ (\(.*\))?$' "$pylint_output_file" >"$pylint_errors"
+
+  # Return 1 if errors were found, otherwise 0
+  ! [ -s "$pylint_errors" ]
+  local result=$(
+    ! [ -s "$pylint_errors" ]
+    echo $?
+  )
+
+  # Cleanup
+  rm "$pylint_output_file" "$pylint_errors"
+
+  return $result
+}
+
+# Function to run mypy, excluding certain files and paths, and capturing the outcome
+run_mypy() {
+  find "${PYTHON_SOURCE_LOCATIONS[@]}" -type f -name "*.py" \
+    \! -name "Ortheus.py" \
+    \! -name "*citest*.py" \
+    \! -path "*/citest/*" -print0 |
+    xargs -0 mypy --config-file pyproject.toml --namespace-packages --explicit-package-bases
+
+  # Return the exit status of mypy
+  return $?
+}
+
+# Define Python source locations
+PYTHON_SOURCE_LOCATIONS=('scripts' 'src/python')
+
+# Run pylint and mypy, capturing their return codes
+run_pylint
+rt1=$?
+
+run_mypy
 rt2=$?
 
-if [[ ($rt1 -eq 0) && ($rt2 -eq 0) ]]; then
-  exit 0
+# Determine exit code based on results
+if [[ $rt1 -eq 0 && $rt2 -eq 0 ]]; then
+  exit 0 # success
+elif [[ $rt1 -ne 0 ]]; then
+  exit 1 # pylint error
+elif [[ $rt2 -ne 0 ]]; then
+  exit 2 # mypy error
 else
-  exit 255
+  exit 3 # error on both
 fi

--- a/travisci/python-linter_harness.sh
+++ b/travisci/python-linter_harness.sh
@@ -32,7 +32,7 @@ run_pylint() {
     ! -name "*citest*.py" \
     ! -path "*/citest/*" -print0 |
     xargs -0 pylint --rcfile=pyproject.toml --verbose \
-      --msg-template='{path}:{line}:{column}: {msg_id}: {msg} ({symbol})' |
+      --msg-template='COMPARA_PYLINT_MSG:{path}:{line}:{column}: {msg_id}: {msg} ({symbol})' |
     tee "$pylint_output_file"
 
   # Keep only lines with pylint messages


### PR DESCRIPTION
## Description

Refinement of the script involves encapsulating functionality within functions, refining the logic for determining success or failure based on `pylint` and `mypy` results, and enhancing the approach to returning results from these functions. The changes make the codebase more streamlined, modular, and maintainable.


## Overview of changes
- Initially, the script directly executed commands without modular separation, making the logic less clear and harder to maintain.
- After, we introduced functions `run_pylint` and `run_mypy` to encapsulate respective functionalities, providing a structured, modular approach.


#### Change 1: Function Encapsulation
- **Before**: Direct execution of `pylint` and `mypy` without function encapsulation.
- **After**: Encapsulated `pylint` and `mypy` executions within `run_pylint` and `run_mypy` functions for better modularity and readability.

#### Change 2: Refined Exit Strategy
- **Before**: Exit codes were determined without explicitly covering all possible outcomes, potentially leading to ambiguity.
- **After**: Introduced a clear and explicit branching structure at the script's end to decide the exit code based on the `pylint` and `mypy` results.

#### Change 3: Declaring `PYTHON_SOURCE_LOCATIONS` Before Use
- **Before**: The `PYTHON_SOURCE_LOCATIONS` variable was declared but not strategically placed for optimal use.
- **After**: Moved the declaration of `PYTHON_SOURCE_LOCATIONS` above its first use, ensuring the variable is defined ahead of time and adhering to best practices for variable declaration and scope.

#### Change 4: Enhanced `pylint` Call with `--msg-template`
- **Before**: `pylint` was called without specifying a message template.
- **After**: Incorporated `--msg-template='{path}:{line}:{column}: {msg_id}: {msg} ({symbol})'` in the `pylint` call to format output messages explicitly, making subsequent grepping for errors more straightforward.

#### Change 5: Direct Grepping for Errors
- **Before**: Indirect error filtering using `grep -v` to exclude non-error messages and lines.
- **After**: Implemented direct grepping for error messages with `grep -E`, focusing on capturing lines that match the error message format. This approach is more efficient and reduces complexity by avoiding multiple filtering steps.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
