### PR TITLE
Bugfix: use the right core db name for _H.longicornis_

### DIFF
--- a/conf/metazoa/allowed_species.json
+++ b/conf/metazoa/allowed_species.json
@@ -137,7 +137,7 @@
     "glyphotaelius_pellucidus_gca936435175v1",
     "gordionus_sp_gca954871325v1rs",
     "habropoda_laboriosa_gca001263275v1rs",
-    "haemaphysalis_longicornis_gca013339765v1",
+    "haemaphysalis_longicornis_gca013339765v2vb",
     "halichondria_panicea_gca963675165v1rs",
     "haliotis_rubra_gca003918875v1rs",
     "haliotis_rufescens_gca023055435v1rs",

--- a/conf/metazoa/biomart_species.json
+++ b/conf/metazoa/biomart_species.json
@@ -137,7 +137,7 @@
     "glyphotaelius_pellucidus_gca936435175v1",
     "gordionus_sp_gca954871325v1rs",
     "habropoda_laboriosa_gca001263275v1rs",
-    "haemaphysalis_longicornis_gca013339765v1",
+    "haemaphysalis_longicornis_gca013339765v2vb",
     "halichondria_panicea_gca963675165v1rs",
     "haliotis_rubra_gca003918875v1rs",
     "haliotis_rufescens_gca023055435v1rs",

--- a/conf/metazoa/mlss_conf.xml
+++ b/conf/metazoa/mlss_conf.xml
@@ -122,7 +122,7 @@
       <genome name="dermatophagoides_pteronyssinus_gca001901225v2"/>
       <genome name="drosophila_melanogaster"/>
       <genome name="eurytemora_carolleeae_gca000591075v1rs"/>
-      <genome name="haemaphysalis_longicornis_gca013339765v1"/>
+      <genome name="haemaphysalis_longicornis_gca013339765v2vb"/>
       <genome name="halyomorpha_halys_gca000696795v2rs"/>
       <genome name="ixodes_scapularis_gca016920785v2"/>
       <genome name="macrobrachium_nipponense_gca015104395v2rs"/>


### PR DESCRIPTION
## Description

Sorry, whilst updating the e114 plans for Metazoa an update slipped my grasp (thank you @vsitnik).