### PR TITLE
Adding triticum aestivum v2 to allowed species PR

### DIFF
--- a/conf/plants/allowed_species.json
+++ b/conf/plants/allowed_species.json
@@ -131,6 +131,7 @@
     "triticum_aestivum_mattis",
     "triticum_aestivum_norin61",
     "triticum_aestivum_paragon",
+    "triticum_aestivum_refseqv2",
     "triticum_aestivum_renan",
     "triticum_aestivum_stanley",
     "triticum_dicoccoides",


### PR DESCRIPTION
## Updating allowed species PR

It was decided to use triticum_aestivum_refseqv2 as an outgroup for barley pangenome. This is a newer version so needs to be added to the allowed species PR. 

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
