### PR TITLE
Remove INPUT_PLUS-enabled funnel checks from MSA pipelines

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MercatorPecan_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MercatorPecan_conf.pm
@@ -581,7 +581,7 @@ sub pipeline_analyses {
              },
              -max_retry_count => 1,
              -priority => 40,
-	     -rc_name => '32Gb_720_hour_job',
+	     -rc_name => '64Gb_720_hour_job',
              -flow_into => {
                  1 => [ 'gerp' ],
                  -1 => [ 'pecan_mem4'],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EpoExtended.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EpoExtended.pm
@@ -156,14 +156,9 @@ sub pipeline_analyses_db_prepare{
             },
             -flow_into => {
                 '2->A' => [ 'extended_genome_alignment' ],
-                'A->1' => [ 'alignment_funnel_check' ],
+                'A->1' => [ 'delete_alignment' ],
             },
             -rc_name => '4Gb_job',
-        },
-
-        {   -logic_name => 'alignment_funnel_check',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
-            -flow_into  => { 1 => { 'delete_alignment' => INPUT_PLUS() } },
         },
 
         # -------------------------------------------------------------[Load species tree]--------------------------------------------------------

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
@@ -367,12 +367,8 @@ sub core_pipeline_analyses {
             -rc_name => '4Gb_job',
             -flow_into => {
                 '2->A' => [ 'extended_genome_alignment' ],
-                'A->1' => [ 'alignment_funnel_check' ],
+                'A->1' => [ 'set_internal_ids_epo_extended' ],
             },
-        },
-        {   -logic_name => 'alignment_funnel_check',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
-            -flow_into  => { 1 => { 'set_internal_ids_epo_extended' => INPUT_PLUS() } },
         },
         {   -logic_name => 'set_internal_ids_epo_extended',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::PairAligner::SetInternalIdsCollection',


### PR DESCRIPTION
## Description

This PR is a partial reversion of #846.

Changes include:
- removing some `INPUT_PLUS`-enabled funnel checks from MSA pipelines; and
- fixing the resource class of `pecan_mem3` in the `MercatorPecan` pipeline.

The `INPUT_PLUS`-enabled funnel checks have not been removed from the `MultipleAlignerStats` pipeline part, as they each have a simple dataflow to a small number of downstream analyses at the end of a pipeline.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
