### PR TITLE
Add LoadCactus pipe config for Metazoa

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/LoadCactus_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/LoadCactus_conf.pm
@@ -1,0 +1,59 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=pod
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Metazoa::LoadCactus_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Metazoa::LoadCactus_conf -host mysql-ens-compara-prod-X -port XXXX
+
+=head1 DESCRIPTION
+
+Specific version of LoadCactus_conf for Metazoa.
+
+=cut
+
+
+package Bio::EnsEMBL::Compara::PipeConfig::Metazoa::LoadCactus_conf;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
+
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::LoadCactus_conf');
+
+
+sub default_options {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::default_options},
+
+        'division' => 'metazoa',
+    };
+}
+
+
+1;


### PR DESCRIPTION
## Description

This PR adds a pipeline config file for loading Metazoa Cactus alignment data from a HAL file into a database.

**Related JIRA tickets:**
- ENSCOMPARASW-7530

## Testing
This pipeline was tested in production.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
