### PR TITLE
Add production task to clean up genome dumps

### DIFF
--- a/conf/fungi/jira_recurrent_tickets.json
+++ b/conf/fungi/jira_recurrent_tickets.json
@@ -192,6 +192,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks#Posthandovertasks-Cleanupgenomedumps",
+            "summary": "Clean up genome dumps"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "Ensure that the division production_reg_conf.pl is up to date on GitHub",
             "summary": "Update conf/<division>/production_reg_conf.pl"
          },

--- a/conf/metazoa/jira_recurrent_tickets.json
+++ b/conf/metazoa/jira_recurrent_tickets.json
@@ -210,6 +210,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks#Posthandovertasks-Cleanupgenomedumps",
+            "summary": "Clean up genome dumps"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "Ensure that the division production_reg_conf.pl is up to date on GitHub",
             "summary": "Update conf/<division>/production_reg_conf.pl"
          },

--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -253,6 +253,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks#Posthandovertasks-Cleanupgenomedumps",
+            "summary": "Clean up genome dumps"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "Ensure that the division production_reg_conf.pl is up to date on GitHub",
             "summary": "Update conf/<division>/production_reg_conf.pl"
          },

--- a/conf/protists/jira_recurrent_tickets.json
+++ b/conf/protists/jira_recurrent_tickets.json
@@ -192,6 +192,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks#Posthandovertasks-Cleanupgenomedumps",
+            "summary": "Clean up genome dumps"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "Ensure that the division production_reg_conf.pl is up to date on GitHub",
             "summary": "Update conf/<division>/production_reg_conf.pl"
          },

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -374,6 +374,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Post-handover+tasks#Posthandovertasks-Cleanupgenomedumps",
+            "summary": "Clean up genome dumps"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "Ensure that the division production_reg_conf.pl is up to date on GitHub",
             "summary": "Update conf/<division>/production_reg_conf.pl"
          },


### PR DESCRIPTION
## Description

Genome dumps take up a significant amount of space, and need to be cleaned up periodically.

This PR adds a production task to clean up genome dumps after Compara handover.

**Related JIRA tickets:**
- ENSCOMPARASW-7233

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
