### PR TITLE
Configure Plants topology for use in e114

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/LoadSpeciesTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/LoadSpeciesTrees_conf.pm
@@ -45,9 +45,9 @@ sub default_options {
 
         'division'              => 'plants',
         'compara_alias_name'    => 'compara_curr',
-        'species_tree'          => $self->o('config_dir') . '/species_tree.branch_len.nw',
+        'species_tree'          => $self->o('config_dir') . '/species_tree.topology.nw',
 
-        'binary'    => 1,  # The tree shared by Plants is expected to be binary
+        'binary'    => 0,  # The tree shared by Plants is not binary
         'n_missing_species_in_tree' => 0,
     };
 }

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/PrepareMasterDatabaseForRelease_conf.pm
@@ -55,7 +55,8 @@ sub default_options {
         'additional_species_file' => $self->o('config_dir') . '/' . 'additional_species.json',
         'species_trees'          => [
             $self->o('config_dir') . '/species_tree.branch_len.nw',
-            $self->o('config_dir') . '/species_tree.rice.branch_len.nw'
+            $self->o('config_dir') . '/species_tree.rice.branch_len.nw',
+            $self->o('config_dir') . '/species_tree.topology.nw',
         ],
     };
 }

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
@@ -61,7 +61,7 @@ sub default_options {
 
     # species tree reconciliation
         # you can define your own species_tree for 'treebest'. It can contain multifurcations
-        'species_tree_input_file'        => $self->check_file_in_ensembl('ensembl-compara/conf/' . $self->o('division') . '/species_tree.branch_len.nw'),
+        'species_tree_input_file'        => $self->check_file_in_ensembl('ensembl-compara/conf/' . $self->o('division') . '/species_tree.topology.nw'),
         'binary_species_tree_input_file' => undef,
 
     # homology_dnds parameters:


### PR DESCRIPTION
This PR would configure the Plants topology for use in Ensembl 114 production pipelilnes.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
