### PR TITLE
Ready the rapid homology pipelines for Slurm and eHive 2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
     - git-ensembl --clone --branch release/110 --secondary_branch main --depth 1 ensembl-production
     - git-ensembl --clone --branch release/110 --secondary_branch main --depth 1 ensembl-metadata
     # yamllint enable rule:line-length
-    - git-ensembl --clone --branch main --depth 1 ensembl-hive
+    - git-ensembl --clone --branch version/2.7.0 --depth 1 ensembl-hive
     - git-ensembl --clone --branch main --depth 1 ensembl-taxonomy
     - ln -s . ensembl-compara
     - git clone --branch v1.6.x --depth 1 https://github.com/bioperl/bioperl-live

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpFastaDatabases.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpFastaDatabases.pm
@@ -55,7 +55,7 @@ sub pipeline_analyses_dump_fasta_dbs {
             -parameters => {
                 'num_parts' => $self->o('num_fasta_parts'),
             },
-            -rc_name    => '500Mb_job',
+            -rc_name    => '1Gb_job',
         },
 
         {   -logic_name => 'make_diamond_db',
@@ -66,7 +66,7 @@ sub pipeline_analyses_dump_fasta_dbs {
                 # db_name should be #fasta_name# with .fasta removed from the end - hive can do that
                 'db_name'     => '#expr( ($_ = #fasta_name#) and $_ =~ s/\.fasta$// and $_)expr#',
             },
-            -rc_name    => '500Mb_job',
+            -rc_name    => '1Gb_job',
         },
     ];
 }

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateReferenceDatabase_conf.pm
@@ -279,7 +279,7 @@ sub core_pipeline_analyses {
                 'species_set_record'     => $self->o('species_set_record'),
                 'queries_to_update_file' => $self->o('queries_to_update_file'),
             },
-            -rc_name       => '500Mb_job',
+            -rc_name       => '1Gb_job',
         },
 
         {   -logic_name    => 'update_reference_genome',
@@ -288,7 +288,7 @@ sub core_pipeline_analyses {
                 'compara_db' => '#ref_db#',
             },
             -hive_capacity => 10,
-            -rc_name       => '500Mb_job',
+            -rc_name       => '1Gb_job',
             -flow_into     => ['load_members'],
         },
 
@@ -307,7 +307,7 @@ sub core_pipeline_analyses {
                 'offset_ids'                  => $self->o('offset_ids'),
             },
             -hive_capacity => 10,
-            -rc_name => '4Gb_job',
+            -rc_name => '4Gb_24_hour_job',
             -flow_into  => ['hc_members_per_genome'],
         },
 
@@ -436,7 +436,7 @@ sub core_pipeline_analyses {
                 'get_nearest_taxonomy_exe' => $self->o('get_nearest_taxonomy_exe'),
             },
             -flow_into  => [ 'email_queries_to_update' ],
-            -rc_name    => '500Mb_job',
+            -rc_name    => '1Gb_job',
         },
 
         {   -logic_name => 'email_queries_to_update',


### PR DESCRIPTION
## Description

This PR readies the reference-update pipeline for Slurm, and both rapid homology pipelines for eHive 2.7.0.

**Related JIRA tickets:**
- ENSCOMPARASW-7673

## Testing

A reference-update pipeline was initialised with the new resource-class config.

Slurm config changes to the homology annotation pipeline were previously implemented and tested as part of ENSCOMPARASW-7672.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
