### PR TITLE
Add CACTUS_DB method type

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/GenomicAlignBlock.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomicAlignBlock.pm
@@ -1423,7 +1423,7 @@ sub get_GenomicAlignTree {
 
     #Check if a GenomicAlignTree object already exists and return
     my $genomic_align_tree;
-    unless ( $self->method_link_species_set->method->type =~ /CACTUS_HAL/  ) {
+    unless ( $self->method_link_species_set->method->type =~ /^(CACTUS_HAL|CACTUS_HAL_PW|CACTUS_DB)$/ ) {
       eval {
           my $genomic_align_tree_adaptor = $self->adaptor->db->get_GenomicAlignTreeAdaptor;
           $genomic_align_tree = $genomic_align_tree_adaptor->fetch_by_GenomicAlignBlock($self);

--- a/modules/Bio/EnsEMBL/Compara/Method.pm
+++ b/modules/Bio/EnsEMBL/Compara/Method.pm
@@ -71,6 +71,7 @@ our %PLAIN_TEXT_DESCRIPTIONS = (
     'PECAN'                 => 'Mercator-Pecan',
     'CACTUS_HAL'            => 'Cactus',
     'CACTUS_HAL_PW'         => 'Cactus (restricted)',
+    'CACTUS_DB'             => 'Cactus',
     'SYNTENY'               => 'Synteny',
     'FAMILY'                => 'Families',
     'PROTEIN_TREES'         => 'Protein-trees',

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/MLSSJobFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/MLSSJobFactory.pm
@@ -92,7 +92,7 @@ sub _check_valid_type {
     unless ($mlss->method->class =~ /^GenomicAlign/) {
         die sprintf("%s (%s) MLSSs cannot be dumped with this pipeline !\n", $mlss->method->type, $mlss->method->class);
     }
-    if ($mlss->method->type =~ /^CACTUS_HAL/) {
+    if ($mlss->method->type =~ /^(CACTUS_HAL|CACTUS_HAL_PW|CACTUS_DB)$/) {
         die "Cactus alignments cannot be dumped because they already exist as files\n";
     }
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/CreateDumpJobs.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/CreateDumpJobs.pm
@@ -96,7 +96,7 @@ sub fetch_input {
 		if ( $mlss_id_to_dump{$mlss->dbID} ) {
 			# new analysis/user defined mlss! must be dumped
 			if ( $method_class =~ /^GenomicAlign/ ) { # all alignments
-				next if ($mlss->method->type =~ /^(CACTUS_HAL|CACTUS_HAL_PW)$/);  # ... except for Cactus
+				next if ($mlss->method->type =~ /^(CACTUS_HAL|CACTUS_HAL_PW|CACTUS_DB)$/);  # ... except for Cactus
 				push( @{$dumps{DumpMultiAlign}}, $mlss );
 				# only dump ancestors when EPO primates has been run
 				$self->param( 'dump_ancestral_alleles', 1 ) if ( $mlss->method->type eq 'EPO' && $mlss->species_set->name eq 'primates' );

--- a/scripts/dumps/verify_ftp_dumps.pl
+++ b/scripts/dumps/verify_ftp_dumps.pl
@@ -64,6 +64,7 @@ my %glob_exp_per_mlss = (
     ENSEMBL_PARALOGUES       => 'tsv/ensembl-compara/homologies/#species_name#/*.tsv.gz tsv/ensembl-compara/homologies/*_collection/#species_name#/*.tsv.gz',
     SPECIES_TREE             => 'compara/species_trees/*.nh',
     CACTUS_HAL               => 'compara/species_trees/*.nh',
+    CACTUS_DB                => 'compara/species_trees/*.nh',
 );
 
 # Prepend ftp_root to each segment of the glob expression

--- a/scripts/pipeline/compara_db_config.rng
+++ b/scripts/pipeline/compara_db_config.rng
@@ -210,6 +210,7 @@
                   <value>EPO_EXTENDED</value>
                   <value>EPO+EPO_EXTENDED</value>
                   <value>CACTUS_HAL</value>
+                  <value>CACTUS_DB</value>
                 </choice>
               </attribute>
               <choice>

--- a/scripts/pipeline/copy_data.pl
+++ b/scripts/pipeline/copy_data.pl
@@ -225,6 +225,7 @@ my %type_to_adaptor = (
                        'EPO'                    => $from_ga_adaptor,
                        'EPO_EXTENDED'           => $from_ga_adaptor,
                        'PECAN'                  => $from_ga_adaptor,
+                       'CACTUS_DB'              => $from_ga_adaptor,
                        'GERP_CONSERVATION_SCORE'    => $from_cs_adaptor,
                        'GERP_CONSTRAINED_ELEMENT'   => $from_ce_adaptor,
                        # Trick to allow the Method but skip counting

--- a/scripts/pipeline/populate_new_database.pl
+++ b/scripts/pipeline/populate_new_database.pl
@@ -763,8 +763,8 @@ sub copy_dna_to_dna_alignments {
     next if ($this_method_link_species_set->method->dbID >= 100);
     ## We ignore LASTZ_PATCH alignments as they should be reloaded fresh every release
     next if ($this_method_link_species_set->method->type eq 'LASTZ_PATCH');
-    ## Skip HAL alignments as there's nothing in the db
-    next if ($this_method_link_species_set->method->type =~ m/CACTUS_HAL/);
+    ## Skip Cactus alignments with nothing in the db
+    next if ($this_method_link_species_set->method->type =~ m/^(CACTUS_HAL|CACTUS_HAL_PW)$/);
 
     print "Copying dna-dna alignments for ", $this_method_link_species_set->name,
         " (", $this_method_link_species_set->dbID, "): ";

--- a/sql/method_link.txt
+++ b/sql/method_link.txt
@@ -23,6 +23,7 @@
 23	CACTUS_HAL_PW	GenomicAlignBlock.pairwise_alignment	Cactus (restricted)
 24	EPO_GEN_ANCHORS	ConservationScore.conservation_score	EPO Anchor generation
 25	POLYPLOID	GenomicAlignBlock.pairwise_alignment	polyploidy-aware self-alignment
+26	CACTUS_DB	GenomicAlignBlock.multiple_alignment	Cactus
 101	SYNTENY	SyntenyRegion.synteny	synteny
 102	SYNTENY_HARD_MASKED	SyntenyRegion.synteny	
 201	ENSEMBL_ORTHOLOGUES	Homology.homology	orthologues

--- a/src/test_data/databases/master/method_link.txt
+++ b/src/test_data/databases/master/method_link.txt
@@ -23,6 +23,7 @@
 23	CACTUS_HAL_PW	GenomicAlignBlock.pairwise_alignment	Cactus (restricted)
 24	EPO_GEN_ANCHORS	ConservationScore.conservation_score	EPO Anchor generation
 25	POLYPLOID	GenomicAlignBlock.pairwise_alignment	polyploidy-aware self-alignment
+26	CACTUS_DB	GenomicAlignBlock.multiple_alignment	Cactus
 101	SYNTENY	SyntenyRegion.synteny	synteny
 102	SYNTENY_HARD_MASKED	SyntenyRegion.synteny	
 201	ENSEMBL_ORTHOLOGUES	Homology.homology	orthologues

--- a/src/test_data/databases/pan/method_link.txt
+++ b/src/test_data/databases/pan/method_link.txt
@@ -23,6 +23,7 @@
 23	CACTUS_HAL_PW	GenomicAlignBlock.pairwise_alignment	Cactus (restricted)
 24	EPO_GEN_ANCHORS	ConservationScore.conservation_score	EPO Anchor generation
 25	POLYPLOID	GenomicAlignBlock.pairwise_alignment	polyploidy-aware self-alignment
+26	CACTUS_DB	GenomicAlignBlock.multiple_alignment	Cactus
 101	SYNTENY	SyntenyRegion.synteny	synteny
 102	SYNTENY_HARD_MASKED	SyntenyRegion.synteny	
 201	ENSEMBL_ORTHOLOGUES	Homology.homology	orthologues


### PR DESCRIPTION
## Description

This PR adds support for a `CACTUS_DB` method type, which can be used to load Cactus alignment data into a Compara database.

**Related JIRA tickets:**
- ENSCOMPARASW-7532

## Testing

These changes have been tested in production.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
