### PR TITLE
Adding a jira ticket to check lastz coverage stats

### DIFF
--- a/conf/fungi/jira_recurrent_tickets.json
+++ b/conf/fungi/jira_recurrent_tickets.json
@@ -92,8 +92,7 @@
             "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "Mark as done when LastZ coverage stats have been computed and checked",
-            "summary": "LastZ coverage stats",
-            "name_on_graph": "LastZ coverage stats"
+            "summary": "Check LastZ coverage stats"
          },
          {
             "assignee": "<RelCo>",

--- a/conf/fungi/jira_recurrent_tickets.json
+++ b/conf/fungi/jira_recurrent_tickets.json
@@ -91,6 +91,13 @@
          {
             "assignee": "<RelCo>",
             "component": "Production tasks",
+            "description": "Mark as done when LastZ coverage stats have been computed and checked",
+            "summary": "LastZ coverage stats",
+            "name_on_graph": "LastZ coverage stats"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
             "description": "*GitHub*: [Synteny_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Synteny_conf.pm]\n{code}isrun init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Synteny_conf -host mysql-ens-compara-prod-X -port XXXX -division <division>{code}",
             "name_on_graph": "Synteny",
             "summary": "Run the Synteny pipeline"

--- a/conf/metazoa/jira_recurrent_tickets.json
+++ b/conf/metazoa/jira_recurrent_tickets.json
@@ -134,6 +134,13 @@
          {
             "assignee": "<RelCo>",
             "component": "Production tasks",
+            "description": "Mark as done when LastZ coverage stats have been computed and checked",
+            "summary": "LastZ coverage stats",
+            "name_on_graph": "LastZ coverage stats"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Add+CACTUS+HAL+Alignment+to+Compara",
             "summary": "Process Cactus data",
             "name_on_graph": "Process Cactus data"

--- a/conf/metazoa/jira_recurrent_tickets.json
+++ b/conf/metazoa/jira_recurrent_tickets.json
@@ -135,8 +135,7 @@
             "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "Mark as done when LastZ coverage stats have been computed and checked",
-            "summary": "LastZ coverage stats",
-            "name_on_graph": "LastZ coverage stats"
+            "summary": "Check LastZ coverage stats"
          },
          {
             "assignee": "<RelCo>",

--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -120,8 +120,7 @@
             "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "Mark as done when LastZ coverage stats have been computed and checked",
-            "summary": "LastZ coverage stats",
-            "name_on_graph": "LastZ coverage stats"
+            "summary": "Check LastZ coverage stats"
          },
          {
             "assignee": "<RelCo>",

--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -119,6 +119,13 @@
          {
             "assignee": "<RelCo>",
             "component": "Production tasks",
+            "description": "Mark as done when LastZ coverage stats have been computed and checked",
+            "summary": "LastZ coverage stats",
+            "name_on_graph": "LastZ coverage stats"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Add+CACTUS+HAL+Alignment+to+Compara",
             "summary": "Process Cactus data",
             "name_on_graph": "Process Cactus data"

--- a/conf/protists/jira_recurrent_tickets.json
+++ b/conf/protists/jira_recurrent_tickets.json
@@ -92,8 +92,7 @@
             "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "Mark as done when LastZ coverage stats have been computed and checked",
-            "summary": "LastZ coverage stats",
-            "name_on_graph": "LastZ coverage stats"
+            "summary": "Check LastZ coverage stats"
          },
          {
             "assignee": "<RelCo>",

--- a/conf/protists/jira_recurrent_tickets.json
+++ b/conf/protists/jira_recurrent_tickets.json
@@ -91,6 +91,13 @@
          {
             "assignee": "<RelCo>",
             "component": "Production tasks",
+            "description": "Mark as done when LastZ coverage stats have been computed and checked",
+            "summary": "LastZ coverage stats",
+            "name_on_graph": "LastZ coverage stats"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
             "description": "*GitHub*: [Synteny_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Synteny_conf.pm]\n{code}isrun init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Synteny_conf -host mysql-ens-compara-prod-X -port XXXX -division <division>{code}",
             "name_on_graph": "Synteny",
             "summary": "Run the Synteny pipeline"

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -266,8 +266,7 @@
             "assignee": "<RelCo>",
             "component": "Production tasks",
             "description": "Mark as done when LastZ coverage stats have been computed and checked",
-            "summary": "LastZ coverage stats",
-            "name_on_graph": "LastZ coverage stats"
+            "summary": "Check LastZ coverage stats"
          },
          {
             "assignee": "<RelCo>",

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -265,6 +265,13 @@
          {
             "assignee": "<RelCo>",
             "component": "Production tasks",
+            "description": "Mark as done when LastZ coverage stats have been computed and checked",
+            "summary": "LastZ coverage stats",
+            "name_on_graph": "LastZ coverage stats"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
             "description": "https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Add+CACTUS+HAL+Alignment+to+Compara",
             "summary": "Process Cactus data",
             "name_on_graph": "Process Cactus data"


### PR DESCRIPTION
Adding a new jira ticket to the Production tasks ticket to check the lastz coverage stats. I have updated this for each division except Pan. 

**Related JIRA tickets:**
- https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-8040 

## Notes
_Optional extra information._

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
