### PR TITLE
Feature/assembly dyad check

### DIFF
--- a/scripts/production/flag_core_issues.pl
+++ b/scripts/production/flag_core_issues.pl
@@ -288,12 +288,14 @@ foreach my $division (@divisions) {
 
                 my $taxon_node = $ncbi_taxa_node_dba->fetch_by_taxon_id($reg_entry_info->{'taxonomy_id'});
                 ok(defined $taxon_node && $taxon_node->isa('Bio::EnsEMBL::Taxonomy::TaxonomyNode'),
-                   "core meta entry 'species.taxonomy_id' is current for '$registry_name' ($db_name)");
+                   "core meta entry 'species.taxonomy_id' is current for '$registry_name' ($db_name)")
+                   || diag sprintf("species.taxonomy_id: %s", $reg_entry_info->{'taxonomy_id'});
 
                 if (defined($reg_entry_info->{'species_taxonomy_id'})) {
                     my $species_taxon_node = $ncbi_taxa_node_dba->fetch_by_taxon_id($reg_entry_info->{'species_taxonomy_id'});
                     ok(defined $species_taxon_node && $species_taxon_node->isa('Bio::EnsEMBL::Taxonomy::TaxonomyNode'),
-                       "core meta entry 'species.species_taxonomy_id' is current for $registry_name");
+                       "core meta entry 'species.species_taxonomy_id' is current for $registry_name")
+                       || diag sprintf("species.species_taxonomy_id: %s", $reg_entry_info->{'species_taxonomy_id'});
                 }
             }
         }
@@ -345,7 +347,8 @@ foreach my $division (@divisions) {
         foreach my $core_key (keys %div_cores_by_key) {
             my $db_name = $div_cores_by_key{$core_key}[0];
             my @clashing_db_names = grep { $_ ne $db_name } keys %{$all_cores_by_key{$core_key}};
-            is_deeply(\@clashing_db_names, [], "$db_name has no database name clashes");
+            is(scalar(@clashing_db_names), 0, "$db_name has no database name clashes")
+                || diag explain [sort @clashing_db_names];
         }
 
         done_testing();


### PR DESCRIPTION
## Description

This PR adds an assembly-dyad check to the `flag_core_issues.pl` script, flagging any (`assembly.accession`, `assembly.default`) pair that matches two or more genomes.

## Overview of changes

Script `flag_core_issues.pl` is updated to:
- add an assembly-dyad check; and
- add diagnostic output to Taxonomy ID and database name clash checks.

## Testing
The assembly-dyad check was tested on Metazoa 114 cores on `vertannot-staging`, with the following relevant output:
```
Modify species name for one of these
    #   Failed test 'assembly dyad ('GCA_000591075.2', 'Eaff_2.0') found for one species'
    #   at /hps/software/users/ensembl/compara/twalsh/modenv/ensembl/114/ensembl-compara/scripts/production/flag_core_issues.pl line 363.
    #          got: '2'
    #     expected: '1'
    # [
    #   'eurytemora_affinis_gca000591075v2',
    #   'eurytemora_carolleeae_gca000591075v1rs'
    # ]
    # Looks like you failed 1 test of 268.
#   Failed test 'Check for assembly dyad clashes (metazoa)'
#   at /hps/software/users/ensembl/compara/twalsh/modenv/ensembl/114/ensembl-compara/scripts/production/flag_core_issues.pl line 369.
# Looks like you failed 1 test of 7.
```

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
