### PR TITLE
Set division collection as default for gene trees

### DIFF
--- a/scripts/pipeline/create_all_mlss.pl
+++ b/scripts/pipeline/create_all_mlss.pl
@@ -556,6 +556,17 @@ $compara_dba->dbc->sql_helper->transaction( -CALLBACK => sub {
                 my $exist_method = $method_adaptor->fetch_by_type($mlss->method->type);
                 $mlss->method($exist_method) if $exist_method;
                 my $exist_ss = $ss_adaptor->fetch_by_GenomeDBs($mlss->species_set->genome_dbs);
+
+                # If all genomes in a division are included in the default gene-tree collection, the
+                # default collection will most likely have been given the name of the division. If so,
+                # we need to set it to 'collection-default' so that the gene-tree pipelines can find it.
+                if ($exist_ss
+                        && $exist_ss->name =~ /^(collection-)?\Q$division_name\E$/
+                        && $mlss->species_set->name =~ /^(collection-)?default$/
+                        && $mlss->method->type =~ /^(PROTEIN_TREES|NC_TREES)$/) {
+                    $exist_ss->name('collection-default');
+                }
+
                 $mlss->species_set($exist_ss) if $exist_ss;
             }
             if ($exist_mlss and !$dry_run) {


### PR DESCRIPTION
## Description

This PR updates the script `create_all_mlss.pl` to set the name of the division collection to `collection-default` if it is used in gene-tree pipelines.

Without this, such collections will need to be renamed manually in order for the gene-tree pipelines to be able to find them.

This fix is relevant to Fungi, Protists and Pan Compara in Ensembl 114.

**Related JIRA tickets:**
- ENSCOMPARASW-6002
- ENSCOMPARASW-7600

## Testing
The changes in this PR were tested as part of a trial run of the `PrepareMasterDatabaseForRelease` pipeline.

See the image attached to ENSCOMPARASW-6002 for an illustration of what is expected to happen to the division collection name of divisions such as Pan Compara during the preparation of the master database.


---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
