### PR TITLE
Prefer prefixed collection names where appropriate

### DIFF
--- a/scripts/pipeline/create_all_mlss.pl
+++ b/scripts/pipeline/create_all_mlss.pl
@@ -567,8 +567,8 @@ $compara_dba->dbc->sql_helper->transaction( -CALLBACK => sub {
                         $compara_dba->dbc->do(
                             'UPDATE species_set_header SET name = ? WHERE species_set_id = ?',
                             undef,
-                            $exist_mlss->species_set->name,
-                            $exist_mlss->species_set->dbID
+                            $mlss_ss_name,
+                            $exist_mlss->species_set->dbID,
                         );
                     }
                 }

--- a/scripts/pipeline/create_all_mlss.pl
+++ b/scripts/pipeline/create_all_mlss.pl
@@ -558,8 +558,19 @@ $compara_dba->dbc->sql_helper->transaction( -CALLBACK => sub {
                 if ($exist_mlss->name ne $mlss->name) {
                     $compara_dba->dbc->do('UPDATE method_link_species_set SET name = ? WHERE method_link_species_set_id = ?', undef, $mlss->name, $exist_mlss->dbID);
                 }
-                if ($exist_mlss->species_set->name ne $mlss->species_set->name) {
-                    $compara_dba->dbc->do('UPDATE species_set_header SET name = ? WHERE species_set_id = ?', undef, $mlss->species_set->name, $exist_mlss->species_set->dbID);
+
+                # Update MLSS species-set name in database ...
+                my $mlss_ss_name = $mlss->species_set->name;
+                if ($mlss_ss_name ne $exist_mlss->species_set->name) {
+                    # ... unless this would have the effect of removing the 'collection-' prefix from a collection.
+                    unless ("collection-$mlss_ss_name" eq $exist_mlss->species_set->name && exists $collections{$mlss_ss_name}) {
+                        $compara_dba->dbc->do(
+                            'UPDATE species_set_header SET name = ? WHERE species_set_id = ?',
+                            undef,
+                            $exist_mlss->species_set->name,
+                            $exist_mlss->species_set->dbID
+                        );
+                    }
                 }
 
                 # handle re-release : when an object was retired, but is being made current again.


### PR DESCRIPTION
## Description

This PR fixes the issue where Murinae and Pig breeds species-set names alternate every release.

These two species sets are each configured in the Vertebrates `mlss_conf.xml` both as a collection (e.g. for Murinae protein trees) and as a regular species set (e.g. for Murinae EPO), with the former having a `collection-` prefix (e.g. `collection-murinae`) and the latter simply the species-set name (e.g. `murinae`). Only one of these species-set names can be stored in the Compara master database.

The script `create_all_mlss.pl` updates the species-set name of an existing MLSS (e.g. Murinae protein trees or EPO),
but only if it differs from the existing species-set name. The effect of this has been for Murinae and Pig breeds collections to alternate species-set names every release between having the `collection-` prefix and lacking it. At best this creates datacheck noise. At worst, these collection name changes have the potential to lead to comparative analyses being run on the wrong dataset.

**Related JIRA tickets:**
- ENSCOMPARASW-5339

## Overview of changes

In the part of `create_all_mlss.pl` where the species-set name of an existing MLSS may be updated, a further set of conditions is added so that the species-set name is not updated if it would have the effect of removing the `collection-` prefix from a collection.

## Testing

These changes were tested in a master-preparation pipeline run on a pre-112 backup of the Vertebrates Compara master database.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
