### PR TITLE
Retiring outdated orthology MLSSes

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
@@ -209,7 +209,7 @@ sub pipeline_analyses_prep_master_db_for_release {
                 'reg_conf'            => $self->o('reg_conf'),
                 'xml_file'            => $self->o('xml_file'),
                 'report_file'         => $self->o('report_file'),
-                'cmd'                 => 'perl #create_all_mlss_exe# --reg_conf #reg_conf# --compara #master_db# -xml #xml_file# --release --output_file #report_file# --verbose',
+                'cmd'                 => 'perl #create_all_mlss_exe# --reg_conf #reg_conf# --compara #master_db# -xml #xml_file# --release --output_file #report_file# --verbose --retire_unmatched_of_type ENSEMBL_ORTHOLOGUES',
             },
             -flow_into  => [ 'tag_alignments_being_patched' ],
         },


### PR DESCRIPTION
The --retire_unmatched_of_type parameter flags the ENSEMBL_ORTHOLOGUES to ensure that the that outdated orthology MLSSes are retired correctly. 

**Related Jira tickets**
[ENSCOMPARASW-7606](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-7606) 

## Overview of changes
The argument "--retire_unmatched_of_type ENSEMBL_ORTHOLOGUES" was added to the command of add_mlss_to_master analysis, this will flag all the outdated orthology MLSSes that need to be retired. 

## Testing
This was tested on Plants master database and Metazoa master database copies, the details of which are included in the ticket above. 

## Notes
_Optional extra information._

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
