### PR TITLE
Prep config tests for Plants BioMart species list

### DIFF
--- a/conf/plants/metaconfig.json
+++ b/conf/plants/metaconfig.json
@@ -1,5 +1,5 @@
 {
     "biomart": {
-        "species_cap": 275
+        "species_cap": 230
     }
 }

--- a/conf/plants/metaconfig.json
+++ b/conf/plants/metaconfig.json
@@ -1,0 +1,5 @@
+{
+    "biomart": {
+        "species_cap": 275
+    }
+}


### PR DESCRIPTION
## Description

This PR:
- adds a Plants `metaconfig.json` file with a proposed BioMart species cap of <s>275</s> 230;
- updates the species-count calculation so that polyploid genomes are weighted by the number of subgenome components, excluding their U-component (e.g. `triticum_aestivum` is counted as having 3 genomes).

Because the updated species-count calculation uses the allowed- and additional-species lists as well as the Plants species topology, automated validation of the BioMart species list depends on the other species-config files being up to date.

## Testing

The updated `division_config.t` has been tested locally.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
