### PR TITLE
Add find_prev_homology_dumps step to gene-tree pipelines

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -259,7 +259,6 @@ sub default_options {
         'homology_method_link_types' => ['ENSEMBL_ORTHOLOGUES'],
         # WGA dump directories for OrthologQMAlignment
         'wga_dumps_dir'      => $self->o('homology_dumps_dir'),
-        'prev_wga_dumps_dir' => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('prev_release'),
         # set how many orthologs should be flowed at a time
         'orth_batch_size'   => 10,
         # set to 1 when all pairwise and multiple WGA complete
@@ -359,7 +358,6 @@ sub default_options {
         'orthotree_dir'             => $self->o('dump_dir') . '/orthotree/',
         'homology_dumps_dir'        => $self->o('dump_dir') . '/homology_dumps/',
         'homology_dumps_shared_dir' => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('ensembl_release'),
-        'prev_homology_dumps_dir'   => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('prev_release'),
 
         # Gene tree stats options
         'gene_tree_stats_shared_dir' => $self->o('gene_tree_stats_shared_basedir') . '/' . $self->o('collection') . '/' . $self->o('ensembl_release'),
@@ -475,11 +473,9 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'hmm_library_version'   => $self->o('hmm_library_version'),
 
         'homology_dumps_dir'        => $self->o('homology_dumps_dir'),
-        'prev_homology_dumps_dir'   => $self->o('prev_homology_dumps_dir'),
         'homology_dumps_shared_dir' => $self->o('homology_dumps_shared_dir'),
         'orthotree_dir'             => $self->o('orthotree_dir'),
         'wga_dumps_dir'             => $self->o('wga_dumps_dir'),
-        'prev_wga_dumps_dir'        => $self->o('prev_wga_dumps_dir'),
         'gene_tree_stats_shared_dir' => $self->o('gene_tree_stats_shared_dir'),
 
         'goc_files_dir'      => $self->o('goc_files_dir'),
@@ -487,7 +483,6 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'hashed_mlss_id'     => '#expr(dir_revhash(#mlss_id#))expr#',
         'goc_file'           => '#goc_files_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.goc.tsv',
         'wga_file'           => '#wga_files_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.wga.tsv',
-        'previous_wga_file'  => defined $self->o('prev_wga_dumps_dir') ? '#prev_wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv' : undef,
         'high_conf_file'     => '#homology_dumps_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.high_conf.tsv',
 
         'output_dir_path'    => $self->o('output_dir_path'),
@@ -819,6 +814,16 @@ sub core_pipeline_analyses {
                 'method_type'      => $self->o('method_type'),
                 'species_set_name' => $self->o('species_set_name'),
                 'release'          => '#ensembl_release#'
+            },
+            -flow_into  => [ 'find_prev_homology_dumps' ],
+        },
+
+        {   -logic_name => 'find_prev_homology_dumps',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::SetPrevHomologyDumpParams',
+            -parameters => {
+                'homology_dumps_shared_basedir' => $self->o('homology_dumps_shared_basedir'),
+                'collection'                    => $self->o('collection'),
+                'prev_release'                  => $self->o('prev_release'),
             },
             -flow_into  => [ 'load_genomedb_factory' ],
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -165,7 +165,6 @@ sub default_options {
             'orthotree_dir'             => $self->o('dump_dir') . '/orthotree/',
             'homology_dumps_dir'        => $self->o('dump_dir'). '/homology_dumps/',
             'homology_dumps_shared_dir' => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('ensembl_release'),
-            'prev_homology_dumps_dir'   => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('prev_release'),
 
 
             # Do we want to do OrthologQMAlignment ?
@@ -175,7 +174,6 @@ sub default_options {
             'homology_method_link_types' => ['ENSEMBL_ORTHOLOGUES'],
             # WGA dump directories for OrthologQMAlignment
             'wga_dumps_dir'      => $self->o('homology_dumps_dir'),
-            'prev_wga_dumps_dir' => $self->o('homology_dumps_shared_basedir') . '/' . $self->o('collection')    . '/' . $self->o('prev_release'),
             # set how many orthologs should be flowed at a time
             'orth_batch_size'   => 10,
             # set to 1 when all pairwise and multiple WGA complete
@@ -243,11 +241,9 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'output_dir_path'           => $self->o('output_dir_path'),
         'dump_dir'                  => $self->o('dump_dir'),
         'homology_dumps_dir'        => $self->o('homology_dumps_dir'),
-        'prev_homology_dumps_dir'   => $self->o('prev_homology_dumps_dir'),
         'homology_dumps_shared_dir' => $self->o('homology_dumps_shared_dir'),
         'orthotree_dir'             => $self->o('orthotree_dir'),
         'wga_dumps_dir'             => $self->o('wga_dumps_dir'),
-        'prev_wga_dumps_dir'        => $self->o('prev_wga_dumps_dir'),
         'gene_dumps_dir'            => $self->o('gene_dumps_dir'),
         'gene_tree_stats_shared_dir' => $self->o('gene_tree_stats_shared_dir'),
 
@@ -256,7 +252,6 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'hashed_mlss_id'     => '#expr(dir_revhash(#mlss_id#))expr#',
         'goc_file'           => '#goc_files_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.goc.tsv',
         'wga_file'           => '#wga_files_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.wga.tsv',
-        'previous_wga_file'  => defined $self->o('prev_wga_dumps_dir') ? '#prev_wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv' : undef,
         'high_conf_file'     => '#homology_dumps_dir#/#hashed_mlss_id#/#mlss_id#.#member_type#.high_conf.tsv',
 
         'skip_epo'      => $self->o('skip_epo'),
@@ -471,6 +466,16 @@ sub core_pipeline_analyses {
                 'method_type'      => $self->o('method_type'),
                 'species_set_name' => $self->o('species_set_name'),
                 'release'          => '#ensembl_release#'
+            },
+            -flow_into  => [ 'find_prev_homology_dumps' ],
+        },
+
+        {   -logic_name => 'find_prev_homology_dumps',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::SetPrevHomologyDumpParams',
+            -parameters => {
+                'homology_dumps_shared_basedir' => $self->o('homology_dumps_shared_basedir'),
+                'collection'                    => $self->o('collection'),
+                'prev_release'                  => $self->o('prev_release'),
             },
             -flow_into  => [ 'load_genomedb_factory' ],
         },

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/SetPrevHomologyDumpParams.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/SetPrevHomologyDumpParams.pm
@@ -1,0 +1,83 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::SetPrevHomologyDumpParams
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::SetPrevHomologyDumpParams;
+
+use strict;
+use warnings;
+
+use File::Spec::Functions qw(catdir);
+use List::Util qw(max);
+
+use Bio::EnsEMBL::Hive::Utils qw(stringify);
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub run {
+    my $self = shift;
+
+    my $homology_dumps_shared_basedir = $self->param_required('homology_dumps_shared_basedir');
+    my $prev_release = $self->param_required('prev_release');
+    my $collection = $self->param_required('collection');
+
+    my $prev_homology_collection_dir = catdir($homology_dumps_shared_basedir, $collection);
+
+    my $prev_homology_dump_dir_path;
+    my $previous_wga_file;
+
+    if ( -d $prev_homology_collection_dir ) {
+
+        opendir(my $dh, $prev_homology_collection_dir) or $self->throw("Could not open directory [$prev_homology_collection_dir]");
+        my @release_dir_names = grep {
+            $_ =~ /^[0-9]+$/
+            && $_ <= $prev_release
+            && -d catdir($prev_homology_collection_dir, $_)
+        } readdir($dh);
+        closedir $dh;
+
+        if (scalar(@release_dir_names) > 0) {
+            my $prev_homology_dump_dir_name = max(@release_dir_names);
+            $prev_homology_dump_dir_path = catdir($prev_homology_collection_dir, $prev_homology_dump_dir_name);
+            $previous_wga_file = '#prev_wga_dumps_dir#/#hashed_mlss_id#/#orth_mlss_id#.#member_type#.wga.tsv';
+        }
+    }
+
+    $self->param('prev_homology_dumps_dir', $prev_homology_dump_dir_path);
+    $self->param('prev_wga_dumps_dir', $prev_homology_dump_dir_path);
+    $self->param('previous_wga_file', $previous_wga_file);
+}
+
+
+sub write_output {
+    my ($self) = @_;
+
+    foreach my $param_name ('prev_homology_dumps_dir', 'prev_wga_dumps_dir', 'previous_wga_file') {
+        $self->add_or_update_pipeline_wide_parameter($param_name, stringify($self->param($param_name)));
+    }
+}
+
+
+1;


### PR DESCRIPTION
## Description

Configuration of previous homology dump data implicitly assumes gene-tree pipelines are run every release. Previous homology dump paths are set using the `prev_release` pipeline parameter (typically the current release minus one).

Most Vertebrates and Plants gene-tree pipelines are not currently run in every Ensembl release, so homology data files are being dumped, but are only being used if gene trees are generated in consecutive releases.

This PR ensures greater utilisation of homology dumps by adding a `find_prev_homology_dumps` analysis (and associated `SetPrevHomologyDumpParams` runnable) to the `ProteinTrees` and `ncRNAtrees` pipelines, which sets the pipeline parameters configuring previous homology dumps, taking those most recently available.

If no homology dumps are available, the relevant pipeline parameters are set to `undef`.

## Testing

These changes were tested by initialising Vertebrates, Plants and Metazoa gene-tree pipelines and running them as far as the `find_prev_homology_dumps` step.

All pipeline parameters configuring previous homology dumps were as expected, including those in Metazoa, which were `undef` due to the unavailability of previous homology dumps.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
