### PR TITLE
Enable configuration of collection strain type

### DIFF
--- a/conf/plants/mlss_conf.xml
+++ b/conf/plants/mlss_conf.xml
@@ -45,7 +45,7 @@
     </collection>
 
     <!-- Wheat cultivars -->
-    <collection name="wheat_cultivars">
+    <collection name="wheat_cultivars" strain_type="cultivar">
       <genome name="aegilops_tauschii"/>
       <genome name="hordeum_vulgare"/>
       <genome name="secale_cereale"/>
@@ -98,7 +98,7 @@
     </collection>
 
     <!-- Rice Cultivars -->
-    <collection name="rice_cultivars">
+    <collection name="rice_cultivars" strain_type="cultivar">
       <genome name="oryza_glaberrima"/>
       <genome name="oryza_brachyantha"/>
       <genome name="oryza_sativa"/>

--- a/conf/vertebrates/mlss_conf.xml
+++ b/conf/vertebrates/mlss_conf.xml
@@ -74,12 +74,12 @@
     </collection>
 
     <!-- Mouse-strains analyses, i.e. incl. the closely relative -->
-    <collection name="murinae">
+    <collection name="murinae" strain_type="strain">
       <taxonomic_group taxon_name="Murinae"/>
     </collection>
 
     <!-- Pig-breeds analyses, incl. closely related outgroups -->
-    <collection name="pig_breeds">
+    <collection name="pig_breeds" strain_type="breed">
       <taxonomic_group taxon_name="Sus"/>
       <genome name="bos_taurus"/>
       <genome name="equus_caballus"/>

--- a/scripts/pipeline/compara_db_config.rng
+++ b/scripts/pipeline/compara_db_config.rng
@@ -146,6 +146,15 @@
                 </attribute>
               </optional>
               <optional>
+                <attribute name="strain_type" blockly:blockName="Predominant strain type of this collection">
+                  <choice>
+                    <value blockly:blockName="Strain">strain</value>
+                    <value blockly:blockName="Breed">breed</value>
+                    <value blockly:blockName="Cultivar">cultivar</value>
+                  </choice>
+                </attribute>
+              </optional>
+              <optional>
                   <element name="base_collection" blockly:blockName="Include collection as base">
                     <attribute name="name" blockly:blockName="Collection name"/>
                   </element>

--- a/scripts/pipeline/create_all_mlss.pl
+++ b/scripts/pipeline/create_all_mlss.pl
@@ -372,6 +372,11 @@ foreach my $collection_node (@{$division_node->findnodes('collections/collection
     my $collection_name = $collection_node->getAttribute('name');
     $collections{$collection_name} = Bio::EnsEMBL::Compara::Utils::MasterDatabase::create_species_set($genome_dbs, "collection-$collection_name", $no_release);
 
+    my $strain_type = $collection_node->getAttribute('strain_type');
+    if (defined $strain_type) {
+        $collections{$collection_name}->add_tag('strain_type', $strain_type);
+    }
+
     my $no_store = $collection_node->getAttribute('no_store') // 0;
     if ($no_store) {
         $unstored_collection_names{$collection_name} = 1;


### PR DESCRIPTION
## Description

In the sidebar menu of a gene view on an Ensembl site, strain-level homologies can be accessed via a menu item which is named from the strain type of the current organism, specifically from the `strain.type` meta entry of the relevant core database.

This has had the potential to result in inconsistent display of the homology menu item for different genomes in the same gene-tree collection, in cases where the `strain.type` meta value of some genomes differ from the designated strain-type of the tree collection (e.g. Oryza rufipogon **strain** W1943 in Rice **cultivars** in e111, European wild boar **isolate** euw1 in Pig **breeds** in e113).

This issue is addressed in [ensembl-webcode PR 1026](https://github.com/Ensembl/ensembl-webcode/pull/1026) by fetching the gene-tree collection strain-type from a `strain_type` `species_set_tag` associated with that collection.

This PR makes it possible to set a collection's `strain_type` via the `mlss_conf.xml` file used to configure Compara collections and analyses.

## Overview of changes

This PR enables configuration of gene-tree collection `strain_type` by:
- adding support for a `strain_type` collection attribute to `scripts/pipeline/compara_db_config.rng`;
- updating `create_all_mlss.pl` to take a collection `strain_type` attribute and add a `strain_type` tag to the corresponding collection; and
- configuring strain types of non-default collections in `conf/vertebrates/mlss_conf.xml` and `conf/plants/mlss_conf.xml`.

## Testing

These changes were tested in a master database prep pipeline run on a pre-112 backup of the Vertebrates Compara master database.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
