### PR TITLE
Include T aestivum Sy Mattis in protein trees

### DIFF
--- a/conf/plants/mlss_conf.xml
+++ b/conf/plants/mlss_conf.xml
@@ -61,6 +61,9 @@
       <genome name="triticum_dicoccoides"/>
       <genome name="triticum_urartu"/>
       <genome name="triticum_turgidum"/>
+      <!-- Include T. aestivum Mattis, but exclude its U-component. -->
+      <genome name="triticum_aestivum_mattis"/>
+      <genome name="triticum_aestivum_mattis" genome_component="U" exclude="1"/>
       <!-- Outgroup -->
       <genome name="brachypodium_distachyon"/>
     </collection>

--- a/modules/Bio/EnsEMBL/Compara/Utils/SpeciesTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/SpeciesTree.pm
@@ -299,7 +299,15 @@ sub new_from_newick {
             my $component_name = $2;
             my $pgdb = $all_genome_dbs{lc $species_name};
             if ($pgdb and $pgdb->is_polyploid and ($component_name =~ /^[A-Z][0-9]?$/)) {
-                $gdb = $pgdb->component_genome_dbs($component_name) or die "No component named '$component_name' in '$species_name'\n";
+                $gdb = $pgdb->component_genome_dbs($component_name);
+
+                # If this node appears to represent the component of a polyploid genome, it must be present in the genome_db table ...
+                if (!$gdb) {
+                    # ... unless the missing component genome is Triticum aestivum Sy Mattis (component U)
+                    unless ($species_name eq 'triticum_aestivum_mattis' && $component_name eq 'U') {
+                        die "No component named '$component_name' in '$species_name'\n";
+                    }
+                }
             }
         }
         if ($gdb) {

--- a/scripts/pipeline/compara_db_config.rng
+++ b/scripts/pipeline/compara_db_config.rng
@@ -62,6 +62,10 @@
               </choice>
             </attribute>
           </optional>
+          <optional>
+            <attribute name="genome_component"
+                       blockly:blockName="If specified, this indicates which genome component is represented by this genome element; an empty attribute string indicates the principal genome"/>
+          </optional>
         </element>
       </choice>
     </oneOrMore>


### PR DESCRIPTION
During Ensembl 106 production, Triticum aestivum Sy Mattis could not be included in the Wheat cultivars protein-trees because its U-component lacks gene members, so it failed a healthcheck which requires that each `genome_db` has at least one gene.

This PR implements an approach to make it possible for the Mattis cultivar to be included in the protein-trees, by which the U-component is excluded from the `wheat_cultivars` collection.