### PR TITLE
Merge Metazoa homologies per MLSS

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ComplementaryProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ComplementaryProteinTrees_conf.pm
@@ -116,16 +116,6 @@ sub core_pipeline_analyses {
             -priority           => $self->o('hc_priority'),
             -batch_size         => 20,
         },
-
-        {
-             -logic_name => 'remove_overlapping_homologies',
-             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::RemoveOverlappingHomologies',
-             -flow_into  => [ 'remove_overlapping_data_by_member' ],
-        },
-        {
-             -logic_name => 'remove_overlapping_data_by_member',
-             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RemoveOverlappingDataByMember',
-        },
     ]
 }
 
@@ -143,8 +133,6 @@ sub tweak_analyses {
         '1->A' => [ 'overall_qc' ],
         'A->1' => [ 'find_overlapping_genomes' ],
     };
-
-    push @{$analyses_by_name->{'fire_final_analyses'}->{'-flow_into'}}, 'remove_overlapping_homologies';
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/MergeDBsIntoRelease_conf.pm
@@ -83,7 +83,16 @@ sub default_options {
             'protostomes_protein_db'    => [qw(ortholog_quality datacheck_results)],
             'insects_protein_db'        => [qw(ortholog_quality datacheck_results)],
             'drosophila_protein_db'     => [qw(ortholog_quality datacheck_results)],
-        }
+        },
+
+        'per_mlss_merge_tables' => [
+            'hmm_annot',
+            'homology',
+            'homology_member',
+            'method_link_species_set_attr',
+            'method_link_species_set_tag',
+            'peptide_align_feature',
+        ],
     }
 }
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -458,6 +458,7 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'db_name'       => $self->o('db_name'),
 
         'ensembl_release' => $self->o('ensembl_release'),
+        'collection'      => $self->o('collection'),
 
         'reg_conf'      => $self->o('reg_conf'),
         'member_type'   => $self->o('member_type'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -458,7 +458,7 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'db_name'       => $self->o('db_name'),
 
         'ensembl_release' => $self->o('ensembl_release'),
-        'collection'      => $self->o('collection'),
+        'collection'      => $self->o('collection'),  # required for per-MLSS homology merge
 
         'reg_conf'      => $self->o('reg_conf'),
         'member_type'   => $self->o('member_type'),

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DBMerge/CopyHomologiesByMLSS.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DBMerge/CopyHomologiesByMLSS.pm
@@ -1,0 +1,147 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=pod
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::DBMerge::CopyHomologiesByMLSS
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::DBMerge::CopyHomologiesByMLSS;
+
+use strict;
+use warnings;
+
+use File::Spec::Functions;
+use JSON qw(decode_json);
+
+use Bio::EnsEMBL::Utils::IO qw(slurp_to_array);
+use Bio::EnsEMBL::Compara::Utils::CopyData qw(:table_copy);
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+sub param_defaults {
+    my $self = shift;
+    return {
+        %{ $self->SUPER::param_defaults() },
+
+        'mode'              => 'ignore',
+        'skip_disable_vars' => 0,
+    };
+}
+
+sub run {
+    my $self = shift;
+
+    my $mlss_info_dir = $self->param_required('mlss_info_dir');
+    my $src_db_name = $self->param_required('src_db_conn');
+    my $mlss_info_file = catfile($mlss_info_dir, "${src_db_name}.json");
+    my $mlss_info = decode_json($self->_slurp($mlss_info_file));
+
+    my $from_dbc   = $self->get_cached_compara_dba('src_db_conn')->dbc;
+    my $to_dbc     = $self->get_cached_compara_dba('dest_db_conn')->dbc;
+    my $table_name = $self->param_required('table');
+    my $replace    = $self->param('mode') eq 'ignore' ? 0 : 1;
+
+    my $from_str = $from_dbc->host . '/' . $from_dbc->dbname;
+    my $to_str   = $to_dbc->host . '/' . $to_dbc->dbname;
+    $self->warning("Copying $table_name per MLSS from $from_str to $to_str");
+
+    if ($table_name =~ /^(homology|homology_member|method_link_species_set_attr|method_link_species_set_tag)$/) {
+
+        foreach my $mlss_id (@{$mlss_info->{'mlss_id'}}) {
+            $self->warning("Copying data for MLSS $mlss_id") if $self->debug;
+
+            my $query;
+            if ($table_name eq 'homology_member') {
+                $query = qq/
+                    SELECT
+                        homology_member.*
+                    FROM
+                        homology
+                    JOIN
+                        homology_member
+                    USING
+                        (homology_id)
+                    WHERE
+                        method_link_species_set_id = $mlss_id
+                /;
+            } else {
+                $query = qq/
+                    SELECT
+                        *
+                    FROM
+                        $table_name
+                    WHERE
+                        method_link_species_set_id = $mlss_id
+                /;
+            }
+
+            copy_data($from_dbc, $to_dbc, $table_name, $query, $replace, $self->param('skip_disable_vars'), $self->debug);
+        }
+
+    } elsif ($table_name =~ /^(hmm_annot|peptide_align_feature)$/) {
+
+        my $mlss_set_gdb_ids = '(' . join(',', @{$mlss_info->{'genome_db_id'}}) . ')';
+
+        my $query;
+        if ($table_name eq 'hmm_annot') {
+            $query = qq/
+                SELECT
+                    hmm_annot.*
+                FROM
+                    hmm_annot
+                JOIN
+                    seq_member
+                USING
+                    (seq_member_id)
+                WHERE
+                    seq_member.genome_db_id IN $mlss_set_gdb_ids
+            /;
+        } else {
+            $query = qq/
+                SELECT
+                    peptide_align_feature.*
+                FROM
+                    peptide_align_feature
+                JOIN
+                    seq_member qmember
+                ON
+                    qmember_id = qmember.seq_member_id
+                JOIN
+                    seq_member hmember
+                ON
+                    hmember_id = hmember.seq_member_id
+                WHERE
+                    qmember.genome_db_id IN $mlss_set_gdb_ids
+                AND
+                    hmember.genome_db_id IN $mlss_set_gdb_ids
+            /;
+        }
+
+        copy_data($from_dbc, $to_dbc, $table_name, $query, $replace, $self->param('skip_disable_vars'), $self->debug);
+
+    } else {
+        $self->die_no_retry("Per-MLSS merge of $table_name has not been implemented");
+    }
+}
+
+1;


### PR DESCRIPTION
## Description

In Ensembl divisions with multiple gene-tree collections, homologies involving species in two or more collections may be inferred more than once, resulting in redundant homology data for the relevant homology MLSS.

Currently this redundancy is eliminated during the protein-trees pipeline by removing potentially clashing homology data per MLSS, and in Metazoa, additionally per gene/sequence member.

The aim of this ticket is to preserve overlapping homologies in Metazoa by merging homologies per MLSS, to facilitate configuration changes such as removal of an overlap species from a higher-precedence collection while retaining homology data for that species in a lower precedence collection.

**Related JIRA tickets:**
- ENSCOMPARASW-7172

## Overview of changes

This PR involves several changes:
- Complementary protein-tree pipelines in Metazoa no longer delete homology data which overlaps with the reference collection(s).
- The protein-trees pipeline now has a `collection` pipeline-wide parameter.
- In conjunction with the existing `ref_collection`/`ref_collection_list` parameters, the `collection` parameter is used in the `DBMergeCheck` runnable to establish the order of precedence between protein-tree pipelines.
- Given the order of precedence of protein-tree pipelines, `DBMergeCheck` fetches the complementary MLSS info for each protein-trees collection (i.e. the set of `genome_db_id` and `method_link_species_set_id` values for which homology data will be merged into the release database).
- For source databases lacking collection information, the union set of all `method_link_species_set_id` values in relevant tables (e.g. `method_link_species_set_tag`) is taken as the complementary set of MLSS IDs, provided that these do not clash with the `method_link_species_set_id` values of any other database. Such databases also have a more limited set of tables which can be merged per MLSS.
- The complementary MLSS info is subsequently used by the `CopyHomologiesByMLSS` runnable to guide the process of merging per MLSS.
- The `MergeDBsIntoRelease_conf` pipeline is restructured to create two parallel branches for merging: one in which data are merged per table (the current approach, and the one to be used for merging most tables), and another in which data are merged per MLSS.

## Testing

Per-MLSS homology merge has been tested on Metazoa 112 protein-tree pipelines, with the result being a test release database whose contents almost exactly match those of `ensembl_compara_metazoa_59_112`. The related Jira ticket has details of the test pipeline and an accounting of any discrepancies between the test database and `ensembl_compara_metazoa_59_112`.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)