### PR TITLE
Add NCBI Taxonomy database consistency check

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -117,6 +117,7 @@ sub executable_locations {
         'ancestral_dump_program'            => $self->check_exe_in_ensembl('ensembl-compara/scripts/ancestral_sequences/get_ancestral_sequence.pl'),
         'ancestral_stats_program'           => $self->check_exe_in_ensembl('ensembl-compara/scripts/ancestral_sequences/get_stats.pl'),
         'BuildSynteny_exe'                  => $self->check_file_in_ensembl('ensembl-compara/scripts/synteny/BuildSynteny.jar'),
+        'check_ncbi_taxa_exe'               => $self->check_exe_in_ensembl('ensembl-compara/scripts/taxonomy/check_ncbi_taxa_consistency.py'),
         'compare_beds_exe'                  => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/compare_beds.pl'),
         'count_genes_in_tree_exe'           => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/count_genes_in_tree.pl'),
         'create_pair_aligner_page_exe'      => $self->check_exe_in_ensembl('ensembl-compara/scripts/report/create_pair_aligner_page.pl'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
@@ -47,7 +47,23 @@ sub pipeline_analyses_prep_master_db_for_release {
                 'cmd' => [$self->o('patch_db_exe'), '--reg_conf', $self->o('reg_conf'), '--reg_alias', '#master_db#', '--fix', '--oldest', '#oldest_patch_release#', '--nointeractive'],
                 'oldest_patch_release' => $self->o('rel_with_suffix'),
             },
-            -flow_into  => ['load_ncbi_node'],
+            -flow_into  => ['check_ncbi_taxa_consistency'],
+        },
+
+        {   -logic_name => 'check_ncbi_taxa_consistency',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -parameters => {
+                'ncbi_taxa_hosts' => 'mysql-ens-sta-1,mysql-ens-sta-1-b,mysql-ens-sta-3,mysql-ens-sta-3-b,mysql-ens-sta-4',
+                'table'           => 'ncbi_taxa_node',
+                'cmd'             => join(' ', (
+                    $self->o('check_ncbi_taxa_exe'),
+                    '--release',
+                    '#ensembl_release#',
+                    '--hosts',
+                    '#ncbi_taxa_hosts#',
+                )),
+            },
+            -flow_into  => ['load_ncbi_node']
         },
 
         {   -logic_name => 'load_ncbi_node',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
@@ -54,11 +54,10 @@ sub pipeline_analyses_prep_master_db_for_release {
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
             -parameters => {
                 'ncbi_taxa_hosts' => 'mysql-ens-sta-1,mysql-ens-sta-1-b,mysql-ens-sta-3,mysql-ens-sta-3-b,mysql-ens-sta-4',
-                'table'           => 'ncbi_taxa_node',
                 'cmd'             => join(' ', (
                     $self->o('check_ncbi_taxa_exe'),
                     '--release',
-                    '#ensembl_release#',
+                    $self->o('ensembl_release'),
                     '--hosts',
                     '#ncbi_taxa_hosts#',
                 )),

--- a/scripts/taxonomy/check_ncbi_taxa_consistency.py
+++ b/scripts/taxonomy/check_ncbi_taxa_consistency.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Check consistency of Ensembl NCBI Taxonomy databases."""
+
+import argparse
+from collections import defaultdict
+import subprocess
+
+from sqlalchemy import create_engine, text
+
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--release", type=int, help="Current Ensembl release.")
+    parser.add_argument(
+        "--hosts", help="Comma-separated list of hosts on which the NCBI Taxonomy database may be found."
+    )
+    args = parser.parse_args()
+
+    db_name = f"ncbi_taxonomy_{args.release}"
+    hosts = args.hosts.split(",")
+
+    db_query = text("""SHOW DATABASES LIKE :db_name""")
+
+    ncbi_taxa_urls = []
+    for host in hosts:
+        cmd_args = [host, "details", "url"]
+
+        output = subprocess.check_output(cmd_args, text=True)
+
+        host_url = output.rstrip()
+        engine = create_engine(host_url)
+        with engine.connect() as conn:
+            db_found = conn.execute(db_query, {"db_name": db_name}).scalar_one_or_none()
+
+        if db_found:
+            ncbi_taxa_urls.append(f"{host_url}{db_name}")
+
+    if not ncbi_taxa_urls:
+        raise RuntimeError("no NCBI Taxonomy databases found")
+
+    import_date_query = text(
+        """\
+        SELECT name FROM ncbi_taxa_name
+        WHERE name_class = 'import date'
+    """
+    )
+
+    dbs_by_import_date = defaultdict(list)
+    for ncbi_taxa_url in ncbi_taxa_urls:
+        engine = create_engine(ncbi_taxa_url)
+        with engine.connect() as conn:
+            import_date = conn.execute(import_date_query).scalar_one()
+            dbs_by_import_date[import_date].append(engine.url)
+
+    if len(dbs_by_import_date) > 1:
+        raise RuntimeError(
+            f"NCBI Taxonomy databases have inconsistent import dates: {sorted(dbs_by_import_date)}"
+        )


### PR DESCRIPTION
## Description

This PR adds an NCBI Taxonomy database consistency check to the `PrepareMasterDatabaseForRelease` pipeline.

This consistency check will fail if there are inconsistent versions of the `ncbi_taxonomy_114` database on production staging servers.

## Testing

The script `check_ncbi_taxa_consistency.py` was initially tested when the copy of `ncbi_taxonomy_114` on the Bacteria staging server was the `2022-11-03` version of the Ensembl NCBI Taxonomy database. The consistency check failed at this stage.

Script `check_ncbi_taxa_consistency.py` was tested in the context of a Pan Compara  `PrepareMasterDatabaseForRelease` pipeline after the copy of `ncbi_taxonomy_114` on the Bacteria staging server had been updated to the `2024-08-28` version of the NCBI Taxonomy database, consistent with copies of `ncbi_taxonomy_114` on other staging hosts. The consistency check passed on this occasion.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
