### PR TITLE
Enable datacheck Jira ticket CSV output

### DIFF
--- a/modules/t/createDCJiraTickets.t
+++ b/modules/t/createDCJiraTickets.t
@@ -36,14 +36,11 @@ standaloneJob(
         'dry_run'                      => 1,
         'create_datacheck_tickets_exe' => '$ENSEMBL_ROOT_DIR/ensembl-compara/scripts/jira_tickets/create_datacheck_tickets.pl',
         'division'                     => 'vertebrates',
-        'test_mode'                    => 1,
     },
-    [
-        [
-            'WARNING',
-            "Command: \$ENSEMBL_ROOT_DIR/ensembl-compara/scripts/jira_tickets/create_datacheck_tickets.pl $test_infile --update --division vertebrates  --dry_run",
-        ],
-    ]
+    undef,
+    {
+        'expect_failure'               => 1,
+    },
 );
 
 standaloneJob(
@@ -54,15 +51,11 @@ standaloneJob(
         'dry_run'                      => 1,
         'create_datacheck_tickets_exe' => '$ENSEMBL_ROOT_DIR/ensembl-compara/scripts/jira_tickets/create_datacheck_tickets.pl',
         'division'                     => 'vertebrates',
-        'test_mode'                    => 1,
-
     },
-    [
-        [
-            'WARNING',
-            "Command: \$ENSEMBL_ROOT_DIR/ensembl-compara/scripts/jira_tickets/create_datacheck_tickets.pl $test_infile --update --division vertebrates --label critical --dry_run",
-        ],
-    ]
+    undef,
+    {
+        'expect_failure'               => 1,
+    },
 );
 
 done_testing();


### PR DESCRIPTION
## Description

This PR makes it possible for the datacheck Jira ticket script to generate a CSV file containing datacheck ticket data, which can then be imported to Jira to create those tickets.

It provides a fallback method of creating Jira tickets in the event that other methods are unavailable.

**Related JIRA tickets:**
- ENSCOMPARASW-7803

## Overview of changes

- Parameters `csv_mode` and `merge_ticket_key` are implemented in runnable `CreateDCJiraTickets`.
- Parameters `-csv` and `-merge_ticket_key` are implemented in script `create_datacheck_tickets.pl`.
- Runnable `CreateDCJiraTickets` dies without retrying where previously it issued a warning.

## Testing

The updated `CreateDCJiraTickets` runnable and `create_datacheck_tickets.pl` script were used to generate a set of datacheck Jira ticket CSV files for Plants release 114 datachecks.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
