### PR TITLE
Add model-name blocklist to ncRNAtrees pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsNcRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsNcRNAtrees_conf.pm
@@ -49,6 +49,9 @@ sub default_options {
             # collection in master that will have overlapping data
             'ref_collection'   => 'default',
 
+            # misc parameters
+            'model_name_blocklist' => [],
+
             # CAFE parameters
             'do_cafe'  => 0,
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ncRNAtrees_conf.pm
@@ -59,6 +59,7 @@ sub default_options {
 
             # misc parameters
             'binary_species_tree_input_file' => $self->o('binary_species_tree'), # you can define your own species_tree for 'CAFE'. It *has* to be binary
+            'model_name_blocklist' => ['tRNA'],
 
             # CAFE parameters
             'do_cafe'  => 1,

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -142,6 +142,7 @@ sub default_options {
             # misc parameters
             'species_tree_input_file'  => '',  # empty value means 'create using genome_db+ncbi_taxonomy information'; can be overriden by a file with a tree in it
             'binary_species_tree_input_file'   => undef, # you can define your own species_tree for 'CAFE'. It *has* to be binary
+            'model_name_blocklist'     => [],
             'skip_epo'                 => 0,   # Never tried this one. It may fail
             'create_ss_picts'          => 0,
 
@@ -597,6 +598,7 @@ sub core_pipeline_analyses {
             {   -logic_name    => 'rfam_classify',
                 -module        => 'Bio::EnsEMBL::Compara::RunnableDB::ncRNAtrees::RFAMClassify',
                 -parameters    => {
+                    'model_name_blocklist' => $self->o('model_name_blocklist'),
                     'mirbase_url'   => $self->o('mirbase_url'),
                 },
                 -flow_into     => [ 'expand_clusters_with_projections' ],

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ncRNAtrees/RFAMClassify.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ncRNAtrees/RFAMClassify.pm
@@ -196,6 +196,9 @@ sub run_rfamclassify {
 sub build_hash_models {
   my $self = shift;
 
+  my $model_name_blocklist = $self->param('model_name_blocklist') // [];
+  my %model_name_block_set = map { $_ => 1 } @{$model_name_blocklist};
+
     # vivification:
   $self->param('rfamclassify', {});
 
@@ -236,6 +239,9 @@ sub build_hash_models {
           push @names_to_match, $transcript_model_id;
         }
       }
+
+      # Filter names-to-match by the model-name blocklist.
+      @names_to_match = grep { !exists $model_name_block_set{$_} } @names_to_match;
 
       # Check them all against the list of known names / model_ids
       my $transcript_model_id;


### PR DESCRIPTION
## Description

In a small number of cases the ncRNAtrees pipeline has grouped unrelated ncRNAs into clusters. 

This happens in the [build_hash_models function of the RFAMClassify runnable](https://github.com/Ensembl/ensembl-compara/blob/9ef7517fbe03da25b2ece4c044794ece866c7a23/modules/Bio/EnsEMBL/Compara/RunnableDB/ncRNAtrees/RFAMClassify.pm#L196-L266). In one case, members have been grouped together in a cluster on the basis of a match of the regex `$gene_description =~ /^(\S+)/` to the first word of their gene description: `tRNA` ([RF00005](http://may2024.archive.ensembl.org/Multi/GeneTree/Image?gt=RF00005)), and consequent problems with aligning these unrelated ncRNAs have necessitated manual intervention in the past ( see ENSCOMPARASW-4650 ).

This PR adds a model-name blocklist to the ncRNAtrees pipeline, which makes it possible to avoid grouping unrelated ncRNAs on the basis of generic terms such as `tRNA` in their description.

**Related JIRA tickets:**
- ENSCOMPARASW-4650
- ENSCOMPARASW-5291

## Overview of changes

In this PR:
- a `model_name_blocklist` parameter is added to the `ncRNAtrees_conf` pipeline config;
- the `RFAMClassify` is updated to filter out elements of the model-name blocklist when grouping ncRNA members; and
- this `model_name_blocklist` parameter is set to filter model name `tRNA` in the default ncRNAtrees pipeline.

## Testing

The changes in this PR were confirmed to work as expected in a test run of the default ncRNAtrees pipeline. (For more details on testing, see ENSCOMPARASW-5291.)

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
