### PR TITLE
Fix gene-tree stats for polyploid components

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -3776,7 +3776,8 @@ sub core_pipeline_analyses {
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
             -rc_name    => '1Gb_1_hour_job',
             -parameters => {
-                'component_genomes' => 0,
+                'component_genomes' => 1,
+                'polyploid_genomes' => 0,
                 'fan_branch_code' => 1,
             },
             -flow_into  => [ 'count_genes_in_tree' ],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -1359,7 +1359,8 @@ sub core_pipeline_analyses {
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
             -rc_name    => '1Gb_job',
             -parameters => {
-                'component_genomes' => 0,
+                'component_genomes' => 1,
+                'polyploid_genomes' => 0,
                 'fan_branch_code' => 1,
             },
             -flow_into  => [ 'count_genes_in_tree' ],

--- a/scripts/pipeline/count_genes_in_tree.pl
+++ b/scripts/pipeline/count_genes_in_tree.pl
@@ -94,6 +94,7 @@ my $nb_genes_unassigned = $nb_genes - $nb_genes_in_tree;
 my $tree_dba = $dba->get_SpeciesTreeAdaptor();
 my $species_tree = $tree_dba->fetch_by_method_link_species_set_id_label($mlss_id, 'default');
 my $species_tree_node = $species_tree->root->find_leaves_by_field('genome_db_id', $genome_db_id)->[0];
+throw("all genes unassigned for genome_db $genome_db_id in  MLSS $mlss_id") if $nb_genes_in_tree == 0;
 $species_tree_node->store_tag('nb_genes_in_tree', $nb_genes_in_tree);
 $species_tree_node->store_tag('nb_genes_unassigned', $nb_genes_unassigned);
 


### PR DESCRIPTION
## Description

In Plants Compara releases 108-111 the `nb_genes_in_tree` statistic was zero on polyploid components (e.g. [protein-tree stats on e109 archive](https://feb2023-plants.ensembl.org/info/genome/compara/prot_tree_stats.html?page=coverage)).

This was due to a misconfiguration of the handling of component genomes in the `gene_count_factory` of the [protein-tree](https://github.com/Ensembl/ensembl-compara/blob/b9a0f677b7666fc88cf64f6b4e57000ddbec7d64/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm#L3734) and [ncRNAtree](https://github.com/Ensembl/ensembl-compara/blob/b9a0f677b7666fc88cf64f6b4e57000ddbec7d64/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm#L1339) pipelines.

This PR fixes the configuration of these pipeline steps and restores the missing gene-tree stats.

**Related JIRA tickets:**
- ENSCOMPARASW-7124

## Overview of changes

- In the `gene_count_factory` step of the `ProteinTrees_conf` and `ncRNAtrees_conf` pipelines, the `component_genomes` option is set to `1` and the `polyploid_genomes` option is set to `0`.
- The script `count_genes_in_tree.pl` fails if `nb_genes_in_tree` stat is zero.

## Testing

This bugfix was tested as part of a joint test pipeline to confirm success of several bugfixes. For details on the test pipeline, see the related Jira ticket.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
