### PR TITLE
Add production task to clean up homology dumps

### DIFF
--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -247,6 +247,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks#Posthandovertasks-Cleanuphomologydumps",
+            "summary": "Clean up homology dumps"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "Ensure that the division production_reg_conf.pl is up to date on GitHub",
             "summary": "Update conf/<division>/production_reg_conf.pl"
          },

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -368,6 +368,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks#Posthandovertasks-Cleanuphomologydumps",
+            "summary": "Clean up homology dumps"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "Ensure that the division production_reg_conf.pl is up to date on GitHub",
             "summary": "Update conf/<division>/production_reg_conf.pl"
          },


### PR DESCRIPTION
## Description

Homology dumps can take up a significant amount of space.

This PR adds a production task to clean up outdated homology dumps every release.

**Related JIRA tickets:**
- ENSCOMPARASW-7237

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
