### PR TITLE
Add healthchecks to concatenate_bedgraph_files

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConservationScores.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConservationScores.pm
@@ -96,6 +96,9 @@ sub pipeline_analyses_dump_conservation_scores {
 
         {   -logic_name     => 'concatenate_bedgraph_files',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::ConcatenateBedGraphFiles',
+            -parameters     => {
+                'healthcheck_list' => ['line_count', 'unexpected_nulls'],
+            },
             -rc_name        => '1Gb_24_hour_job',
             -flow_into      => 'convert_to_bigwig',
         },

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/ConcatenateBedGraphFiles.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/ConcatenateBedGraphFiles.pm
@@ -15,17 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Hive::RunnableDB::FTPDumps::ConcatenateBedGraphFiles
@@ -42,8 +31,37 @@ package Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::ConcatenateBedGraphFiles;
 use strict;
 use warnings;
 
+use Bio::EnsEMBL::Compara::Utils::FlatFile qw(check_for_null_characters check_line_counts get_line_count);
+use Bio::EnsEMBL::Hive::Utils qw(destringify);
+
 use base ('Bio::EnsEMBL::Hive::Process');
 
+
+sub param_defaults {
+    return {
+        'healthcheck_list' => [],
+    };
+}
+
+sub fetch_input {
+    my $self = shift;
+
+    # for some reason, all_bedgraph_files can contain undefs - filter them out
+    my @input_bedgraph_files = grep { defined $_ } @{$self->param_required('all_bedgraph_files')};
+
+    my $healthcheck_list = destringify($self->param_required('healthcheck_list'));
+    if (grep { $_ eq 'line_count' } @{$healthcheck_list}) {
+
+        my $exp_line_count = 0;
+        foreach my $input_bedgraph_file ( @input_bedgraph_files ) {
+            $exp_line_count += get_line_count($input_bedgraph_file) - 1  # excl header line
+        }
+
+        $self->param('exp_line_count', $exp_line_count);
+    }
+
+    $self->param('input_bedgraph_files', \@input_bedgraph_files);
+}
 
 sub run {
     my $self = shift;
@@ -51,14 +69,36 @@ sub run {
     my $output_file = $self->param_required('bedgraph_file');
     unlink $output_file;
 
-    # for some reason, all_bedgraph_files can contain undefs - filter them out
-    my @all_bedgraph_files = grep { defined $_ } @{$self->param_required('all_bedgraph_files')};
+    my @all_bedgraph_files = @{$self->param_required('input_bedgraph_files')};
 
     $self->run_system_command(['cp', shift @all_bedgraph_files, $output_file], { die_on_failure => 1 });
 
     foreach my $input_file ( @all_bedgraph_files ) {
         $self->run_system_command("tail -n+2 '$input_file' >> '$output_file'", { die_on_failure => 1 });
     }
+
+    if ($self->param_is_defined('healthcheck_list')) {
+        $self->_healthcheck();
+    }
 }
+
+sub _healthcheck {
+    my $self = shift;
+
+    my $healthcheck_list = destringify($self->param('healthcheck_list'));
+    my $output_file = $self->param('bedgraph_file');
+
+    foreach my $hc_type (@{$healthcheck_list}) {
+        if ( $hc_type eq 'line_count' ) {
+            my $exp_line_count = $self->param_required('exp_line_count') + 1; # incl header line
+            check_line_counts($output_file, $exp_line_count);
+        } elsif ( $hc_type eq 'unexpected_nulls' ) {
+            check_for_null_characters($output_file);
+        } else {
+            $self->die_no_retry("Healthcheck type '$hc_type' not recognised");
+        }
+    }
+}
+
 
 1;


### PR DESCRIPTION
## Description

This PR adds `line_count` and `unexpected_nulls` healthchecks to the `concatenate_bedgraph_files` step of the Compara FTP dump pipeline.

**Related JIRA tickets:**
- ENSCOMPARASW-8099
- ENSCOMPARASW-8102

## Testing

These changes were tested by running the `DumpConservationScores` section of the Compara FTP dump pipeline for an example genome in an example conservation-score dataset.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
