### PR TITLE
Facilitate CACTUS_DB pipeline and data config

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadCactus_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadCactus_conf.pm
@@ -210,42 +210,8 @@ sub core_pipeline_analyses {
         {   -logic_name => 'hal_registration_entry_point',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => [
-                    WHEN( '#do_alt_mlss#' => 'find_pairwise_mlss_ids' ),
                     'load_hal_mapping',
             ]
-        },
-
-        {   -logic_name => 'find_pairwise_mlss_ids',
-            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
-            -parameters => {
-                'db_conn'    => '#master_db#',
-                'inputquery' => 'SELECT mlss.method_link_species_set_id AS pw_mlss_id FROM method_link_species_set mlss JOIN method_link USING (method_link_id) JOIN species_set ss USING (species_set_id) JOIN (species_set ss_ref JOIN method_link_species_set mlss_ref USING (species_set_id)) USING (genome_db_id) WHERE mlss_ref.method_link_species_set_id = #mlss_id# AND type = "CACTUS_HAL_PW" GROUP BY mlss.method_link_species_set_id HAVING COUNT(*) = 2',
-            },
-            -flow_into  => {
-                2   => { 'copy_alt_mlss' => INPUT_PLUS() },
-            },
-        },
-
-        {   -logic_name => 'copy_alt_mlss',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::CopyDataWithFK',
-            -parameters => {
-                'db_conn'                    => '#master_db#',
-                'method_link_species_set_id' => '#pw_mlss_id#',
-                'expand_tables'              => 0,
-            },
-            -flow_into  => [ 'connect_alt_mlss' ],
-            -analysis_capacity  => 1,
-        },
-
-        {   -logic_name => 'connect_alt_mlss',
-            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
-            -parameters => {
-                'sql' => [
-                    'UPDATE method_link_species_set alt_mlss JOIN method_link_species_set ref_mlss SET alt_mlss.url = ref_mlss.url WHERE alt_mlss.method_link_species_set_id = #pw_mlss_id# AND ref_mlss.method_link_species_set_id = #mlss_id#',
-                    'INSERT IGNORE INTO method_link_species_set_tag (method_link_species_set_id, tag, value) VALUES (#pw_mlss_id#, "alt_hal_mlss", "#mlss_id#")',
-                ],
-            },
-            -analysis_capacity  => 1,
         },
 
         {   -logic_name => 'load_hal_mapping',

--- a/scripts/pipeline/compara_db_config.rng
+++ b/scripts/pipeline/compara_db_config.rng
@@ -253,6 +253,9 @@
               <optional>
                 <attribute name="url" blockly:blockName="URL field for CACTUS_HAL"/>
               </optional>
+              <optional>
+                <attribute name="ref_genome" blockly:blockName="Reference genome"/>
+              </optional>
             </element>
           </oneOrMore>
         </element>


### PR DESCRIPTION
## Description

This PR makes some changes to facilitate MLSS and pipeline configuration of `CACTUS_DB` MLSSes:
- `alt_mlss` steps are removed from the `LoadCactus` pipeline, since there is currently no support for `CACTUS_DB_PW`;
- support for a `ref_genome` attribute is added to the schema file `compara_db_config.rng` and the script `create_all_mlss.pl`; and
- the `genome_db` filter in `create_all_mlss.pl` function `make_species_set_from_XML_node` now checks if a `genome_component` attribute is defined before comparing it with the configured `genome_component`, resulting in cleaner output when explicitly configuring a principal `GenomeDB`.

## Testing
These changes were tested as part of trial runs of the `PrepareMasterDatabaseForRelease` and `LoadCactus` pipelines.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
