### PR TITLE
Remove INPUT_PLUS-enabled funnel checks from gene-tree pipelines

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/CAFE.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/CAFE.pm
@@ -44,9 +44,6 @@ package Bio::EnsEMBL::Compara::PipeConfig::Parts::CAFE;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Hive::Version v2.4;
-use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
-
 sub pipeline_analyses_cafe_with_full_species_tree {
     my ($self) = @_;
     return [
@@ -120,7 +117,7 @@ sub pipeline_analyses_cafe {
              -rc_name => '4Gb_24_hour_job',
              -flow_into => {
                  '2->A' => [ 'CAFE_analysis' ],
-                 'A->1' => [ 'CAFE_funnel_check' ],
+                 'A->1' => [ 'hc_cafe_results' ],
              },
             },
 
@@ -175,11 +172,6 @@ sub pipeline_analyses_cafe {
             -hive_capacity => $self->o('cafe_capacity'),
             -batch_size    => 20,
             -rc_name       => '2Gb_job',
-        },
-
-        {   -logic_name => 'CAFE_funnel_check',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
-            -flow_into  => { 1 => { 'hc_cafe_results' => INPUT_PLUS() } },
         },
 
         {   -logic_name         => 'hc_cafe_results',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DataCheckFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DataCheckFactory.pm
@@ -46,13 +46,8 @@ sub pipeline_analyses_datacheck_factory {
             -max_retry_count   => 0,
             -flow_into         => {
                 '2->A' => { 'datacheck_fan' => INPUT_PLUS() },
-                'A->1' => [ 'dc_funnel_check' ],
+                'A->1' => [ 'datacheck_funnel' ],
             },
-        },
-
-        {   -logic_name => 'dc_funnel_check',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
-            -flow_into  => { 1 => { 'datacheck_funnel' => INPUT_PLUS() } },
         },
 
         {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/GeneSetQC.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/GeneSetQC.pm
@@ -41,8 +41,6 @@ Questions may also be sent to the Ensembl help desk at
 
 package Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneSetQC;
 
-use Bio::EnsEMBL::Hive::Version v2.4;
-use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf; # For WHEN and INPUT_PLUS
 
 use strict;
 use warnings;
@@ -55,7 +53,7 @@ sub pipeline_analyses_GeneSetQC {
         #    -parameters =>  {'compara_db'   => $self->o('compara_db')},
             -flow_into  =>  {
                 '2->A'       => ['get_split_genes'],
-                'A->2'   =>  ['gene_qc_funnel_check'],
+                'A->2'       => ['store_tags'],
             },
             -hive_capacity  => $self->o('genesetQC_capacity'),
             -rc_name => '2Gb_job',
@@ -130,12 +128,6 @@ sub pipeline_analyses_GeneSetQC {
                 2   => ['?table_name=gene_member_qc'],
             },
             -analysis_capacity  => 50,
-        },
-
-        {   -logic_name => 'gene_qc_funnel_check',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
-            -flow_into  => { 2 => { 'store_tags' => INPUT_PLUS() } },
-            -analysis_capacity  => 10,
         },
 
         {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/OrthologQMAlignment.pm
@@ -48,7 +48,7 @@ sub pipeline_analyses_ortholog_qm_alignment {
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::PairCollection',
             -flow_into  => {
                 '2->B' => [ 'select_mlss' ],
-                'B->1' => [ 'mlss_selection_funnel_check' ],
+                'B->1' => [ 'ortholog_mlss_factory' ],
                 '3'    => [ 'reset_mlss' ],
             },
         },
@@ -73,11 +73,6 @@ sub pipeline_analyses_ortholog_qm_alignment {
             -analysis_capacity => 50,
         },
 
-        {   -logic_name => 'mlss_selection_funnel_check',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
-            -flow_into  => { 1 => { 'ortholog_mlss_factory' => INPUT_PLUS() } },
-        },
-
         {   -logic_name => 'ortholog_mlss_factory',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::OrthologMLSSFactory',
             -parameters => {
@@ -85,7 +80,7 @@ sub pipeline_analyses_ortholog_qm_alignment {
             },
             -flow_into  => {
                 '2->A' => { 'calculate_wga_coverage' => INPUT_PLUS() },
-                'A->1' => [ 'wga_coverage_funnel_check' ],
+                'A->1' => [ 'check_file_copy' ],
             }
         },
 
@@ -104,11 +99,6 @@ sub pipeline_analyses_ortholog_qm_alignment {
                 3 => [ '?table_name=ortholog_quality' ],
             },
             -rc_name => '2Gb_24_hour_job',
-        },
-
-        {   -logic_name => 'wga_coverage_funnel_check',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
-            -flow_into  => { 1 => { 'check_file_copy' => INPUT_PLUS() } },
         },
 
         {   -logic_name  => 'check_file_copy',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -1005,14 +1005,8 @@ sub core_pipeline_analyses {
                                   },
                 -flow_into => {
                                '1->A' => [ 'genomic_alignment', WHEN('#tree_model_id#' => 'infernal') ],
-                               'A->1' => [ 'tree_funnel_check' ],
+                               'A->1' => [ 'treebest_mmerge' ],
                               },
-            },
-
-            {   -logic_name => 'tree_funnel_check',
-                -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
-                -flow_into  => { 1 => { 'treebest_mmerge' => INPUT_PLUS() } },
-                %hc_params,
             },
 
             {   -logic_name    => 'create_ss_picts',


### PR DESCRIPTION
## Description

This PR is a partial reversion of #850.

It removes all `INPUT_PLUS`-enabled funnel checks from gene-tree pipelines.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
