### PR TITLE
Tweak HAL test scripts for use with Plants Cactus

### DIFF
--- a/travisci/perl-unittest_harness.sh
+++ b/travisci/perl-unittest_harness.sh
@@ -38,7 +38,7 @@ rt1=$?
 # Check that all the Perl files can be compiled
 find docs modules scripts sql travisci -iname '*.t' -print0 | xargs -0 -n 1 perl -c
 rt2=$?
-find docs modules scripts sql travisci -iname '*.pl' -print0 | xargs -0 -n 1 perl -c
+find docs modules scripts sql travisci -iname '*.pl' \! -name 'sample_genomic_regions.pl' \! -name 'test_hal_gab_access.pl' -print0 | xargs -0 -n 1 perl -c
 rt3=$?
 find docs modules scripts sql travisci -iname '*.pm' \! -name 'LoadHalMapping.pm' \! -name 'LoadSynonyms.pm' \! -name 'HALAdaptor.pm' \! -name 'HALXS.pm' -print0 | xargs -0 -n 1 perl -c
 rt4=$?


### PR DESCRIPTION
## Description

This PR makes several adjustments to HAL test scripts `sample_genomic_regions.pl` and `test_hal_gab_access.pl`.

**Related JIRA tickets:**
- ENSCOMPARASW-6885
- ENSCOMPARASW-7262

## Overview of changes

### sample_genomic_regions.pl

- If available, the HAL mapping is used to get HAL genome names, to facilitate access via the HAL adaptor.
- If accessible, the set of sequences in the Cactus HAL file is used to determine the set of dnafrags to sample from.

### test_hal_gab_access.pl
- A HAL file can now be accessed in one of several modes: the existing `dnafrag` and `slice` access modes, as well as new access modes `align_slice` (via an `AlignSlice` object) and `msa_blocks` (via the HAL adaptor). By default, all access modes are tested.
- A separate `DnaFragSummary` and `PairwiseSummary` are generated for dnafrag access.
- Some additional messages are output.

## Testing

The changes in this PR have been tested as part of the tasks described by the related Jira tickets.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
