### PR TITLE
Protosostomes GOC taxlevel update

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProtostomesProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProtostomesProteinTrees_conf.pm
@@ -56,7 +56,7 @@ sub default_options {
 
         'threshold_levels' => [
             {
-		        'taxa'          => [ 'Caenorhabditis', 'Crassostrea', 'Cyclophyllidea', 'Haliotis', 'Octopus', 'Rhipicephalinae', 'Schistosoma', 'Spirurina' ],
+		        'taxa'          => [ 'Caenorhabditis', 'Crassostrea', 'Cyclophyllidea', 'Ditrysia', 'Haliotis', 'Octopus', 'Rhipicephalinae', 'Schistosoma', 'Spirurina' ],
                 'thresholds'    => [ 50, 50, 25 ],
             },
             {


### PR DESCRIPTION
## GOC taxlevel configurations in light of new species being added in release 114 

The details of the config updates for each new species is attached in the following Spreadsheet. 
https://docs.google.com/spreadsheets/d/12tLRJMarS7MI0WhlsVXXTeeLgqLhoQ4CBSj_OMco-IE/edit?gid=0#gid=0 

## Overview of changes
After going over every new species, it seems that we don't have many config updates since some species are already covered by existing config and others don't have a suitable pair for which the GOC scores cannot be computed. 

I have added the Clade Ditrysia to the ProtostomesProteinTrees_conf.pm 

## Notes
_Optional extra information._

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
