### PR TITLE
Streamline Pig EPOwithExt pipeline config

### DIFF
--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -175,7 +175,7 @@
          {
             "assignee": "<RelCo>",
             "component": "Production tasks",
-            "description": "*GitHub*: [EPOwithExt_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwithExt_conf.pm]\n{code}isrun init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EPOwithExt_conf -host mysql-ens-compara-prod-X -port XXXX -division <division> -species_set_name pig_breeds{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
+            "description": "*GitHub*: [PigBreedsEPOwithExt_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/PigBreedsEPOwithExt_conf.pm]\n{code}isrun init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::PigBreedsEPOwithExt_conf -host mysql-ens-compara-prod-X -port XXXX{code}\n(!) remember to set {{pipeline_wide_parameters.lastz_complete}} to 1 when relevant LASTZs are ready",
             "summary": "Run the Pigs EPOwithExt pipeline",
             "name_on_graph": "EPOwithExt:Pigs"
          },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwithExt_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwithExt_conf.pm
@@ -88,6 +88,8 @@ sub default_options {
         'trim_anchor_align_capacity'    => 500,
 
         # Options
+        # linked MLSS is unreleased (e.g. Pig breeds EPO)
+        'linked_mlss_unreleased'     => 0,
         # Avoid reusing any species?
         'do_not_reuse_list'          => undef,
         #skip this module if set to 1
@@ -175,6 +177,7 @@ sub core_pipeline_analyses {
                 'species_set_name' => $self->o('species_set_name'),
                 'release'          => $self->o('ensembl_release'),
                 'add_sister_mlsss' => 1,
+                'linked_mlss_unreleased' => $self->o('linked_mlss_unreleased'),
             },
             -input_ids  => [{}],
             -flow_into  => {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/PigBreedsEPOwithExt_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/PigBreedsEPOwithExt_conf.pm
@@ -1,0 +1,51 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::PigBreedsEPOwithExt_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::PigBreedsEPOwithExt_conf.pm \
+        -host mysql-ens-compara-prod-X -port XXXX
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::PigBreedsEPOwithExt_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::EPOwithExt_conf');
+
+sub default_options {
+    my ($self) = @_;
+
+    return {
+        %{$self->SUPER::default_options},
+
+        'division'               => 'vertebrates',
+        'linked_mlss_unreleased' => 1,
+        'method_type'            => 'EPO_EXTENDED',
+        'species_set_name'       => 'pig_breeds',
+    };
+}
+
+1;


### PR DESCRIPTION
## Description

The `EPOwithExt` pipeline currently does not support the case where a released EPO-Extended alignment is linked to an unreleased EPO alignment (e.g. Pig breeds EPO).

This PR automates adds such support.

**Related JIRA tickets:**
- ENSCOMPARASW-7332

## Testing

These changes were tested in production.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
