### PR TITLE
Remove duplicate assembly (affinis: gca000591075v2) following species name change (carolleeae)

### DIFF
--- a/conf/metazoa/allowed_species.json
+++ b/conf/metazoa/allowed_species.json
@@ -127,7 +127,6 @@
     "dufourea_novaeangliae_gca001272555v1rs",
     "echinococcus_granulosus_gca000524195v1rs",
     "eufriesea_mexicana_gca001483705v1rs",
-    "eurytemora_affinis_gca000591075v2",
     "eurytemora_carolleeae_gca000591075v1rs",
     "exaiptasia_diaphana_gca001417965v1",
     "folsomia_candida",

--- a/conf/metazoa/biomart_species.json
+++ b/conf/metazoa/biomart_species.json
@@ -127,7 +127,6 @@
     "dufourea_novaeangliae_gca001272555v1rs",
     "echinococcus_granulosus_gca000524195v1rs",
     "eufriesea_mexicana_gca001483705v1rs",
-    "eurytemora_affinis_gca000591075v2",
     "eurytemora_carolleeae_gca000591075v1rs",
     "exaiptasia_diaphana_gca001417965v1",
     "folsomia_candida",

--- a/conf/metazoa/mlss_conf.xml
+++ b/conf/metazoa/mlss_conf.xml
@@ -21,7 +21,7 @@
       <genome name="daphnia_pulex_gca021134715v1rs"/>
       <genome name="daphnia_pulicaria_gca021234035v2rs"/>
       <genome name="drosophila_melanogaster"/>
-      <genome name="eurytemora_affinis_gca000591075v2"/>
+      <genome name="eurytemora_carolleeae_gca000591075v1rs"/>
       <genome name="halyomorpha_halys_gca000696795v2rs"/>
       <genome name="homarus_americanus_gca018991925v1"/>
       <genome name="homarus_gammarus_gca958450375v1"/>


### PR DESCRIPTION
## Description
Compara team processing Metazoa e114 realised two separate production names were linked to the same GCA accession and Assembly.default (Eaff2v0.0). This was due to a species name change to initial records loaded on GCAv2 from affinis -> carolleeae:
- eurytemora_affinis_gca000591075v2
- eurytemora_carolleeae_gca000591075v1rs 


**Related JIRA tickets:**
- [ENSCOMPARASW-9897](https://www.ebi.ac.uk/panda/jira/browse/ENSPROD-9897)

## Overview of changes
Remove redundancy of assembly GCA_000591075.2 (Eaff2v0.0) linked to two sp production names. 

#### Change 1
Removal of MLSS, allowed_sp and biomart records linked to sp.production_name`eurytemora_affinis_gca000591075v2`. 

## Testing
NA

## Notes
PR request from compara to metazoa to fix above issue to allow restarting of compara processing. Production team must first update metadata db following the dropping of eurytemora_affinis_gca000591075v2 from staging 3. 

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
