### PR TITLE
Set ncRNA member canonical to match core gene

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ncRNAtrees/GenomeStoreNCMembers.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ncRNAtrees/GenomeStoreNCMembers.pm
@@ -159,8 +159,6 @@ sub store_ncrna_gene {
     my $gene_member_adaptor = $self->compara_dba->get_GeneMemberAdaptor();
     my $seq_member_adaptor = $self->compara_dba->get_SeqMemberAdaptor();
 
-    my $longest_ncrna_member;
-    my $max_ncrna_length = 0;
     my $gene_member;
     my $gene_member_stored = 0;
 
@@ -219,13 +217,7 @@ sub store_ncrna_gene {
 
         $self->_store_seq_member_projection($ncrna_member, $transcript);
 
-        if (length($transcript_spliced_seq) > $max_ncrna_length) {
-            $max_ncrna_length = length($transcript_spliced_seq);
-            $longest_ncrna_member = $ncrna_member;
-        }
-    }
-    if (defined $longest_ncrna_member) {
-        $seq_member_adaptor->_set_member_as_canonical($longest_ncrna_member);
+        $seq_member_adaptor->_set_member_as_canonical($ncrna_member) if $transcript->is_canonical;
     }
 
     return $gene_member;


### PR DESCRIPTION
## Description

During development of the `CanonicalMemberCore` datacheck, some  ncRNA genes were flagged as having a canonical transcript which did not match their corresponding core gene. This was because the ncRNA canonical was being set ([here](https://github.com/Ensembl/ensembl-compara/blob/40ae4936333d8f416f6ed0ebfc2934bac7eed075/modules/Bio/EnsEMBL/Compara/RunnableDB/ncRNAtrees/GenomeStoreNCMembers.pm#L227-L229)) according to which transcript was the longest, which doesn't always match the annotated canonical transcript in the core database.

This PR changes that behaviour so that the Compara canonical ncRNA member is set from the canonical transcript of the corresponding core gene.

**Related JIRA tickets:**
- ENSCOMPARASW-7220
- ENSCOMPARASW-7221

## Testing
This bugfix was tested as part of a joint test pipeline to confirm success of several bugfixes. For details on the test pipeline, see the related Jira ticket.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
