### PR TITLE
Prepare Compara for eHive 2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
     - git-ensembl --clone --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH --depth 1 ensembl
     - git-ensembl --clone --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH --depth 1 ensembl-datacheck
     # yamllint enable rule:line-length
-    - git-ensembl --clone --branch main --depth 1 ensembl-hive
+    - git-ensembl --clone --branch version/2.7.0 --depth 1 ensembl-hive
     - git-ensembl --clone --branch main --depth 1 ensembl-taxonomy
     - ln -s . ensembl-compara
     - git clone --branch v1.6.x --depth 1 https://github.com/bioperl/bioperl-live

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/BaseAge_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/BaseAge_conf.pm
@@ -46,7 +46,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::BaseAge_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For INPUT_PLUS
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/BuildNewMasterDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/BuildNewMasterDatabase_conf.pm
@@ -46,7 +46,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::BuildNewMasterDatabase_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::PrepareMasterDatabaseForRelease;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/CITest/BuildCITestMasterDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/CITest/BuildCITestMasterDatabase_conf.pm
@@ -54,7 +54,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::CITest::BuildCITestMasterDatabase_con
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::BuildNewMasterDatabase_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateHmmProfiles_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateHmmProfiles_conf.pm
@@ -39,7 +39,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::CreateHmmProfiles_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateSpeciesTree_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateSpeciesTree_conf.pm
@@ -41,7 +41,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::CreateSpeciesTree_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DatachecksForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DatachecksForRelease_conf.pm
@@ -36,7 +36,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::DatachecksForRelease_conf;
 
 use strict;
 use warnings;
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf; # for WHEN and INPUT_PLUS
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::DataCheckFactory;
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpConstrainedElements_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpConstrainedElements_conf.pm
@@ -39,7 +39,7 @@ use strict;
 use warnings;
 no warnings 'qw';
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpConstrainedElements;
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpGenomes_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpGenomes_conf.pm
@@ -46,7 +46,7 @@ use strict;
 use warnings;
 
 # We need WHEN and INPUT_PLUS
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpHomologiesByMLSS_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpHomologiesByMLSS_conf.pm
@@ -40,7 +40,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::DumpHomologiesByMLSS_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;           # Allow this particular config to use conditional dataflow
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpHomologiesForPosttree;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpTrees_conf.pm
@@ -40,7 +40,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::DumpTrees_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;           # Allow this particular config to use conditional dataflow
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpTrees;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/DumpMultiAlign_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/DumpMultiAlign_conf.pm
@@ -38,7 +38,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::EG::DumpMultiAlign_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::DumpMultiAlign_conf');
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOAnchors_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOAnchors_conf.pm
@@ -48,7 +48,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::EPOAnchors_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EPO_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EPO_conf.pm
@@ -36,7 +36,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::EPO_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For INPUT_PLUS
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::EPOMapAnchors;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwithExt_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EPOwithExt_conf.pm
@@ -38,7 +38,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::EPOwithExt_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For INPUT_PLUS
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::EPOMapAnchors;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EpoExtended_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EpoExtended_conf.pm
@@ -46,7 +46,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::EpoExtended_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;           # Allow this particular config to use conditional dataflow
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::MultipleAlignerStats;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Families_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Families_conf.pm
@@ -44,7 +44,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Families_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/PostHomologyMerge_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/PostHomologyMerge_conf.pm
@@ -35,7 +35,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Fungi::PostHomologyMerge_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::PostHomologyMerge_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/PrepareMasterDatabaseForRelease_conf.pm
@@ -41,7 +41,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Fungi::PrepareMasterDatabaseForReleas
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::PrepareMasterDatabaseForRelease_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/GeneMemberHomologyStatsFM_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/GeneMemberHomologyStatsFM_conf.pm
@@ -43,7 +43,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::GeneMemberHomologyStatsFM_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneMemberHomologyStats;
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/GeneSetQC_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/GeneSetQC_conf.pm
@@ -46,7 +46,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::GeneSetQC_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneSetQC;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/GeneTreeHealthChecks_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/GeneTreeHealthChecks_conf.pm
@@ -57,7 +57,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::GeneTreeHealthChecks_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For WHEN and INPUT_PLUS
 use base ('Bio::EnsEMBL::Hive::PipeConfig::EnsemblGeneric_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HighConfidenceOrthologs_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HighConfidenceOrthologs_conf.pm
@@ -48,7 +48,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::HighConfidenceOrthologs_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::HighConfidenceOrthologs;
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ImportPatchAlignmentsToRef_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ImportPatchAlignmentsToRef_conf.pm
@@ -39,7 +39,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::ImportPatchAlignmentsToRef_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.3;
+use Bio::EnsEMBL::Hive::Version v2.4;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Legacy/EPO_pt2_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Legacy/EPO_pt2_conf.pm
@@ -53,7 +53,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Legacy::EPO_pt2_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For INPUT_PLUS
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::EPOMapAnchors;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadCactus_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadCactus_conf.pm
@@ -28,7 +28,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::LoadCactus_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
@@ -35,7 +35,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::LoadMembers_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadSpeciesTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadSpeciesTrees_conf.pm
@@ -40,7 +40,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::LoadSpeciesTrees_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.3;
+use Bio::EnsEMBL::Hive::Version v2.3;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MercatorPecan_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MercatorPecan_conf.pm
@@ -35,7 +35,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::MercatorPecan_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::MultipleAlignerStats;
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeDBsIntoRelease_conf.pm
@@ -42,7 +42,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::MergeDBsIntoRelease_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For WHEN and INPUT_PLUS
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/LoadCactus_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/LoadCactus_conf.pm
@@ -39,7 +39,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Metazoa::LoadCactus_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/PostHomologyMerge_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/PostHomologyMerge_conf.pm
@@ -34,7 +34,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Metazoa::PostHomologyMerge_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For WHEN and INPUT_PLUS
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::PostHomologyMerge_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/PrepareMasterDatabaseForRelease_conf.pm
@@ -40,7 +40,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Metazoa::PrepareMasterDatabaseForRele
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::PrepareMasterDatabaseForRelease_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/OrthologQM_Alignment_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/OrthologQM_Alignment_conf.pm
@@ -82,7 +82,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::OrthologQM_Alignment_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::OrthologQMAlignment;
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/OrthologQM_GeneOrderConservation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/OrthologQM_GeneOrderConservation_conf.pm
@@ -42,7 +42,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::OrthologQM_GeneOrderConservation_conf
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;  
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::GOC;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAligner_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAligner_conf.pm
@@ -60,7 +60,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::PairAligner_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');  # All Hive databases configuration files should inherit from HiveGeneric, directly or indirectly

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/PrepareMasterDatabaseForRelease_conf.pm
@@ -38,7 +38,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Pan::PrepareMasterDatabaseForRelease_
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::PrepareMasterDatabaseForRelease_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DataCheckFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DataCheckFactory.pm
@@ -30,7 +30,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Parts::DataCheckFactory;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf; # For WHEN and INPUT_PLUS
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::DataCheckFan;
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DataCheckFan.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DataCheckFan.pm
@@ -30,7 +30,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Parts::DataCheckFan;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf; # For WHEN and INPUT_PLUS
 
 sub pipeline_analyses_datacheck_fan {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpAncestralAlleles.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpAncestralAlleles.pm
@@ -33,7 +33,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpAncestralAlleles;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;  # Allow this particular config to use conditional dataflow and INPUT_PLUS
 
 sub pipeline_analyses_dump_anc_alleles {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConstrainedElements.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConstrainedElements.pm
@@ -34,7 +34,7 @@ use strict;
 use warnings;
 no warnings 'qw';
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;  # For INPUT_PLUS
 
 sub pipeline_analyses_dump_constrained_elems {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpSpeciesTrees.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpSpeciesTrees.pm
@@ -33,7 +33,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpSpeciesTrees;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 sub pipeline_analyses_dump_species_trees {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
@@ -33,7 +33,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpTrees;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;  # Allow this particular config to use conditional dataflow and INPUT_PLUS
 
 sub pipeline_analyses_dump_trees {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOAncestral.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOAncestral.pm
@@ -31,7 +31,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Parts::EPOAncestral;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;  # For WHEN and INPUT_PLUS
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOMapAnchors.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOMapAnchors.pm
@@ -33,7 +33,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Parts::EPOMapAnchors;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For INPUT_PLUS
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/MultipleAlignerStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/MultipleAlignerStats.pm
@@ -31,7 +31,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Parts::MultipleAlignerStats;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For WHEN
  
 sub pipeline_analyses_multiple_aligner_stats {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
@@ -34,7 +34,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Parts::PrepareMasterDatabaseForReleas
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/LoadCactus_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/LoadCactus_conf.pm
@@ -39,7 +39,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Plants::LoadCactus_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/PostHomologyMerge_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/PostHomologyMerge_conf.pm
@@ -40,7 +40,7 @@ use strict;
 use warnings;
 
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For WHEN and INPUT_PLUS
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/PrepareMasterDatabaseForRelease_conf.pm
@@ -40,7 +40,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Plants::PrepareMasterDatabaseForRelea
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::PrepareMasterDatabaseForRelease_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PostHomologyMerge_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PostHomologyMerge_conf.pm
@@ -42,7 +42,7 @@ use strict;
 use warnings;
 
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For WHEN and INPUT_PLUS
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
@@ -48,7 +48,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::PrepareMasterDatabaseForRelease_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::PrepareMasterDatabaseForRelease;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -37,7 +37,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::ProteinTrees_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.5;
+use Bio::EnsEMBL::Hive::Version v2.5;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::CAFE;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/PostHomologyMerge_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/PostHomologyMerge_conf.pm
@@ -35,7 +35,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Protists::PostHomologyMerge_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::PostHomologyMerge_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/PrepareMasterDatabaseForRelease_conf.pm
@@ -41,7 +41,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Protists::PrepareMasterDatabaseForRel
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::PrepareMasterDatabaseForRelease_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/RegisterHALFile_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/RegisterHALFile_conf.pm
@@ -53,7 +53,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::RegisterHALFile_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For INPUT_PLUS
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ReindexMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ReindexMembers_conf.pm
@@ -65,7 +65,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::ReindexMembers_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For WHEN and INPUT_PLUS
 
 use Bio::EnsEMBL::Compara::PipeConfig::GeneTreeHealthChecks_conf;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Synteny_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Synteny_conf.pm
@@ -46,7 +46,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Synteny_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');  # All Hive databases configuration files should inherit from HiveGeneric, directly or indirectly

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/BaseAge_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/BaseAge_conf.pm
@@ -44,7 +44,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::BaseAge_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::BaseAge_conf');
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/LoadCactus_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/LoadCactus_conf.pm
@@ -39,7 +39,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::LoadCactus_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/LoadSpeciesTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/LoadSpeciesTrees_conf.pm
@@ -37,7 +37,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::LoadSpeciesTrees_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.3;
+use Bio::EnsEMBL::Hive::Version v2.3;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::LoadSpeciesTrees_conf');
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MercatorPecan_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MercatorPecan_conf.pm
@@ -35,7 +35,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::MercatorPecan_conf;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::MercatorPecan_conf');
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/PostHomologyMerge_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/PostHomologyMerge_conf.pm
@@ -40,7 +40,7 @@ use strict;
 use warnings;
 
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For WHEN and INPUT_PLUS
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/PrepareMasterDatabaseForRelease_conf.pm
@@ -40,7 +40,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::PrepareMasterDatabaseFor
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::PrepareMasterDatabaseForRelease_conf');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -35,7 +35,7 @@ package Bio::EnsEMBL::Compara::PipeConfig::ncRNAtrees_conf ;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version 2.4;
+use Bio::EnsEMBL::Hive::Version v2.4;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For WHEN and INPUT_PLUS
 
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::CAFE;


### PR DESCRIPTION
## Description

This PR prepares Compara for eHive 2.7.0:
- the eHive branch is set to `version/2.7.0` in the Travis CI config;
- `Bio::EnsEMBL::Hive::Version` statements use v-strings.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
