### PR TITLE
Add registryless resource class, use in dump pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
@@ -481,7 +481,7 @@ sub core_pipeline_analyses {
 
         {   -logic_name     => 'clean_dump_hash',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name        => '1Gb_job',
+            -rc_name        => '1Gb_registryless_job',
             -parameters     => {
                 'cmd' => 'rm -rf #work_dir#',
             },


### PR DESCRIPTION
## Description

The `clean_dump_hash` step of the Compara FTP dump pipeline removes the `dump_hash` directory, but it may fail when rerun if the dump registry file (i.e. `dump_hash/dump_reg_conf.pm`) is removed in an initial run.

This PR adds a `1Gb_registryless_job` resource class and configures `clean_dump_hash` to use it, so that it can run even if the dump registry has been deleted.

**Related JIRA tickets:**
- ENSCOMPARASW-7222

## Testing
A test dump pipeline was initialised, its dump registry file was deleted, and a `clean_dump_hash` job was subsequently run successfully.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
