### PR TITLE
Remove ortholog and topup clustering modes

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateHmmProfiles_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateHmmProfiles_conf.pm
@@ -115,7 +115,6 @@ sub default_options {
         'mafft_runtime'             => 7200,
         'treebest_threshold_n_residues' => 10000,
         'treebest_threshold_n_genes'    => 400,
-        'update_threshold_trees'    => 0.2,
 
     # alignment filtering options
         'threshold_n_genes'       => 20,
@@ -984,7 +983,7 @@ sub core_pipeline_analyses {
             -module             => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::CreateClustersets',
             -parameters         => {
                 member_type     => 'protein',
-                'additional_clustersets'    => [qw(treebest phyml-aa phyml-nt nj-dn nj-ds nj-mm raxml raxml_parsimony raxml_bl notung copy raxml_update filter_level_1 filter_level_2 filter_level_3 filter_level_4 fasttree )],
+                'additional_clustersets'    => [qw(treebest phyml-aa phyml-nt nj-dn nj-ds nj-mm raxml raxml_parsimony raxml_bl notung filter_level_1 filter_level_2 filter_level_3 filter_level_4 fasttree)],
             },
             -flow_into          => [ 'cluster_tagging_factory' ],
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -64,8 +64,7 @@ sub default_options {
 
             # How will the pipeline create clusters (families) ?
             # Possible values: 'rfam' (default) or 'ortholog'
-            #   'blastp' means that the pipeline will clusters genes according to their RFAM accession
-            #   'ortholog' means that the pipeline will use previously inferred orthologs to perform a cluster projection
+            #   'rfam' means that the pipeline will cluster genes according to their RFAM accession
             'clustering_mode'           => 'rfam',
 
         'master_db'   => 'compara_master',
@@ -653,10 +652,7 @@ sub core_pipeline_analyses {
                                'type'              => 'infernal',
                                'skip_consensus'    => 1,
                               },
-            -flow_into     => WHEN(
-                                   '#clustering_mode# eq "ortholog"' => 'ortholog_cluster',
-                                   ELSE 'rfam_classify',
-                               ),
+            -flow_into     => [ 'rfam_classify' ],
         },
 
 # ---------------------------------------------[run RFAM classification]--------------------------------------------------------------
@@ -703,16 +699,6 @@ sub core_pipeline_analyses {
                 -flow_into  => [ 'clusterset_backup' ],
                 %hc_params,
             },
-
-        {   -logic_name => 'ortholog_cluster',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::OrthologClusters',
-            -parameters => {
-                'sort_clusters'         => 1,
-                'add_model_id'          => 1,
-            },
-            -rc_name    => '2Gb_job',
-            -flow_into  => 'expand_clusters_with_projections',
-        },
 
         {   -logic_name         => 'expand_clusters_with_projections',
             -module             => 'Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::ExpandClustersWithProjections',

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CopyTreesFromDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CopyTreesFromDB.pm
@@ -21,15 +21,9 @@ limitations under the License.
 
 Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::CopyTreesFromDB
 
-=head1 DESCRIPTION
+=head1 DEPRECATION NOTICE
 
-1) Used to copy all the trees from a previous database.
-
-2) It identifies the genes in compara_dba that have been updated, deleted or added
-when compared to the reuse_compara_dba.
-
-3) It disavows all the genes that were flagged by FlagUpdateClusters.pm and stored
-in gene_tree_root_tag as "updated_genes_list", "added_genes_list" and "deleted_genes_list"
+This runnable is deprecated, and may be removed in a future release.
 
 =cut
 
@@ -43,6 +37,8 @@ use base ('Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::StoreTree');
 
 sub fetch_input {
     my $self = shift @_;
+
+        $self->warning("RunnableDB::GeneTrees::CopyTreesFromDB is deprecated, and may be removed in a future release");
 
         #get compara_dba adaptor
         $self->param( 'compara_dba', $self->compara_dba );

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/FlagUpdateClusters.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/FlagUpdateClusters.pm
@@ -21,15 +21,9 @@ limitations under the License.
 
 Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::FlagUpdateClusters
 
-=head1 DESCRIPTION
+=head1 DEPRECATION NOTICE
 
-1) This module loops through all the genes from the current and previous databases.
-
-2) Identifies and flags the genes that have been updated, deleted or newly added and
-stores them as appropriate: "updated_genes_list", "added_genes_list" and "deleted_genes_list"
-
-3) Checks for all the flagged genes (%flagged) in the list of members from all the
-root_ids and updated the flag "needs_update" in the gene_tree_root_tag table.
+This runnable is deprecated, and may be removed in a future release.
 
 =cut
 
@@ -45,6 +39,8 @@ use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 
 sub fetch_input {
     my $self = shift @_;
+
+    $self->warning("RunnableDB::GeneTrees::FlagUpdateClusters is deprecated, and may be removed in a future release");
 
     #get reuse_compara_dba adaptor
     $self->param( 'reuse_compara_dba', $self->get_cached_compara_dba('reuse_db') );

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/CopyAlignmentsFromDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/CopyAlignmentsFromDB.pm
@@ -16,27 +16,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-=head1 CONTACT
-
-Please email comments or questions to the public Ensembl
-developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-Questions may also be sent to the Ensembl help desk at
-<http://www.ensembl.org/Help/Contact>.
-
-=cut
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::CopyTreesFromDB
 
-=head1 DESCRIPTION
+=head1 DEPRECATION NOTICE
 
-1) Used to copy all the alignments from a previous database.
-
-2) But it wont add any new genes at this point. New genes will be addeed by mafft/raxml
+This runnable is deprecated, and may be removed in a future release.
 
 =cut
 
@@ -51,6 +37,8 @@ use base ('Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::StoreTree');
 
 sub fetch_input {
     my $self = shift @_;
+
+        $self->warning("RunnableDB::ProteinTrees::CopyAlignmentsFromDB is deprecated, and may be removed in a future release");
 
         #Get adaptors
         #----------------------------------------------------------------------------------------------------------------------------

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/MafftUpdate.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/MafftUpdate.pm
@@ -15,17 +15,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::MafftUpdate
 
-=head1 DESCRIPTION
+=head1 DEPRECATION NOTICE
 
-This RunnableDB adds gene sequences to already existing alignments by
-retrieving genes from the gene_tree_root_tag 'updated_genes_list' which
-contains a comma separated string value of "stable_id genome_db_id"
+This runnable is deprecated, and may be removed in a future release.
 
 =cut
 
@@ -49,6 +45,8 @@ sub param_defaults {
 
 sub fetch_input {
     my ($self) = @_;
+
+    $self->warning("RunnableDB::ProteinTrees::MafftUpdate is deprecated, and may be removed in a future release");
 
     #get current tree adaptor
     $self->param( 'current_tree_adaptor', $self->compara_dba->get_GeneTreeAdaptor );

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/OrthologClusters.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/OrthologClusters.pm
@@ -15,37 +15,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::OrthologClusters
 
-=head1 DESCRIPTION
+=head1 DEPRECATION NOTICE
 
-This is the RunnableDB makes clusters consisting of given species list  orthologues(connected components, not necessarily complete graphs).
-
-example:
-
-standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::OrthologClusters
-
-=head1 AUTHORSHIP
-
-Ensembl Team. Individual contributions can be found in the GIT log.
-
-=head1 APPENDIX
-
-The rest of the documentation details each of the object methods.
-Internal methods are usually preceded with an underscore (_)
+This runnable is deprecated, and may be removed in a future release.
 
 =cut
 
@@ -80,6 +56,8 @@ sub param_defaults {
 sub fetch_input {
 
 	my $self = shift;
+
+    $self->warning("RunnableDB::ProteinTrees::OrthologClusters is deprecated, and may be removed in a future release");
 
 	$self->param('previous_dba' , $self->get_cached_compara_dba('ref_ortholog_db') );
 	$self->param('prev_homolog_adaptor', $self->param('previous_dba')->get_HomologyAdaptor);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/RAxML_update.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/RAxML_update.pm
@@ -16,15 +16,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
+=head1 NAME
 
-=head1 CONTACT
+Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RAxML_update
 
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+=head1 DEPRECATION NOTICE
 
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
+This runnable is deprecated, and may be removed in a future release.
 
 =cut
 
@@ -52,6 +50,14 @@ sub param_defaults {
             'output_clusterset_id'  => 'raxml_update',
             'check_split_genes' 	=> 0,
     };
+}
+
+sub fetch_input {
+    my $self = shift;
+
+    $self->warning("RunnableDB::ProteinTrees::RAxML_update is deprecated, and may be removed in a future release");
+
+    $self->SUPER::fetch_input();
 }
 
 1;

--- a/sql/pipeline-tables.sql
+++ b/sql/pipeline-tables.sql
@@ -282,7 +282,7 @@ CREATE TABLE hmm_thresholding (
 
 -- ----------------------------------------------------------------------------------
 --
--- Table structure for table 'seq_member_id_current_reused_map'
+-- Table structure for table 'seq_member_id_current_reused_map' (DEPRECATED)
 --
 -- overview: Add new table to be used by copy_trees_from_previous_release in order to
 --           rename old seq_member_ids with the current ones.


### PR DESCRIPTION
## Description

This PR would remove the `ortholog` and `topup` clustering modes from the gene-tree pipelines.

Neither mode has been used in production for quite some time. Furthermore, topup mode has been broken since `release/110`, since it uses a runnable (`CopyTreesFromDB`) which calls the obsolete method `MemberAdaptor::fetch_by_stable_id`.

**Related JIRA tickets:**
- ENSCOMPARASW-4179
- ENSCOMPARASW-7053
- ENSCOMPARASW-7055

## Overview of changes

This draft PR would:
- remove the option to configure `ortholog` or `topup` clustering mode from the protein-trees pipeline, and remove the `ortholog` clustering mode from the ncRNA-trees pipeline;
- remove all pipeline analyses related to the `ortholog` and `topup` clustering modes;
- remove related pipeline parameters, including the `copy` and `raxml_update` clusterset_ids;
- add deprecation information to each of the runnables involved in the `ortholog` and `topup` clustering modes, and to the `seq_member_id_current_reused_map` table in `pipeline-tables.sql`; and
- add a `treebreak_decision` pipeline step to simplify the pipeline in the vicinity of the `QuickTreeBreak` loop.

This image shows a section of the pipeline following these changes:
![sans_topup_mode](https://github.com/user-attachments/assets/55d725d6-f34c-4db1-b626-5df9e86c56da)

## Testing

These changes were tested during a run of the Pan Compara protein-trees pipeline as part of `release/114` production.

(Some minor changes to documentation and parameters were made after the pipeline run.)

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
