### PR TITLE
Update release graph to clarify major relationships

### DIFF
--- a/conf/fungi/jira_recurrent_tickets.json
+++ b/conf/fungi/jira_recurrent_tickets.json
@@ -38,7 +38,8 @@
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/pages/viewpage.action?pageId=97126141\n*GitHub*: [<Division>/PrepareMasterDatabaseForRelease_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/<Division>/PrepareMasterDatabaseForRelease_conf.pm]\n{code}isrun init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::<Division>::PrepareMasterDatabaseForRelease_conf -host mysql-ens-compara-prod-4 -port 4401{code}",
-            "summary": "Prepare the master database"
+            "summary": "Prepare the master database",
+            "name_on_graph": "Prepare master DB"
          },
          {
             "assignee": "<RelCo>",
@@ -78,8 +79,7 @@
             "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "Review the gene-tree stats for each gene-tree pipeline, and address any issues.",
-            "summary": "Check gene-tree stats",
-            "name_on_graph": "Check gene-tree stats"
+            "summary": "Check gene-tree stats"
          },
          {
             "assignee": "<RelCo>",
@@ -107,28 +107,29 @@
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Creation+of+a+new+release+database",
-            "summary": "Create Release Database"
+            "summary": "Create Release Database",
+            "name_on_graph": "Create Release DB"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+DNA+data",
             "summary": "Merge DNA data",
-            "name_on_graph": "Merge all alignments for WGA Orthology QC"
+            "name_on_graph": "Merge all for OrthWGA"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines#Mergethehomologypipelines-Preliminaries",
             "summary": "Backup release database",
-            "name_on_graph": "Backup the release database before merging the homology data"
+            "name_on_graph": "Backup release DB"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines",
             "summary": "Merge the homology pipelines",
-            "name_on_graph": "Merge the homology pipelines"
+            "name_on_graph": "Merge homologies"
          },
          {
             "assignee": "<RelCo>",

--- a/conf/metazoa/jira_recurrent_tickets.json
+++ b/conf/metazoa/jira_recurrent_tickets.json
@@ -38,7 +38,8 @@
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/pages/viewpage.action?pageId=97126141\n*GitHub*: [<Division>/PrepareMasterDatabaseForRelease_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/<Division>/PrepareMasterDatabaseForRelease_conf.pm]\n{code}isrun init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::<Division>::PrepareMasterDatabaseForRelease_conf -host mysql-ens-compara-prod-6 -port 4616{code}",
-            "summary": "Prepare the master database"
+            "summary": "Prepare the master database",
+            "name_on_graph": "Prepare master DB"
          },
          {
             "assignee": "<RelCo>",
@@ -93,8 +94,7 @@
             "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "Review the gene-tree stats for each gene-tree pipeline, and address any issues.",
-            "summary": "Check gene-tree stats",
-            "name_on_graph": "Check gene-tree stats"
+            "summary": "Check gene-tree stats"
          },
          {
             "assignee": "<RelCo>",
@@ -135,8 +135,15 @@
             "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Add+CACTUS+HAL+Alignment+to+Compara",
-            "summary": "Register HAL alignment data",
-            "name_on_graph": "Register HAL alignment data"
+            "summary": "Process Cactus data",
+            "name_on_graph": "Process Cactus data"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
+            "description": "Mark as done when all CACTUS_DB alignments have been merged into the new release database.",
+            "summary": "Merge Cactus data",
+            "name_on_graph": "Merge Cactus data"
          },
          {
             "assignee": "<RelCo>",
@@ -157,28 +164,29 @@
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Creation+of+a+new+release+database",
-            "summary": "Create Release Database"
+            "summary": "Create Release Database",
+            "name_on_graph": "Create Release DB"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+DNA+data",
             "summary": "Merge DNA data",
-            "name_on_graph": "Merge all alignments for WGA Orthology QC"
+            "name_on_graph": "Merge all for OrthWGA"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines#Mergethehomologypipelines-Preliminaries",
             "summary": "Backup release database",
-            "name_on_graph": "Backup the release database before merging the homology data"
+            "name_on_graph": "Backup release DB"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines",
             "summary": "Merge the homology pipelines",
-            "name_on_graph": "Merge the homology pipelines"
+            "name_on_graph": "Merge homologies"
          },
          {
             "assignee": "<RelCo>",

--- a/conf/pan/jira_recurrent_tickets.json
+++ b/conf/pan/jira_recurrent_tickets.json
@@ -38,7 +38,8 @@
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/pages/viewpage.action?pageId=97126141\n*GitHub*: [<Division>/PrepareMasterDatabaseForRelease_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/<Division>/PrepareMasterDatabaseForRelease_conf.pm]\n{code}isrun init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::<Division>::PrepareMasterDatabaseForRelease_conf -host mysql-ens-compara-prod-7 -port 4617{code}",
-            "summary": "Prepare the master database"
+            "summary": "Prepare the master database",
+            "name_on_graph": "Prepare master DB"
          },
          {
             "assignee": "<RelCo>",
@@ -65,8 +66,7 @@
             "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "Review the gene-tree stats for each gene-tree pipeline, and address any issues.",
-            "summary": "Check gene-tree stats",
-            "name_on_graph": "Check gene-tree stats"
+            "summary": "Check gene-tree stats"
          }
       ],
       "labels": ["Production_anchor"],
@@ -80,14 +80,15 @@
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Creation+of+a+new+release+database",
-            "summary": "Create Release Database"
+            "summary": "Create Release Database",
+            "name_on_graph": "Create Release DB"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines",
             "summary": "Merge the homology pipelines",
-            "name_on_graph": "Merge the homology pipelines"
+            "name_on_graph": "Merge homologies"
          },
          {
             "assignee": "<RelCo>",

--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -38,7 +38,8 @@
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/pages/viewpage.action?pageId=97126141\n*GitHub*: [<Division>/PrepareMasterDatabaseForRelease_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/<Division>/PrepareMasterDatabaseForRelease_conf.pm]\n{code}isrun init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::<Division>::PrepareMasterDatabaseForRelease_conf -host mysql-ens-compara-prod-5 -port 4615{code}",
-            "summary": "Prepare the master database"
+            "summary": "Prepare the master database",
+            "name_on_graph": "Prepare master DB"
          },
          {
             "assignee": "<RelCo>",
@@ -99,8 +100,7 @@
             "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "Review the gene-tree stats for each gene-tree pipeline, and address any issues.",
-            "summary": "Check gene-tree stats",
-            "name_on_graph": "Check gene-tree stats"
+            "summary": "Check gene-tree stats"
          },
          {
             "assignee": "<RelCo>",
@@ -113,8 +113,15 @@
             "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Add+CACTUS+HAL+Alignment+to+Compara",
-            "summary": "Register HAL alignment data",
-            "name_on_graph": "Register HAL alignment data"
+            "summary": "Process Cactus data",
+            "name_on_graph": "Process Cactus data"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
+            "description": "Mark as done when all CACTUS_DB alignments have been merged into the new release database.",
+            "summary": "Merge Cactus data",
+            "name_on_graph": "Merge Cactus data"
          },
          {
             "assignee": "<RelCo>",
@@ -127,8 +134,7 @@
             "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "Review the stats for each MSA pipeline, and address any issues.",
-            "summary": "Check MSA stats",
-            "name_on_graph": "Check MSA stats"
+            "summary": "Check MSA stats"
          },
          {
             "assignee": "<RelCo>",
@@ -149,34 +155,36 @@
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Creation+of+a+new+release+database",
-            "summary": "Create Release Database"
+            "summary": "Create Release Database",
+            "name_on_graph": "Create Release DB"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+DNA+data",
             "summary": "Merge DNA data",
-            "name_on_graph": "Merge all alignments for WGA Orthology QC"
+            "name_on_graph": "Merge all for OrthWGA"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines#Mergethehomologypipelines-Preliminaries",
             "summary": "Backup release database",
-            "name_on_graph": "Backup the release database before merging the homology data"
+            "name_on_graph": "Backup release DB"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Creation+of+a+new+ancestral+database",
-            "summary": "Build a new ancestral sequence core database"
+            "summary": "Build a new ancestral sequence core database",
+            "name_on_graph": "Build ancestral DB"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines",
             "summary": "Merge the homology pipelines",
-            "name_on_graph": "Merge the homology pipelines"
+            "name_on_graph": "Merge homologies"
          },
          {
             "assignee": "<RelCo>",

--- a/conf/protists/jira_recurrent_tickets.json
+++ b/conf/protists/jira_recurrent_tickets.json
@@ -38,7 +38,8 @@
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/pages/viewpage.action?pageId=97126141\n*GitHub*: [<Division>/PrepareMasterDatabaseForRelease_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/<Division>/PrepareMasterDatabaseForRelease_conf.pm]\n{code}isrun init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::<Division>::PrepareMasterDatabaseForRelease_conf -host mysql-ens-compara-prod-8 -port 4618{code}",
-            "summary": "Prepare the master database"
+            "summary": "Prepare the master database",
+            "name_on_graph": "Prepare master DB"
          },
          {
             "assignee": "<RelCo>",
@@ -78,8 +79,7 @@
             "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "Review the gene-tree stats for each gene-tree pipeline, and address any issues.",
-            "summary": "Check gene-tree stats",
-            "name_on_graph": "Check gene-tree stats"
+            "summary": "Check gene-tree stats"
          },
          {
             "assignee": "<RelCo>",
@@ -107,28 +107,29 @@
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Creation+of+a+new+release+database",
-            "summary": "Create Release Database"
+            "summary": "Create Release Database",
+            "name_on_graph": "Create Release DB"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+DNA+data",
             "summary": "Merge DNA data",
-            "name_on_graph": "Merge all alignments for WGA Orthology QC"
+            "name_on_graph": "Merge all for OrthWGA"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines#Mergethehomologypipelines-Preliminaries",
             "summary": "Backup release database",
-            "name_on_graph": "Backup the release database before merging the homology data"
+            "name_on_graph": "Backup release DB"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines",
             "summary": "Merge the homology pipelines",
-            "name_on_graph": "Merge the homology pipelines"
+            "name_on_graph": "Merge homologies"
          },
          {
             "assignee": "<RelCo>",

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -38,7 +38,8 @@
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "*Confluence*: https://www.ebi.ac.uk/seqdb/confluence/pages/viewpage.action?pageId=97126141\n*GitHub*: [<Division>/PrepareMasterDatabaseForRelease_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/<Division>/PrepareMasterDatabaseForRelease_conf.pm]\n{code}isrun init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::<Division>::PrepareMasterDatabaseForRelease_conf -host mysql-ens-compara-prod-1 -port 4485{code}",
-            "summary": "Prepare the master database"
+            "summary": "Prepare the master database",
+            "name_on_graph": "Prepare master DB"
          },
          {
             "assignee": "<RelCo>",
@@ -120,8 +121,7 @@
             "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "Review the gene-tree stats for each gene-tree pipeline, and address any issues.",
-            "summary": "Check gene-tree stats",
-            "name_on_graph": "Check gene-tree stats"
+            "summary": "Check gene-tree stats"
          },
          {
             "assignee": "<RelCo>",
@@ -225,8 +225,7 @@
             "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "Review the stats for each MSA pipeline, and address any issues.",
-            "summary": "Check MSA stats",
-            "name_on_graph": "Check MSA stats"
+            "summary": "Check MSA stats"
          },
          {
             "assignee": "<RelCo>",
@@ -240,21 +239,21 @@
              "component": "Production tasks",
              "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+DNA+data#MergetheDNAdata-Patchalignments",
              "summary": "Align the human patches against the primary human assembly",
-             "name_on_graph": "Patches against their primary assembly:Human"
+             "name_on_graph": "LastZ patches:Human"
          },
          {
              "assignee": "<RelCo>",
              "component": "Production tasks",
              "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+DNA+data#MergetheDNAdata-Patchalignments",
              "summary": "Align the mouse patches against the primary mouse assembly",
-             "name_on_graph": "Patches against their primary assembly:Mouse"
+             "name_on_graph": "LastZ patches:Mouse"
          },
          {
              "assignee": "<RelCo>",
              "component": "Production tasks",
              "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+DNA+data#MergetheDNAdata-Patchalignments",
              "summary": "Align the zebrafish patches against the primary zebrafish assembly",
-             "name_on_graph": "Patches against their primary assembly:Zebrafish"
+             "name_on_graph": "LastZ patches:Zebrafish"
          },
          {
             "assignee": "<RelCo>",
@@ -267,8 +266,15 @@
             "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Add+CACTUS+HAL+Alignment+to+Compara",
-            "summary": "Register HAL alignment data",
-            "name_on_graph": "Register HAL alignment data"
+            "summary": "Process Cactus data",
+            "name_on_graph": "Process Cactus data"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
+            "description": "Mark as done when all CACTUS_DB alignments have been merged into the new release database.",
+            "summary": "Merge Cactus data",
+            "name_on_graph": "Merge Cactus data"
          },
          {
             "assignee": "<RelCo>",
@@ -296,34 +302,36 @@
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Creation+of+a+new+release+database",
-            "summary": "Create Release Database"
+            "summary": "Create Release Database",
+            "name_on_graph": "Create Release DB"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+DNA+data",
             "summary": "Merge DNA data",
-            "name_on_graph": "Merge all alignments for WGA Orthology QC"
+            "name_on_graph": "Merge all for OrthWGA"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines#Mergethehomologypipelines-Preliminaries",
             "summary": "Backup release database",
-            "name_on_graph": "Backup the release database before merging the homology data"
+            "name_on_graph": "Backup release DB"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Creation+of+a+new+ancestral+database",
-            "summary": "Build a new ancestral sequence core database"
+            "summary": "Build a new ancestral sequence core database",
+            "name_on_graph": "Build ancestral DB"
          },
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Merge+the+homology+pipelines",
             "summary": "Merge the homology pipelines",
-            "name_on_graph": "Merge the homology pipelines"
+            "name_on_graph": "Merge homologies"
          },
          {
             "assignee": "<RelCo>",

--- a/scripts/jira_tickets/compara_merged.dot
+++ b/scripts/jira_tickets/compara_merged.dot
@@ -1,22 +1,24 @@
 digraph {
     rankdir=LR;  # Left-to-right graph instead of top-to-bottom
-    "Register HAL alignment data";
-    "Patches against their primary assembly";
+    "Process Cactus data" -> "Merge Cactus data";
 
     "Genome dumps" -> { "Species-tree", "LastZ" };
-    "Species-tree" -> { "EPOwithExt", "Protein-trees", "Update MSA", "Mercator Pecan" };
+    "Species-tree" -> { "EPOwithExt", "ncRNA-trees", "Mercator Pecan", "Protein-trees", "Update MSA" };
     "Merge all LastZ" -> "EPOwithExt";
     "Member loading" -> { "Protein-trees", "ncRNA-trees", "Gene-tree reindexing", "Alt-alleles import" };
-    { "EPOwithExt", "Update MSA" } -> "Check MSA stats";
-    { "Merge all LastZ", "Check MSA stats" } -> "Merge all alignments for WGA Orthology QC";
-    "Merge all alignments for WGA Orthology QC" -> "Protein-trees" [fontsize="8", label="Orthologues\nonly"];
-    "Merge all alignments for WGA Orthology QC" -> "ncRNA-trees" [fontsize="8", label="Orthologues\nonly"];
+    { "EPOwithExt", "Merge all LastZ", "Update MSA" } -> "Merge all for OrthWGA";
+    "Merge all for OrthWGA" -> { "Protein-trees", "ncRNA-trees" } [fontsize="8", label="Orthologues\nonly"];
+
+    "Prepare master DB" -> { "Create Release DB", "Genome dumps", "LastZ patches", "Member loading", "Process Cactus data" };
+    "Create Release DB" -> { "Merge all LastZ", "Merge Cactus data" };
+    "EPOwithExt" -> "Build ancestral DB";
+
     "LastZ" -> "Merge all LastZ" -> "Synteny";
 
-    { "Protein-trees", "ncRNA-trees" } -> "Check gene-tree stats";
-    { "Check gene-tree stats", "Gene-tree reindexing", "Alt-alleles import" } -> "Backup the release database before merging the homology data";
-    "Backup the release database before merging the homology data" -> "Merge the homology pipelines";
+    { "Alt-alleles import", "Gene-tree reindexing", "ncRNA-trees", "Protein-trees" } -> "Backup release DB";
+    "Backup release DB" -> "Merge homologies";
 
+    // Shows finer-grained relationships
     "Gene-tree reindexing" -> "ncRNA-trees" [style="dashed", dir=none, fontsize="8", label="XOR"];
     "Gene-tree reindexing" -> "Protein-trees" [style="dashed", dir=none, fontsize="8", label="XOR"];
     "EPOwithExt" -> "EPOwithExt" [style="dashed", fontsize="8", label="Anchor\nmapping\nonly", headport="Primates:e", tailport="Mammals:e"];
@@ -26,5 +28,7 @@ digraph {
     "Update MSA" -> "Mercator Pecan" [style="dashed", dir=none, fontsize="8", label="XOR"];
 
     // Helps laying out the graph
-    {rank = same; "Genome dumps"; "Member loading"; }
+    { rank = same; "Genome dumps"; "Member loading"; "Prepare master DB"; "Species-tree"; }
+    { rank = same; "Alt-alleles import"; "Gene-tree reindexing"; "ncRNA-trees"; "Protein-trees"; }
+    { rank = same; "EPOwithExt"; "Mercator Pecan"; "Update MSA"; }
 }


### PR DESCRIPTION
## Description

The changes in this PR update the Compara release graph to clarify the relationships between production tasks, and have the effect that every task in the graph has at least one dependency relationship to another task.

This PR:
- adds tasks "Prepare master DB", "Create Release DB" and "Build ancestral DB";
- drops tasks "Check gene-tree stats" and "Check MSA stats" from the graph;
- splits "Register HAL alignment data" into "Process Cactus data" (which may represent either registering or loading of a Cactus alignment) and "Merge Cactus data" (which marks the point at which `CACTUS_DB` alignments have been copied/merged to the release database);
- shortens several task names (e.g. "Merge all alignments for WGA Orthology QC" becomes "Merge all for OrthWGA");
- in addition to shortening "Patches against their primary assembly" to "LastZ patches", links this task to "Create Release DB";
- adds some structural changes so that related tasks are grouped together.

This screenshot shows the proposed graph:
![release_graph_update](https://github.com/user-attachments/assets/d09a9d0d-5936-4e24-857c-05129c7176cb)

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
