### PR TITLE
Switch off homology dumps in divisions not using them

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/ProteinTrees_conf.pm
@@ -154,7 +154,6 @@ sub default_options {
         # Do we extract overall statistics for each pair of species ?
         'do_homology_stats'      => 0,
         # Do we need a mapping between homology_ids of this database to another database ?
-        # This parameter is automatically set to 1 when the GOC pipeline is going to run with a reuse database
         'do_homology_id_mapping' => 0,
         # homology dumps options
         'prev_homology_dumps_dir'   => undef,

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/ProteinTrees_conf.pm
@@ -74,8 +74,9 @@ sub default_options {
         # Do we want the Gene QC part to run?
         'do_gene_qc'             => 0,
         # Do we need a mapping between homology_ids of this database to another database?
-        # This parameter is automatically set to 1 when the GOC pipeline is going to run with a reuse database
         'do_homology_id_mapping' => 0,
+        # Do we expect to need shared homology dumps in a future release to facilitate reuse of WGA coverage data ?
+        'homology_dumps_shared_dir' => undef,
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
@@ -78,8 +78,9 @@ sub default_options {
         # Do we want the Gene QC part to run?
         'do_gene_qc'             => 0,
         # Do we need a mapping between homology_ids of this database to another database?
-        # This parameter is automatically set to 1 when the GOC pipeline is going to run with a reuse database
         'do_homology_id_mapping' => 0,
+        # Do we expect to need shared homology dumps in a future release to facilitate reuse of WGA coverage data ?
+        'homology_dumps_shared_dir' => undef,
 
         # hive_capacity values for some analyses:
         'blastp_capacity'           => 420,

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/ProteinTrees_conf.pm
@@ -76,8 +76,9 @@ sub default_options {
         # Do we extract overall statistics for each pair of species ?
         'do_homology_stats'      => 1,
         # Do we need a mapping between homology_ids of this database to another database ?
-        # This parameter is automatically set to 1 when the GOC pipeline is going to run with a reuse database
         'do_homology_id_mapping' => 0,
+        # Do we expect to need shared homology dumps in a future release to facilitate reuse of WGA coverage data ?
+        'homology_dumps_shared_dir' => undef,
 
         # In this structure, the "thresholds" are for resp. the GOC score, the WGA coverage and %identity
         'threshold_levels' => [

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -353,7 +353,6 @@ sub default_options {
         # Do we extract overall statistics for each pair of species ?
         'do_homology_stats'      => 1,
         # Do we need a mapping between homology_ids of this database to another database ?
-        # This parameter is automatically set to 1 when the GOC pipeline is going to run with a reuse database
         'do_homology_id_mapping' => 1,
 
         # homology dumps options

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/ProteinTrees_conf.pm
@@ -81,8 +81,9 @@ sub default_options {
         # Do we want the Gene QC part to run?
         'do_gene_qc'             => 0,
         # Do we need a mapping between homology_ids of this database to another database?
-        # This parameter is automatically set to 1 when the GOC pipeline is going to run with a reuse database
         'do_homology_id_mapping' => 0,
+        # Do we expect to need shared homology dumps in a future release to facilitate reuse of WGA coverage data ?
+        'homology_dumps_shared_dir' => undef,
         # Quick tree break is not suitable for protists dataset due to divergence causing inappropriate subtrees
         'use_quick_tree_break' => 0,
 


### PR DESCRIPTION
## Description

Shared homology dumps are currently reused only in gene-tree pipelines which use `homology_id_mapping` to help `calculate_wga_coverage`.

This PR switches off homology dumps for divisions in which homology dumps are not currently used.

It also removes an outdated comment about GOC reuse.

**Related JIRA tickets:**
- ENSCOMPARASW-7235

## Testing
An example pipeline was initialised to confirm that pipeline-wide parameter `homology_dumps_shared_dir` was set correctly.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
