### PR TITLE
Repair repair_mlss_tags.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,15 @@ readme = {file = ["README.md"]}
 version = {file = ["PIP_VERSION"]}
 
 [tool.pytest.ini_options]
-# CITest project is on hold and it needs to be updated before resuming its unit tests
-addopts = "-v --tb=native --server=mysql://ensadmin:$ENSADMIN_PSW@mysql-ens-compara-prod-1:4485/ --ignore=src/python/tests/test_citest.py"
+addopts = [
+    "-v",
+    "--tb=native",
+    "--server=mysql://ensadmin:${ENSADMIN_PSW}@mysql-ens-compara-prod-1:4485/",
+    # CITest project is on hold and it needs to be updated before resuming its unit tests
+    "--ignore=src/python/tests/test_citest.py",
+    # Ignoring MLSS tag repair script unit test pending approval of ensembl-utils PR 29
+    "--ignore=src/python/tests/test_repair_mlss_tags.py",
+]
 testpaths = ["src/python/tests"]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,8 +92,6 @@ addopts = [
     "--server=mysql://ensadmin:${ENSADMIN_PSW}@mysql-ens-compara-prod-1:4485/",
     # CITest project is on hold and it needs to be updated before resuming its unit tests
     "--ignore=src/python/tests/test_citest.py",
-    # Ignoring MLSS tag repair script unit test pending approval of ensembl-utils PR 29
-    "--ignore=src/python/tests/test_repair_mlss_tags.py",
 ]
 testpaths = ["src/python/tests"]
 

--- a/scripts/pipeline/time_pipeline.py
+++ b/scripts/pipeline/time_pipeline.py
@@ -20,7 +20,7 @@
 import sys
 import re
 import argparse
-from typing import Dict, Any, Union
+from typing import Any, Union
 from datetime import datetime, timedelta
 
 from sqlalchemy import create_engine, text

--- a/scripts/production/repair_mlss_tags.py
+++ b/scripts/production/repair_mlss_tags.py
@@ -89,7 +89,7 @@ def repair_mlss_tag(dbc: DBConnection, mlss_tag: str) -> None:
         mlss_tag: MLSS tag as found in the ``method_link_species_set_tag`` table.
 
     """
-    with dbc.connect() as connection:
+    with dbc.begin() as connection:
         # Get the MLSS tags in method_link_species_set_tag table
         mlss_tag_values = connection.execute(text(
             f"SELECT method_link_species_set_id AS mlss_id, value "

--- a/src/python/tests/test_repair_mlss_tags.py
+++ b/src/python/tests/test_repair_mlss_tags.py
@@ -45,11 +45,11 @@ class TestRepairMLSSTags:
     # autouse=True makes this fixture be executed before any test_* method of this class, and scope='class' to
     # execute it only once per class parametrization
     @pytest.fixture(scope='class', autouse=True)
-    def setup(self, test_dbs: UnitTestDB) -> None:
+    def setup(self, test_dbs: dict[str, UnitTestDB]) -> None:
         """Loads the required fixtures and values as class attributes.
 
         Args:
-            test_dbs: Unit test database (fixture).
+            test_dbs: Unit test databases (fixture).
 
         """
         # Use type(self) instead of self as a workaround to @classmethod decorator (unsupported by pytest and
@@ -122,7 +122,7 @@ class TestRepairMLSSTags:
 
         """
         # Alter the MLSS tags table so there is something to repair
-        with self.dbc.connect() as connection:
+        with self.dbc.begin() as connection:
             connection.execute(text("SET FOREIGN_KEY_CHECKS = 0"))
             for sql in alt_queries:
                 connection.execute(text(sql))
@@ -138,7 +138,7 @@ class TestRepairMLSSTags:
             assert set(output.decode().strip().split("\n")) == exp_stdout
             if exp_tag_value:
                 # Check the database has the expected information
-                with self.dbc.connect() as connection:
+                with self.dbc.begin() as connection:
                     result = connection.execute(text(
                         f"SELECT method_link_species_set_id AS mlss_id, value "
                         f"FROM method_link_species_set_tag WHERE tag = '{mlss_tag}'"


### PR DESCRIPTION
## Description

Neither script `repair_mlss_tags.py` nor its unit test `test_repair_mlss_tags.py` have been behaving as expected.

This PR addresses the issues in both.

Pending approval of [ensembl-utils PR 29](https://github.com/Ensembl/ensembl-utils/pull/29), or implementation of equivalent functionality to enable use of a MySQL `UnitTestDB`, the `pyproject.toml` is configured to ignore `test_repair_mlss_tags.py`.

**Related JIRA tickets:**
- ENSCOMPARASW-7668

## Testing

With these changes in conjunction with those of ensembl-utils PR 29, `test_repair_mlss_tags.py` passed locally.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
