### PR TITLE
Apply EPO filter based on good_for_alignment flag

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ncRNAtrees/NCRecoverEPO.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ncRNAtrees/NCRecoverEPO.pm
@@ -261,10 +261,10 @@ sub iterate_over_lowcov_mlsss {
     my @gab_ids;
     $self->param('low_cov_leaves_to_delete', []);
     foreach my $epo_low_mlss (@$epolow_mlsss) {
-        my $epo_hc_mlss = $epo_low_mlss->get_linked_mlss_by_tag('base_mlss_id')
-            || die "Could not find the matching 'EPO' MLSS in ".$self->param('epo_db')."\n";
-        my %hc_gdb_id = (map {$_->dbID => 1} @{$epo_hc_mlss->species_set->genome_dbs});
-        my @lowcov_gdbs = grep {not exists $hc_gdb_id{$_->dbID}} @{$epo_low_mlss->species_set->genome_dbs};
+        my @epo_low_mlss_gdbs = @{$epo_low_mlss->species_set->genome_dbs};
+        my @good_gdbs = grep {$_->is_good_for_alignment} @epo_low_mlss_gdbs;
+        my %hc_gdb_id = (map {$_->dbID => 1} @good_gdbs);
+        my @lowcov_gdbs = grep {not exists $hc_gdb_id{$_->dbID}} @epo_low_mlss_gdbs;
         my %low_gdb_id = (map {$_->dbID => 1} @lowcov_gdbs);
         my $gab_id = $self->run_low_coverage_best_in_alignment($epo_low_mlss, \%hc_gdb_id, \%low_gdb_id);
         push @gab_ids, $gab_id if $gab_id;


### PR DESCRIPTION
## Description

With the recent change of some `"good_for_alignment"` genomes to be EPO-Extended-only, filtering of ncRNA clusters in `NCRecoverEPO` has been applied to an increasing number of genomes that might in the past have been included in EPO alignments. At the same time, such genomes tend to have lower coverage than they might if included in EPO, making it harder for their members to pass the filters applied in `NCRecoverEPO`.

This PR aims to mitigate the issue by changing `NCRecoverEPO` to apply the EPO filter only to genomes for which the `is_good_for_alignment` attribute is false.

**Related JIRA tickets:**
- ENSCOMPARASW-7637

## Testing
This was tested in trial runs of the ncRNA-trees pipeline.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
