### PR TITLE
Updating inconsistent error message in PatchDB runnable

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PatchDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PatchDB.pm
@@ -59,7 +59,7 @@ sub run {
 	my $patch_run = $self->run_command($cmd);
 
     my $err = $patch_run->err;
-    $err =~ s/Warning: Using a password on the command line interface can be insecure.\s+//gi; # account for expected err
+    $err =~ s/\[Warning\] Using a password on the command line interface can be insecure.\s+//gi; # account for expected err
 	if ( $err ne '' ) {
 		if ( $self->param('ignore_failure') ) {
 			$self->warning("STDERR: " . $patch_run->err);


### PR DESCRIPTION
The error message has been slightly updated because of which the pipeline was completing early and not flowing into the next analysis. 

## Overview of changes
The message was updated to exactly match the error message obtained in the msg table of sbhurji_prep_metazoa_master_for_rel_114. 

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
