### PR TITLE
Update name of Giardia lamblia in Pan config

### DIFF
--- a/conf/pan/additional_species.json
+++ b/conf/pan/additional_species.json
@@ -162,7 +162,7 @@
         "cryptomonas_paramecium_gca_000194455",
         "dictyostelium_discoideum",
         "emiliania_huxleyi",
-        "giardia_lamblia",
+        "giardia_intestinalis_gca000002435v2",
         "guillardia_theta",
         "leishmania_major",
         "monosiga_brevicollis_mx1_gca_000002865",


### PR DESCRIPTION
## Description

This PR updates the Pan Compara config to replace `giardia_lamblia` with `giardia_intestinalis_gca000002435v2`.
