### PR TITLE
Restore alt host registry config

### DIFF
--- a/conf/fungi/production_reg_conf.pl
+++ b/conf/fungi/production_reg_conf.pl
@@ -38,7 +38,9 @@ my $prev_eg_release = $curr_eg_release - 1;
 
 # ---------------------- DATABASE HOSTS -----------------------------------------
 
-my $curr_nv_host = $curr_release % 2 == 0 ? 'mysql-ens-sta-3' : 'mysql-ens-sta-3-b';
+my ($curr_nv_host, $curr_nv_port) = $curr_release % 2 == 0
+    ? ('mysql-ens-sta-3', 4160)
+    : ('mysql-ens-sta-3-b', 4686);
 
 my ($prev_nv_host, $prev_nv_port) = $prev_release % 2 == 0
     ? ('mysql-ens-sta-3', 4160)
@@ -63,7 +65,6 @@ my @collection_groups = qw(
 
 # Server for single species fungal cores
 Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertannot-staging:4573/$curr_release");
-Bio::EnsEMBL::Compara::Utils::Registry::remove_multi();
 
 # Ensure we're using the correct cores for species that overlap with other divisions
 my @overlap_species = qw(saccharomyces_cerevisiae);
@@ -83,6 +84,22 @@ foreach my $group ( @collection_groups ) {
     );
 }
 
+# ---------------------- CURRENT CORE DATABASES : ALTERNATE HOSTS ----------------
+
+# Fungi single-species cores
+#Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@$curr_nv_host:$curr_nv_port/$curr_release");
+#Bio::EnsEMBL::Compara::Utils::Registry::remove_multi();
+
+# Fungi collection cores
+#foreach my $group ( @collection_groups ) {
+#    Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
+#        -host   => $curr_nv_host,
+#        -port   => $curr_nv_port,
+#        -user   => 'ensro',
+#        -pass   => '',
+#        -dbname => "fungi_${group}_collection_core_${curr_eg_release}_${curr_release}_1",
+#    );
+#}
 
 # ---------------------- PREVIOUS CORE DATABASES---------------------------------
 

--- a/conf/metazoa/production_reg_conf.pl
+++ b/conf/metazoa/production_reg_conf.pl
@@ -38,7 +38,9 @@ my $prev_eg_release = $curr_eg_release - 1;
 
 # ---------------------- DATABASE HOSTS -----------------------------------------
 
-my $curr_nv_host = $curr_release % 2 == 0 ? 'mysql-ens-sta-3' : 'mysql-ens-sta-3-b';
+my ($curr_nv_host, $curr_nv_port) = $curr_release % 2 == 0
+    ? ('mysql-ens-sta-3', 4160)
+    : ('mysql-ens-sta-3-b', 4686);
 
 my ($prev_nv_host, $prev_nv_port) = $prev_release % 2 == 0
     ? ('mysql-ens-sta-3', 4160)
@@ -57,6 +59,12 @@ my $overlap_cores = {
     'drosophila_melanogaster' => [ 'mysql-ens-vertannot-staging', "drosophila_melanogaster_core_${curr_eg_release}_${curr_release}_10" ],
 };
 Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $overlap_cores );
+
+# ---------------------- CURRENT CORE DATABASES : ALTERNATE HOSTS ----------------
+
+# Official staging servers
+#Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@$curr_nv_host:$curr_nv_port/$curr_release");
+#Bio::EnsEMBL::Compara::Utils::Registry::remove_multi();
 
 # ---------------------- PREVIOUS CORE DATABASES---------------------------------
 
@@ -86,13 +94,6 @@ my $compara_dbs = {
     'protostomes_ptrees' => [ 'mysql-ens-compara-prod-9', 'thiagogenez_protostomes_metazoa_protein_trees_112' ],
     'insects_ptrees'     => [ 'mysql-ens-compara-prod-8', '' ],
     'drosophila_ptrees'  => [ 'mysql-ens-compara-prod-9', 'thiagogenez_pangenome_drosophila_metazoa_protein_trees_112' ],
-
-    # LastZ dbs
-    # 'lastz_batch_1' => [ 'mysql-ens-compara-prod-X', '' ],
-    # 'lastz_batch_2' => [ 'mysql-ens-compara-prod-X', '' ],
-
-    # synteny
-    # 'compara_syntenies' => [ 'mysql-ens-compara-prod-X', '' ],
 };
 
 Bio::EnsEMBL::Compara::Utils::Registry::add_compara_dbas( $compara_dbs );

--- a/conf/pan/production_reg_conf.pl
+++ b/conf/pan/production_reg_conf.pl
@@ -40,13 +40,23 @@ my @overlap_species = qw(saccharomyces_cerevisiae drosophila_melanogaster caenor
 
 # ---------------------- DATABASE HOSTS -----------------------------------------
 
-my ($prev_vert_host, $prev_vert_port) = $prev_release % 2 == 0
-    ? ('mysql-ens-sta-1', 4519)
-    : ('mysql-ens-sta-1-b', 4685);
+my ($curr_vert_host, $curr_vert_port, $curr_nv_host, $curr_nv_port);
+if ($curr_release % 2 == 0) {
+    ($curr_vert_host, $curr_vert_port) = ('mysql-ens-sta-1', 4519);
+    ($curr_nv_host, $curr_nv_port)     = ('mysql-ens-sta-3', 4160);
+} else {
+    ($curr_vert_host, $curr_vert_port) = ('mysql-ens-sta-1-b', 4685);
+    ($curr_nv_host, $curr_nv_port)     = ('mysql-ens-sta-3-b', 4686);
+}
 
-my ($prev_nv_host, $prev_nv_port) = $prev_release % 2 == 0
-    ? ('mysql-ens-sta-3', 4160)
-    : ('mysql-ens-sta-3-b', 4686);
+my ($prev_vert_host, $prev_vert_port, $prev_nv_host, $prev_nv_port);
+if ($prev_release % 2 == 0) {
+    ($prev_vert_host, $prev_vert_port) = ('mysql-ens-sta-1', 4519);
+    ($prev_nv_host, $prev_nv_port)     = ('mysql-ens-sta-3', 4160);
+} else {
+    ($prev_vert_host, $prev_vert_port) = ('mysql-ens-sta-1-b', 4685);
+    ($prev_nv_host, $prev_nv_port)     = ('mysql-ens-sta-3-b', 4686);
+}
 
 # ---------------------- CURRENT CORE DATABASES----------------------------------
 
@@ -69,6 +79,24 @@ Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
     -pass   => '',
     -dbname => "bacteria_0_collection_core_${curr_eg_release}_${curr_release}_1",
 );
+
+# ---------------------- CURRENT CORE DATABASES : ALTERNATE HOSTS ----------------
+
+# Vertebrates server
+#Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@$curr_vert_host:$curr_vert_port/$curr_release");
+# But remove the non-vertebrates species
+#Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species);
+#Bio::EnsEMBL::Compara::Utils::Registry::remove_multi();
+# Non-Vertebrates server
+#Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@$curr_nv_host:$curr_nv_port/$curr_release");
+# Bacteria server is not alternated between releases
+#Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
+#    -host   => 'mysql-ens-sta-4',
+#    -port   => 4494,
+#    -user   => 'ensro',
+#    -pass   => '',
+#    -dbname => "bacteria_0_collection_core_${curr_eg_release}_${curr_release}_1",
+#);
 
 # ---------------------- PREVIOUS CORE DATABASES---------------------------------
 

--- a/conf/plants/production_reg_conf.pl
+++ b/conf/plants/production_reg_conf.pl
@@ -40,15 +40,23 @@ my @overlap_species = qw(saccharomyces_cerevisiae drosophila_melanogaster caenor
 
 # ---------------------- DATABASE HOSTS -----------------------------------------
 
-my $curr_nv_host = $curr_release % 2 == 0 ? 'mysql-ens-sta-3' : 'mysql-ens-sta-3-b';
+my ($curr_vert_host, $curr_vert_port, $curr_nv_host, $curr_nv_port);
+if ($curr_release % 2 == 0) {
+    ($curr_vert_host, $curr_vert_port) = ('mysql-ens-sta-1', 4519);
+    ($curr_nv_host, $curr_nv_port)     = ('mysql-ens-sta-3', 4160);
+} else {
+    ($curr_vert_host, $curr_vert_port) = ('mysql-ens-sta-1-b', 4685);
+    ($curr_nv_host, $curr_nv_port)     = ('mysql-ens-sta-3-b', 4686);
+}
 
-my ($prev_vert_host, $prev_vert_port) = $prev_release % 2 == 0
-    ? ('mysql-ens-sta-1', 4519)
-    : ('mysql-ens-sta-1-b', 4685);
-
-my ($prev_nv_host, $prev_nv_port) = $prev_release % 2 == 0
-    ? ('mysql-ens-sta-3', 4160)
-    : ('mysql-ens-sta-3-b', 4686);
+my ($prev_vert_host, $prev_vert_port, $prev_nv_host, $prev_nv_port);
+if ($prev_release % 2 == 0) {
+    ($prev_vert_host, $prev_vert_port) = ('mysql-ens-sta-1', 4519);
+    ($prev_nv_host, $prev_nv_port)     = ('mysql-ens-sta-3', 4160);
+} else {
+    ($prev_vert_host, $prev_vert_port) = ('mysql-ens-sta-1-b', 4685);
+    ($prev_nv_host, $prev_nv_port)     = ('mysql-ens-sta-3-b', 4686);
+}
 
 # ---------------------- CURRENT CORE DATABASES----------------------------------
 
@@ -64,6 +72,15 @@ my $overlap_cores = {
 };
 Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $overlap_cores );
 
+# ---------------------- CURRENT CORE DATABASES : ALTERNATE HOSTS ----------------
+
+# Use the official staging servers
+#Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@$curr_nv_host:$curr_nv_port/$curr_release");
+# and remove the Non-Vertebrates version of the shared species
+#Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species);
+#Bio::EnsEMBL::Compara::Utils::Registry::remove_multi();
+# before loading the Vertebrates version
+#Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@$curr_vert_host:$curr_vert_port/$curr_release");
 
 # ---------------------- PREVIOUS CORE DATABASES---------------------------------
 

--- a/conf/protists/production_reg_conf.pl
+++ b/conf/protists/production_reg_conf.pl
@@ -37,7 +37,9 @@ my $prev_eg_release = $curr_eg_release - 1;
 
 # ---------------------- DATABASE HOSTS -----------------------------------------
 
-my $curr_nv_host = $curr_release % 2 == 0 ? 'mysql-ens-sta-3' : 'mysql-ens-sta-3-b';
+my ($curr_nv_host, $curr_nv_port) = $curr_release % 2 == 0
+    ? ('mysql-ens-sta-3', 4160)
+    : ('mysql-ens-sta-3-b', 4686);
 
 my ($prev_nv_host, $prev_nv_port) = $prev_release % 2 == 0
     ? ('mysql-ens-sta-3', 4160)
@@ -73,6 +75,23 @@ foreach my $group ( @collection_groups ) {
         -dbname => "protists_${group}_collection_core_${curr_eg_release}_${curr_release}_1",
     );
 }
+
+# ---------------------- CURRENT CORE DATABASES : ALTERNATE HOSTS ----------------
+
+# Protists single-species cores
+#Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@$curr_nv_host:$curr_nv_port/$curr_release");
+#Bio::EnsEMBL::Compara::Utils::Registry::remove_multi();
+
+# Protists collection cores
+#foreach my $group ( @collection_groups ) {
+#    Bio::EnsEMBL::Compara::Utils::Registry::load_collection_core_database(
+#        -host   => $curr_nv_host,
+#        -port   => $curr_nv_port,
+#        -user   => 'ensro',
+#        -pass   => '',
+#        -dbname => "protists_${group}_collection_core_${curr_eg_release}_${curr_release}_1",
+#    );
+#}
 
 # ---------------------- PREVIOUS CORE DATABASES---------------------------------
 

--- a/conf/vertebrates/production_reg_conf.pl
+++ b/conf/vertebrates/production_reg_conf.pl
@@ -35,7 +35,10 @@ my $prev_release = $curr_release - 1;
 
 # ---------------------- DATABASE HOSTS -----------------------------------------
 
-my $curr_vert_host = $curr_release % 2 == 0 ? 'mysql-ens-sta-1' : 'mysql-ens-sta-1-b';
+my ($curr_vert_host, $curr_vert_port) = $curr_release % 2 == 0
+    ? ('mysql-ens-sta-1', 4519)
+    : ('mysql-ens-sta-1-b', 4685);
+
 
 my ($prev_vert_host, $prev_vert_port) = $prev_release % 2 == 0
     ? ('mysql-ens-sta-1', 4519)
@@ -55,6 +58,12 @@ my $overlap_cores = {
     'saccharomyces_cerevisiae' => [ 'mysql-ens-vertannot-staging', "saccharomyces_cerevisiae_core_" . $curr_release . "_4" ],
 };
 Bio::EnsEMBL::Compara::Utils::Registry::add_core_dbas( $overlap_cores );
+
+# ---------------------- CURRENT CORE DATABASES : ALTERNATE HOSTS ----------------
+
+# Vertebrates staging server
+#Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@$curr_vert_host:$curr_vert_port/$curr_release");
+#Bio::EnsEMBL::Compara::Utils::Registry::remove_multi();
 
 # ---------------------- PREVIOUS CORE DATABASES---------------------------------
 


### PR DESCRIPTION
Though Compara pipelines almost always access core databases on `vertannot-staging`, once in a while it may be necessary to configure the Compara registry to use production staging servers.

In anticipation of that, this PR updates Compara registries with alternative host config for production staging servers.

These changes were tested by running `flag_core_issues.pl` on updated registries on the `release/112` branch.

All checks passed, except for Plants, which flagged the following issue:
```
    #   Failed test 'oryza_sativa_ir64_core_59_112_1 release'
    #   at /hps/software/users/ensembl/compara/twalsh/repos/e112/ensembl-compara/scripts/production/flag_core_issues.pl line 247.
    #          got: '111'
    #     expected: '112'
    # Looks like you failed 1 test of 272.
#   Failed test 'Check core database metadata (plants)'
#   at /hps/software/users/ensembl/compara/twalsh/repos/e112/ensembl-compara/scripts/production/flag_core_issues.pl line 253.
# Looks like you failed 1 test of 12.
```

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
