### PR TITLE
Add second handover task to Pan production config

### DIFF
--- a/conf/pan/jira_recurrent_tickets.json
+++ b/conf/pan/jira_recurrent_tickets.json
@@ -97,6 +97,13 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Handover+the+database+and+the+Age+of+Base+file#HandoverthedatabaseandtheAgeofBasefile-Non-vertebratesdivisionswithoutanancestraldatabase(e.g.Pan,Metazoa)",
+            "labels": ["Handover_anchor"],
+            "summary": "Handover of release DB"
+         }
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Testing+the+staging+website#Testingthestagingwebsite-Homologyside",
             "summary": "test the homologies data"
          },
@@ -111,7 +118,7 @@
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Handover+the+database+and+the+Age+of+Base+file#HandoverthedatabaseandtheAgeofBasefile-Non-vertebratesdivisionswithoutanancestraldatabase(e.g.Pan,Metazoa)",
             "labels": ["Handover_anchor"],
-            "summary": "Handover of release DB"
+            "summary": "Resubmit handover of updated release DB if needed"
          }
       ],
       "labels": ["Merge_anchor"],

--- a/conf/pan/jira_recurrent_tickets.json
+++ b/conf/pan/jira_recurrent_tickets.json
@@ -100,7 +100,7 @@
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Handover+the+database+and+the+Age+of+Base+file#HandoverthedatabaseandtheAgeofBasefile-Non-vertebratesdivisionswithoutanancestraldatabase(e.g.Pan,Metazoa)",
             "labels": ["Handover_anchor"],
             "summary": "Handover of release DB"
-         }
+         },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",


### PR DESCRIPTION
## Description

With the change of the Pan Compara SOP to hand over on completion of datachecks, then rehandover if necessary following staging-site checks, this PR splits the handover task into two.

The [relevant SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Handover+the+database+and+the+Age+of+Base+file#HandoverthedatabaseandtheAgeofBasefile-Non-vertebratesdivisionswithoutanancestraldatabase(e.g.Pan,Metazoa)) has been updated to provide some info on whether and how to do a second handover.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
