### PR TITLE
Add automatic check of BioMart species cap

### DIFF
--- a/conf/metazoa/metaconfig.json
+++ b/conf/metazoa/metaconfig.json
@@ -1,0 +1,5 @@
+{
+    "biomart": {
+        "species_cap": 275
+    }
+}

--- a/conf/vertebrates/metaconfig.json
+++ b/conf/vertebrates/metaconfig.json
@@ -1,0 +1,5 @@
+{
+    "biomart": {
+        "species_cap": 227
+    }
+}

--- a/travisci/all-housekeeping/division_config.t
+++ b/travisci/all-housekeeping/division_config.t
@@ -97,7 +97,7 @@ sub test_division {
                     foreach my $name (@{$additional_species->{$other_div}}) {
                         ok(exists $other_div_allowed_species{$name}, "$name is allowed");
                     }
-                }
+                };
             }
         }
     }
@@ -113,12 +113,12 @@ sub test_division {
         my $biomart_species = decode_json(slurp($biomart_species_file));
         subtest "$biomart_species_file species cap" => sub {
             cmp_ok(scalar(@{$biomart_species}), '<=', $biomart_species_cap, "species count within limit");
-        }
+        };
         subtest "$biomart_species_file vs $allowed_species_file" => sub {
             foreach my $name (@{$biomart_species}) {
                 ok(exists $allowed_species{$name}, "$name is allowed");
             }
-        }
+        };
     }
 
     # Nothing to test but it's alright. Not all divisions have files to cross-check

--- a/travisci/all-housekeeping/division_config.t
+++ b/travisci/all-housekeeping/division_config.t
@@ -105,7 +105,7 @@ sub test_division {
     # Load biomart_species.json if it exists
     my $biomart_species_file = File::Spec->catfile($division_dir, 'biomart_species.json');
     if (-e $biomart_species_file and %allowed_species) {
-        my $metaconfig_file = File::Spec->catfile($division_dir, 'metaconfig.yml');
+        my $metaconfig_file = File::Spec->catfile($division_dir, 'metaconfig.json');
         my $metaconfig = decode_json(slurp($metaconfig_file));
         my $biomart_species_cap = $metaconfig->{'biomart'}{'species_cap'};
         # 5. All species listed in biomart_species.json exist in allowed_species.json

--- a/travisci/all-housekeeping/division_config.t
+++ b/travisci/all-housekeeping/division_config.t
@@ -105,9 +105,15 @@ sub test_division {
     # Load biomart_species.json if it exists
     my $biomart_species_file = File::Spec->catfile($division_dir, 'biomart_species.json');
     if (-e $biomart_species_file and %allowed_species) {
+        my $metaconfig_file = File::Spec->catfile($division_dir, 'metaconfig.yml');
+        my $metaconfig = decode_json(slurp($metaconfig_file));
+        my $biomart_species_cap = $metaconfig->{'biomart'}{'species_cap'};
         # 5. All species listed in biomart_species.json exist in allowed_species.json
         $has_files_to_test = 1;
         my $biomart_species = decode_json(slurp($biomart_species_file));
+        subtest "$biomart_species_file species cap" => sub {
+            cmp_ok(scalar(@{$biomart_species}), '<=', $biomart_species_cap, "species count within limit");
+        }
         subtest "$biomart_species_file vs $allowed_species_file" => sub {
             foreach my $name (@{$biomart_species}) {
                 ok(exists $allowed_species{$name}, "$name is allowed");


### PR DESCRIPTION
## Description

This draft PR would introduce an automatic check of the BioMart species cap.

- the Metazoa BioMart species cap is configured to 275 on the basis of intentions ticket [ENSINT-1549](https://www.ebi.ac.uk/panda/jira/browse/ENSINT-1549), which declared a species cap for Metazoa.
- the Vertebrates BioMart species cap is configured to the current size of the BioMart species list (227).

## Testing

This PR would include a species cap check in `division_config.t`.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
