### PR TITLE
Assign cellular component on change of chunk set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,7 +166,6 @@ jobs:
       python: 3.9
       name: "Python linter"
       install:
-        - pip uninstall dataclasses -y
         - pip install pylint mypy
         - pip install .
       script: ./travisci/python-linter_harness.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -166,6 +166,7 @@ jobs:
       python: 3.9
       name: "Python linter"
       install:
+        - pip uninstall dataclasses -y
         - pip install pylint mypy
         - pip install .
       script: ./travisci/python-linter_harness.sh

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/ChunkAndGroupDna.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/ChunkAndGroupDna.pm
@@ -263,6 +263,7 @@ sub store_chunk_in_chunkset {
         if (!$self->param('mix_cellular_components') and ($self->param('current_cellular_component') ne $chunk->dnafrag->cellular_component)) {
             print "Creating new chunkset for ".$chunk->dnafrag->cellular_component."\n";
             $self->define_new_chunkset;
+            $self->param('current_cellular_component', $chunk->dnafrag->cellular_component);
         }
     } else {
         $self->param('current_cellular_component', $chunk->dnafrag->cellular_component);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/CreatePairAlignerJobs.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PairAligner/CreatePairAlignerJobs.pm
@@ -128,7 +128,26 @@ sub createPairAlignerJobs
 
   # Prepopulate the cellular_component
   foreach my $query_dnafrag_chunk_set (@{$query_dnafrag_chunk_set_list}) {
-    my $query_cellular_component = $query_dnafrag_chunk_set->get_all_DnaFragChunks->[0]->dnafrag->cellular_component;
+
+    my $query_cellular_component;
+    if (!$self->param('mix_cellular_components')) {
+        my $query_dnafrag_chunks = $query_dnafrag_chunk_set->get_all_DnaFragChunks();
+        my %query_cellular_component_set = map { $_->dnafrag->cellular_component => 1 } @{$query_dnafrag_chunks};
+        my @query_cellular_components = keys %query_cellular_component_set;
+
+        if (scalar(@query_cellular_components) == 1) {
+            $query_cellular_component = $query_cellular_components[0];
+        } else {
+            $self->die_no_retry(
+                sprintf(
+                    "query chunk set %d has mixed components (%s)",
+                    $query_dnafrag_chunk_set->dbID,
+                    join(', ', @query_cellular_components),
+                )
+            );
+        }
+    }
+
     $query_dnafrag_chunk_set->{'tmp_query_cellular_component'} = $query_cellular_component;
   }
 
@@ -137,7 +156,24 @@ sub createPairAlignerJobs
     
     $pairaligner_hash->{'dbChunkSetID'} = $target_dnafrag_chunk_set->dbID;
 
-    my $target_cellular_component = $target_dnafrag_chunk_set->get_all_DnaFragChunks->[0]->dnafrag->cellular_component;
+    my $target_cellular_component;
+    if (!$self->param('mix_cellular_components')) {
+        my $target_dnafrag_chunks = $target_dnafrag_chunk_set->get_all_DnaFragChunks();
+        my %target_cellular_component_set = map { $_->dnafrag->cellular_component => 1 } @{$target_dnafrag_chunks};
+        my @target_cellular_components = keys %target_cellular_component_set;
+
+        if (scalar(@target_cellular_components) == 1) {
+            $target_cellular_component = $target_cellular_components[0];
+        } else {
+            $self->die_no_retry(
+                sprintf(
+                    "target chunk set %d has mixed components (%s)",
+                    $pairaligner_hash->{'dbChunkSetID'},
+                    join(', ', @target_cellular_components),
+                )
+            );
+        }
+    }
 
     foreach my $query_dnafrag_chunk_set (@{$query_dnafrag_chunk_set_list}) {
 


### PR DESCRIPTION
## Description

The `mix_cellular_components` option of the `ChunkAndGroupDna` runnable has not been behaving as it should. For some time, not all organelle genomes have been processed by the LastZ pipeline.

This PR addresses that by ensuring the `current_cellular_component` parameter is set when a DnaFrag chunk's cellular component changes relative to the previous chunk.

It also updates the `CreatePairAlignerJobs` runnable to check that query and target chunk sets do not contain a mixture of DnaFrag chunks from different components when `mix_cellular_components` is switched off.

## Testing

These changes have been tested in pipeline `twalsh_vertebrates_lastz_test_batch_20240624`.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
