### PR TITLE
Drop Rotifera species from reference sets (temporarily)

### DIFF
--- a/conf/references/allowed_species.json
+++ b/conf/references/allowed_species.json
@@ -1,7 +1,6 @@
 [
     "acropora_millepora_gca013753865v1rs",
     "acyrthosiphon_pisum_gca005508785v2rs",
-    "adineta_vaga",
     "aedes_aegypti_lvpagwg",
     "aegilops_tauschii",
     "agrilus_planipennis_gca000699045v2rs",

--- a/conf/references/mlss_conf.xml
+++ b/conf/references/mlss_conf.xml
@@ -372,7 +372,7 @@
       <!-- Tardigrada -->
       <genome name="hypsibius_exemplaris_gca002082055v1gb"/>
       <!-- Rotifera -->
-      <genome name="adineta_vaga"/>
+      <!-- <genome name="adineta_vaga"/> -->
       <!-- Nematoda -->
       <genome name="ascaris_suum"/>
       <genome name="brugia_malayi"/>
@@ -431,7 +431,7 @@
       <!-- Tardigrada -->
       <genome name="hypsibius_exemplaris_gca002082055v1gb"/>
       <!-- Rotifera -->
-      <genome name="adineta_vaga"/>
+      <!-- <genome name="adineta_vaga"/> -->
       <!-- Nematoda -->
       <genome name="strongyloides_ratti"/>
       <genome name="haemonchus_contortus_gca000469685v2wb"/>


### PR DESCRIPTION
## Description

_Adineta vaga_ has some issues that prevent it to be loaded into Ensembl Beta. Since there is no good alternative already present in Ensembl Beta at the minute, we are going to drop it from the reference sets, but only temporarily: we will load and submit a replacement as soon as possible, so when the next reference sets update happens, this new one can be used instead.
