### PR TITLE
Suppress overlap species warnings in production registries

### DIFF
--- a/conf/fungi/production_reg_conf.pl
+++ b/conf/fungi/production_reg_conf.pl
@@ -36,6 +36,10 @@ my $prev_release = $curr_release - 1;
 my $curr_eg_release = $ENV{'CURR_EG_RELEASE'};
 my $prev_eg_release = $curr_eg_release - 1;
 
+# Species found on both vertebrates and non-vertebrates servers
+my @overlap_species = qw(saccharomyces_cerevisiae drosophila_melanogaster caenorhabditis_elegans);
+Bio::EnsEMBL::Compara::Utils::Registry::suppress_overlap_species_warnings(\@overlap_species);
+
 # ---------------------- DATABASE HOSTS -----------------------------------------
 
 my ($curr_nv_host, $curr_nv_port) = $curr_release % 2 == 0
@@ -67,7 +71,6 @@ my @collection_groups = qw(
 Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertannot-staging:4573/$curr_release");
 
 # Ensure we're using the correct cores for species that overlap with other divisions
-my @overlap_species = qw(saccharomyces_cerevisiae);
 Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species);
 my $overlap_cores = {
     'saccharomyces_cerevisiae' => [ 'mysql-ens-vertannot-staging', "saccharomyces_cerevisiae_core_${curr_eg_release}_${curr_release}_4" ],

--- a/conf/pan/production_reg_conf.pl
+++ b/conf/pan/production_reg_conf.pl
@@ -37,6 +37,7 @@ my $prev_eg_release = $curr_eg_release - 1;
 
 # Species found on both vertebrates and non-vertebrates servers
 my @overlap_species = qw(saccharomyces_cerevisiae drosophila_melanogaster caenorhabditis_elegans);
+Bio::EnsEMBL::Compara::Utils::Registry::suppress_overlap_species_warnings(\@overlap_species);
 
 # ---------------------- DATABASE HOSTS -----------------------------------------
 

--- a/conf/plants/production_reg_conf.pl
+++ b/conf/plants/production_reg_conf.pl
@@ -37,6 +37,7 @@ my $prev_eg_release = $curr_eg_release - 1;
 
 # Species found on both vertebrates and non-vertebrates servers
 my @overlap_species = qw(saccharomyces_cerevisiae drosophila_melanogaster caenorhabditis_elegans);
+Bio::EnsEMBL::Compara::Utils::Registry::suppress_overlap_species_warnings(\@overlap_species);
 
 # ---------------------- DATABASE HOSTS -----------------------------------------
 

--- a/conf/protists/production_reg_conf.pl
+++ b/conf/protists/production_reg_conf.pl
@@ -35,6 +35,10 @@ my $prev_release = $curr_release - 1;
 my $curr_eg_release = $ENV{'CURR_EG_RELEASE'};
 my $prev_eg_release = $curr_eg_release - 1;
 
+# Species found on both vertebrates and non-vertebrates servers
+my @overlap_species = qw(saccharomyces_cerevisiae drosophila_melanogaster caenorhabditis_elegans);
+Bio::EnsEMBL::Compara::Utils::Registry::suppress_overlap_species_warnings(\@overlap_species);
+
 # ---------------------- DATABASE HOSTS -----------------------------------------
 
 my ($curr_nv_host, $curr_nv_port) = $curr_release % 2 == 0

--- a/conf/vertebrates/production_reg_conf.pl
+++ b/conf/vertebrates/production_reg_conf.pl
@@ -33,6 +33,10 @@ use Bio::EnsEMBL::Compara::Utils::Registry;
 my $curr_release = $ENV{'CURR_ENSEMBL_RELEASE'};
 my $prev_release = $curr_release - 1;
 
+# Species found on both vertebrates and non-vertebrates servers
+my @overlap_species = qw(caenorhabditis_elegans drosophila_melanogaster saccharomyces_cerevisiae);
+Bio::EnsEMBL::Compara::Utils::Registry::suppress_overlap_species_warnings(\@overlap_species);
+
 # ---------------------- DATABASE HOSTS -----------------------------------------
 
 my ($curr_vert_host, $curr_vert_port) = $curr_release % 2 == 0
@@ -50,7 +54,6 @@ my ($prev_vert_host, $prev_vert_port) = $prev_release % 2 == 0
 Bio::EnsEMBL::Registry->load_registry_from_url("mysql://ensro\@mysql-ens-vertannot-staging:4573/$curr_release");
 
 # Ensure we're using the correct cores for species that overlap with other divisions
-my @overlap_species = qw(drosophila_melanogaster caenorhabditis_elegans saccharomyces_cerevisiae);
 Bio::EnsEMBL::Compara::Utils::Registry::remove_species(\@overlap_species);
 my $overlap_cores = {
     'drosophila_melanogaster' => [ 'mysql-ens-vertannot-staging', "drosophila_melanogaster_core_" . $curr_release . "_11" ],

--- a/modules/Bio/EnsEMBL/Compara/Utils/Registry.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/Registry.pm
@@ -180,6 +180,22 @@ sub remove_multi {
     }
 }
 
+=head2 suppress_overlap_species_warnings
+
+  Example     : Bio::EnsEMBL::Compara::Utils::Registry::suppress_overlap_species_warnings();
+  Description : Can be used to suppress registry warnings for species in multiple divisions
+  Returntype  : none
+  Exceptions  : none
+
+=cut
+
+sub suppress_overlap_species_warnings {
+    my $overlap_species_names = shift;
+    my $overlap_subpattern = '(' . join('|', @{$overlap_species_names}) . ')';
+    my $overlap_regex = qr/WARN: Species \(${overlap_subpattern}\) and group \(core\) same for two seperate databases/;
+    $SIG{'__WARN__'} = sub { warn $_[0] unless $_[0] =~ $overlap_regex; }
+}
+
 
 =head2 add_core_dbas
 


### PR DESCRIPTION
## Description

This PR would:
- add a `suppress_overlap_species_warnings` function to the `Bio::EnsEMBL::Compara::Utils::Registry` module;
- call this function in every Compara production registry.

This has the effect of suppressing warnings that occur when known 'overlap' species (`drosophila_melanogaster`, `caenorhabditis_elegans`, `saccharomyces_cerevisiae`) are represented by multiple core databases. In current Compara registries, these overlap cores are configured in such a way that the appropriate core is available, so the warnings can be safely ignored in this particular context.

For example:
```
WARN: Species saccharomyces_cerevisiae and group (core) same for two seperate databases
```

## Testing

All the updated registries were executed on the command line to check that the relevant warnings were suppressed.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
