### PR TITLE
Making the list of extensions to check for BLAST databases complete

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/BlastAndParsePAF.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/BlastAndParsePAF.pm
@@ -122,7 +122,7 @@ sub fetch_input {
         #                           unannotated.fasta.01.pog
         my $fastafile = $self->param('blast_db');
 
-        foreach my $ext (qw(phr pin pog psq)) {
+        foreach my $ext (qw(pdb phr pin pjs pog pos pot psq ptf pto)) {
             my @files = glob("$fastafile*.$ext");
             #Check if we have at least one file per each extension type
             die "Cound no find blast_db: $ext" unless @files;


### PR DESCRIPTION
## Description

The list of extensions of database files generated by makeblastdb version 2.2.30+ was not complete.

**Related JIRA tickets:**
- ENSCOMPARASW-7616

## Overview of changes

#### Change 1
Updated the list of extensions to look for when checking the completeness of generated BLAST databases.

## Testing
The list was double checked by running makeblastdb on an example file and consulting the documentation.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
