### PR TITLE
Add method to get homology TSV dump species path

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomeDB.pm
@@ -891,4 +891,30 @@ sub get_faidx_helper {
 }
 
 
+=head2 _get_ftp_dump_relative_path
+
+  Example     : my $genome_rel_path = $genome_db->_get_ftp_dump_relative_path();
+  Description : Returns the expected directory path for FTP dumps of data files for
+                this genome, relative to the homology TSV dump base directory.
+                This internal method is intended to be consistent with Production FTP dump code:
+                https://github.com/Ensembl/ensembl-production/blob/c945a38/modules/Bio/EnsEMBL/Production/Pipeline/Common/Base.pm#L198
+  Returntype  : String
+  Exceptions  : none
+
+=cut
+
+sub _get_ftp_dump_relative_path {
+    my ($self) = @_;
+
+    my $rel_path = $self->name;
+    my $core_dba = $self->db_adaptor;
+    if ($core_dba->is_multispecies()) {
+        if ($core_dba->dbc->dbname() =~ /^(?<collection_core_prefix>.+)\_core\_/) {
+            $rel_path = $+{'collection_core_prefix'} . '/' . $rel_path;
+        }
+    }
+
+    return $rel_path;
+}
+
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
@@ -221,7 +221,7 @@ sub pipeline_analyses_dump_trees {
         {   -logic_name => 'concatenate_mlss_homologies_tsv',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::ConcatenateTSV',
             -parameters => {
-                'output_file' => '#tsv_dir#/#species_name#/#name_root#.homologies.tsv',
+                'output_file' => '#tsv_dir#/#species_path#/#name_root#.homologies.tsv',
                 'healthcheck_list' => ['line_count', 'unexpected_nulls'],
                 'exp_line_count' => '#genome_exp_line_count#',
             },

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/HomologyGenomeMLSSFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/HomologyGenomeMLSSFactory.pm
@@ -64,8 +64,15 @@ sub run {
     my $collection = $mlss->species_set;
 
     my @collection_gdbs = grep { !$_->genome_component } @{$collection->genome_dbs};
-    my %gdb_id_to_name = map { $_->dbID => $_->name } @collection_gdbs;
-    my @collection_gdb_ids = sort { $a <=> $b } keys %gdb_id_to_name;
+
+    my %gdb_info;
+    foreach my $gdb (@collection_gdbs) {
+        $gdb_info{$gdb->dbID} = {
+            'species_name' => $gdb->name,
+            'species_path' => $gdb->_get_ftp_dump_relative_path(),
+        };
+    }
+    my @collection_gdb_ids = sort { $a <=> $b } keys %gdb_info;
 
     my $homology_methods = $method_dba->fetch_all_by_class_pattern('^Homology\.homology$');
     my @homology_method_types = map { $_->type } @{$homology_methods};
@@ -166,7 +173,8 @@ sub run {
         my $gdb_exp_line_count = $gdb_hom_counts{$gdb_id}{'expected_homology_count'} // 0;
         my %fan_output_id = (
             'genome_db_id' => $gdb_id,
-            'species_name' => $gdb_id_to_name{$gdb_id},
+            'species_name' => $gdb_info{$gdb_id}{'species_name'},
+            'species_path' => $gdb_info{$gdb_id}{'species_path'},
             'biotype_group_list' => $biotype_group_sql_list,
             'genome_exp_line_count' => $gdb_exp_line_count,
             'column_names' => ['hom_mlss_id', 'exp_line_count'],

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/DumpHomologiesTSV.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/DumpHomologiesTSV.pm
@@ -101,11 +101,8 @@ sub fetch_input {
 
     if (my $genome_db_id = $self->param('genome_db_id')) {
         my $genome_db   = $compara_dba->get_GenomeDBAdaptor->fetch_by_dbID($genome_db_id);
-        my $name        = $genome_db->name;
+        my $name        = $genome_db->_get_ftp_dump_relative_path();
 
-        if ($genome_db->db_adaptor->is_multispecies()) {
-            $name = $1.'/'.$name if $genome_db->db_adaptor->dbc->dbname() =~ /(.+)\_core/;
-        }
         $self->param('species_name', $name);
         $self->param('extra_filter', 'AND gm1.genome_db_id = '.$genome_db_id);
     } elsif ( my $mlss_id = $self->param('mlss_id') ) {


### PR DESCRIPTION
## Description

This PR fixes an issue introduced by [ensembl-compara PR 880](https://github.com/Ensembl/ensembl-compara/pull/880), whereby all per-species homology TSV dump files are being generated in a directory directly within the homology TSV dump base directory. This is inconsistent with the expected behaviour, whereby genomes in collection core databases are grouped together in a subdirectory.

It also centralises generation of homology dump TSV paths, and makes it more explicit that per-genome homology TSV dump paths may have more than one directory.

## Testing
This update has been tested in a run of the Compara FTP pipeline.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
