### PR TITLE
adding Fowl into REST verification script

### DIFF
--- a/scripts/production/Verify_Compara_REST_Endpoints.pl
+++ b/scripts/production/Verify_Compara_REST_Endpoints.pl
@@ -89,11 +89,11 @@ if ($division eq "vertebrates"){
     $homology_type            = 'orthologues';
     $homology_method_link     = 'ENSEMBL_ORTHOLOGUES';
 
-    $cactus_species           = 'rattus_norvegicus';
-    $cactus_region            = '2:56040000-56040100:1';
-    $cactus_species_set       = 'murinae';
+    $cactus_species           = 'gallus_gallus';
+    $cactus_region            = '5:38111022-38265293';
+    $cactus_species_set       = 'collection-fowl';
 
-    $skip_cactus              = 1;
+    $skip_cactus              = 0;
 }
 elsif($division eq "plants"){
     $gene_member_id           = "AT3G52430";


### PR DESCRIPTION
## Description

A test case has been added for the Fowl Cactus alignment to the REST verification script 'Verify_Compara_REST_Endpoints.pl'

**Related JIRA tickets:**
- [ENSCOMPARASW-6470](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-6470)

## Testing
_How was this tested? Have new unit tests been included?_

```bash
perl ensembl-compara/scripts/production/Verify_Compara_REST_Endpoints.pl --division vertebrates -server https://rest.ensembl.org

Testing https://rest.ensembl.org

### Compara REST endpoint TESTS ###

Testing GET genetree/id/:id

ok 1 - Check JSON validity
ok 2 - Check phyloXml validity
ok 3 - Check orthoXml validity
ok 4 - Check New Hampshire NH validity
ok 5 - Check seqs alignment == 1 validity
ok 6 - Check seqs alignment == 0 validity
ok 7 - Check cigar line == 1 validity
ok 8 - Check cigar line == 0 validity
ok 9 - Check Callback validity
ok 10 - check prune species validity
ok 11 - check prune taxon validity
ok 12 - check sequence eq none validity

Testing GET genetree by member/id/:species/:id

ok 13 - Check JSON validity
ok 14 - Check phyloXml validity
ok 15 - Check orthoXml validity
ok 16 - Check New Hampshire NH validity
ok 17 - check gene tree member validity

Testing GET genetree by member symbol/:species/:symbol

ok 18 - Check JSON validity
ok 19 - Check phyloXml validity
ok 20 - Check New Hampshire NH validity
ok 21 - Check gene tree by symbol validity

Testing GET Cafe tree/id/:id

ok 22 - Check JSON validity
ok 23 - Check New Hampshire NH validity
ok 24 - check cafe tree nh simple format validity

Testing GET Cafe tree by member/id/:species/:id

ok 25 - Check JSON validity
ok 26 - Check New Hampshire NH validity
ok 27 - Check get cafe tree by transcript member validity

Testing GET Cafe tree by member symbol/:species/:symbol

ok 28 - Check JSON validity
ok 29 - Check New Hampshire NH validity
ok 30 - Check get cafe tree member by symbol validity

Testing GET EPO alignment region/:species/:region

ok 31 - Check json validity
ok 32 - Check phyloXml validity
ok 33 - Check get alignment region and unaligned sequences
ok 34 - Check alignment region display_species_set option validity

Testing GET alignment region/:species/:region on HAL file

ok 35 - Check json validity
ok 36 - Check phyloXml validity
ok 37 - Check phyloXml validity with unaligned sequences
ok 38 - Check get alignment region method option

Testing GET homology /id/:species/:id

ok 39 - Check JSON validity
ok 40 - Check orthoXml validity
ok 41 - Check homology endpoint target_taxon option validity
ok 42 - Check homology endpoint target species option Validity
ok 43 - Check homology endpoint sequence CDNA option validity
ok 44 - Check homology endpoint sequence protein option validity
ok 45 - Check homology endpoint sequence none option validity
ok 46 - Check homology endpoint type option validity
ok 47 - Check homology endpoint aligned =0 option validity
ok 48 - Check homology endpoint cigar line =1 validity
ok 49 - Check homology endpoint cigar line =0 validity
ok 50 - Check homology endpoint format validity

Testing GET homology by symbol and species/:species/:symbol

ok 51 - Check homology species symbol endpoint format validity
ok 52 - Check homology species symbol endpoint target species option validity
1..52
```
---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
