### PR TITLE
MVP homologies: save reference database version and collection information

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/HomologyAnnotation_conf.pm
@@ -277,6 +277,7 @@ sub core_pipeline_analyses {
                 '2->A' => [ 'diamond_blastp' ],
                 '1->A' => [ 'make_query_blast_db' ],
                 'A->3' => [ 'create_mlss_and_batch_members' ],
+                4 => [ '?accu_name=refcoll_info&accu_address={genome_db_id}&accu_input_variable=refcoll_info' ],
             },
         },
 
@@ -298,7 +299,7 @@ sub core_pipeline_analyses {
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => {
                 '1->A'  => { 'datacheck_factory' => { 'compara_db' => $self->o('compara_db'), %dc_parameters } },
-                'A->1'  => [ 'create_db_factory' ],
+                'A->1'  => [ {'create_db_factory' => INPUT_PLUS()}],
             }
         },
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/BlastFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/BlastFactory.pm
@@ -98,10 +98,9 @@ sub write_output {
     my $gdb_adaptor       = $self->compara_dba->get_GenomeDBAdaptor;
 
     # Connect to the reference database:
-    my $refdb_compara_dba   = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba(  $self->param_required('rr_ref_db') );
+    my $refdb_compara_dba   = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba( $self->param_required('rr_ref_db') );
     my $refdb_meta          = $refdb_compara_dba->get_MetaContainer;
-    $refdb_meta->is_multispecies(1);
-    $refdb_meta->species_id(1);
+    # refdb_version meta entry must have an integer species_id (which is set to 1 by default)
     # Get the reference database version from the meta table:
     my $refdb_version       = $refdb_meta->single_value_by_key('refdb_version');
     if (! defined $refdb_version || $refdb_version eq '') {
@@ -119,7 +118,7 @@ sub write_output {
         my $ref_dump_dir  = $self->param_required('ref_dump_dir');
         # Returns all the directories (fasta, split_fasta & diamond pre-indexed db) under all the references
         my $ref_dirs      = collect_species_set_dirs($self->param_required('rr_ref_db'), $ref_taxa, $ref_dump_dir);
-        my $query_gdb = $gdb_adaptor->fetch_by_dbID($genome_db_id);
+        my $query_gdb     = $gdb_adaptor->fetch_by_dbID($genome_db_id);
 
         $self->dataflow_output_id( { 'genome_db_id' => $genome_db_id, 'ref_taxa' => $ref_taxa }, 1 );
         my $refcoll_info = {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/DumpHomologyStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/DumpHomologyStats.pm
@@ -55,10 +55,9 @@ sub run {
     mkpath($out_dir, 1, oct("755"));
 
     # Connect to per-species compara database:
-    my $compara_dba   = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba(  $self->param_required('per_species_db') );
+    my $compara_dba   = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba( $self->param_required('per_species_db') );
     my $meta          = $compara_dba->get_MetaContainer;
-    $meta->is_multispecies(1);
-    $meta->species_id($self->param_required('genome_db_id'));
+    $meta->species_id(1);
     # Get the reference collection info from the accumulator:
     my $refcoll_info = $self->param_required('refcoll_info')->{$self->param_required('genome_db_id')};
     # Set meta keys for reference database and collection:

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/DumpHomologyStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/DumpHomologyStats.pm
@@ -57,7 +57,6 @@ sub run {
     # Connect to per-species compara database:
     my $compara_dba   = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba( $self->param_required('per_species_db') );
     my $meta          = $compara_dba->get_MetaContainer;
-    $meta->species_id(1);
     # Get the reference collection info from the accumulator:
     my $refcoll_info = $self->param_required('refcoll_info')->{$self->param_required('genome_db_id')};
     # Set meta keys for reference database and collection:

--- a/modules/t/blastFactoryHomologyAnnotation.t
+++ b/modules/t/blastFactoryHomologyAnnotation.t
@@ -50,6 +50,17 @@ my $blast_db_1 = "$ref_dump_dir/homo_sapiens.GRCh38.2019-06.dmnd";
 my $blast_db_2 = "$ref_dump_dir/rattus_norvegicus.RGSC3.4.2009-03-Ensembl.dmnd";
 
 # Expected dataflow output
+my $exp_dataflow_0 = {
+    'genome_db_id' => 135,
+    'refcoll_info' => {
+        'query_assembly' => 'CanFam3.1',
+        'query_genebuild' => '2011-11-Ensembl',
+        'query_prodname' => 'canis_lupus_familiaris',
+        'ref_coll' => 'collection-mammalia',
+        'refdb_version' => 'refdb-test'
+        }
+};
+
 my $exp_dataflow_1 = {
     'genome_db_id' => 135,
     'ref_taxa' => 'collection-mammalia'
@@ -107,6 +118,11 @@ standaloneJob(
     },
     # Output
     [
+        [
+            'DATAFLOW',
+            $exp_dataflow_0,
+            4
+        ],
         [
             'DATAFLOW',
             $exp_dataflow_1,

--- a/modules/t/blastFactoryHomologyAnnotation.t
+++ b/modules/t/blastFactoryHomologyAnnotation.t
@@ -120,13 +120,13 @@ standaloneJob(
     [
         [
             'DATAFLOW',
-            $exp_dataflow_0,
-            4
+            $exp_dataflow_1,
+            1
         ],
         [
             'DATAFLOW',
-            $exp_dataflow_1,
-            1
+            $exp_dataflow_0,
+            4
         ],
         [
             'DATAFLOW',

--- a/scripts/production/homology_stats_rapid.py
+++ b/scripts/production/homology_stats_rapid.py
@@ -156,10 +156,11 @@ def get_meta_value(rr_dbc: Connection, key: str) -> str:
         query = text(
             f"""
                 SELECT meta_value FROM meta
-                WHERE meta_key='{key}';
+                WHERE meta_key=:meta_key;
                 """
         )
-        result = connection.execute(query).fetchone()
+        params = {"meta_key": key}
+        result = connection.execute(query, params).fetchone()
     return result["meta_value"]
 
 
@@ -188,10 +189,7 @@ def main() -> None:
         }
 
     if args.refcoll:
-        json_data["refcoll_info"] = {
-            "refdb_version": get_meta_value(rr_dbc, "refdb_version"),
-            "ref_coll": get_meta_value(rr_dbc, "ref_coll"),
-        }
+        json_data["refcoll_info"] = {k: get_meta_value(rr_dbc, k) for k in ["refdb_version", "ref_coll"]}
 
     with open(args.output, "w", encoding="utf-8") as outfile:
         json.dump(json_data, outfile)

--- a/scripts/production/homology_stats_rapid.py
+++ b/scripts/production/homology_stats_rapid.py
@@ -154,7 +154,7 @@ def get_meta_value(rr_dbc: Connection, key: str) -> str:
     """
     with rr_dbc.connect() as connection:
         query = text(
-            f"""
+            """
                 SELECT meta_value FROM meta
                 WHERE meta_key=:meta_key;
                 """

--- a/src/test_data/databases/test_ref_compara/meta.txt
+++ b/src/test_data/databases/test_ref_compara/meta.txt
@@ -24,3 +24,4 @@
 170	\N	patch	patch_109_110_b.sql|case_insensitive_stable_id_again
 171	\N	patch	patch_109_110_c.sql|ncbi_taxa_name_varchar500
 172	\N	patch	patch_109_110_d.sql|meta_table_updates
+173	1	refdb_version	refdb-test


### PR DESCRIPTION
## Description

This PR ensures that the reference database version and the reference collection information is saved for each query genome, both in the output per-species compara database as meta keys, and in the statistics JSON dump.
This will enable the loading of this information into the metadata database.

**Related JIRA tickets:**
- ENSCOMPARASW-8012

## Overview of changes

#### Change 1
Modified the `BlastFactory` runnable and the pipeline config to save the relevant information into an accumulator.

#### Change 2
Modified the runnable dumping the statistics to JSON to add the relevant meta keys to the per-species compara database.

#### Change 3
Modified the Python script dumping the statistics to include the reference collection information. Also this script was reformatted with updated black settings.

## Testing
The PR was tested by running the pipeline on two species.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
