### PR TITLE
Add GAB method to check overlap with target locus

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/GenomicAlignBlock.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomicAlignBlock.pm
@@ -1155,6 +1155,29 @@ sub _create_from_a_list_of_ungapped_genomic_align_blocks {
   return $self;
 }
 
+# Return true if this GenomicAlignBlock overlaps the given locus, false otherwise. The locus may be
+# a Bio::EnsEMBL::Compara::Locus object or a hashref with keys 'dnafrag_id', 'dnafrag_start' and 'dnafrag_end'.
+# This method is adapted from, and should remain consistent with, the fetch_by_Slice_MethodLinkSpeciesSet
+# method in the Bio::EnsEMBL::Compara::DBSQL::AlignSliceAdaptor module.
+sub _overlaps_Locus {
+    my ($self, $target_locus) = @_;
+
+    if (!defined $target_locus) {
+        throw("Target locus must be specified!");
+    }
+
+    my $overlap_status = 0;
+    foreach my $genomic_align (@{$self->get_all_GenomicAligns()}) {
+        if ($genomic_align->dnafrag->dbID == $target_locus->{'dnafrag_id'}
+                && $genomic_align->dnafrag_start <= $target_locus->{'dnafrag_end'}
+                && $genomic_align->dnafrag_end >= $target_locus->{'dnafrag_start'}) {
+            $overlap_status = 1;
+            last;
+        }
+    }
+
+    return $overlap_status;
+}
 
 =head2 get_all_ungapped_GenomicAlignBlocks
 


### PR DESCRIPTION
## Description

With the addition of a new `CACTUS_DB` method type (#805), it has become apparent that addition of support of this method type to Ensembl web code would likely require some adjustments, particularly to handle overlap between aligned regions that are present in multiple `GenomicAlignBlocks`.

Though such overlaps can occur — under the current Cactus-loading implementation — in genomes that have not been used as a MAF reference, they cannot occur in the genome that was used as a MAF reference. Because of this, the MAF reference genome can be used to disambiguate overlapping `GenomicAlignBlocks` and to filter them so as to keep only the `GenomicAlignBlock` overlapping a particular MAF reference region.

To support efforts to adapt Ensembl web code to handle `CACTUS_DB` alignments, this PR adds private method `GenomicAlignBlock::_overlaps_Locus` to the Compara API, which returns `1` if the given `GenomicAlignBlock` has any `GenomicAlign` objects overlapping the specified `$target_locus`, and `0` otherwise.

**Related JIRA tickets:**
- ENSCOMPARASW-7532

## Testing

These changes were tested in use by viewing regions with overlapping `GenomicAlignBlocks` on a web sandbox.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
