### PR TITLE
Log to standard output by default

### DIFF
--- a/scripts/production/homology_dump_cleanup.py
+++ b/scripts/production/homology_dump_cleanup.py
@@ -20,6 +20,7 @@ import argparse
 import logging
 import os
 import shutil
+import sys
 import textwrap
 from typing import Any, List, Optional, Tuple
 
@@ -243,10 +244,16 @@ def cleanup_homology_dumps(
         div_info : A list of tuples containing division information,
         first tuple has the division name and the second tuple has the schema version
     """
+    logging_kwargs: dict = {
+        "format": "%(asctime)s - %(message)s",
+        "level": logging.INFO,
+    }
     if log_file:
-        logging.basicConfig(
-            filename=log_file, level=logging.INFO, format="%(asctime)s - %(message)s"
-        )
+        logging_kwargs["filename"] = log_file
+    else:
+        logging_kwargs["stream"] = sys.stdout
+    logging.basicConfig(**logging_kwargs)
+
 
     div_path = os.path.join(homology_dumps_dir, div_info[0][0])
     iterate_collection_dirs(div_path, collections, before_release, dry_run)


### PR DESCRIPTION
## Description

The `homology_dump_cleanup.py` script makes it possible to automatically clean up homology dumps.

This PR tweaks the logging config so that if the user doesn't specify a log file, logs are printed to standard output.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
