### PR TITLE
Fixed handling of SeqMember version

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/SeqMember.pm
+++ b/modules/Bio/EnsEMBL/Compara/SeqMember.pm
@@ -172,6 +172,9 @@ sub new_from_Transcript {
     my ($start, $end) = ($transcript->seq_region_start, $transcript->seq_region_end);
     my $stable_id = $transcript->stable_id ||
       throw("COREDB error: does not contain transcript stable id for transcript_id ".$transcript->dbID."\n");
+    my $stable_id_version = $transcript->version ||
+      throw("COREDB error: does not contain transcript stable id version for transcript_id ".$transcript->dbID."\n");
+
 
     if ($translate) {
         my ($start, $end) = ($transcript->coding_region_start, $transcript->coding_region_end);
@@ -182,6 +185,8 @@ sub new_from_Transcript {
 
         $stable_id = $transcript->translation->stable_id ||
             throw("COREDB error: does not contain translation stable id for translation_id ".$transcript->translation->dbID."\n");
+        $stable_id_version = $transcript->translation->version ||
+            throw("COREDB error: does not contain translation stable version id for translation_id ".$transcript->translation->dbID."\n");
 
         $seq_string = $transcript->translation->seq;
 
@@ -205,7 +210,7 @@ sub new_from_Transcript {
 
     my $seq_member = Bio::EnsEMBL::Compara::SeqMember->new_fast({
         _stable_id => $stable_id,
-        _version => $transcript->version,
+        _version => $stable_id_version,
         _display_label => ($transcript->display_xref ? $transcript->display_xref->display_id : undef),
         dnafrag_start => $start,
         dnafrag_end => $end,

--- a/modules/Bio/EnsEMBL/Compara/SeqMember.pm
+++ b/modules/Bio/EnsEMBL/Compara/SeqMember.pm
@@ -172,8 +172,7 @@ sub new_from_Transcript {
     my ($start, $end) = ($transcript->seq_region_start, $transcript->seq_region_end);
     my $stable_id = $transcript->stable_id ||
       throw("COREDB error: does not contain transcript stable id for transcript_id ".$transcript->dbID."\n");
-    my $stable_id_version = $transcript->version ||
-      throw("COREDB error: does not contain transcript stable id version for transcript_id ".$transcript->dbID."\n");
+    my $stable_id_version = $transcript->version;
 
 
     if ($translate) {
@@ -185,8 +184,7 @@ sub new_from_Transcript {
 
         $stable_id = $transcript->translation->stable_id ||
             throw("COREDB error: does not contain translation stable id for translation_id ".$transcript->translation->dbID."\n");
-        $stable_id_version = $transcript->translation->version ||
-            throw("COREDB error: does not contain translation stable version id for translation_id ".$transcript->translation->dbID."\n");
+        $stable_id_version = $transcript->translation->version;
 
         $seq_string = $transcript->translation->seq;
 


### PR DESCRIPTION
## Description

In [line 208 of the SeqMember module](https://github.com/Ensembl/ensembl-compara/blob/40ae4936333d8f416f6ed0ebfc2934bac7eed075/modules/Bio/EnsEMBL/Compara/SeqMember.pm#L208), in the SeqMember::new_from_Transcript method, the SeqMember stable ID version is set from the transcript, but for protein-coding sequences this should be set from the translation.

**Related JIRA tickets:**
- ENSCOMPARASW-7218

## Overview of changes

#### Change 1

## Testing


---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
