### PR TITLE
Complete transition to Slurm meadow

### DIFF
--- a/docs/production/READMEs/protein_trees.rst
+++ b/docs/production/READMEs/protein_trees.rst
@@ -160,7 +160,7 @@ To configure the pipeline:
 - make a copy of PipeConfig/Example/EnsemblProteinTrees_conf.pm into PipeConfig/Example/
 - update the package name
 - update the parameters in the default_options() section
-- check that your grid engine is parameterized in resource_classes(): by default, only LSF is.
+- check that your grid engine is parameterized in resource_classes(): by default, only Slurm is.
 
 Here follows a description of each category of parameters
 
@@ -383,8 +383,8 @@ beekeeper parameters
 All the z*_capacity parameters are tuned to fit the capacity of our MySQL servers. You might want to initially reduce them, and gradually increase
 them "as long as the database holds" :) The relative proportion of each analysis should probably stay the same
 
-The "resource_classes" of the configuration file defined how beekeeper should run each category of job. These are LSF parameters that you may only
-want to change if you don't have a LSF installation
+The "resource_classes" of the configuration file defined how beekeeper should run each category of job. These are Slurm parameters that you may only
+want to change if you don't have a Slurm installation
 
 Run the pipeline
 ----------------
@@ -646,7 +646,11 @@ SELECT value FROM gene_tree_root_tag WHERE root_id=458053 AND tag = 'model_name'
 
   .. code-block:: sql
 
-     SELECT * FROM lsf_usage WHERE analysis LIKE "raxml(%"
+     SELECT logic_name, role_id, worker_resource_usage.*
+     FROM worker_resource_usage
+     JOIN role USING (worker_id)
+     JOIN analysis_base USING (analysis_id)
+     WHERE logic_name LIKE "raxml%";
 
 * Get running times and alignment lengths:
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateHmmProfiles_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/CreateHmmProfiles_conf.pm
@@ -238,7 +238,7 @@ sub resource_classes {
     return {
         %{$self->SUPER::resource_classes('include_multi_threaded')},  # inherit the standard resource classes, incl. multi-threaded
 
-         '4Gb_big_tmp_job'  => { 'LSF' => ['-C0 -M4000 -R"select[mem>4000] rusage[mem=4000]"', '-worker_base_tmp_dir ' . $self->o('big_tmp_dir')] },
+         '4Gb_big_tmp_job'  => { 'SLURM' => ['--mem=4g', '-worker_base_tmp_dir ' . $self->o('big_tmp_dir')] },
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -162,57 +162,46 @@ sub resource_classes_single_thread {
     my $resource_class_templates = {
         # 1 Gb seems to be the minimum we need nowadays
         '1Gb_job' => {
-            'LSF'   => '-C0 -M1000 -R"select[mem>1000] rusage[mem=1000]"',
             'SLURM' => '--mem=1g',
         },
 
         '2Gb_job' => {
-            'LSF'   => '-C0 -M2000 -R"select[mem>2000] rusage[mem=2000]"',
             'SLURM' => '--mem=2g',
         },
 
         '4Gb_job' => {
-            'LSF'   => '-C0 -M4000 -R"select[mem>4000] rusage[mem=4000]"',
             'SLURM' => '--mem=4g',
         },
 
         '8Gb_job' => {
-            'LSF'   => '-C0 -M8000 -R"select[mem>8000] rusage[mem=8000]"',
             'SLURM' => '--mem=8g',
         },
 
         '16Gb_job' => {
-            'LSF'   => '-C0 -M16000 -R"select[mem>16000] rusage[mem=16000]"',
             'SLURM' => '--mem=16g',
         },
 
         '24Gb_job' => {
-            'LSF'   => '-C0 -M24000 -R"select[mem>24000] rusage[mem=24000]"',
             'SLURM' => '--mem=24g',
         },
 
         '32Gb_job' => {
-            'LSF'   => '-C0 -M32000 -R"select[mem>32000] rusage[mem=32000]"',
             'SLURM' => '--mem=32g',
         },
 
         '48Gb_job' => {
-            'LSF'   => '-C0 -M48000 -R"select[mem>48000] rusage[mem=48000]"',
             'SLURM' => '--mem=48g',
         },
 
         '64Gb_job' => {
-            'LSF'   => '-C0 -M64000 -R"select[mem>64000] rusage[mem=64000]"',
             'SLURM' => '--mem=64g',
         },
 
         '96Gb_job' => {
-            'LSF'   => '-C0 -M96000 -R"select[mem>96000] rusage[mem=96000]"',
             'SLURM' => '--mem=96g',
         },
 
         '512Gb_job' => {
-            'LSF'   => '-q bigmem -C0 -M512000 -R"select[mem>512000] rusage[mem=512000]"',
             'SLURM' => '--mem=512g',
         },
     };
@@ -230,22 +219,18 @@ sub resource_classes_single_thread {
     my %additional_resource_classes = (
 
         '1Gb_6_hour_job' => {
-            'LSF'   => ['-C0 -M1000 -R"select[mem>1000] rusage[mem=1000]" -W 6:00'],
             'SLURM' => ['--mem=1g --time=6:00:00'],
         },
 
         '2Gb_6_hour_job' => {
-            'LSF'   => ['-C0 -M2000 -R"select[mem>2000] rusage[mem=2000]" -W 6:00'],
             'SLURM' => ['--mem=2g --time=6:00:00'],
         },
 
         '1Gb_datamover_job' => {
-            'LSF'   => ['-q datamover -C0 -M1000 -R"select[mem>1000] rusage[mem=1000]"'],
             'SLURM' => ['--partition=datamover --mem=1g --time=24:00:00'],
         },
 
         '1Gb_registryless_job' => {
-            'LSF'   => ['-C0 -M1000 -R"select[mem>1000] rusage[mem=1000]"'],
             'SLURM' => ['--mem=1g --time=24:00:00'],
         },
     );
@@ -264,263 +249,211 @@ sub resource_classes_multi_thread {
     my $resource_class_templates = {
 
         '1Gb_2c_job' => {
-            'LSF'   => '-C0 -n 2 -M1000 -R"span[hosts=1] select[mem>1000] rusage[mem=1000]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=2 --mem=1g',
         },
 
         '2Gb_2c_job' => {
-            'LSF'   => '-C0 -n 2 -M2000 -R"span[hosts=1] select[mem>2000] rusage[mem=2000]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=2 --mem=2g',
         },
 
         '4Gb_2c_job' => {
-            'LSF'   => '-C0 -n 2 -M4000 -R"span[hosts=1] select[mem>4000] rusage[mem=4000]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=2 --mem=4g',
         },
 
         '8Gb_2c_job' => {
-            'LSF'   => '-C0 -n 2 -M8000 -R"span[hosts=1] select[mem>8000] rusage[mem=8000]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=2 --mem=8g',
         },
 
         '1Gb_4c_job' => {
-            'LSF'   => '-n 4 -C0 -M1000 -R"select[mem>1000] rusage[mem=1000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=4 --mem=1g',
         },
 
         '2Gb_4c_job' => {
-            'LSF'   => '-n 4 -C0 -M2000 -R"select[mem>2000] rusage[mem=2000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=4 --mem=2g',
         },
 
         '4Gb_4c_job' => {
-            'LSF'   => '-n 4 -C0 -M4000 -R"select[mem>4000] rusage[mem=4000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=4 --mem=4g',
         },
 
         '8Gb_4c_job' => {
-            'LSF'   => '-n 4 -C0 -M8000 -R"select[mem>8000] rusage[mem=8000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=4 --mem=8g',
         },
 
         '16Gb_4c_job' => {
-            'LSF'   => '-n 4 -C0 -M16000 -R"select[mem>16000] rusage[mem=16000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=4 --mem=16g',
         },
 
         '32Gb_4c_job' => {
-            'LSF'   => '-n 4 -C0 -M32000 -R"select[mem>32000] rusage[mem=32000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=4 --mem=32g',
         },
 
         '1Gb_8c_job' => {
-            'LSF'   => '-n 8 -C0 -M1000 -R"select[mem>1000] rusage[mem=1000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=8 --mem=1g',
         },
 
         '2Gb_8c_job' => {
-            'LSF'   => '-n 8 -C0 -M2000 -R"select[mem>2000] rusage[mem=2000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=8 --mem=2g',
         },
 
         '2Gb_8c_job' => {
-            'LSF'   => '-n 8 -C0 -M2000 -R"select[mem>2000] rusage[mem=2000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=8 --mem=2g',
         },
 
         '4Gb_8c_job' => {
-            'LSF'   => '-n 8 -C0 -M4000 -R"select[mem>4000] rusage[mem=4000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=8 --mem=4g',
         },
 
         '8Gb_8c_job' => {
-            'LSF'   => '-n 8 -C0 -M8000 -R"select[mem>8000] rusage[mem=8000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=8 --mem=8g',
         },
 
         '16Gb_8c_job' => {
-            'LSF'   => '-n 8 -C0 -M16000 -R"select[mem>16000] rusage[mem=16000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=8 --mem=16g',
         },
 
         '32Gb_8c_job' => {
-            'LSF'   => '-n 8 -C0 -M32000 -R"select[mem>32000] rusage[mem=32000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=8 --mem=32g',
         },
 
         '64Gb_8c_job' => {
-            'LSF'   => '-n 8 -C0 -M64000 -R"select[mem>64000] rusage[mem=64000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=8 --mem=64g',
         },
 
         '96Gb_8c_job' => {
-            'LSF'   => '-n 8 -C0 -M96000 -R"select[mem>96000] rusage[mem=96000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=8 --mem=96g',
         },
 
         '8Gb_16c_job' => {
-            'LSF'   => '-n 16 -C0 -M8000 -R"select[mem>8000] rusage[mem=8000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=16 --mem=8g',
         },
 
         '16Gb_16c_job' => {
-            'LSF'   => '-n 16 -C0 -M16000 -R"select[mem>16000] rusage[mem=16000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=16 --mem=16g',
         },
 
         '32Gb_16c_job' => {
-            'LSF'   => '-n 16 -C0 -M32000 -R"select[mem>32000] rusage[mem=32000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=16 --mem=32g',
         },
 
         '64Gb_16c_job' => {
-            'LSF'   => '-n 16 -C0 -M64000 -R"select[mem>64000] rusage[mem=64000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=16 --mem=64g',
         },
 
         '128Gb_16c_job' => {
-            'LSF'   => '-n 16 -C0 -M128000 -R"select[mem>128000] rusage[mem=128000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=16 --mem=128g',
         },
 
         '16Gb_32c_job' => {
-            'LSF'   => '-n 32 -C0 -M16000 -R"select[mem>16000] rusage[mem=16000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=32 --mem=16g',
         },
 
         '32Gb_32c_job' => {
-            'LSF'   => '-n 32 -C0 -M32000 -R"select[mem>32000] rusage[mem=32000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=32 --mem=32g',
         },
 
         '64Gb_32c_job' => {
-            'LSF'   => '-n 32 -C0 -M64000 -R"select[mem>64000] rusage[mem=64000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=32 --mem=64g',
         },
 
         '128Gb_32c_job' => {
-            'LSF'   => '-n 32 -C0 -M128000 -R"select[mem>128000] rusage[mem=128000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=32 --mem=128g',
         },
 
         '4Gb_48c_job' => {
-            'LSF'   => '-n 48 -C0 -M4000 -R"span[hosts=1] select[mem>4000] rusage[mem=4000]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=48 --mem=4g',
         },
 
         '16Gb_48c_job' => {
-            'LSF'   => '-n 48 -C0 -M16000 -R"select[mem>16000] rusage[mem=16000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=48 --mem=16g',
         },
 
         '32Gb_48c_job' => {
-            'LSF'   => '-n 48 -C0 -M32000 -R"select[mem>32000] rusage[mem=32000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=48 --mem=32g',
         },
 
         '64Gb_48c_job' => {
-            'LSF'   => '-n 48 -C0 -M64000 -R"select[mem>64000] rusage[mem=64000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=48 --mem=64g',
         },
 
         '128Gb_48c_job' => {
-            'LSF'   => '-n 48 -C0 -M128000 -R"select[mem>128000] rusage[mem=128000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=48 --mem=128g',
         },
 
         '256Gb_48c_job' => {
-            'LSF'   => '-n 48 -C0 -M256000 -R"select[mem>256000] rusage[mem=256000] span[hosts=1]"',
             'SLURM' => '--nodes=1 --ntasks 1 --cpus-per-task=48 --mem=256g',
         },
 
 
         '8Gb_4c_mpi' => {
-            'LSF'   => '-q mpi -n 4 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=4]"',
             'SLURM' => '--ntasks=4 --ntasks-per-node=4 --mem=8g',
         },
 
         '8Gb_8c_mpi' => {
-            'LSF'    => '-q mpi -n 8 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=8]"',
             'SLURM'  => '--ntasks=8 --ntasks-per-node=8 --mem=8g',
         },
 
         '8Gb_16c_mpi' => {
-            'LSF'    => '-q mpi -n 16 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=16]"',
             'SLURM'  => '--ntasks=16 --ntasks-per-node=16 --mem=8g',
         },
 
         '8Gb_24c_mpi' => {
-            'LSF'    => '-q mpi -n 24 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=12]"',
             'SLURM'  => '--ntasks=24 --ntasks-per-node=12 --mem=8g',
         },
 
         '8Gb_32c_mpi' => {
-            'LSF'    => '-q mpi -n 32 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=16]"',
             'SLURM'  => '--ntasks=32 --ntasks-per-node=16 --mem=8g',
         },
 
         '8Gb_48c_mpi' => {
-            'LSF'    => '-q mpi -n 48 -M8000 -R"select[mem>8000] rusage[mem=8000] same[model] span[ptile=16]"',
             'SLURM'  => '--ntasks=48 --ntasks-per-node=16 --mem=8g',
         },
 
         '16Gb_4c_mpi' => {
-            'LSF'    => '-q mpi -n 4 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=4]"',
             'SLURM'  => '--ntasks=4 --ntasks-per-node=4 --mem=16g',
         },
 
         '16Gb_8c_mpi' => {
-            'LSF'    => '-q mpi -n 8 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=8]"',
             'SLURM'  => '--ntasks=8 --ntasks-per-node=8 --mem=16g',
         },
 
         '16Gb_16c_mpi' => {
-            'LSF'    => '-q mpi -n 16 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=16]"',
             'SLURM'  => '--ntasks=16 --ntasks-per-node=16 --mem=16g',
         },
 
         '16Gb_24c_mpi' => {
-            'LSF'    => '-q mpi -n 24 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=12]"',
             'SLURM'  => '--ntasks=24 --ntasks-per-node=12 --mem=16g',
         },
 
         '16Gb_32c_mpi' => {
-            'LSF'    => '-q mpi -n 32 -M16000 -R"select[mem>16000] rusage[mem=16000] same[model] span[ptile=16]"',
             'SLURM'  => '--ntasks=32 --ntasks-per-node=16 --mem=16g',
         },
 
         '32Gb_4c_mpi' => {
-            'LSF'    => '-q mpi -n 4 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=4]"',
             'SLURM'  => '--ntasks=4 --ntasks-per-node=4 --mem=32g',
         },
 
         '32Gb_8c_mpi' => {
-            'LSF'    => '-q mpi -n 8 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=8]"',
             'SLURM'  => '--ntasks=8 --ntasks-per-node=8 --mem=32g',
         },
 
         '32Gb_16c_mpi' => {
-            'LSF'    => '-q mpi -n 16 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=16]"',
             'SLURM'  => '--ntasks=16 --ntasks-per-node=16 --mem=32g',
         },
 
         '32Gb_24c_mpi' => {
-            'LSF'    => '-q mpi -n 24 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=12]"',
             'SLURM'  => '--ntasks=24 --ntasks-per-node=12 --mem=32g',
         },
 
         '32Gb_32c_mpi' => {
-            'LSF'    => '-q mpi -n 32 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=16]"',
             'SLURM'  => '--ntasks=32 --ntasks-per-node=16 --mem=32g',
         },
 
         '32Gb_48c_mpi' => {
-            'LSF'    => '-q mpi -n 48 -M32000 -R"select[mem>32000] rusage[mem=32000] same[model] span[ptile=16]"',
             'SLURM'  => '--ntasks=48 --ntasks-per-node=16 --mem=32g',
         },
 
         '64Gb_4c_mpi' => {
-            'LSF'    => '-q mpi -n 4 -M64000 -R"select[mem>64000] rusage[mem=64000] same[model] span[ptile=4]"',
             'SLURM'  => '--ntasks=4 --ntasks-per-node=4 --mem=64g',
         },
     };
@@ -580,19 +513,15 @@ sub _generate_resource_classes {
 
     my %time_limits = (
         '1_hour' => {
-            'LSF'   => '',
             'SLURM' => '--time=1:00:00',
         },
         '24_hour' => {
-            'LSF'   => '',
             'SLURM' => '--time=24:00:00',
         },
         '168_hour' => {
-            'LSF'   => '',
             'SLURM' => '--time=168:00:00',
         },
         '720_hour' => {
-            'LSF'   => '-q long -W 720:00',
             'SLURM' => '--time=720:00:00',
         },
     );

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/CAFE.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/CAFE.pm
@@ -115,6 +115,7 @@ sub pipeline_analyses_cafe {
                              'cafe_shell'   => $self->o('cafe_shell'),
                             },
              -rc_name => '4Gb_24_hour_job',
+             -meadow_type => 'SLURM',
              -flow_into => {
                  '2->A' => [ 'CAFE_analysis' ],
                  'A->1' => [ 'hc_cafe_results' ],
@@ -133,6 +134,7 @@ sub pipeline_analyses_cafe {
                             },
              -rc_name => '1Gb_8c_24_hour_job',
              -hive_capacity => $self->o('cafe_capacity'),
+             -meadow_type => 'SLURM',
              -flow_into => {
                  -1 => 'CAFE_analysis_himem',
                  -2 => 'CAFE_analysis_himem',
@@ -152,6 +154,7 @@ sub pipeline_analyses_cafe {
                             },
              -rc_name => '4Gb_48c_24_hour_job',
              -hive_capacity => $self->o('cafe_capacity'),
+             -meadow_type => 'SLURM',
              -flow_into => {
                  2 => 'CAFE_json_himem',
              },

--- a/modules/Bio/EnsEMBL/Compara/Production/Analysis/Pecan.pm
+++ b/modules/Bio/EnsEMBL/Compara/Production/Analysis/Pecan.pm
@@ -121,7 +121,7 @@ sub run_pecan {
   my $alignment_file = "$tmp_dir/pecan.mfa";
   my $this_genomic_align_block = new Bio::EnsEMBL::Compara::GenomicAlignBlock;
 
-  sleep 30 unless -e $alignment_file; # give LSF time to die properly if MEMLIMIT is hit
+  sleep 30 unless -e $alignment_file; # give the job scheduler time to die properly if MEMLIMIT is hit
 
   unless (-e $alignment_file) {
       # Note that this error message will be caught by RunnableDB::MercatorPecan::Pecan

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ComparaHMM/BuildSeedHmms.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ComparaHMM/BuildSeedHmms.pm
@@ -172,7 +172,7 @@ sub _fetch_and_compose {
             unless ( ( -e $tmp_hmm_file ) and ( -s $tmp_hmm_file ) ) {
 
                 # The file is not there / empty ... MEMLIMIT going on ? Let's have
-                # a break and give LSF the chance to kill us
+                # a break and give the job scheduler the chance to kill us
                 sleep 3;
             }
         }
@@ -184,7 +184,7 @@ sub _fetch_and_compose {
             unless ( ( -e $tmp_hmm_file ) and ( -s $tmp_hmm_file ) ) {
 
                 # The file is not there / empty ... MEMLIMIT going on ? Let's have
-                # a break and give LSF the chance to kill us
+                # a break and give the job scheduler the chance to kill us
                 sleep 3;
             }
         }
@@ -219,7 +219,7 @@ sub _run_hmmpress {
            ) {
 
         # The file is not there / empty ... MEMLIMIT going on ? Let's have
-        # a break and give LSF the chance to kill us
+        # a break and give the job scheduler the chance to kill us
         sleep 3;
     }
 } ## end sub _run_hmmpress

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/MercatorPecan/Pecan.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/MercatorPecan/Pecan.pm
@@ -871,7 +871,7 @@ sub _run_ortheus {
 
 	print STDOUT "**NEWICK: $newick\nFILES: ", join(" -- ", @$all_files), "\n";
     } else {
-        sleep 30; # give LSF time to die properly if MEMLIMIT is hit
+        sleep 30; # give the job scheduler time to die properly if MEMLIMIT is hit
         unless (-e $tree_file) {
             warn "No output at all and not a MEMLIMIT\n";
             $self->complete_early_if_branch_connected("Not enough memory available in this analysis. New job created in the #-1 branch\n", -1);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/BuildHMM.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/BuildHMM.pm
@@ -212,7 +212,7 @@ sub run_buildhmm {
     my $cmd_out = $self->run_command($cmd, { die_on_failure => 1 });
     unless ((-e $hmm_file) and (-s $hmm_file)) {
         # The file is not there / empty ... MEMLIMIT going on ? Let's have
-        # a break and give LSF the chance to kill us
+        # a break and give the job scheduler the chance to kill us
         sleep 30;
     }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/MSA.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/MSA.pm
@@ -148,7 +148,7 @@ sub write_output {
             my $aln_ok = $self->parse_and_store_alignment_into_proteintree;
             unless ($aln_ok) {
                 # Probably an ongoing MEMLIMIT
-                # Let's wait a bit to let LSF kill the worker as it should
+                # Let's wait a bit to let the job scheduler kill the worker as it should
                 sleep 30;
                 # If we're still there, there is something weird going on.
                 # Perhaps not a MEMLIMIT, after all. Let's die and hope that

--- a/modules/Bio/EnsEMBL/Compara/Utils/RunCommand.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/RunCommand.pm
@@ -86,7 +86,7 @@ sub new_and_exec {
 
     if (($runCmd->exit_code >= 256) or (($options->{'use_bash_pipefail'} or $use_bash_errexit) and ($runCmd->exit_code >= 128))) {
         # The process was killed. Perhaps a MEMLIMIT ? Wait a little bit to
-        # allow LSF to kill this process too
+        # allow the job scheduler to kill this process too
         sleep(30);
     }
     $runCmd->die_with_log if $runCmd->exit_code && $options->{die_on_failure};

--- a/modules/t/housekeeping_checkAllLinuxbrewPaths.t
+++ b/modules/t/housekeeping_checkAllLinuxbrewPaths.t
@@ -24,7 +24,7 @@ unless ($ENV{LINUXBREW_HOME}) {
     plan skip_all => 'No linuxbrew installation available ($LINUXBREW_HOME missing)';
 }
 
-my $software_config_path = $ARGV[0] || $ENV{ENSEMBL_ROOT_DIR} . '/ensembl-compara/conf/software/LSF.codon.json';
+my $software_config_path = $ARGV[0] || $ENV{ENSEMBL_ROOT_DIR} . '/ensembl-compara/conf/software/SLURM.slurm.json';
 die "Cannot find file: $software_config_path\n" unless -e $software_config_path;
 
 find_and_check('check_file_in_cellar', sub {

--- a/scripts/dumps/bulk_genome_dump_from_core.py
+++ b/scripts/dumps/bulk_genome_dump_from_core.py
@@ -50,27 +50,6 @@ def parse_arguments():
     return parser.parse_args()
 
 
-def detect_job_scheduler():
-    """
-    Detect if the system is using SLURM, LSF, or no job scheduler.
-
-    Returns:
-        str: The name of the detected job scheduler ('SLURM', 'LSF') or 'NONE' if no known scheduler is found.
-    """
-
-    schedulers = {
-        "SLURM": "srun",
-        "LSF": "bsub",
-    }
-
-    for scheduler, command in schedulers.items():
-        if subprocess.run(["which", command], check=False).returncode == 0:
-            return scheduler
-
-    logging.error("No job scheduler detected.")
-    sys.exit(1)
-
-
 def subprocess_call(
     command,
     stdout_file="/dev/null",
@@ -85,7 +64,7 @@ def subprocess_call(
         command (list): The command that the subprocess will execute.
         stdout_file (str): Job scheduler standard output file (default: '/dev/null').
         stderr_file (str): Job scheduler standard error file (default: '/dev/null').
-        use_job_scheduler (bool): If True, the command will be submitted to a job scheduler.
+        use_job_scheduler (bool): If True, the command will be submitted to the Slurm job scheduler.
         job_name (bool): If using the job scheduler, this sets the job name.
 
     Returns:
@@ -95,35 +74,21 @@ def subprocess_call(
         RuntimeError if the subprocess return code is nonzero.
     """
     if use_job_scheduler:
-        job_scheduler = detect_job_scheduler()
 
         if not job_name:
             job_name = os.path.basename(__file__)
 
-        if job_scheduler == "SLURM":
-            command = [
-                "sbatch",
-                "--time=1-00",
-                "--mem-per-cpu=4gb",
-                "--cpus-per-task=1",
-                "--export=ALL",
-                f"--output={stdout_file}",
-                f"--error={stderr_file}",
-                f"--job-name={job_name}",
-                f"--wrap={shlex.join(command)}",
-            ]
-        elif job_scheduler == "LSF":
-            command = [
-                "bsub",
-                "-W",
-                "1:00",
-                "-R",
-                "rusage[mem=4096]",
-                "-J",
-                job_name,
-                f"-o {stdout_file}",
-                f"-e {stderr_file}",
-            ] + command
+        command = [
+            "sbatch",
+            "--time=1-00",
+            "--mem-per-cpu=4gb",
+            "--cpus-per-task=1",
+            "--export=ALL",
+            f"--output={stdout_file}",
+            f"--error={stderr_file}",
+            f"--job-name={job_name}",
+            f"--wrap={shlex.join(command)}",
+        ]
 
     logging.info("Running: %s", " ".join(command))
     with subprocess.Popen(


### PR DESCRIPTION
## Description

This PR completes the transition to the Slurm meadow in relevant code and documentation.

**Related JIRA tickets:**
- ENSCOMPARASW-7215
- ENSCOMPARASW-7614
- ENSCOMPARASW-7634

## Overview of changes

Changes include:
- removing LSF parameters from Hive pipeline config files;
- updating `housekeeping_checkAllLinuxbrewPaths.t` to use the default Slurm software config file (`SLURM.slurm.json`);
- configuring CAFE pipeline analyses with the Slurm meadow;
- limiting job-scheduler support to Slurm in `bulk_genome_dump_from_core.py`;
- replacing references to LSF with mentions of "Slurm" or "the job scheduler", as appropriate; and
- replacing an outdated example query of the `lsf_usage` table in the protein-trees pipeline documentation.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
