### PR TITLE
added mouse strain

### DIFF
--- a/conf/vertebrates/allowed_species.json
+++ b/conf/vertebrates/allowed_species.json
@@ -148,6 +148,7 @@
     "mus_musculus_dba2j",
     "mus_musculus_fvbnj",
     "mus_musculus_lpj",
+	"mus_musculus_molossinusjf1msj",
     "mus_musculus_nodshiltj",
     "mus_musculus_nzohlltj",
     "mus_musculus_pwkphj",


### PR DESCRIPTION
## Description

Adding one mouse strain to list of allowed species

No tickets related.

## Overview of changes
Mus musculus molossinus genome assembly JF1_MsJ_v3, gca921999095v2.
I avoided using 3 underscores, mashing the subspecies name and the strain.

#### Change 1
Added mus_musculus_m[...] to the list of allowed species.

## Testing
Not tested.

## Notes
It shouldn't conflict with anything, as it's a strain.
---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
