### PR TITLE
Update Hive resource classes for e114

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateHmmProfiles_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateHmmProfiles_conf.pm
@@ -924,7 +924,7 @@ sub core_pipeline_analyses {
             -flow_into => {
                 1 => [ 'hcluster_parse_output' ],
             },
-            -rc_name => '32Gb_job',
+            -rc_name => '32Gb_24_hour_job',
         },
 
         {   -logic_name => 'hcluster_parse_output',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/Lastz_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/Lastz_conf.pm
@@ -94,12 +94,12 @@ sub tweak_analyses {
           'alignment_nets'                                => '2Gb_job',
           'create_alignment_nets_jobs'                    => '2Gb_job',
           'create_alignment_chains_jobs'                  => '4Gb_job',
-          'create_filter_duplicates_jobs'                 => '2Gb_job',
+          'create_filter_duplicates_jobs'                 => '2Gb_24_hour_job',
           'create_pair_aligner_jobs'                      => '2Gb_job',
           'populate_new_database'                         => '8Gb_job',
           'parse_pair_aligner_conf'                       => '4Gb_job',
-          $self->o('pair_aligner_logic_name')             => '4Gb_job',
-          $self->o('pair_aligner_logic_name') . "_himem1" => '8Gb_job',
+          $self->o('pair_aligner_logic_name')             => '4Gb_24_hour_job',
+          $self->o('pair_aligner_logic_name') . "_himem"  => '8Gb_24_hour_job',
     );
     foreach my $logic_name (keys %overriden_rc_names) {
         $analyses_by_name->{$logic_name}->{'-rc_name'} = $overriden_rc_names{$logic_name};

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/Lastz_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/Lastz_conf.pm
@@ -60,12 +60,12 @@ sub tweak_analyses {
         'alignment_nets'                              => '2Gb_job',
         'create_alignment_nets_jobs'                  => '2Gb_job',
         'create_alignment_chains_jobs'                => '4Gb_job',
-        'create_filter_duplicates_jobs'               => '2Gb_job',
+        'create_filter_duplicates_jobs'               => '2Gb_24_hour_job',
         'create_pair_aligner_jobs'                    => '2Gb_job',
         'populate_new_database'                       => '8Gb_job',
         'parse_pair_aligner_conf'                     => '4Gb_job',
-        $self->o('pair_aligner_logic_name')           => '4Gb_job',
-        $self->o('pair_aligner_logic_name')."_himem1" => '8Gb_job',
+        $self->o('pair_aligner_logic_name')           => '4Gb_24_hour_job',
+        $self->o('pair_aligner_logic_name')."_himem"  => '8Gb_24_hour_job',
     );
 
     foreach my $logic_name (keys %overriden_rc_names) {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MercatorPecan_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MercatorPecan_conf.pm
@@ -340,6 +340,7 @@ sub pipeline_analyses {
                 'where'         => 'hgenome_db_id IN (#reuse_ss_csv#)',
             },
             -hive_capacity => $self->o('reuse_capacity'),
+            -rc_name => '1Gb_24_hour_job',
         },
 
 # ---------------------------------------------[load the rest of members]------------------------------------------------------------
@@ -373,7 +374,7 @@ sub pipeline_analyses {
             -parameters => {'coding_exons' => 1,
 			    'min_length' => 20,
                 },
-	    -rc_name => '4Gb_job',
+            -rc_name => '4Gb_24_hour_job',
         },
 
 
@@ -444,7 +445,7 @@ sub pipeline_analyses {
             },
             -batch_size => 10,
             -hive_capacity => $self->o('blast_capacity'),
-	    -rc_name => '2Gb_job',
+            -rc_name => '2Gb_24_hour_job',
         },
 
 
@@ -464,7 +465,7 @@ sub pipeline_analyses {
 			      'input_dir'   => $self->o('input_dir'),
 			      'all_hits'    => $self->o('all_hits'),
 			    },
-	     -rc_name => '2Gb_job',
+	     -rc_name => '2Gb_24_hour_job',
              -analysis_capacity => 8,
          },
 
@@ -474,7 +475,7 @@ sub pipeline_analyses {
 			     'input_dir' => $self->o('input_dir'),
                              'mercator_exe' => $self->o('mercator_exe'),
 			    },
-	     -rc_name => '32Gb_job',
+	     -rc_name => '32Gb_168_hour_job',
              -flow_into => {
                  "2->A" => WHEN (
                     "(#total_residues_count# <= 3000000) || ( #dnafrag_count# <= 10 )"                          => "pecan",
@@ -511,7 +512,7 @@ sub pipeline_analyses {
 		-1 => [ 'pecan_mem1'],
 		-2 => [ 'pecan_mem1'], #RUNLIMIT
              },
-	    -rc_name => '2Gb_job',
+	    -rc_name => '2Gb_24_hour_job',
          },
 
          {   -logic_name => 'pecan_mem1',
@@ -529,7 +530,7 @@ sub pipeline_analyses {
              },
              -max_retry_count => 1,
              -priority => 15,
-	     -rc_name => '8Gb_job',
+	     -rc_name => '8Gb_24_hour_job',
              -hive_capacity => $self->o('pecan_himem_capacity'),
              -flow_into => {
                  1 => [ 'gerp' ],
@@ -552,7 +553,7 @@ sub pipeline_analyses {
              },
              -max_retry_count => 1,
              -priority => 20,
-	     -rc_name => '16Gb_job',
+	     -rc_name => '16Gb_168_hour_job',
              -hive_capacity => $self->o('pecan_himem_capacity'),
              -flow_into => {
                  1 => [ 'gerp' ],
@@ -575,7 +576,7 @@ sub pipeline_analyses {
              },
              -max_retry_count => 1,
              -priority => 40,
-	     -rc_name => '32Gb_job',
+	     -rc_name => '32Gb_720_hour_job',
              -flow_into => {
                  1 => [ 'gerp' ],
                  -1 => [ 'pecan_mem4'],
@@ -597,7 +598,7 @@ sub pipeline_analyses {
              },
              -max_retry_count => 1,
              -priority => 50,
-             -rc_name => '96Gb_job',
+             -rc_name => '96Gb_720_hour_job',
              -flow_into => {
                  1 => [ 'gerp' ],
              },
@@ -614,6 +615,7 @@ sub pipeline_analyses {
              -hive_capacity => $self->o('gerp_capacity'),
              -flow_into => {
 		 -1 => [ 'gerp_himem'], #retry with more memory
+                 -2 => [ 'gerp_himem'], #retry with more time
              },
 	     -rc_name => '1Gb_job',
          },
@@ -624,7 +626,7 @@ sub pipeline_analyses {
 		 'gerp_exe_dir'    => $self->o('gerp_exe_dir'),
              },
             -hive_capacity => $self->o('gerp_capacity'),
-	     -rc_name => '4Gb_job',
+	     -rc_name => '4Gb_24_hour_job',
          },
 
  	 {  -logic_name => 'update_max_alignment_length',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/Lastz_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/Lastz_conf.pm
@@ -61,12 +61,12 @@ sub tweak_analyses {
         'alignment_nets'            => '2Gb_job',
         'create_alignment_nets_jobs'=> '2Gb_job',
         'create_alignment_chains_jobs'  => '4Gb_job',
-        'create_filter_duplicates_jobs'     => '2Gb_job',
+        'create_filter_duplicates_jobs'     => '2Gb_24_hour_job',
         'create_pair_aligner_jobs'  => '2Gb_job',
         'populate_new_database' => '8Gb_job',
         'parse_pair_aligner_conf' => '4Gb_job',
-        $self->o('pair_aligner_logic_name') => '4Gb_job',
-        $self->o('pair_aligner_logic_name')."_himem1" => '8Gb_job',
+        $self->o('pair_aligner_logic_name') => '4Gb_24_hour_job',
+        $self->o('pair_aligner_logic_name')."_himem" => '8Gb_24_hour_job',
     );
 
     foreach my $logic_name (keys %overriden_rc_names) {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAligner_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAligner_conf.pm
@@ -137,7 +137,7 @@ sub default_options {
         #'window_size' => 1000000,
         'window_size' => 10000,
 	'filter_duplicates_rc_name' => '1Gb_job',
-    'filter_duplicates_himem_rc_name' => '8Gb_job',
+    'filter_duplicates_himem_rc_name' => '8Gb_24_hour_job',
 
 	 #linear_gap=>medium for more closely related species, 'loose' for more distant
 	'linear_gap' => 'medium',
@@ -290,7 +290,7 @@ sub core_pipeline_analyses {
                                'only_cellular_component' => $self->o('only_cellular_component'),
                                'mix_cellular_components' => $self->o('mix_cellular_components'),
 			      },
-	       -rc_name => '2Gb_job',
+	       -rc_name => '2Gb_24_hour_job',
  	    },
 
         {   -logic_name    => 'create_pair_aligner_jobs',
@@ -314,6 +314,7 @@ sub core_pipeline_analyses {
             },
             -flow_into         => {
                 -1 => [ $self->o('pair_aligner_logic_name') . '_himem' ],  # MEMLIMIT
+                -2 => [ $self->o('pair_aligner_logic_name') . '_himem' ],  # RUNLIMIT
             },
             -analysis_capacity => $self->o('pair_aligner_analysis_capacity'),
             -batch_size        => $self->o('pair_aligner_batch_size'),
@@ -356,7 +357,7 @@ sub core_pipeline_analyses {
 	        -flow_into => {
 			       2 => { 'filter_duplicates' => INPUT_PLUS() },
 			     },
-	       -rc_name => '1Gb_job',
+	       -rc_name => '2Gb_24_hour_job',
  	    },
  	     {  -logic_name   => 'filter_duplicates',
  	       -module        => 'Bio::EnsEMBL::Compara::RunnableDB::PairAligner::FilterDuplicates',
@@ -368,6 +369,7 @@ sub core_pipeline_analyses {
 	       -can_be_empty  => 1,
 	       -flow_into => {
 			       -1 => [ 'filter_duplicates_himem' ], # MEMLIMIT
+                   -2 => [ 'filter_duplicates_himem' ], # RUNLIMIT
 			     },
 	       -rc_name => $self->o('filter_duplicates_rc_name'),
  	    },
@@ -478,6 +480,7 @@ sub core_pipeline_analyses {
  	       -parameters => $self->o('net_parameters'),
 	       -flow_into => {
 			      -1 => [ 'alignment_nets_himem' ],  # MEMLIMIT
+			      -2 => [ 'alignment_nets_himem' ],  # RUNLIMIT
 			     },
 	       -rc_name => '1Gb_job',
  	    },
@@ -489,8 +492,9 @@ sub core_pipeline_analyses {
                -can_be_empty => 1,
                -flow_into => {
                    -1 => [ 'alignment_nets_hugemem' ],  # MEMLIMIT
+                   -2 => [ 'alignment_nets_hugemem' ],  # RUNLIMIT
                },
-	       -rc_name => '4Gb_job',
+	       -rc_name => '4Gb_24_hour_job',
  	    },
             {   -logic_name     => 'alignment_nets_hugemem',
                 -hive_capacity  => $self->o('net_hive_capacity'),
@@ -498,7 +502,7 @@ sub core_pipeline_analyses {
                 -module         => 'Bio::EnsEMBL::Compara::RunnableDB::PairAligner::AlignmentNets',
                 -parameters     => $self->o('net_parameters'),
                 -can_be_empty   => 1,
-                -rc_name        => '8Gb_job',
+                -rc_name        => '8Gb_24_hour_job',
             },
  	    {
 	       -logic_name => 'remove_inconsistencies_after_net',
@@ -529,6 +533,7 @@ sub core_pipeline_analyses {
               -batch_size    => $self->o('filter_duplicates_batch_size'),
               -flow_into => {
                               -1 => [ 'filter_duplicates_net_himem' ], # MEMLIMIT
+                              -2 => [ 'filter_duplicates_net_himem' ], # RUNLIMIT
                             },
               -can_be_empty  => 1,
               -rc_name => $self->o('filter_duplicates_rc_name'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/ProteinTrees_conf.pm
@@ -115,7 +115,7 @@ sub tweak_analyses {
     ## Extend this section to redefine the resource names of some analysis
     my %overriden_rc_names = (
         'HMMer_classifyPantherScore'    => '2Gb_24_hour_job',
-        'hcluster_run'                  => '1Gb_job',
+        'hcluster_run'                  => '1Gb_24_hour_job',
         'hcluster_parse_output'         => '2Gb_job',
         # Many decision-type analyses take more memory for Pan. Because of the fatter Registry ?
     );

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/CAFE.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/CAFE.pm
@@ -131,10 +131,11 @@ sub pipeline_analyses_cafe {
                              'cafe_shell'           => $self->o('cafe_shell'),
                              'num_threads'          => 8,   
                             },
-             -rc_name => '1Gb_8c_168_hour_job',
+             -rc_name => '1Gb_8c_24_hour_job',
              -hive_capacity => $self->o('cafe_capacity'),
              -flow_into => {
                  -1 => 'CAFE_analysis_himem',
+                 -2 => 'CAFE_analysis_himem',
                  2 => 'CAFE_json',
              },
             },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOMapAnchors.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOMapAnchors.pm
@@ -221,6 +221,7 @@ sub pipeline_analyses_epo_anchor_mapping {
                 },
                 -flow_into => {
                     -1 => 'map_anchors_no_server_himem',
+                    -2 => 'map_anchors_no_server_himem',
                 },
                 -batch_size => $self->o('map_anchors_batch_size'),
                 -hive_capacity => $self->o('map_anchors_capacity'),
@@ -237,7 +238,7 @@ sub pipeline_analyses_epo_anchor_mapping {
                 },
                 -batch_size => $self->o('map_anchors_batch_size'),
                 -hive_capacity => $self->o('map_anchors_capacity'),
-                -rc_name => '32Gb_job',
+                -rc_name => '32Gb_24_hour_job',
                 -max_retry_count => 1,
             },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EpoExtended.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EpoExtended.pm
@@ -299,6 +299,7 @@ sub pipeline_analyses_epo_ext_alignment {
             -analysis_capacity  => 700,
             -flow_into => {
                 -1 => [ 'gerp_himem'], #retry with more memory
+                -2 => [ 'gerp_himem'], #retry with more time
             },
             -rc_name => '2Gb_job',
         },
@@ -309,7 +310,7 @@ sub pipeline_analyses_epo_ext_alignment {
                 'gerp_exe_dir' => $self->o('gerp_exe_dir'),
             },
             -analysis_capacity  => 700,
-            -rc_name => '4Gb_job',
+            -rc_name => '4Gb_24_hour_job',
         },
     ];
 }
@@ -324,7 +325,7 @@ sub pipeline_analyses_db_complete {
             -flow_into => {
                 1 => [ 'set_internal_ids_again' ],
             },
-            -rc_name => '2Gb_job',
+            -rc_name => '2Gb_24_hour_job',
         },
 
         # ----------------------------------------[In case the mlss_ids are not in the right order]----------------------------------------------

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/GOC.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/GOC.pm
@@ -92,6 +92,7 @@ sub pipeline_analyses_goc {
             },
             -flow_into => {
                -1 => 'compute_goc_himem',
+               -2 => 'compute_goc_himem',
            },
            -rc_name => '1Gb_24_hour_job',
            -hive_capacity  =>  $self->o('goc_capacity'),
@@ -105,7 +106,7 @@ sub pipeline_analyses_goc {
                 'homology_flatfile' => '#flatfile_basename#.homologies.tsv',
                 'output_file'       => '#flatfile_basename#.goc.tsv',
             },
-           -rc_name => '4Gb_job',
+           -rc_name => '4Gb_24_hour_job',
            -hive_capacity  =>  $self->o('goc_capacity'),
         },
     ];

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/HighConfidenceOrthologs.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/HighConfidenceOrthologs.pm
@@ -146,6 +146,7 @@ sub pipeline_analyses_high_confidence {
             -max_retry_count => 0,
             -flow_into       => {
                 -1 => [ 'import_homology_table_himem' ],
+                -2 => [ 'import_homology_table_himem' ],
             }
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/Lastz_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/Lastz_conf.pm
@@ -66,12 +66,12 @@ sub tweak_analyses {
         'alignment_nets'            => '2Gb_job',
         'create_alignment_nets_jobs'=> '2Gb_job',
         'create_alignment_chains_jobs'  => '4Gb_job',
-        'create_filter_duplicates_jobs'     => '2Gb_job',
+        'create_filter_duplicates_jobs'     => '2Gb_24_hour_job',
         'create_pair_aligner_jobs'  => '2Gb_job',
         'populate_new_database' => '8Gb_job',
         'parse_pair_aligner_conf' => '4Gb_job',
-        $self->o('pair_aligner_logic_name') => '4Gb_job',
-        $self->o('pair_aligner_logic_name')."_himem1" => '8Gb_job',
+        $self->o('pair_aligner_logic_name') => '4Gb_24_hour_job',
+        $self->o('pair_aligner_logic_name')."_himem" => '8Gb_24_hour_job',
     );
     foreach my $logic_name (keys %overriden_rc_names) {
         $analyses_by_name->{$logic_name}->{'-rc_name'} = $overriden_rc_names{$logic_name};

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
@@ -112,7 +112,7 @@ sub tweak_analyses {
     $analyses_by_name->{'treebest'}->{'-rc_name'} = '4Gb_24_hour_job';
     $analyses_by_name->{'members_against_allspecies_factory'}->{'-rc_name'} = '2Gb_job';
     $analyses_by_name->{'members_against_nonreusedspecies_factory'}->{'-rc_name'} = '2Gb_job';
-    $analyses_by_name->{'hcluster_run'}->{'-rc_name'} = '1Gb_job';
+    $analyses_by_name->{'hcluster_run'}->{'-rc_name'} = '1Gb_24_hour_job';
     $analyses_by_name->{'hcluster_parse_output'}->{'-rc_name'} = '2Gb_job';
     $analyses_by_name->{'exon_boundaries_prep_himem'}->{'-rc_name'} = '8Gb_job';
     $analyses_by_name->{'homology_factory'}->{'-rc_name'}         = '1Gb_job';

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -1105,6 +1105,7 @@ sub core_pipeline_analyses {
             },
             -flow_into  => [ 'members_against_nonreusedspecies_factory' ],
             -hive_capacity => $self->o('reuse_capacity'),
+            -rc_name => '1Gb_24_hour_job',
         },
 
         {   -logic_name => 'paf_create_empty_table',
@@ -1618,7 +1619,7 @@ sub core_pipeline_analyses {
             -flow_into => {
                 1 => [ 'hcluster_parse_output' ],
             },
-            -rc_name => '32Gb_job',
+            -rc_name => '32Gb_24_hour_job',
         },
 
         {   -logic_name => 'hcluster_parse_output',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/Lastz_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/Lastz_conf.pm
@@ -61,12 +61,12 @@ sub tweak_analyses {
         'alignment_nets'            => '2Gb_job',
         'create_alignment_nets_jobs'=> '2Gb_job',
         'create_alignment_chains_jobs'  => '4Gb_job',
-        'create_filter_duplicates_jobs'     => '2Gb_job',
+        'create_filter_duplicates_jobs'     => '2Gb_24_hour_job',
         'create_pair_aligner_jobs'  => '2Gb_job',
         'populate_new_database' => '8Gb_job',
         'parse_pair_aligner_conf' => '4Gb_job',
-        $self->o('pair_aligner_logic_name') => '4Gb_job',
-        $self->o('pair_aligner_logic_name')."_himem1" => '8Gb_job',
+        $self->o('pair_aligner_logic_name') => '4Gb_24_hour_job',
+        $self->o('pair_aligner_logic_name')."_himem" => '8Gb_24_hour_job',
     );
 
     foreach my $logic_name (keys %overriden_rc_names) {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/RegisterHALFile_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/RegisterHALFile_conf.pm
@@ -276,7 +276,7 @@ sub pipeline_analyses {
         {
             -logic_name => 'generate_pairwise_coverage_stats',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::HAL::halCoverageStats',
-            -rc_name    => '4Gb_job',
+            -rc_name    => '4Gb_24_hour_job',
         },
 
         {   -logic_name => 'per_genome_coverage_factory',
@@ -289,7 +289,7 @@ sub pipeline_analyses {
 
         {   -logic_name => 'hal_seq_chunk_factory',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::HAL::halSeqChunkFactory',
-            -rc_name    => '4Gb_job',
+            -rc_name    => '4Gb_24_hour_job',
             -parameters => {
                 'hal_stats_exe' => $self->o('halStats_exe'),
             },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Synteny_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Synteny_conf.pm
@@ -233,7 +233,7 @@ sub pipeline_analyses {
                                '1' => [ 'build_synteny' ],
                               },
               -analysis_capacity => $self->o('dumpgff_capacity'), #database intensive
-              -rc_name => '2Gb_job',
+              -rc_name => '2Gb_24_hour_job',
             },
             #Build synteny regions
             { -logic_name => 'build_synteny',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ProteinTrees_conf.pm
@@ -108,7 +108,7 @@ sub tweak_analyses {
     ## Extend this section to redefine the resource names of some analysis
     my %overriden_rc_names = (
         'CAFE_table'                => '24Gb_24_hour_job',
-        'hcluster_run'              => '1Gb_job',
+        'hcluster_run'              => '1Gb_24_hour_job',
         'hcluster_parse_output'     => '4Gb_job',
         'split_genes'               => 'default',   # This is 250Mb
         'CAFE_species_tree'         => '24Gb_job',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -896,6 +896,7 @@ sub core_pipeline_analyses {
                                   },
                 -flow_into     => {
                                   -1 => [ 'infernal_himem' ],
+                                  -2 => [ 'infernal_himem' ],
                                    1 => [ 'pre_secondary_structure_decision', WHEN('#create_ss_picts#' => 'create_ss_picts' ) ],
                                   },
                 -rc_name       => '1Gb_24_hour_job',
@@ -909,7 +910,7 @@ sub core_pipeline_analyses {
                                    'cmalign_exe' => $self->o('cmalign_exe'),
                                   },
                 -flow_into     => [ 'pre_secondary_structure_decision', WHEN('#create_ss_picts#' => 'create_ss_picts' ) ],
-                -rc_name       => '16Gb_job',
+                -rc_name       => '2Gb_24_hour_job',
             },
 
             {   -logic_name => 'pre_secondary_structure_decision',
@@ -971,6 +972,7 @@ sub core_pipeline_analyses {
                             },
              -flow_into => {
                            -1 => [ 'pre_sec_struct_tree_2_cores' ], # This analysis also has more memory
+                           -2 => [ 'pre_sec_struct_tree_2_cores' ], # This analysis also has a higher runlimit
                             2 => [ 'secondary_structure_decision' ],
                             3 => [ 'pre_sec_struct_tree_2_cores' ], #After trying to restart RAxML we should escalate the capacity.
                            },
@@ -988,10 +990,11 @@ sub core_pipeline_analyses {
                            },
             -flow_into => {
                            -1 => [ 'pre_sec_struct_tree_4_cores' ], # This analysis also has more memory
+                           -2 => [ 'pre_sec_struct_tree_4_cores' ],
                             2 => [ 'secondary_structure_decision' ],
                             3 => [ 'pre_sec_struct_tree_4_cores' ],
                           },
-            -rc_name => '1Gb_2c_24_hour_job',
+            -rc_name => '1Gb_2c_168_hour_job',
         },
 
         {   -logic_name    => 'pre_sec_struct_tree_4_cores', ## pre_sec_struct_tree
@@ -1005,6 +1008,7 @@ sub core_pipeline_analyses {
                            },
             -flow_into => {
                            -1 => [ 'pre_sec_struct_tree_8_cores' ], # This analysis also has more memory
+                           -2 => [ 'pre_sec_struct_tree_8_cores' ],
                             2 => [ 'secondary_structure_decision' ],
                             3 => [ 'pre_sec_struct_tree_8_cores' ],
                            },
@@ -1051,6 +1055,7 @@ sub core_pipeline_analyses {
                            },
             -flow_into => {
                            -1 => [ 'sec_struct_model_tree_2_cores' ],   # This analysis has more cores *and* more memory
+                           -2 => [ 'sec_struct_model_tree_2_cores' ],
                             3 => [ 'sec_struct_model_tree_2_cores' ],
                           },
             -rc_name => '1Gb_24_hour_job',
@@ -1067,6 +1072,7 @@ sub core_pipeline_analyses {
                            },
             -flow_into => {
                            -1 => [ 'sec_struct_model_tree_4_cores' ],   # This analysis has more cores *and* more memory
+                           -2 => [ 'sec_struct_model_tree_4_cores' ],
                             3 => [ 'sec_struct_model_tree_4_cores' ],
                        },
             -rc_name => '1Gb_2c_24_hour_job',
@@ -1083,6 +1089,7 @@ sub core_pipeline_analyses {
                            },
             -flow_into => {
                            -1 => [ 'sec_struct_model_tree_8_cores' ],   # This analysis has more cores *and* more memory
+                           -2 => [ 'sec_struct_model_tree_8_cores' ],
                             3 => [ 'sec_struct_model_tree_8_cores' ],
                        },
             -rc_name => '1Gb_4c_24_hour_job',


### PR DESCRIPTION
## Description

This PR applies Slurm-related updates to eHive resource classes for those actively used production pipelines that have not yet been updated.

It also makes changes reflecting adjustments during Ensembl release 113 production (see the [Ensembl Compara release 113 intentions document](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Intentions+for+release+113)).

**Related JIRA tickets:**
- ENSCOMPARASW-7165
- ENSCOMPARASW-7166
- ENSCOMPARASW-7167
- ENSCOMPARASW-7168

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
