### PR TITLE
Extract unflanked ncRNA alignment from genomic alignment

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ncRNAtrees/NCTreeBestMMerge.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ncRNAtrees/NCTreeBestMMerge.pm
@@ -196,7 +196,8 @@ sub write_output {
         if ($gene_tree->gene_align_id
                 && $gene_tree->has_tag('genomic_alignment_gene_align_id')) {
             my $genomic_alignment_gene_align_id = $gene_tree->get_value_for_tag('genomic_alignment_gene_align_id');
-            if ($gene_tree->gene_align_id == $genomic_alignment_gene_align_id) {
+            if ($gene_tree->gene_align_id == $genomic_alignment_gene_align_id
+                    && $gene_tree->seq_type eq 'seq_with_flanking') {
                 my $gene_align_adaptor = $self->compara_dba->get_GeneAlignAdaptor();
 
                 if ($gene_tree->has_tag('unflanked_alignment_gene_align_id')) {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ncRNAtrees/NCTreeBestMMerge.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ncRNAtrees/NCTreeBestMMerge.pm
@@ -197,7 +197,7 @@ sub write_output {
                 && $gene_tree->has_tag('genomic_alignment_gene_align_id')) {
             my $genomic_alignment_gene_align_id = $gene_tree->get_value_for_tag('genomic_alignment_gene_align_id');
             if ($gene_tree->gene_align_id == $genomic_alignment_gene_align_id
-                    && $gene_tree->seq_type eq 'seq_with_flanking') {
+                    && defined $gene_tree->seq_type && $gene_tree->seq_type eq 'seq_with_flanking') {
                 my $gene_align_adaptor = $self->compara_dba->get_GeneAlignAdaptor();
 
                 if ($gene_tree->has_tag('unflanked_alignment_gene_align_id')) {


### PR DESCRIPTION
## Description

Many ncRNA trees and homologies have artefactual alignments, believed to be due to the generation of alignment sequences from a combination of an unflanked ncRNA sequence and the CIGAR of a flanked alignment.

This PR seeks to address the issue by extracting an unflanked ncRNA alignment from a genomic alignment during `genomic_alignment` (if possible), and then setting that unflanked alignment as the primary alignment of the gene tree in `treebest_mmerge` (if appropriate).

**Related JIRA tickets:**
- ENSCOMPARASW-7556

## Overview of changes

This PR makes the following changes:
- in runnable `NCGenomicAlignment`, if the genomic alignment is flanked, and if none of the members have transcript edits, and if all the members have exon boundaries, an unflanked alignment is extracted from the given flanked alignment and stored; and
- in runnable `NCTreeBestMMerge`, if a flanked genomic alignment is the primary alignment of the given gene tree, it is replaced with an unflanked genomic alignment if available; otherwise it is replaced with a trivial alignment if appropriate.

## Testing
See the related ticket for more info on testing.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
