### PR TITLE
Travis: set minimum Python version to 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,9 +141,10 @@ jobs:
       script: ./travisci/perl-linter_harness.sh
 
     - language: python
-      python: 3.8
+      python: 3.9
       name: "Python unit tests on the minimum version"
       install:
+        - pip install --upgrade pip
         - pip install .[test]
       script:
         - pytest --server=mysql://travis@127.0.0.1:3306/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ensembl-compara"
 description = "Ensembl Compara's Python library"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 dynamic = [
     "readme",
     "version",
@@ -38,7 +38,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
-    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]


### PR DESCRIPTION
## Description

**Related JIRA tickets:**
- ENSCOMPARASW-7241

## Overview of changes

#### Change 1
Set minimum Python version to 3.9.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
