### PR TITLE
Uninstall dataclasses from Travis environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -165,6 +165,7 @@ jobs:
       python: 3.9
       name: "Python linter"
       install:
+        - pip uninstall dataclasses -y
         - pip install pylint mypy
         - pip install .
       script: ./travisci/python-linter_harness.sh

--- a/scripts/pipeline/symlink_prev_dump.py
+++ b/scripts/pipeline/symlink_prev_dump.py
@@ -90,6 +90,8 @@ if __name__ == "__main__":
     elif args.mlss_path_type == "directory":
         root_to_mlss_dir_path = mlss_path
         path_spec = "*"
+    else:
+        raise ValueError(f"unknown MLSS path type: {args.mlss_path_type}")
 
     prev_mlss_dir_path = prev_ftp_dump_root / root_to_mlss_dir_path
     prev_mlss_file_paths = list(prev_mlss_dir_path.glob(path_spec))


### PR DESCRIPTION
## Description

Script `travisci/python-linter_harness.sh` has been failing with error...
```
AttributeError: module 'typing' has no attribute '_ClassVar'
```
...reportedly due to the presence of a `dataclasses` backport package in the Python linter environment (see PR #482).

This PR addresses the issue by uninstalling the `dataclasses` backport package from the Python linter environment.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
