### PR TITLE
Uninstall dataclasses from e113 Travis environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,6 +166,7 @@ jobs:
       python: 3.9
       name: "Python linter"
       install:
+        - pip uninstall dataclasses -y
         - pip install pylint mypy
         - pip install .
       script: ./travisci/python-linter_harness.sh

--- a/scripts/hal_alignment/process_cactus_maf.py
+++ b/scripts/hal_alignment/process_cactus_maf.py
@@ -18,7 +18,6 @@
 import argparse
 import json
 import os
-import re
 import shutil
 from tempfile import TemporaryDirectory
 
@@ -30,14 +29,14 @@ import numpy as np
 
 def trimming_maf_iterator(stream):
     """Yields a MAF block with gap-only columns trimmed out."""
-    for i, maf_block in enumerate(MafIterator(stream), start=1):
-        gap_column = np.vstack(np.repeat(b"-", len(maf_block)))
-        block_arr = np.array(maf_block, dtype=bytes)
+    for aln_block in MafIterator(stream):
+        gap_column = np.vstack(np.repeat(b"-", len(aln_block)))
+        block_arr = np.array(aln_block, dtype=bytes)
         gap_col_mask = (block_arr == gap_column).all(axis=0)
         if gap_col_mask.any():
-            for row, rec in zip(block_arr[:, ~gap_col_mask], maf_block):
-                rec.seq = Seq(row.tobytes().decode("ascii"))
-        yield maf_block
+            for row_arr, aln_row in zip(block_arr[:, ~gap_col_mask], aln_block):
+                aln_row.seq = Seq(row_arr.tobytes().decode("ascii"))
+        yield aln_block
 
 
 if __name__ == "__main__":

--- a/scripts/pipeline/symlink_prev_dump.py
+++ b/scripts/pipeline/symlink_prev_dump.py
@@ -90,6 +90,8 @@ if __name__ == "__main__":
     elif args.mlss_path_type == "directory":
         root_to_mlss_dir_path = mlss_path
         path_spec = "*"
+    else:
+        raise ValueError(f"unknown MLSS path type: {args.mlss_path_type}")
 
     prev_mlss_dir_path = prev_ftp_dump_root / root_to_mlss_dir_path
     prev_mlss_file_paths = list(prev_mlss_dir_path.glob(path_spec))


### PR DESCRIPTION
## Description

Script `travisci/python-linter_harness.sh` has been failing with error...
```
AttributeError: module 'typing' has no attribute '_ClassVar'
```
...reportedly due to the presence of a `dataclasses` backport package in the Python linter environment (see PR #482).

This PR addresses the issue by uninstalling the `dataclasses` backport package from the Python linter environment.

It also address any Python linting issues that were previously masked by it.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
