### PR TITLE
Make resource classes consistent with cmd_max_runtime

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateHmmProfiles_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateHmmProfiles_conf.pm
@@ -1090,7 +1090,7 @@ sub core_pipeline_analyses {
             },
             -hive_capacity        => $self->o('mcoffee_capacity'),
             -batch_size           => 20,
-            -rc_name    => '1Gb_job',
+            -rc_name    => '1Gb_24_hour_job',
             -flow_into => {
                -1 => [ 'mcoffee' ],  # MEMLIMIT
                -2 => [ 'mafft' ],
@@ -1107,7 +1107,7 @@ sub core_pipeline_analyses {
                 'escape_branch'         => -1,
             },
             -analysis_capacity    => $self->o('mcoffee_capacity'),
-            -rc_name    => '2Gb_job',
+            -rc_name    => '2Gb_24_hour_job',
             -priority   => $self->o('mcoffee_priority'),
             -flow_into => {
                -1 => [ 'mcoffee_himem' ],  # MEMLIMIT
@@ -1139,7 +1139,7 @@ sub core_pipeline_analyses {
                 'escape_branch'         => -2,
             },
             -hive_capacity        => $self->o('mcoffee_capacity'),
-            -rc_name    => '8Gb_job',
+            -rc_name    => '8Gb_24_hour_job',
             -priority   => $self->o('mcoffee_himem_priority'),
             -flow_into => {
                -1 => [ 'mafft_himem' ],
@@ -1443,7 +1443,7 @@ sub core_pipeline_analyses {
             },
             -hive_capacity        => $self->o('mcoffee_capacity'),
             -batch_size           => 20,
-            -rc_name    => '1Gb_job',
+            -rc_name    => '1Gb_24_hour_job',
             -flow_into => {
                -1 => [ 'cdhit_mcoffee' ],  # MEMLIMIT
                -2 => [ 'cdhit_mafft' ],
@@ -1460,7 +1460,7 @@ sub core_pipeline_analyses {
                 'escape_branch'         => -1,
             },
             -analysis_capacity    => $self->o('mcoffee_capacity'),
-            -rc_name    => '2Gb_job',
+            -rc_name    => '2Gb_24_hour_job',
             -priority   => $self->o('mcoffee_priority'),
             -flow_into => {
                -1 => [ 'cdhit_mcoffee_himem' ],  # MEMLIMIT
@@ -1492,7 +1492,7 @@ sub core_pipeline_analyses {
                 'escape_branch'         => -2,
             },
             -hive_capacity        => $self->o('mcoffee_capacity'),
-            -rc_name    => '8Gb_job',
+            -rc_name    => '8Gb_24_hour_job',
             -priority   => $self->o('mcoffee_himem_priority'),
             -flow_into => {
                -1 => [ 'cdhit_mafft_himem' ],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -1839,7 +1839,7 @@ sub core_pipeline_analyses {
             },
             -hive_capacity        => $self->o('mcoffee_short_capacity'),
             -batch_size           => 20,
-            -rc_name   => '1Gb_24_hour_job',
+            -rc_name   => '1Gb_6_hour_job',
             -flow_into => {
                -1 => [ 'mcoffee' ],  # MEMLIMIT
                -2 => [ 'mafft' ],
@@ -2502,7 +2502,7 @@ sub core_pipeline_analyses {
                 'escape_branch'             => -1,
             },
             -hive_capacity  => $self->o('raxml_capacity'),
-            -rc_name 		=> '16Gb_48c_job',
+            -rc_name 		=> '16Gb_48c_168_hour_job',
             -flow_into      => {
                 -1 => [ 'raxml_parsimony_48_cores_himem' ],
                 -2 => [ 'fasttree' ],
@@ -2517,7 +2517,7 @@ sub core_pipeline_analyses {
                 'cmd_max_runtime'           => '518400',
             },
             -hive_capacity  => $self->o('raxml_capacity'),
-            -rc_name 		=> '32Gb_48c_job',
+            -rc_name 		=> '32Gb_48c_168_hour_job',
             -flow_into      => {
                 -2 => [ 'fasttree' ],
             }
@@ -2579,7 +2579,7 @@ sub core_pipeline_analyses {
                 'cmd_max_runtime'       => '518400',
             },
             -hive_capacity        => $self->o('examl_capacity'),
-            -rc_name => '32Gb_8c_mpi',
+            -rc_name => '32Gb_8c_168_hour_mpi',
         },
 
         {   -logic_name => 'examl_16_cores',
@@ -2603,7 +2603,7 @@ sub core_pipeline_analyses {
                 'cmd_max_runtime'       => '518400',
             },
             -hive_capacity        => $self->o('examl_capacity'),
-            -rc_name => '32Gb_16c_mpi',
+            -rc_name => '32Gb_16c_168_hour_mpi',
         },
 
         {   -logic_name => 'examl_32_cores',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -956,7 +956,7 @@ sub core_pipeline_analyses {
                             2 => [ 'secondary_structure_decision' ],
                             3 => [ 'pre_sec_struct_tree_4_cores' ],
                           },
-            -rc_name => '1Gb_2c_job',
+            -rc_name => '1Gb_2c_24_hour_job',
         },
 
         {   -logic_name    => 'pre_sec_struct_tree_4_cores', ## pre_sec_struct_tree
@@ -973,7 +973,7 @@ sub core_pipeline_analyses {
                             2 => [ 'secondary_structure_decision' ],
                             3 => [ 'pre_sec_struct_tree_8_cores' ],
                            },
-            -rc_name => '1Gb_4c_job',
+            -rc_name => '1Gb_4c_24_hour_job',
         },
 
         {   -logic_name    => 'pre_sec_struct_tree_8_cores', ## pre_sec_struct_tree
@@ -1018,6 +1018,7 @@ sub core_pipeline_analyses {
                            -1 => [ 'sec_struct_model_tree_2_cores' ],   # This analysis has more cores *and* more memory
                             3 => [ 'sec_struct_model_tree_2_cores' ],
                           },
+            -rc_name => '1Gb_24_hour_job',
         },
 
         {   -logic_name    => 'sec_struct_model_tree_2_cores', ## sec_struct_model_tree
@@ -1049,7 +1050,7 @@ sub core_pipeline_analyses {
                            -1 => [ 'sec_struct_model_tree_8_cores' ],   # This analysis has more cores *and* more memory
                             3 => [ 'sec_struct_model_tree_8_cores' ],
                        },
-            -rc_name => '1Gb_4c_job',
+            -rc_name => '1Gb_4c_24_hour_job',
         },
 
         {   -logic_name    => 'sec_struct_model_tree_8_cores', ## sec_struct_model_tree
@@ -1060,7 +1061,7 @@ sub core_pipeline_analyses {
                             'cmd_max_runtime'       => '86400',
                             'raxml_number_of_cores' => 8,
                            },
-            -rc_name => '2Gb_8c_job',
+            -rc_name => '2Gb_8c_24_hour_job',
         },
 
         {   -logic_name    => 'genomic_alignment',


### PR DESCRIPTION
## Description

A `cmd_max_runtime` parameter is used in the analyses of several pipelines, and places a time limit on the associated analysis.

This PR updates the resource classes of Hive analyses in several pipelines so that they are more consistent with the `cmd_max_runtime` parameter.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
