### PR TITLE
Patching core test databases for release 116

### DIFF
--- a/src/test_data/databases/core/felis_catus/meta.txt
+++ b/src/test_data/databases/core/felis_catus/meta.txt
@@ -1,4 +1,4 @@
-1	\N	schema_version	114
+1	\N	schema_version	115
 2	\N	patch	patch_38_39_a.sql|status_enum
 3	\N	patch	patch_38_39_b.sql|unique_assembly
 4	\N	patch	patch_38_39_c.sql|multiversion_objects
@@ -320,3 +320,4 @@
 1504	\N	patch	patch_112_113_a.sql|schema_version
 1505	\N	patch	patch_112_113_b.sql|Ensure meta_value is not null
 1506	\N	patch	patch_113_114_a.sql|schema_version
+1507	\N	patch	patch_114_115_a.sql|schema_version

--- a/src/test_data/databases/core/felis_catus/table.sql
+++ b/src/test_data/databases/core/felis_catus/table.sql
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=1507 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=1508 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,

--- a/src/test_data/databases/core/homo_sapiens/meta.txt
+++ b/src/test_data/databases/core/homo_sapiens/meta.txt
@@ -1,5 +1,5 @@
 1717	1	xref.timestamp	2012-06-20 23:23:29
-1	\N	schema_version	114
+1	\N	schema_version	115
 2	\N	patch	patch_52_53_a.sql|schema_version
 3	\N	patch	patch_52_53_b.sql|external_db_type_enum
 4	\N	patch	patch_52_53_c.sql|identity_xref_rename
@@ -270,3 +270,4 @@
 1826	\N	patch	patch_112_113_a.sql|schema_version
 1827	\N	patch	patch_112_113_b.sql|Ensure meta_value is not null
 1828	\N	patch	patch_113_114_a.sql|schema_version
+1829	\N	patch	patch_114_115_a.sql|schema_version

--- a/src/test_data/databases/core/homo_sapiens/table.sql
+++ b/src/test_data/databases/core/homo_sapiens/table.sql
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=1829 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=1830 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,

--- a/src/test_data/databases/core/mus_musculus/meta.txt
+++ b/src/test_data/databases/core/mus_musculus/meta.txt
@@ -1,5 +1,5 @@
 1	\N	schema_type	core
-2	\N	schema_version	114
+2	\N	schema_version	115
 3	\N	patch	patch_65_66_a.sql|schema_version
 4	\N	patch	patch_65_66_b.sql|fix_external_db_id
 5	\N	patch	patch_65_66_c.sql|reorder_unmapped_obj_index
@@ -211,3 +211,4 @@
 668	\N	patch	patch_112_113_a.sql|schema_version
 669	\N	patch	patch_112_113_b.sql|Ensure meta_value is not null
 670	\N	patch	patch_113_114_a.sql|schema_version
+671	\N	patch	patch_114_115_a.sql|schema_version

--- a/src/test_data/databases/core/mus_musculus/table.sql
+++ b/src/test_data/databases/core/mus_musculus/table.sql
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=671 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=672 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,

--- a/src/test_data/databases/core/pan_troglodytes/meta.txt
+++ b/src/test_data/databases/core/pan_troglodytes/meta.txt
@@ -1,5 +1,5 @@
 1	\N	schema_type	core
-2	\N	schema_version	114
+2	\N	schema_version	115
 3	\N	patch	patch_61_62_a.sql|schema_version
 4	\N	patch	patch_61_62_b.sql|synonym_field_extension
 5	\N	patch	patch_61_62_c.sql|db_name_db_release_idx
@@ -222,3 +222,4 @@
 763	\N	patch	patch_112_113_a.sql|schema_version
 764	\N	patch	patch_112_113_b.sql|Ensure meta_value is not null
 765	\N	patch	patch_113_114_a.sql|schema_version
+766	\N	patch	patch_114_115_a.sql|schema_version

--- a/src/test_data/databases/core/pan_troglodytes/table.sql
+++ b/src/test_data/databases/core/pan_troglodytes/table.sql
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=766 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=767 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,

--- a/src/test_data/databases/core/triticum_aestivum/meta.txt
+++ b/src/test_data/databases/core/triticum_aestivum/meta.txt
@@ -1,5 +1,5 @@
 1	\N	schema_type	core
-2	\N	schema_version	114
+2	\N	schema_version	115
 3	\N	patch	patch_68_69_a.sql|schema_version
 4	1	species.taxonomy_id	4565
 6	1	species.alias	bread wheat
@@ -186,3 +186,4 @@
 268	\N	patch	patch_112_113_a.sql|schema_version
 269	\N	patch	patch_112_113_b.sql|Ensure meta_value is not null
 270	\N	patch	patch_113_114_a.sql|schema_version
+271	\N	patch	patch_114_115_a.sql|schema_version

--- a/src/test_data/databases/core/triticum_aestivum/table.sql
+++ b/src/test_data/databases/core/triticum_aestivum/table.sql
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=271 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=272 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,


### PR DESCRIPTION
Patching the core test databases with schema version 115.
---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
