### PR TITLE
Use tree refinement and constraint topology in species tree pipeline

### DIFF
--- a/pipelines/SpeciesTreeFromBusco/nextflow.config
+++ b/pipelines/SpeciesTreeFromBusco/nextflow.config
@@ -45,6 +45,8 @@ params {
     min_taxa = 0.5
     // Name of outgroup taxon:
     outgroup = ""
+    // Constraining topology:
+    cons_nwk = ""
     // If 'sensitive' is a nonempty string, use sensitive miniprot mode:
     sensitive = ""
     // If 'use_anno' is a nonempty string, use ensembl-anno/GenBlast instead of miniprot:


### PR DESCRIPTION
## Description

There is a need for specifying a topology constraint in the pipeline in order to allow adding new genomes to an existing topology while keeping it fixed.

**Related JIRA tickets:**
- ENSCOMPARASW-7374

## Overview of changes

#### Change 1
Using the astral tree as starting topology instead of constraint in the protein branch length calculation step.

#### Change 2

Added option to specify constraining topology as a newick file.

## Testing
The pipeline was tested on the vertebrates 112 division. The run finished in 5 hours.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
