### PR TITLE
Move supertree-only leaf functionality to is_supertree_bud

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/DBSQL/GeneTreeAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/GeneTreeAdaptor.pm
@@ -648,29 +648,28 @@ sub _clean_supertree {
 
     my $gtn_adaptor = $self->db->get_GeneTreeNodeAdaptor;
 
-    my $supertree_leaf = $subtree_root->parent;
-    my $supertree_root = $supertree_leaf->root;
+    my $subtree_parent_node = $subtree_root->parent;
+    my $supertree_root = $subtree_parent_node->root;
     my $supertree_gene_align_id = $supertree_root->tree->gene_align_id;
 
-    my @supertree_leaves = @{$supertree_root->tree->get_all_leaves};
-    my @supertree_leaf_ids = map {$_->node_id} @supertree_leaves;
-    if ( scalar(@supertree_leaves) < 3 ) {
+    my @supertree_buds = @{$supertree_root->tree->get_all_supertree_buds};
+    if ( scalar(@supertree_buds) < 3 ) {
         # removing a node from this supertree results in a single-leaf tree
         # delete the whole supertree, leaving the other subtree intact
-        foreach my $supertree_leaf ( @supertree_leaves ) {
+        foreach my $supertree_bud ( @supertree_buds ) {
             # link the subtree to the supertree's parent
             # this is usually a clusterset, but may be another supertree
             # (there is no easy way to do this using API calls in place of raw SQL)
             my $unlink_subtree_sql = "UPDATE gene_tree_node SET parent_id = ? WHERE parent_id = ?";
             my $sth = $self->prepare($unlink_subtree_sql);
-            $sth->execute($supertree_root->parent->node_id, $supertree_leaf->node_id);
+            $sth->execute($supertree_root->parent->node_id, $supertree_bud->node_id);
         }
 
         $self->delete_tree($supertree_root->tree);
     } else {
         # remove the deleted subtree's parent node and minimize the supertree
         # (i.e. clean up single-child nodes)
-        $gtn_adaptor->delete_node($supertree_leaf);
+        $gtn_adaptor->delete_node($subtree_parent_node);
         my $pruned_supertree = $supertree_root->tree;
         my @orig_child_nodes = map {$_->node_id} @{$pruned_supertree->root->get_all_nodes()};
 

--- a/modules/Bio/EnsEMBL/Compara/GeneTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/GeneTree.pm
@@ -970,6 +970,36 @@ sub get_all_sorted_leaves {
 }
 
 
+=head2 get_all_supertree_buds
+
+ Example     : my @buds = @{$supertree->get_all_supertree_buds};
+ Description : Returns a list of all the buds of this supertree
+ ReturnType  : Reference to list of GeneTreeNode objects representing the buds of
+               this supertree. In an unexpanded supertree, bud nodes are leaves.
+               In an expanded supertree, each bud node is the parent of a subtree root.
+ Exceptions  : Throws if GeneTree object is not of tree type 'supertree'.
+
+=cut
+
+sub get_all_supertree_buds {
+    my $self = shift;
+
+    if ($self->tree_type ne 'supertree') {
+        throw(
+            sprintf(
+                "GeneTree has tree type '%s', but method get_all_supertree_buds only supports trees of type 'supertree'",
+                $self->tree_type,
+            )
+        );
+    }
+
+    my $buds = [];
+    $self->root->_recursive_get_all_supertree_buds($buds);
+    my @bud_list = sort {$a->node_id <=> $b->node_id} @{$buds};
+    return \@bud_list;
+}
+
+
 =head2 get_leaf_by_Member
 
   Arg [1]     : Member: the member to search in the tree

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/QuickTreeBreak.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/QuickTreeBreak.pm
@@ -317,8 +317,11 @@ sub rec_update_tags {
 
         $cluster->adaptor->_store_all_tags($cluster);
 
-    } elsif (!$node->is_leaf) {
-        $node->store_tag('tree_support', 'quicktree');
+    } else {
+        if (!$node->is_supertree_bud) {
+            $node->store_tag('tree_support', 'quicktree');
+        }
+
         foreach my $child (@{$node->children}) {
             $self->rec_update_tags($child);
         }


### PR DESCRIPTION
## Description

To address issues with the gene-tree reindexing pipeline, [Compara PR #286](https://github.com/Ensembl/ensembl-compara/pull/286) extended the definition of a leaf for a supertree to include the case where a node had 1 child such that that child is a subtree root node.

This change to the definition of a leaf led to some issues in Compara 105 production, and [Compara PR #319](https://github.com/Ensembl/ensembl-compara/pull/319) addressed these issues in part by revising the effective definition of a supertree leaf in `GeneTreeNode::is_leaf`.

Following these changes, `GeneTreeNode::is_leaf` returns `1` for a supertree leaf if the supertree has not been expanded (and therefore has no children, just like a regular leaf), but returns `0` if the subtrees have been expanded. At the same time, unary internal supertree nodes are now classified as leaves.

This draft PR aims to address these issues by separating out the supertree-only leaf functionality to a `GeneTreeNode::is_supertree_bud` method to be used in situations where supertree buds are of interest, and reverts `GeneTreeNode::is_leaf` to its previous behaviour.

**Related JIRA tickets:**
- ENSCOMPARASW-4658
- ENSCOMPARASW-7520
- ENSCOMPARASW-7628

## Overview of changes

- `GeneTreeNode::is_leaf` is reverted to its previous behaviour, returning `1` if a node has zero children, and `0` otherwise.
- Method `GeneTreeNode::is_supertree_bud` is added. This method returns `1` if the given node is a supertree bud. In an unexpanded supertree, bud nodes are leaves. In an expanded supertree, each bud node is the parent of a subtree root.
- Method `GeneTree::get_all_supertree_buds` is added. This returns a reference to an array containing all the buds of a given supertree.
- Method `GeneTree::get_all_supertree_buds` is used as appropriate in the `GeneTreeAdaptor::_clean_supertree` method and in the `QuickTreeBreak` runnable. The `QuickTreeBreak` runnable is also changed so that recursion of `rec_update_tags` is not interrupted by a supertree bud.

## Testing
Test pipelines are in progress to ensure that these changes work as expected.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
