### PR TITLE
Extend supertree healthchecks

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/GeneTreeHealthChecks_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/GeneTreeHealthChecks_conf.pm
@@ -113,7 +113,7 @@ sub pipeline_analyses {
                 'inputquery'    => 'SELECT COUNT(*) AS species_count FROM genome_db',
             },
             -flow_into => {
-                1 => [ 'all_trees_factory', 'hc_members_globally', 'hc_global_tree_set', 'default_trees_factory' ],
+                1 => [ 'all_trees_factory', 'hc_members_globally', 'hc_global_tree_set', 'hc_supertree_factory', 'default_trees_factory' ],
                 2 => [ 'species_factory' ],
             },
         },
@@ -131,6 +131,21 @@ sub pipeline_analyses {
             -parameters         => {
                 mode            => 'global_tree_set',
             },
+            %hc_analysis_params,
+        },
+
+        {   -logic_name => 'hc_supertree_factory',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+            -parameters => {
+                'inputquery' => 'SELECT root_id AS gene_tree_id FROM gene_tree_root WHERE tree_type = "supertree"',
+            },
+            -flow_into  => {
+                2 => 'hc_supertree'
+            },
+        },
+
+        {   -logic_name => 'hc_supertree',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::HCOneSupertree',
             %hc_analysis_params,
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -1809,6 +1809,7 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'hc_supertree',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::HCOneSupertree',
+            %hc_analysis_params,
         },
 
         {   -logic_name         => 'hc_global_tree_set',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -693,6 +693,7 @@ sub core_pipeline_analyses {
 
             { -logic_name => 'hc_supertree',
               -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::HCOneSupertree',
+              %hc_analysis_params,
             },
 
             { -logic_name => 'fire_cafe',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -693,7 +693,7 @@ sub core_pipeline_analyses {
 
             { -logic_name => 'hc_supertree',
               -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::HCOneSupertree',
-              %hc_analysis_params,
+              %hc_params,
             },
 
             { -logic_name => 'fire_cafe',

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/HCOneSupertree.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/HCOneSupertree.pm
@@ -1,0 +1,46 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::HCOneSupertree
+
+=head1 DESCRIPTION
+
+This runnable calls supertree healthchecks for the
+supertree referred to by parameter 'gene_tree_id'.
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::HCOneSupertree;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::SqlHealthChecks;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub run {
+    my $self= shift @_;
+
+    Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::SqlHealthChecks::_embedded_call($self, 'supertrees');
+}
+
+
+1;


### PR DESCRIPTION
## Description

Supertree topology issues have been detected in at least three instances ([ENSINT-1546](https://www.ebi.ac.uk/panda/jira/browse/ENSINT-1546), [ENSCOMPARASW-5047](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-5047) and [ENSCOMPARASW-7628](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-7628)), and have likely occurred in other cases.

This PR:
- extends supertree healthchecks to catch a broader range of issues;
- adds runnable `HCOneSupertree` to facilitate supertree healthchecks in gene-tree pipelines;
- inserts `hc_supertree` and `hc_supertree_factory` analyses in `ProteinTrees`, `ncRNAtrees` and `ReindexMembers` pipelines to check all supertrees in parallel with `hc_global_tree_set`; and
- makes minor adjustments to pipeline plumbing in the vicinity of the supertree healthcheck analyses.

**Related JIRA tickets:**
- ENSCOMPARASW-5047

## Testing

Example `ProteinTrees`, `ncRNAtrees` and `ReindexMembers` pipelines were initialised to confirm that `hc_supertree_factory` and `hc_supertree` were configured correctly, and that other pipeline changes had been successful.

In addition, a `ReindexMembers` pipeline testing other features but incorporating these changes completed the `hc_supertree_factory` and `hc_supertree` steps successfully.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)