### PR TITLE
Enable dumping of supertree, dumping tree by stable ID

### DIFF
--- a/scripts/dumps/dumpTreeMSA_id.pl
+++ b/scripts/dumps/dumpTreeMSA_id.pl
@@ -175,6 +175,11 @@ foreach my $tree_id (@tree_ids) {
            ;
 
   my $root = $tree->root;
+
+  if ($root->is_supertree()) {
+      $tree->expand_subtrees;
+  }
+
   my $cafe_tree = $dba->get_CAFEGeneFamilyAdaptor->fetch_by_GeneTree($tree);
 
   $tree_id = "tree.".$tree_id;


### PR DESCRIPTION
## Description

The changes in this PR extend the script `dumpTreeMSA_id.pl` to add support for:
- dumping a supertree; and
- dumping a tree by stable ID.

**Related JIRA tickets:**
- ENSCOMPARASW-7302

## Testing

The updated script was tested by dumping a supertree by stable ID from the Ensembl Compara 111 database.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
