### PR TITLE
Add prefer_for_genomes attribute, update tags in MLSS update

### DIFF
--- a/conf/plants/mlss_conf.xml
+++ b/conf/plants/mlss_conf.xml
@@ -447,9 +447,15 @@
 
   <gene_trees>
     <protein_trees collection="default"/>
-    <protein_trees collection="wheat_cultivars"/>
+    <protein_trees
+      collection="wheat_cultivars"
+      prefer_for_genomes="secale_cereale triticum_aestivum"
+    />
     <protein_trees collection="rice_cultivars"/>
-    <protein_trees collection="barley_cultivars"/>
+    <protein_trees
+      collection="barley_cultivars"
+      prefer_for_genomes="hordeum_vulgare"
+    />
   </gene_trees>
 
   <species_trees>

--- a/scripts/pipeline/compara_db_config.rng
+++ b/scripts/pipeline/compara_db_config.rng
@@ -302,9 +302,17 @@
             <choice>
               <element name="protein_trees" blockly:blockName="Protein-trees">
                 <attribute name="collection" blockly:blockName="Collection name"/>
+                <optional>
+                  <attribute name="prefer_for_genomes"
+                             blockly:blockName="If we must choose, this is the preferred strain collection for the given space-delimited list of genomes."/>
+                </optional>
               </element>
               <element name="nc_trees" blockly:blockName="ncRNA-trees">
                 <attribute name="collection" blockly:blockName="Collection name"/>
+                <optional>
+                  <attribute name="prefer_for_genomes"
+                             blockly:blockName="If we must choose, this is the preferred strain collection for the given space-delimited list of genomes."/>
+                </optional>
               </element>
             </choice>
           </oneOrMore>

--- a/scripts/pipeline/compara_db_config.rng
+++ b/scripts/pipeline/compara_db_config.rng
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<grammar xmlns="http://relaxng.org/ns/structure/1.0" xmlns:blockly="http://blockly.com/">
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes" xmlns:blockly="http://blockly.com/">
   <define name="new_species_set">
     <oneOrMore>
       <choice>
@@ -304,14 +304,26 @@
                 <attribute name="collection" blockly:blockName="Collection name"/>
                 <optional>
                   <attribute name="prefer_for_genomes"
-                             blockly:blockName="If we must choose, this is the preferred strain collection for the given space-delimited list of genomes."/>
+                             blockly:blockName="If we must choose, this is the preferred strain collection for the given space-delimited list of genomes.">
+                    <list>
+                      <oneOrMore>
+                        <data type="string"/>
+                      </oneOrMore>
+                    </list>
+                  </attribute>
                 </optional>
               </element>
               <element name="nc_trees" blockly:blockName="ncRNA-trees">
                 <attribute name="collection" blockly:blockName="Collection name"/>
                 <optional>
                   <attribute name="prefer_for_genomes"
-                             blockly:blockName="If we must choose, this is the preferred strain collection for the given space-delimited list of genomes."/>
+                             blockly:blockName="If we must choose, this is the preferred strain collection for the given space-delimited list of genomes.">
+                    <list>
+                      <oneOrMore>
+                        <data type="string"/>
+                      </oneOrMore>
+                    </list>
+                  </attribute>
                 </optional>
               </element>
             </choice>

--- a/scripts/pipeline/compara_db_config.rng
+++ b/scripts/pipeline/compara_db_config.rng
@@ -147,10 +147,14 @@
               </optional>
               <optional>
                 <attribute name="strain_type" blockly:blockName="Predominant strain type of this collection">
+                  <!-- This should be kept in sync with strain types in the StrainType datacheck. -->
                   <choice>
                     <value blockly:blockName="Strain">strain</value>
                     <value blockly:blockName="Breed">breed</value>
                     <value blockly:blockName="Cultivar">cultivar</value>
+                    <value blockly:blockName="Ecotype">ecotype</value>
+                    <value blockly:blockName="Haplotype">haplotype</value>
+                    <value blockly:blockName="Isolate">isolate</value>
                   </choice>
                 </attribute>
               </optional>

--- a/scripts/pipeline/create_all_mlss.pl
+++ b/scripts/pipeline/create_all_mlss.pl
@@ -125,7 +125,7 @@ use Bio::EnsEMBL::Compara::Utils::MasterDatabase;
 
 
 use constant CONFIG_MLSS_TAGS => qw(prefer_for_genomes reference_species);
-use constant CONFIG_SS_TAGS => qw(strain_type);
+use constant CONFIG_SS_TAGS => qw(display_name strain_type);
 
 
 my $help;

--- a/travisci/all-housekeeping/division_config.t
+++ b/travisci/all-housekeeping/division_config.t
@@ -34,6 +34,9 @@ my %mlss_xml_genome_paths = (
     'pairwise_alignment' => ['ref_genome', 'target_genome'],
     'one_vs_all'         => ['ref_genome'],
     'all_vs_one'         => ['target_genome'],
+    'multiple_alignment' => ['ref_genome'],
+    'nc_trees'           => ['prefer_for_genomes'],
+    'protein_trees'      => ['prefer_for_genomes'],
 );
 
 
@@ -72,23 +75,27 @@ sub test_division {
     if (-e $mlss_file) {
         my $xml_document = $xml_parser->parse_file($mlss_file);
         my $root_node    = $xml_document->documentElement();
-        my @names_to_test;
+        my @nodes_to_test;
         while (my ($node_name, $attr_names) = each %mlss_xml_genome_paths) {
             foreach my $genome_node (@{$root_node->findnodes("//$node_name")}) {
                 foreach my $attr_name (@$attr_names) {
-                    my $name = $genome_node->getAttribute($attr_name);
-                    push @names_to_test, [$name, "<$node_name $attr_name='$name'>"];
+                    next unless $genome_node->hasAttribute($attr_name);
+                    my $attr_value = $genome_node->getAttribute($attr_name);
+                    my @names = split(/ /, $attr_value);
+                    push @nodes_to_test, [\@names, qq/<$node_name $attr_name="$attr_value">/];
                 }
             }
         }
 
-        if (%allowed_species and scalar(@names_to_test) > 0) {
+        if (%allowed_species and scalar(@nodes_to_test) > 0) {
             # All species listed in mlss_conf.xml exist in allowed_species.json
             $has_files_to_test = 1;
             subtest "$mlss_file vs $allowed_species_file" => sub {
-                foreach my $a (@names_to_test) {
-                    my ($name, $node) = @$a;
-                    ok(exists $allowed_species{$name}, "$node is allowed");
+                foreach my $test_case (@nodes_to_test) {
+                    my ($names, $node) = @$test_case;
+                    foreach my $name (@$names) {
+                        ok(exists $allowed_species{$name}, "$name in MLSS conf node '$node' is allowed");
+                    }
                 }
             };
         }

--- a/travisci/all-housekeeping/division_config.t
+++ b/travisci/all-housekeeping/division_config.t
@@ -67,7 +67,7 @@ sub test_division {
                      ;
 
     foreach my $name (keys %allowed_species) {
-        like($name, $prod_name_re, "Production name has conventional format");
+        like($name, $prod_name_re, "Production name '$name' has conventional format");
     }
 
     # Load the MLSS XML file if it exists


### PR DESCRIPTION
## Description

This PR:
- adds support for a `prefer_for_genomes` attribute in `protein_trees` and `nc_trees` elements of the `compara_db_config.rng` schema;
- sets this attribute in the `wheat_cultivars` and `barley_cultivars` protein-tree config of the Plants Compara `mlss_conf.xml`, so that Wheat cultivars are preferred for `secale_cereale` and `triticum_aestivum`, and the Barley pangenome is preferred for `hordeum_vulgare`;
- fixes a bug in `create_all_mlss.pl` whereby existing species sets and MLSSes would not necessarily have their configurable tags updated by changes in the `mlss_conf.xml` file;
- adds validation of `prefer_for_genomes` (and multiple alignment `ref_genome`) attributes to `division_config.t`; and
- includes the relevant production name in the the production name test description.

**Related JIRA tickets:**
- ENSCOMPARASW-8093
- ENSCOMPARASW-8096

## Testing

These changes were tested by rerunning the e114 Plants Compara master database prep pipeline, with the relevant config changes for Wheat, and using a modified Rice protein-tree collection as a standin for the Barley pangenome.

Behaviour of `create_all_mlss.pl` was tested for an existing collection/MLSS with Wheat cultivars, and for a new collection/MLSS with the modified Rice cultivars collection.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
