### PR TITLE
Spruce up Compara FTP dump pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpMultiAlign_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpMultiAlign_conf.pm
@@ -112,6 +112,13 @@ sub hive_meta_table {
     };
 }
 
+sub resource_classes {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::resource_classes('include_multi_threaded')},
+    };
+}
+
 sub pipeline_wide_parameters {
     my ($self) = @_;
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpTrees_conf.pm
@@ -77,7 +77,8 @@ sub default_options {
         'readme_dir'  => $self->check_dir_in_ensembl('ensembl-compara/docs/ftp'),                                      # where the template README files are
 
         'base_dir'    => $self->o('pipeline_dir'),                                                                      # where the final dumps will be stored
-        'hash_dir'    => '#base_dir#/dump_hash/#division#_#basename#',                                                  # where directory hash is created and maintained
+        'tree_hash_dir' => '#base_dir#/dump_hash/#division#_#basename#/trees',                                          # where directory hash is created and maintained
+        'mlss_hash_dir' => '#base_dir#/dump_hash/#division#_#basename#/mlsses',
         'target_dir'  => '#base_dir#/#division#',                                                                       # where the dumps are put (all within subdirectories)
         'xml_dir'     => '#target_dir#/xml/ensembl-compara/homologies/',                                                # where the XML dumps are put
         'emf_dir'     => '#target_dir#/emf/ensembl-compara/homologies/',                                                # where the EMF dumps are put
@@ -95,7 +96,8 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
 
         'base_dir'      => $self->o('base_dir'),
         'target_dir'    => $self->o('target_dir'),
-        'hash_dir'      => $self->o('hash_dir'),
+        'tree_hash_dir' => $self->o('tree_hash_dir'),
+        'mlss_hash_dir' => $self->o('mlss_hash_dir'),
         'xml_dir'       => $self->o('xml_dir'),
         'emf_dir'       => $self->o('emf_dir'),
         'tsv_dir'       => $self->o('tsv_dir'),
@@ -125,6 +127,14 @@ sub hive_meta_table {
 }
 
 
+sub resource_classes {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::resource_classes('include_multi_threaded')},
+    };
+}
+
+
 =head2 pipeline_analyses
 
     Description : Implements pipeline_analyses() interface method of Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf that defines the structure of the pipeline: analyses, jobs, rules, etc.
@@ -149,11 +159,16 @@ sub pipeline_analyses {
     my ($self) = @_;
 
     my $pa = Bio::EnsEMBL::Compara::PipeConfig::Parts::DumpTrees::pipeline_analyses_dump_trees($self);
+
+    # dump_trees_pipeline_start
     $pa->[0]->{'-input_ids'} = [{}];
-    $pa->[1]->{'-parameters'} = {
+
+    # collection_factory
+    $pa->[2]->{'-parameters'} = {
         'column_names'      => [ 'clusterset_id', 'member_type' ],
         'inputlist'         => [ [$self->o('clusterset_id'), $self->o('member_type')] ],
     };
+
     return $pa;
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -114,6 +114,7 @@ sub executable_locations {
         # -> now recorded separately for each meadow, cf meadow_options()
 
         # Internal dependencies (Compara scripts)
+        'add_hmm_lib_exe'                   => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/add_hmm_lib.py'),
         'ancestral_dump_program'            => $self->check_exe_in_ensembl('ensembl-compara/scripts/ancestral_sequences/get_ancestral_sequence.pl'),
         'ancestral_stats_program'           => $self->check_exe_in_ensembl('ensembl-compara/scripts/ancestral_sequences/get_stats.pl'),
         'BuildSynteny_exe'                  => $self->check_file_in_ensembl('ensembl-compara/scripts/synteny/BuildSynteny.jar'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpMultiAlign.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpMultiAlign.pm
@@ -120,11 +120,7 @@ sub pipeline_analyses_dump_multi_align {
             },
             -max_retry_count    => 0,
             -flow_into => {
-              1 => WHEN(
-                '#run_emf2maf#' => [ 'emf2maf' ],
-                '!#run_emf2maf# && !#make_tar_archive#' => [ 'compress_aln' ],
-                # '!#make_tar_archive#' => [ 'compress_aln' ],
-              ),
+              1  => 'emf2maf_decision',
               -1 => 'dumpMultiAlign_himem',
             },
         },
@@ -136,10 +132,13 @@ sub pipeline_analyses_dump_multi_align {
                 'registry' => '#reg_conf#',
             },
             -max_retry_count    => 0,
+            -flow_into => 'emf2maf_decision',
+        },
+        {  -logic_name      => 'emf2maf_decision',
+            -module         => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into => [ WHEN(
                 '#run_emf2maf#' => [ 'emf2maf' ],
                 '!#run_emf2maf# && !#make_tar_archive#' => [ 'compress_aln' ],
-                # '!#make_tar_archive#' => [ 'compress_aln' ],
             ) ],
         },
         {   -logic_name     => 'emf2maf',
@@ -151,9 +150,9 @@ sub pipeline_analyses_dump_multi_align {
         },
         {   -logic_name     => 'compress_aln',
             -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -rc_name        => '1Gb_job',
+            -rc_name        => '1Gb_4c_job',
             -parameters     => {
-                'cmd'           => 'gzip -f -9 #output_file#',
+                'cmd'           => 'pigz -p 4 --force --best #output_file#',
             },
         },
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/AddHMMLib.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/AddHMMLib.pm
@@ -15,21 +15,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::AddHMMLib
 
-=head1 DESCRIPTION
+=head1 DEPRECATION NOTICE
 
-Will add a symlink to the HMM library to the FTP. The library is a
-compressed tar archive that will automatically be generated if missing or
-invalid.
-
-The reference tar archive is given in "ref_tar_path_templ" and the symlink
-will be put under the dir/name given in "tar_ftp_path". If needed, the
-archive will be generated from "hmm_library_basedir".
+This runnable is deprecated, and may be removed in a future release.
 
 =cut
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/ConcatenateTSV.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/ConcatenateTSV.pm
@@ -1,0 +1,118 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::ConcatenateTSV
+
+=head1 DESCRIPTION
+
+This runnable concatenates many TSV files into one,
+keeping the header from the first input TSV file only.
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::ConcatenateTSV;
+
+use strict;
+use warnings;
+
+use File::Basename qw(fileparse);
+use File::Copy qw(move);
+use File::Path qw(make_path);
+use File::Spec::Functions qw(catfile);
+use File::Temp qw(tempdir);
+
+use Bio::EnsEMBL::Compara::Utils::FlatFile qw(check_for_null_characters check_line_counts);
+use Bio::EnsEMBL::Hive::Utils qw(destringify);
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub run {
+    my $self = shift;
+
+    my $input_tsv_files = $self->param_required('tsv_files');
+    $self->warning('tsv_files: ' . JSON->new->pretty->encode($input_tsv_files));
+
+    my ($first_input_tsv_file, @other_input_tsv_files) = grep { defined $_ } @{$input_tsv_files};
+    my $cat_tsv_file_path = $self->param_required('output_file');
+
+    my($cat_tsv_file_name, $cat_tsv_parent_dir) = fileparse($cat_tsv_file_path);
+
+    my $temp_dir = tempdir( CLEANUP => 1, DIR => $self->worker_temp_directory );
+    my $temp_cat_tsv_file_path = catfile($temp_dir, $cat_tsv_file_name);
+
+    my $cmd1 = "cp $first_input_tsv_file $temp_cat_tsv_file_path";
+    $self->run_command($cmd1, { die_on_failure => 1 });
+
+    foreach my $other_input_tsv_file (@other_input_tsv_files) {
+        my $cmd2 = "tail -n +2 $other_input_tsv_file >> $temp_cat_tsv_file_path";
+        $self->run_command($cmd2, { die_on_failure => 1 });
+    }
+
+    $self->param('temp_cat_tsv_file_path', $temp_cat_tsv_file_path);
+    $self->param('cat_tsv_parent_dir', $cat_tsv_parent_dir);
+}
+
+
+sub write_output {
+    my $self = shift;
+
+    my $temp_cat_tsv_file_path = $self->param_required('temp_cat_tsv_file_path');
+    my $cat_tsv_parent_dir = $self->param_required('cat_tsv_parent_dir');
+    my $cat_tsv_file_path = $self->param_required('output_file');
+
+    if ( $self->param_is_defined('healthcheck') || $self->param_is_defined('healthcheck_list') ) {
+        $self->_healthcheck();
+    }
+
+    make_path($cat_tsv_parent_dir);
+    move($temp_cat_tsv_file_path, $cat_tsv_file_path);
+}
+
+
+sub _healthcheck {
+    my $self = shift;
+
+    my $temp_cat_csv_file_path = $self->param('temp_cat_tsv_file_path');
+
+    my $healthcheck_list;
+    if ( $self->param_is_defined('healthcheck') && $self->param_is_defined('healthcheck_list') ) {
+        $self->throw("Only one of parameters 'healthcheck' or 'healthcheck_list' can be defined")
+    } elsif ( $self->param_is_defined('healthcheck') ) {
+        $healthcheck_list = [$self->param('healthcheck')];
+    } elsif ( $self->param_is_defined('healthcheck_list') ) {
+        $healthcheck_list = destringify($self->param('healthcheck_list'));
+    } else {
+        $self->throw("One of parameters 'healthcheck' or 'healthcheck_list' must be defined")
+    }
+
+    foreach my $hc_type (@{$healthcheck_list}) {
+        if ( $hc_type eq 'line_count' ) {
+            my $exp_line_count = $self->param_required('exp_line_count') + 1; # incl header line
+            check_line_counts($temp_cat_csv_file_path, $exp_line_count);
+        } elsif ( $hc_type eq 'unexpected_nulls' ) {
+            check_for_null_characters($temp_cat_csv_file_path);
+        } else {
+            $self->die_no_retry("Healthcheck type '$hc_type' not recognised");
+        }
+    }
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/HomologyGenomeMLSSFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/HomologyGenomeMLSSFactory.pm
@@ -1,0 +1,189 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::HomologyGenomeMLSSFactory
+
+=head1 DESCRIPTION
+
+This runnable generates dataflows for dumping homologies per genome and MLSS.
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::HomologyGenomeMLSSFactory;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub param_defaults {
+    return {
+        'fan_branch_code'    => 3,
+        'funnel_branch_code' => 2,
+    }
+}
+
+
+sub fetch_input {
+    my ($self) = @_;
+
+    my $clusterset_id = $self->param_required('clusterset_id');
+    my $member_type = $self->param_required('member_type');
+    my $member_type_map = $self->param_required('member_type_map');
+
+    my $mlss_dba = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor();
+    my $method_dba = $self->compara_dba->get_MethodAdaptor();
+
+    my $method_type;
+    if ($member_type eq 'protein') {
+        $method_type = 'PROTEIN_TREES';
+    } elsif ($member_type eq 'ncrna') {
+        $method_type = 'NCRNA_TREES';
+    } else {
+        $self->die_no_retry("unknown member_type: $member_type");
+    }
+
+    my $mlss = $mlss_dba->fetch_by_method_link_type_species_set_name($method_type, $clusterset_id);
+    my $collection = $mlss->species_set;
+
+    my @collection_gdbs = grep { !$_->genome_component } @{$collection->genome_dbs};
+    my %gdb_id_to_name = map { $_->dbID => $_->name } @collection_gdbs;
+    my @collection_gdb_ids = sort { $a <=> $b } keys %gdb_id_to_name;
+
+    my $homology_methods = $method_dba->fetch_all_by_class_pattern('^Homology\.homology$');
+    my @homology_method_types = map { $_->type } @{$homology_methods};
+
+    my %gdb_to_hom_mlss_ids;
+    foreach my $method_type (@homology_method_types) {
+        foreach my $i ( 0 .. $#collection_gdb_ids ) {
+            my $gdb1_id = $collection_gdb_ids[$i];
+            foreach my $j ( $i .. $#collection_gdb_ids ) {
+                my $gdb2_id = $collection_gdb_ids[$j];
+
+                my @homology_mlss_gdb_ids;
+                if ($gdb2_id == $gdb1_id) {  # e.g. homoeology MLSS
+                    @homology_mlss_gdb_ids = ($gdb1_id);
+                } else {  # e.g. orthology MLSS
+                    @homology_mlss_gdb_ids = ($gdb1_id, $gdb2_id);
+                }
+
+                my $mlss = $mlss_dba->fetch_by_method_link_type_GenomeDBs($method_type, \@homology_mlss_gdb_ids);
+                next unless defined $mlss and $mlss->is_current;
+                foreach my $gdb_id (@homology_mlss_gdb_ids) {
+                    push(@{$gdb_to_hom_mlss_ids{$gdb_id}}, $mlss->dbID);
+                }
+            }
+        }
+    }
+
+    my @biotype_groups = @{$member_type_map->{$member_type}};
+    my $biotype_group_placeholders = '(' . join(',', ('?') x @biotype_groups) . ')';
+    my $biotype_group_sql_list = "('" . join("','", @biotype_groups) . "')";
+
+    my $helper = $self->compara_dba->dbc->sql_helper;
+
+    my %gdb_mlss_hom_counts;
+    my %gdb_hom_counts;
+    my %cset_hom_counts;
+    foreach my $gdb_id (sort keys %gdb_to_hom_mlss_ids) {
+        my @hom_mlss_ids = @{$gdb_to_hom_mlss_ids{$gdb_id}};
+
+        print STDERR "Querying homologies of genome with dbID $gdb_id ...\n" if $self->debug;
+
+        my $hom_mlss_id_placeholders = '(' . join(',', ('?') x @hom_mlss_ids) . ')';
+
+        my $sql = qq/
+            SELECT
+                method_link_species_set_id,
+                is_high_confidence,
+                COUNT(*)
+            FROM
+                homology h
+            JOIN (
+                homology_member hm1
+                JOIN gene_member gm1 USING (gene_member_id)
+                JOIN genome_db gdb1 USING (genome_db_id)
+                JOIN seq_member sm1 USING (seq_member_id)
+            ) USING (homology_id)
+            JOIN (
+                homology_member hm2
+                JOIN gene_member gm2 USING (gene_member_id)
+                JOIN genome_db gdb2 USING (genome_db_id)
+                JOIN seq_member sm2 USING (seq_member_id)
+            ) USING (homology_id)
+            WHERE
+                method_link_species_set_id IN $hom_mlss_id_placeholders
+                AND hm1.gene_member_id > hm2.gene_member_id
+                AND gm1.biotype_group IN $biotype_group_placeholders
+                AND gm1.genome_db_id = ?
+            GROUP BY
+                method_link_species_set_id,
+                is_high_confidence;
+        /;
+
+        my $params = [@hom_mlss_ids, @biotype_groups, $gdb_id];
+        my $results = $helper->execute( -SQL => $sql, -PARAMS => $params );
+
+        foreach my $result (@{$results}) {
+            my ($hom_mlss_id, $is_high_confidence, $hom_count) = @{$result};
+
+            $gdb_mlss_hom_counts{$gdb_id}{$hom_mlss_id}{'expected_homology_count'} += $hom_count;
+            $gdb_hom_counts{$gdb_id}{'expected_homology_count'} += $hom_count;
+            $cset_hom_counts{'expected_homology_count'} += $hom_count;
+
+            if (defined $is_high_confidence) {
+                $cset_hom_counts{'expected_strict_orthology_count'} += $hom_count * $is_high_confidence;
+                $cset_hom_counts{'expected_orthology_count'} += $hom_count;
+            }
+        }
+    }
+
+    foreach my $gdb_id (sort keys %gdb_to_hom_mlss_ids) {
+        my @hom_mlss_ids = @{$gdb_to_hom_mlss_ids{$gdb_id}};
+
+        my @input_list;
+        foreach my $hom_mlss_id (@hom_mlss_ids) {
+            my $mlss_exp_line_count = $gdb_mlss_hom_counts{$gdb_id}{$hom_mlss_id}{'expected_homology_count'} // 0;
+            push(@input_list, [$hom_mlss_id, $mlss_exp_line_count]);
+        }
+
+        my $gdb_exp_line_count = $gdb_hom_counts{$gdb_id}{'expected_homology_count'} // 0;
+        my %fan_output_id = (
+            'genome_db_id' => $gdb_id,
+            'species_name' => $gdb_id_to_name{$gdb_id},
+            'biotype_group_list' => $biotype_group_sql_list,
+            'genome_exp_line_count' => $gdb_exp_line_count,
+            'column_names' => ['hom_mlss_id', 'exp_line_count'],
+            'inputlist' => \@input_list,
+        );
+
+        $self->dataflow_output_id(\%fan_output_id, $self->param('fan_branch_code'));
+    }
+
+    my %funnel_output_id = (
+        'exp_ortho_count' => $cset_hom_counts{'expected_orthology_count'},
+        'exp_strict_ortho_count' => $cset_hom_counts{'expected_strict_orthology_count'},
+        'clusterset_exp_line_count' => $cset_hom_counts{'expected_homology_count'},
+    );
+    $self->dataflow_output_id(\%funnel_output_id, $self->param('funnel_branch_code'));
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/MapMemberTypes.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/MapMemberTypes.pm
@@ -1,0 +1,92 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::MapMemberTypes
+
+=head1 DESCRIPTION
+
+This runnable generates mapping of gene-tree member type to gene member biotype
+groups, checking that there is no overlap between the sets of biotype groups.
+
+=cut
+
+
+package Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::MapMemberTypes;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub run {
+    my $self = shift;
+
+    my $helper = $self->compara_dba->dbc->sql_helper;
+
+    my $sql = q/
+        SELECT DISTINCT
+            member_type,
+            biotype_group
+        FROM
+            gene_member gm
+        JOIN
+            seq_member sm ON sm.seq_member_id = gm.canonical_member_id
+        JOIN
+            gene_tree_node gtn ON gtn.seq_member_id = sm.seq_member_id
+        JOIN
+            gene_tree_root gtr ON gtn.root_id = gtr.root_id
+        WHERE
+            gtr.ref_root_id IS NULL
+    /;
+
+    my $results = $helper->execute( -SQL => $sql, -USE_HASHREFS => 1 );
+
+    my %member_type_map;
+    my %biotype_group_counts;
+    foreach my $result (@{$results}) {
+        my $member_type = $result->{'member_type'};
+        my $biotype_group = $result->{'biotype_group'};
+        push(@{$member_type_map{$member_type}}, $biotype_group);
+        $biotype_group_counts{$biotype_group} += 1;
+    }
+
+    my @overlapping_biotype_groups = grep { $biotype_group_counts{$_} > 1 } keys %biotype_group_counts;
+
+    if (@overlapping_biotype_groups) {
+        $self->die_no_retry(
+            sprintf(
+                "gene trees of different member types have overlapping biotype groups: %s",
+                join(',', @overlapping_biotype_groups),
+            )
+        );
+    }
+
+    $self->param('member_type_map', \%member_type_map);
+}
+
+
+sub write_output {
+    my $self = shift;
+
+    $self->dataflow_output_id({'member_type_map' => $self->param('member_type_map')}, 2);
+}
+
+
+1;

--- a/scripts/pipeline/add_hmm_lib.py
+++ b/scripts/pipeline/add_hmm_lib.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Add HMM library archive to flat-file dump."""
+
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import shutil
+from tempfile import TemporaryDirectory
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--curr_ftp_dump_root",
+        required=True,
+        help="Main dump root directory of the current Ensembl release.",
+    )
+    parser.add_argument(
+        "--prev_ftp_dump_root",
+        required=True,
+        help="Main dump root directory of previous Ensembl release.",
+    )
+    parser.add_argument(
+        "--curr_ftp_pub_root",
+        required=True,
+        help="FTP publication root directory of current release.",
+    )
+    parser.add_argument(
+        "--prev_ftp_pub_root",
+        required=True,
+        help="FTP publication root directory of previous release.",
+    )
+    parser.add_argument(
+        "--hmm_library_basedir",
+        required=True,
+        help="Path of HMM library base directory.",
+    )
+    parser.add_argument(
+        "--ref_tar_path_templ",
+        required=True,
+        help="Template of reference HMM library tar archive path.",
+    )
+    parser.add_argument(
+        "--tar_dir_path",
+        required=True,
+        help="Path of directory containing archive, relative to the main dump root directory.",
+    )
+    args = parser.parse_args()
+
+    curr_ftp_dump_root = Path(args.curr_ftp_dump_root)
+    prev_ftp_dump_root = Path(args.prev_ftp_dump_root)
+    curr_ftp_pub_root = Path(args.curr_ftp_pub_root)
+    prev_ftp_pub_root = Path(args.prev_ftp_pub_root)
+    hmm_library_basedir = Path(args.hmm_library_basedir)
+    tar_dir_path = Path(args.tar_dir_path)
+
+    library_name = hmm_library_basedir.name
+    ref_tar_path = Path(args.ref_tar_path_templ % library_name)
+    ref_tar_md5sum_path = ref_tar_path.with_suffix(".gz.md5sum")
+
+    if not curr_ftp_dump_root.is_absolute():
+        raise ValueError(
+            f"value of --curr_ftp_dump_root must be an absolute path,"
+            f" but appears to be relative: {str(curr_ftp_dump_root)!r}"
+        )
+    if not prev_ftp_dump_root.is_absolute():
+        raise ValueError(
+            f"value of --prev_ftp_dump_root must be an absolute path,"
+            f" but appears to be relative: {str(prev_ftp_dump_root)!r}"
+        )
+    if not curr_ftp_pub_root.is_absolute():
+        raise ValueError(
+            f"value of --curr_ftp_pub_root must be an absolute path,"
+            f" but appears to be relative: {str(curr_ftp_pub_root)!r}"
+        )
+    if not prev_ftp_pub_root.is_absolute():
+        raise ValueError(
+            f"value of --prev_ftp_pub_root must be an absolute path,"
+            f" but appears to be relative: {str(prev_ftp_pub_root)!r}"
+        )
+    if tar_dir_path.is_absolute():
+        raise ValueError(
+            f"value of --tar_dir_path must be a relative path,"
+            f" but appears to be absolute: {str(tar_dir_path)!r}"
+        )
+
+    with TemporaryDirectory() as tmp_dir:
+        tmp_dir_path = Path(tmp_dir)
+
+        tar_file_confirmed_ok = False
+        if ref_tar_path.is_file():
+
+            md5sum_check_cmds = ["md5sum", "--check", ref_tar_md5sum_path]
+            try:
+                output = subprocess.check_output(
+                    md5sum_check_cmds, cwd=ref_tar_md5sum_path.parent, encoding="utf-8", text=True
+                )
+            except subprocess.CalledProcessError:
+                pass
+            else:
+                output = output.rstrip()
+                if output == f"{ref_tar_path.name}: OK":
+                    tar_file_confirmed_ok = True
+
+        if not tar_file_confirmed_ok:
+            tmp_ref_tar_path = tmp_dir_path / ref_tar_path.name
+            tmp_ref_tar_md5sum_path = tmp_dir_path / f"{ref_tar_path.name}.md5sum"
+
+            tar_czf_cmd_args = [
+                "tar",
+                "czf",
+                str(tmp_ref_tar_path),
+                "-C",
+                str(hmm_library_basedir.parent),
+                library_name,
+            ]
+            subprocess.run(tar_czf_cmd_args, check=True)
+
+            gzip_test_cmd_args = [
+                "gzip",
+                "--test",
+                str(tmp_ref_tar_path),
+            ]
+            subprocess.run(gzip_test_cmd_args, check=True)
+
+            md5sum_gen_cmds = [
+                "md5sum",
+                tmp_ref_tar_path.name,
+            ]
+            with open(tmp_ref_tar_md5sum_path, mode="w", encoding="utf-8") as out_file_obj:
+                subprocess.run(
+                    md5sum_gen_cmds, stdout=out_file_obj, cwd=tmp_dir_path, encoding="utf-8", check=True
+                )
+
+            shutil.move(tmp_ref_tar_path, ref_tar_path)
+            shutil.move(tmp_ref_tar_md5sum_path, ref_tar_md5sum_path)
+
+    prev_compara_dir_path = prev_ftp_dump_root / tar_dir_path
+    prev_hmm_tar_file_path = None
+
+    if prev_compara_dir_path.is_dir():
+        path_spec = "multi_division_hmm_lib*.tar.gz"
+        prev_hmm_tar_file_paths = list(prev_compara_dir_path.glob(path_spec))
+
+        if len(prev_hmm_tar_file_paths) == 1:
+            prev_hmm_tar_file_path = prev_hmm_tar_file_paths[0]
+        elif len(prev_hmm_tar_file_paths) > 1:
+            raise RuntimeError(
+                f"path spec {path_spec!r} matches multiple archive"
+                f" files in directory {str(prev_compara_dir_path)!r}"
+            )
+
+    curr_compara_dir_path = curr_ftp_dump_root / tar_dir_path
+    curr_hmm_tar_file_path = curr_compara_dir_path / ref_tar_path.name
+    os.makedirs(curr_compara_dir_path, mode=0o775, exist_ok=True)
+
+    if prev_hmm_tar_file_path and (
+        ref_tar_path.name == prev_hmm_tar_file_path.name
+        # HMM lib files will retain the library name from e114 onwards,
+        # so from e115, it should be safe to delete the following line.
+        or prev_hmm_tar_file_path.name == "multi_division_hmm_lib.tar.gz"
+    ):
+        compara_dir_to_root_path = os.path.relpath(curr_ftp_dump_root, start=curr_compara_dir_path)
+        curr_to_prev_root_path = Path(os.path.relpath(prev_ftp_pub_root, start=curr_ftp_pub_root))
+
+        new_symlink_target = (
+            compara_dir_to_root_path / curr_to_prev_root_path / tar_dir_path / prev_hmm_tar_file_path.name
+        )
+
+        if prev_hmm_tar_file_path.is_symlink():
+            prev_symlink_target = Path(os.readlink(prev_hmm_tar_file_path))
+            if not prev_symlink_target.is_absolute():
+                new_symlink_target = Path(os.path.normpath(new_symlink_target.parent / prev_symlink_target))
+
+        with TemporaryDirectory(dir=curr_compara_dir_path, prefix=".symlink_tmp_") as tmp_dir:
+            tmp_hmm_tar_file_path = os.path.join(tmp_dir, curr_hmm_tar_file_path.name)
+            os.symlink(new_symlink_target, tmp_hmm_tar_file_path)
+            shutil.move(tmp_hmm_tar_file_path, curr_hmm_tar_file_path)
+
+    else:
+        shutil.copyfile(ref_tar_path, curr_hmm_tar_file_path)

--- a/scripts/pipeline/add_hmm_lib.py
+++ b/scripts/pipeline/add_hmm_lib.py
@@ -104,10 +104,10 @@ if __name__ == "__main__":
         tar_file_confirmed_ok = False
         if ref_tar_path.is_file():
 
-            md5sum_check_cmds = ["md5sum", "--check", ref_tar_md5sum_path]
+            md5sum_check_cmd_args = ["md5sum", "--check", str(ref_tar_md5sum_path)]
             try:
                 output = subprocess.check_output(
-                    md5sum_check_cmds, cwd=ref_tar_md5sum_path.parent, encoding="utf-8", text=True
+                    md5sum_check_cmd_args, cwd=ref_tar_md5sum_path.parent, encoding="utf-8", text=True
                 )
             except subprocess.CalledProcessError:
                 pass
@@ -137,13 +137,13 @@ if __name__ == "__main__":
             ]
             subprocess.run(gzip_test_cmd_args, check=True)
 
-            md5sum_gen_cmds = [
+            md5sum_gen_cmd_args = [
                 "md5sum",
                 tmp_ref_tar_path.name,
             ]
             with open(tmp_ref_tar_md5sum_path, mode="w", encoding="utf-8") as out_file_obj:
                 subprocess.run(
-                    md5sum_gen_cmds, stdout=out_file_obj, cwd=tmp_dir_path, encoding="utf-8", check=True
+                    md5sum_gen_cmd_args, stdout=out_file_obj, cwd=tmp_dir_path, encoding="utf-8", check=True
                 )
 
             shutil.move(tmp_ref_tar_path, ref_tar_path)

--- a/scripts/pipeline/add_hmm_lib.py
+++ b/scripts/pipeline/add_hmm_lib.py
@@ -169,7 +169,7 @@ if __name__ == "__main__":
     os.makedirs(curr_compara_dir_path, mode=0o775, exist_ok=True)
 
     if prev_hmm_tar_file_path and (
-        ref_tar_path.name == prev_hmm_tar_file_path.name
+        ref_tar_path.name == prev_hmm_tar_file_path.name  # pylint: disable=consider-using-in
         # HMM lib files will retain the library name from e114 onwards,
         # so from e115, it should be safe to delete the following line.
         or prev_hmm_tar_file_path.name == "multi_division_hmm_lib.tar.gz"


### PR DESCRIPTION
## Description

This PR makes several tweaks to the Compara FTP dump pipeline.

**Related JIRA tickets:**
- ENSCOMPARASW-7051
- ENSCOMPARASW-7980
- ENSCOMPARASW-8027

## Overview of changes

- Each gene-tree collection's homologies are dumped per MLSS, then concatenated per genome and collection. This results in the inclusion of homologies in the 'overlap' between gene-tree collections (e.g. Drosophila melanogaster paralogues in the Drosophila pangenome). It also results in greater compression of the homology dump files, and smaller homology dump files on average.
- Further file size reductions are achieved in the `DumpTrees` and `DumpMultiAlign` pipeline parts, by compressing files using `pigz` with the `--best` compression option.
- The `AddHMMLib` runnable is replaced by the script `add_hmm_lib.py`, which 1) verifies the HMM lib archive against a checksum, regenerating the HMM lib archive if necessary; and 2) generates a symlink if the HMM lib archive is unchanged since the previous release. 
- A stable-ID clash bug is fixed in `HomologiesTSVToOrthoXML`.
- In `DumpAllForRelease`, the `dump_for_uniprot` analysis is run only in Vertebrates. This enables the `remove_uniprot_file` pipeline step to be removed.
- A `file_fate_decision` step is added to simplify the `DumpTrees` pipeline part.
- An `emf2maf_decision` step is added to simplify the `DumpMultiAlign` pipeline part.

## Testing
See related ticket [ENSCOMPARASW-8027](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-8027) for more info on testing.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
