### PR TITLE
Store homology ranges, compute hom stats after merge

### DIFF
--- a/conf/metazoa/mlss_conf.xml
+++ b/conf/metazoa/mlss_conf.xml
@@ -374,10 +374,22 @@
   </multiple_alignments>
 
   <gene_trees>
-    <protein_trees collection="default"/>
-    <protein_trees collection="protostomes"/>
-    <protein_trees collection="insects"/>
-    <protein_trees collection="pangenome_drosophila"/>
+    <protein_trees
+        collection="default"
+        homology_range_index="0"
+    />
+    <protein_trees
+        collection="protostomes"
+        homology_range_index="10"
+    />
+    <protein_trees
+        collection="insects"
+        homology_range_index="20"
+    />
+    <protein_trees
+        collection="pangenome_drosophila"
+        homology_range_index="30"
+    />
   </gene_trees>
 
 </compara_db>

--- a/conf/plants/mlss_conf.xml
+++ b/conf/plants/mlss_conf.xml
@@ -446,14 +446,22 @@
   </self_alignments>
 
   <gene_trees>
-    <protein_trees collection="default"/>
+    <protein_trees
+      collection="default"
+      homology_range_index="0"
+    />
     <protein_trees
       collection="wheat_cultivars"
+      homology_range_index="20"
       prefer_for_genomes="secale_cereale triticum_aestivum"
     />
-    <protein_trees collection="rice_cultivars"/>
+    <protein_trees
+      collection="rice_cultivars"
+      homology_range_index="30"
+    />
     <protein_trees
       collection="barley_cultivars"
+      homology_range_index="40"
       prefer_for_genomes="hordeum_vulgare"
     />
   </gene_trees>

--- a/conf/vertebrates/mlss_conf.xml
+++ b/conf/vertebrates/mlss_conf.xml
@@ -639,12 +639,34 @@
   </assembly_patches>
 
   <gene_trees>
-    <protein_trees collection="default"/>
-    <protein_trees collection="murinae"/>
-    <protein_trees collection="pig_breeds"/>
-    <nc_trees collection="default"/>
-    <nc_trees collection="murinae"/>
-    <nc_trees collection="pig_breeds"/>
+    <protein_trees
+      collection="default"
+      homology_range_index="0"
+    />
+    <!--
+      homology_range_index 13 is currently reserved for ENSEMBL_PROJECTIONS
+      see: modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/ImportAltAlleGroupsAsHomologies.pm#L77
+    -->
+    <nc_trees
+      collection="default"
+      homology_range_index="14"
+    />
+    <protein_trees
+      collection="murinae"
+      homology_range_index="18"
+    />
+    <nc_trees
+      collection="murinae"
+      homology_range_index="19"
+    />
+    <protein_trees
+      collection="pig_breeds"
+      homology_range_index="20"
+    />
+    <nc_trees
+      collection="pig_breeds"
+      homology_range_index="21"
+    />
   </gene_trees>
 
   <species_trees>

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/MethodLinkSpeciesSetAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/MethodLinkSpeciesSetAdaptor.pm
@@ -693,23 +693,23 @@ sub fetch_current_gene_tree_mlsses {
 }
 
 
-=head2 fetch_gene_tree_homology_mlsses
+=head2 _fetch_gene_tree_homology_mlsses
 
   Arg  1     : Bio::EnsEMBL::Compara::MethodLinkSpeciesSet object representing a gene-tree MLSS.
-  Example    : my $homology_mlsses = $mlssa->fetch_gene_tree_homology_mlsses($mlss);
-  Description: Fetch current homology MLSSes within and between genomes
-               that are represented in the specified gene-tree MLSS.
+  Example    : my $homology_mlsses = $mlssa->_fetch_gene_tree_homology_mlsses($mlss);
+  Description: Internal method to fetch current homology MLSSes within and between
+               genomes that are represented in the specified gene-tree MLSS.
   Returntype : Arrayref of homology MLSSes represented in the given gene-tree MLSS.
   Exceptions : throws if specified MLSS is not current or does
                not represent a gene-tree MethodLinkSpeciesSet
 
 =cut
 
-sub fetch_gene_tree_homology_mlsses {
+sub _fetch_gene_tree_homology_mlsses {
     my ($self, $mlss) = @_;
 
     unless ($mlss->is_current && ($mlss->method->type ne 'PROTEIN_TREES' || $mlss->method->type ne 'NC_TREES')) {
-        throw("MethodLinkSpeciesSetAdaptor::fetch_gene_tree_homology_mlsses() can only be used for current gene-tree MLSSes");
+        throw("MethodLinkSpeciesSetAdaptor::_fetch_gene_tree_homology_mlsses() can only be used for current gene-tree MLSSes");
     }
 
     my $homology_methods = $self->db->get_MethodAdaptor->fetch_all_by_class_pattern('^Homology\.homology$');

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/MethodLinkSpeciesSetAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/MethodLinkSpeciesSetAdaptor.pm
@@ -653,6 +653,94 @@ sub fetch_by_method_link_type_species_set_name {
 }
 
 
+=head2 fetch_current_gene_tree_mlsses
+
+  Example    : my $gene_tree_mlsses = $mlssa->fetch_current_gene_tree_mlsses();
+  Description: Fetch current gene-tree MLSSes from the database.
+  Returntype : Arrayref of current gene-tree MethodLinkSpeciesSet objects
+  Exceptions : throws if any two gene-tree MLSSes have the same homology range index
+
+=cut
+
+sub fetch_current_gene_tree_mlsses {
+    my ($self) = @_;
+
+    my %mlsses_by_range_index;
+    foreach my $method_type ('PROTEIN_TREES', 'NC_TREES') {
+        foreach my $gene_tree_mlss (@{$self->fetch_all_by_method_link_type($method_type)}) {
+            next unless $gene_tree_mlss->is_current;
+
+            my $homology_range_index = $gene_tree_mlss->get_value_for_tag('homology_range_index', 0);
+
+            if (exists $mlsses_by_range_index{$homology_range_index}) {
+                throw(
+                    sprintf(
+                        "MLSSes %d and %d have a clashing homology range index %d",
+                        $mlsses_by_range_index{$homology_range_index}->dbID,
+                        $gene_tree_mlss->dbID,
+                        $homology_range_index,
+                    )
+                );
+            }
+
+            $mlsses_by_range_index{$homology_range_index} = $gene_tree_mlss;
+        }
+    }
+
+    my @ordered_homology_range_indices = sort { $a <=> $b } keys %mlsses_by_range_index;
+
+    return [map { $mlsses_by_range_index{$_} } @ordered_homology_range_indices];
+}
+
+
+=head2 fetch_gene_tree_homology_mlsses
+
+  Arg  1     : Bio::EnsEMBL::Compara::MethodLinkSpeciesSet object representing a gene-tree MLSS.
+  Example    : my $homology_mlsses = $mlssa->fetch_gene_tree_homology_mlsses($mlss);
+  Description: Fetch current homology MLSSes within and between genomes
+               that are represented in the specified gene-tree MLSS.
+  Returntype : Arrayref of homology MLSSes represented in the given gene-tree MLSS.
+  Exceptions : throws if specified MLSS is not current or does
+               not represent a gene-tree MethodLinkSpeciesSet
+
+=cut
+
+sub fetch_gene_tree_homology_mlsses {
+    my ($self, $mlss) = @_;
+
+    unless ($mlss->is_current && ($mlss->method->type ne 'PROTEIN_TREES' || $mlss->method->type ne 'NC_TREES')) {
+        throw("MethodLinkSpeciesSetAdaptor::fetch_gene_tree_homology_mlsses() can only be used for current gene-tree MLSSes");
+    }
+
+    my $homology_methods = $self->db->get_MethodAdaptor->fetch_all_by_class_pattern('^Homology\.homology$');
+    my @collection_gdb_ids = map { $_->dbID } @{$mlss->species_set->genome_dbs};
+
+    my @homology_mlsses;
+    foreach my $method (@{$homology_methods}) {
+
+        foreach my $i ( 0 .. $#collection_gdb_ids ) {
+            my $gdb1_id = $collection_gdb_ids[$i];
+            foreach my $j ( $i .. $#collection_gdb_ids ) {
+                my $gdb2_id = $collection_gdb_ids[$j];
+
+                my @homology_mlss_gdb_ids;
+                if ($gdb2_id == $gdb1_id) {  # e.g. homoeology MLSS
+                    @homology_mlss_gdb_ids = ($gdb1_id);
+                } else {  # e.g. orthology MLSS
+                    @homology_mlss_gdb_ids = ($gdb1_id, $gdb2_id);
+                }
+
+                my $homology_mlss = $self->fetch_by_method_link_type_GenomeDBs($method->type, \@homology_mlss_gdb_ids);
+                next unless defined $homology_mlss and $homology_mlss->is_current;
+                push(@homology_mlsses, $homology_mlss);
+            }
+        }
+    }
+
+    return \@homology_mlsses;
+}
+
+
 ######################################################################
 # Implements Bio::EnsEMBL::Compara::DBSQL::BaseReleaseHistoryAdaptor #
 ######################################################################

--- a/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
+++ b/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
@@ -445,7 +445,7 @@ sub find_homology_mlss_sets {
     foreach my $gene_tree_mlss ($self, @ref_mlsses) {
         my $gene_tree_mlss_id = $gene_tree_mlss->dbID;
         $gdb_id_map{$gene_tree_mlss_id} = [map { $_->dbID } @{$gene_tree_mlss->species_set->genome_dbs}];
-        my $hom_mlsses = $mlss_dba->fetch_gene_tree_homology_mlsses($gene_tree_mlss);
+        my $hom_mlsses = $mlss_dba->_fetch_gene_tree_homology_mlsses($gene_tree_mlss);
         $hom_mlss_id_map{$gene_tree_mlss_id} = [map { $_->dbID } @{$hom_mlsses}];
     }
 

--- a/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
+++ b/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
@@ -548,16 +548,16 @@ sub find_pairwise_reference {
 }
 
 
-=head2 get_gene_tree_member_biotype_groups
+=head2 _get_gene_tree_member_biotype_groups
 
-  Example    : my $biotype_groups = $mlss->get_gene_tree_member_biotype_groups();
-  Description: Get biotype groups for members in this gene-tree MLSS.
+  Example    : my $biotype_groups = $mlss->_get_gene_tree_member_biotype_groups();
+  Description: Internal method to get biotype groups for members in this gene-tree MLSS.
   Returntype : Listref of biotype groups.
   Exceptions : none
 
 =cut
 
-sub get_gene_tree_member_biotype_groups {
+sub _get_gene_tree_member_biotype_groups {
     my ($self) = @_;
 
     my $biotype_group_tag = $self->get_value_for_tag('member_biotype_groups');

--- a/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
+++ b/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
@@ -406,10 +406,10 @@ sub filename {
 }
 
 
-=head2 find_homology_mlss_sets
+=head2 _find_homology_mlss_sets
 
-  Example    : my $mlss_info = $mlss->find_homology_mlss_sets();
-  Description: Find homology MLSS sets for this gene-tree MLSS.
+  Example    : my $mlss_info = $mlss->_find_homology_mlss_sets();
+  Description: Internal method to find homology MLSS sets for this gene-tree MLSS.
   Returntype : Hashref containing a breakdown of several categories of MLSS-related info:
                a) 'complementary_gdb_ids': Arrayref of GenomeDB IDs of those genomes in
                   the given MLSS that are not in reference gene-tree MLSSes.
@@ -423,11 +423,11 @@ sub filename {
 
 =cut
 
-sub find_homology_mlss_sets {
+sub _find_homology_mlss_sets {
     my ($self) = @_;
 
     unless ($self->is_current && ($self->method->type ne 'PROTEIN_TREES' || $self->method->type ne 'NC_TREES')) {
-        throw("MethodLinkSpeciesSet::find_homology_mlss_sets() can only be used for current gene-tree MLSSes");
+        throw("MethodLinkSpeciesSet::_find_homology_mlss_sets() can only be used for current gene-tree MLSSes");
     }
 
     my $mlss_dba = $self->adaptor->db->get_MethodLinkSpeciesSetAdaptor();

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ComplementaryProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ComplementaryProteinTrees_conf.pm
@@ -24,7 +24,7 @@ Bio::EnsEMBL::Compara::PipeConfig::Metazoa::ComplementaryProteinTrees_conf
 =head1 SYNOPSIS
 
     init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Metazoa::ComplementaryProteinTrees_conf -host mysql-ens-compara-prod-X -port XXXX \
-        -collection <complementary_collection> -ref_collection 'default'
+        -collection <complementary_collection>
 
 =head1 DESCRIPTION
 
@@ -49,28 +49,11 @@ sub default_options {
     return {
         %{$self->SUPER::default_options},
 
-    # complementary collection parameters:
-
-        # Collection(s) in master that may have overlapping data. Potentially overlapping clusters
-        # and homologies are removed during the complementary protein-trees pipeline. This should be
-        # defined in the PipeConfig file for each complementary collection (or on the command line).
-        'ref_collection_list' => undef,
-
     # mapping parameters:
 
         'do_stable_id_mapping' => 0,
         'do_treefam_xref' => 0,
     };
-}
-
-
-sub pipeline_wide_parameters {
-    my ($self) = @_;
-    return {
-        %{$self->SUPER::pipeline_wide_parameters},
-
-        'ref_collection_list' => $self->o('ref_collection_list'),
-    }
 }
 
 
@@ -83,9 +66,6 @@ sub core_pipeline_analyses {
         {
             -logic_name => 'find_overlapping_genomes',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::FindOverlappingGenomes',
-            -parameters => {
-                'collection' => $self->o('collection'),
-            },
             -flow_into  => [ 'check_strains_cluster_factory' ],
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/DrosophilaProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/DrosophilaProteinTrees_conf.pm
@@ -48,8 +48,6 @@ sub default_options {
         %{$self->SUPER::default_options},
 
         'collection'          => 'pangenome_drosophila',
-        'dbID_range_index'    => 30,
-        'ref_collection_list' => ['default', 'protostomes', 'insects'],
         'label_prefix'        => 'pangenome_drosophila_',
 
         # GOC parameters:

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/InsectsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/InsectsProteinTrees_conf.pm
@@ -47,8 +47,6 @@ sub default_options {
         %{$self->SUPER::default_options},
 
         'collection'          => 'insects',
-        'dbID_range_index'    => 20,
-        'ref_collection_list'      => ['default','protostomes'],
         'label_prefix' => 'insects_',
 
         #GOC parameters:

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProtostomesProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProtostomesProteinTrees_conf.pm
@@ -46,9 +46,7 @@ sub default_options {
     return {
         %{$self->SUPER::default_options},
 
-        'collection'          => 'protostomes',
-        'dbID_range_index'    => 10,
-        'ref_collection_list' => ['default'],
+        'collection'   => 'protostomes',
         'label_prefix' => 'protostomes_',
 
         #GOC parameters:

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/BarleyCultivarsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/BarleyCultivarsProteinTrees_conf.pm
@@ -42,7 +42,6 @@ sub default_options {
 
         # Parameters to allow merging different protein-tree collections
         'collection'       => 'barley_cultivars',
-        'dbID_range_index' => 40,
         'label_prefix'     => 'barley_cultivars_',
 
         # Flatten all the genomes under species 'Hordeum vulgare'

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/CultivarsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/CultivarsProteinTrees_conf.pm
@@ -53,9 +53,6 @@ sub default_options {
         'do_stable_id_mapping'  => 0,
         'do_treefam_xref'       => 0,
 
-        # Collection in master that will have overlapping data:
-        'ref_collection' => 'default',
-
         # Extra analyses:
         # Gain/loss analysis?
         'do_cafe'    => 0,
@@ -73,7 +70,6 @@ sub pipeline_wide_parameters {
         %{$self->SUPER::pipeline_wide_parameters},
 
         'cdna'           => $self->o('use_dna_for_phylogeny'),
-        'ref_collection' => $self->o('ref_collection'),
     }
 }
 
@@ -86,9 +82,6 @@ sub core_pipeline_analyses {
         # Include strain-specific analyses
         {   -logic_name => 'find_overlapping_genomes',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::FindOverlappingGenomes',
-            -parameters => {
-                'collection' => $self->o('collection'),
-            },
             -flow_into  => [ 'check_strains_cluster_factory' ],
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/RiceCultivarsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/RiceCultivarsProteinTrees_conf.pm
@@ -45,7 +45,6 @@ sub default_options {
 
         # Parameters to allow merging different runs of the pipeline
         'collection'       => 'rice_cultivars',  # The name of the species-set within that division
-        'dbID_range_index' => 30,
         'label_prefix'     => 'rice_cultivars_',
 
         # Flatten all the species under the "Oryza" genus

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/WheatCultivarsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/WheatCultivarsProteinTrees_conf.pm
@@ -45,7 +45,6 @@ sub default_options {
 
         # Parameters to allow merging different runs of the pipeline
         'collection'       => 'wheat_cultivars',  # The name of the species-set within that division
-        'dbID_range_index' => 20,
         'label_prefix'     => 'wheat_cultivars_',
 
         # Flatten all the species under the "Triticum" genus

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PostHomologyMerge_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PostHomologyMerge_conf.pm
@@ -28,10 +28,9 @@ Bio::EnsEMBL::Compara::PipeConfig::PostHomologyMerge_conf
 
 This pipeline combines a few steps that are run after having merged the
 homology-side of things from each gene-tree pipeline into the release database:
-    - Updates the 'families' column in gene_member_hom_stats table (if
-      "'do_member_stats_fam' => 1")
     - Generate the MLSS tag 'perc_orth_above_wga_thresh' combining the WGA stats
       from both gene-tree pipelines
+    - Update the 'gene_member_hom_stats' table
 
 =cut
 
@@ -46,8 +45,6 @@ use Bio::EnsEMBL::Hive::Version v2.4;
 
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For WHEN and INPUT_PLUS
 
-use Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneMemberHomologyStats;
-
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
 
 
@@ -56,9 +53,15 @@ sub default_options {
     return {
         %{$self->SUPER::default_options},
 
+        'master_db'       => 'compara_master',
         'compara_db'      => 'compara_curr',
-        
-        'do_member_stats_fam' => 1,
+
+        'homology_method_types'      => ['ENSEMBL_ORTHOLOGUES', 'ENSEMBL_PARALOGUES', 'ENSEMBL_HOMOEOLOGUES'],
+        'per_mlss_homology_dump_dir' => $self->o('pipeline_dir') . '/' . 'homologies',
+
+        # Datacheck parameters
+        'db_type'         => 'compara',
+        'output_dir_path' => $self->o('pipeline_dir') . '/' . 'datachecks',
     };
 }
 
@@ -72,44 +75,115 @@ sub hive_meta_table {
     }
 }
 
+sub pipeline_create_commands {
+    my ($self) = @_;
+
+    return [
+        @{$self->SUPER::pipeline_create_commands},
+
+        $self->pipeline_create_commands_rm_mkdir(['output_dir_path', 'per_mlss_homology_dump_dir']),
+    ];
+}
 
 sub pipeline_wide_parameters {
     my ($self) = @_;
     return {
         %{$self->SUPER::pipeline_wide_parameters},          # here we inherit anything from the base class
 
+        'master_db'             => $self->o('master_db'),
+        'compara_db'            => $self->o('compara_db'),
         'db_conn'               => $self->o('compara_db'),
 
-        'do_member_stats_fam'   => $self->o('do_member_stats_fam'),
+        'homology_method_types'      => $self->o('homology_method_types'),
+        'per_mlss_homology_dump_dir' => $self->o('per_mlss_homology_dump_dir'),
+
+        # Datacheck parameters
+        'db_type'         => $self->o('db_type'),
+        'output_dir_path' => $self->o('output_dir_path'),
     }
 }
 
-
-sub pipeline_analyses {
+sub core_pipeline_analyses {
     my ($self) = @_;
 
     return [
-        {   -logic_name => 'backbone_family_member_stats',
-            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-            -input_ids  => [ {
-                    'compara_db'    => $self->o('compara_db'),
-                } ],
-            -flow_into  => {
-                '1->A' => [WHEN( '#do_member_stats_fam#' => 'stats_families')],
-                'A->1' => ['summarise_wga_stats'],
+        {   -logic_name => 'summarise_wga_stats',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::SummariseWGAStats',
+            -input_ids  => [ {} ],
+            -flow_into  => 'check_homology_ranges',
+        },
+
+        {   -logic_name => 'check_homology_ranges',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::DataCheckFan',
+            -parameters => {
+                'datacheck_names' => [ 'HomologyRanges' ],
+                'registry_file'   => $self->o('reg_conf'),
+            },
+            -flow_into  => 'homology_dumps_mlss_id_factory',
+        },
+
+        {   -logic_name => 'homology_dumps_mlss_id_factory',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::MLSSIDFactory',
+            -parameters => {
+                'methods' => {
+                    'ENSEMBL_HOMOEOLOGUES' => 2,
+                    'ENSEMBL_ORTHOLOGUES' => 2,
+                    'ENSEMBL_PARALOGUES' => 2,
+                },
+                'line_count' => 1,
+            },
+            -flow_into => {
+                '2->A' => ['dump_per_mlss_homologies_tsv'],
+                'A->1' => ['homology_dump_funnel_check'],
             },
         },
 
-        {   -logic_name => 'summarise_wga_stats',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::SummariseWGAStats',
-            -flow_into  => ['backbone_end'],
+        {   -logic_name => 'dump_per_mlss_homologies_tsv',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::DumpHomologiesTSV',
+            -rc_name    => '1Gb_24_hour_job',
+            -parameters => {
+                'hashed_id'   => '#expr(dir_revhash(#mlss_id#))expr#',
+                'output_file' => '#per_mlss_homology_dump_dir#/#hashed_id#/#mlss_id#.homologies.tsv',
+                'input_query' => q/
+                    SELECT
+                        hm1.gene_member_id,
+                        hm2.gene_member_id AS homology_gene_member_id
+                    FROM
+                        homology h
+                    JOIN
+                        homology_member hm1 USING (homology_id)
+                    JOIN
+                        homology_member hm2 USING (homology_id)
+                    WHERE
+                        hm1.gene_member_id < hm2.gene_member_id
+                        #extra_filter#
+                /,
+                'healthcheck_list' => [
+                    'line_count',
+                    'unexpected_nulls',
+                ],
+            },
+            -hive_capacity => 10,
         },
 
-        {   -logic_name => 'backbone_end',
-            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+        {   -logic_name => 'homology_dump_funnel_check',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
+            -flow_into  => 'hom_stats_genome_factory',
         },
 
-        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneMemberHomologyStats::pipeline_analyses_fam_stats($self) },
+        {   -logic_name => 'hom_stats_genome_factory',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
+            -parameters => {
+                'all_in_current_gene_trees' => 1,
+            },
+            -rc_name    => '4Gb_job',
+            -flow_into  => { 2 => 'update_genome_hom_stats' },
+        },
+
+        {   -logic_name => 'update_genome_hom_stats',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::UpdateGenomeHomologyStats',
+            -hive_capacity => 5,
+        },
     ];
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -504,7 +504,6 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'do_homology_stats' => $self->o('do_homology_stats'),
         'do_hmm_export'     => $self->o('do_hmm_export'),
         'do_gene_qc'        => $self->o('do_gene_qc'),
-        'dbID_range_index'  => $self->o('dbID_range_index'),
         'dna_alns_complete' => $self->o('dna_alns_complete'), # manually change to 1 when all wgas have finished
 
         'mapped_gene_ratio_per_taxon' => $self->o('mapped_gene_ratio_per_taxon'),
@@ -1037,13 +1036,13 @@ sub core_pipeline_analyses {
             -parameters => {
                 'source_species_names'  => $self->o('projection_source_species_names'),
             },
-            -flow_into  => WHEN('#dbID_range_index#' => 'offset_homology_tables' ),
+            -flow_into  => WHEN('#homology_range_index#' => 'offset_homology_tables' ),
         },
 
         {   -logic_name => 'offset_homology_tables',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::OffsetTables',
             -parameters => {
-                'range_index'   => '#dbID_range_index#',
+                'range_index' => '#homology_range_index#',
             },
         },
 
@@ -3512,7 +3511,7 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'rib_fire_tree_stats',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-            -flow_into  => 'gene_count_factory',
+            -flow_into  => [ 'gene_count_factory', 'store_member_biotype_group_tag' ],
         },
 
         {   -logic_name => 'rib_fire_hmm_build',
@@ -3763,6 +3762,10 @@ sub core_pipeline_analyses {
             -parameters => {
                 'gene_count_exe' => $self->o('count_genes_in_tree_exe'),
             },
+        },
+
+        {   -logic_name => 'store_member_biotype_group_tag',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::StoreMemberBiotypeGroupTag',
         },
 
         {   -logic_name => 'homology_stats_factory',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MurinaeNcRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MurinaeNcRNAtrees_conf.pm
@@ -42,11 +42,7 @@ sub default_options {
     return {
             %{$self->SUPER::default_options},
 
-            # Must be given on the command line
-            #'mlss_id'          => 40100,
-
             'collection'        => 'murinae',       # The name of the species-set within that division
-            'dbID_range_index'  => 19,
             'label_prefix'      => 'mur_',
 
             'projection_source_species_names' => ['mus_musculus'],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MurinaeProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MurinaeProteinTrees_conf.pm
@@ -54,7 +54,6 @@ sub default_options {
 
     # Parameters to allow merging different runs of the pipeline
         'collection'            => 'murinae',       # The name of the species-set within that division
-        'dbID_range_index'      => 18,
         'label_prefix'          => 'mur_',
 
         'multifurcation_deletes_all_subnodes' => [ 10088 ], # All the species under the "Mus" genus are flattened, i.e. it's rat vs a rake of mice

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/PigBreedsNcRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/PigBreedsNcRNAtrees_conf.pm
@@ -31,8 +31,7 @@ Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::PigBreedsNcRNAtrees_conf
 
 =head1 SYNOPSIS
 
-    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::PigBreedsNcRNAtrees_conf -host mysql-ens-compara-prod-X -port XXXX \
-        -mlss_id <curr_pig_breeds_ncrna_mlss_id>
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::PigBreedsNcRNAtrees_conf -host mysql-ens-compara-prod-X -port XXXX
 
 =head1 DESCRIPTION
 
@@ -61,11 +60,7 @@ sub default_options {
     return {
             %{$self->SUPER::default_options},
 
-            # Must be given on the command line
-            #'mlss_id'          => 40100,
-
             'collection'        => 'pig_breeds',       # The name of the species-set within that division
-            'dbID_range_index'  => 21,
             'label_prefix'      => 'pig_breeds_',
 
             'projection_source_species_names' => ['sus_scrofa'],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/PigBreedsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/PigBreedsProteinTrees_conf.pm
@@ -74,7 +74,6 @@ sub default_options {
 
     # Parameters to allow merging different runs of the pipeline
         'collection'            => 'pig_breeds',       # The name of the species-set within that division
-        'dbID_range_index'      => 20,
         'label_prefix'          => 'pig_breeds_',
 
         'multifurcation_deletes_all_subnodes' => [ 9822 ], # All the species under the "Sus" genus are flattened, i.e. it's cow vs a rake of pigs

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsNcRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsNcRNAtrees_conf.pm
@@ -46,9 +46,6 @@ sub default_options {
 
             'skip_epo'          => 1,
 
-            # collection in master that will have overlapping data
-            'ref_collection'   => 'default',
-
             # misc parameters
             'model_name_blocklist' => [],
 
@@ -63,8 +60,6 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
     my ($self) = @_;
     return {
         %{$self->SUPER::pipeline_wide_parameters},          # here we inherit anything from the base class
-
-        'ref_collection'   => $self->o('ref_collection'),
     }
 }
 
@@ -75,9 +70,6 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'find_overlapping_genomes',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::FindOverlappingGenomes',
-            -parameters => {
-                'collection' => $self->o('collection'),
-            },
             -flow_into  => [ 'check_strains_cluster_factory' ],
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
@@ -57,11 +57,6 @@ sub default_options {
         'do_stable_id_mapping'      => 0,
         'do_treefam_xref'           => 0,
 
-    # connection parameters to various databases:
-
-        # collection in master that will have overlapping data
-        'ref_collection'   => 'default',
-
     # Extra analyses
         # gain/loss analysis ?
         'do_cafe'                => 0,
@@ -79,7 +74,6 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         %{$self->SUPER::pipeline_wide_parameters},          # here we inherit anything from the base class
 
         'cdna'              => $self->o('use_dna_for_phylogeny'),
-        'ref_collection'    => $self->o('ref_collection'),
     }
 }
 
@@ -92,9 +86,6 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'find_overlapping_genomes',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::FindOverlappingGenomes',
-            -parameters => {
-                'collection' => $self->o('collection'),
-            },
             -flow_into  => [ 'check_strains_cluster_factory' ],
         },
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DBMergeCheck.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DBMergeCheck.pm
@@ -330,6 +330,10 @@ sub run {
 
                 if (defined $mlss_id) {
 
+                    my $member_type = destringify(
+                        $pipeline_param_dba->fetch_all("param_name = 'member_type'", 'one_per_key', undef, 'param_value')
+                    );
+
                     my $mlss = $master_dba->get_MethodLinkSpeciesSetAdaptor->fetch_by_dbID($mlss_id);
                     $mlss_info = $mlss->find_homology_mlss_sets();
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DBMergeCheck.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DBMergeCheck.pm
@@ -335,7 +335,7 @@ sub run {
                     );
 
                     my $mlss = $master_dba->get_MethodLinkSpeciesSetAdaptor->fetch_by_dbID($mlss_id);
-                    $mlss_info = $mlss->find_homology_mlss_sets();
+                    $mlss_info = $mlss->_find_homology_mlss_sets();
 
                     # Pipelines with collections can be merged per homology MLSS and member type.
                     # This allows for merging protein and ncRNA homologies in the same MLSS from

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/HomologyGenomeMLSSFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/HomologyGenomeMLSSFactory.pm
@@ -72,7 +72,7 @@ sub run {
         };
     }
 
-    my $homology_mlsses = $mlss_dba->fetch_gene_tree_homology_mlsses($mlss);
+    my $homology_mlsses = $mlss_dba->_fetch_gene_tree_homology_mlsses($mlss);
 
     my %gdb_id_to_name;
     my %is_ortholog_mlss;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/HomologyGenomeMLSSFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/HomologyGenomeMLSSFactory.pm
@@ -46,7 +46,6 @@ sub run {
 
     my $clusterset_id = $self->param_required('clusterset_id');
     my $member_type = $self->param_required('member_type');
-    my $member_type_map = $self->param_required('member_type_map');
 
     my $mlss_dba = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor();
     my $method_dba = $self->compara_dba->get_MethodAdaptor();
@@ -72,37 +71,21 @@ sub run {
             'species_path' => $gdb->_get_ftp_dump_relative_path(),
         };
     }
-    my @collection_gdb_ids = sort { $a <=> $b } keys %gdb_info;
 
-    my $homology_methods = $method_dba->fetch_all_by_class_pattern('^Homology\.homology$');
-    my @homology_method_types = map { $_->type } @{$homology_methods};
+    my $homology_mlsses = $mlss_dba->fetch_gene_tree_homology_mlsses($mlss);
 
+    my %gdb_id_to_name;
     my %is_ortholog_mlss;
     my %gdb_to_hom_mlss_ids;
-    foreach my $method_type (@homology_method_types) {
-        foreach my $i ( 0 .. $#collection_gdb_ids ) {
-            my $gdb1_id = $collection_gdb_ids[$i];
-            foreach my $j ( $i .. $#collection_gdb_ids ) {
-                my $gdb2_id = $collection_gdb_ids[$j];
-
-                my @homology_mlss_gdb_ids;
-                if ($gdb2_id == $gdb1_id) {  # e.g. homoeology MLSS
-                    @homology_mlss_gdb_ids = ($gdb1_id);
-                } else {  # e.g. orthology MLSS
-                    @homology_mlss_gdb_ids = ($gdb1_id, $gdb2_id);
-                }
-
-                my $mlss = $mlss_dba->fetch_by_method_link_type_GenomeDBs($method_type, \@homology_mlss_gdb_ids);
-                next unless defined $mlss and $mlss->is_current;
-                $is_ortholog_mlss{$mlss->dbID} = $method_type eq 'ENSEMBL_ORTHOLOGUES';
-                foreach my $gdb_id (@homology_mlss_gdb_ids) {
-                    push(@{$gdb_to_hom_mlss_ids{$gdb_id}}, $mlss->dbID);
-                }
-            }
+    foreach my $homology_mlss (@{$homology_mlsses}) {
+        $is_ortholog_mlss{$homology_mlss->dbID} = $homology_mlss->method->type eq 'ENSEMBL_ORTHOLOGUES';
+        foreach my $gdb (@{$homology_mlss->species_set->genome_dbs}) {
+            push(@{$gdb_to_hom_mlss_ids{$gdb->dbID}}, $homology_mlss->dbID);
+            $gdb_id_to_name{$gdb->dbID} = $gdb->name;
         }
     }
 
-    my @biotype_groups = @{$member_type_map->{$member_type}};
+    my @biotype_groups = @{$mlss->get_gene_tree_member_biotype_groups()};
     my $biotype_group_placeholders = '(' . join(',', ('?') x @biotype_groups) . ')';
     my $biotype_group_sql_list = "('" . join("','", @biotype_groups) . "')";
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/HomologyGenomeMLSSFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/HomologyGenomeMLSSFactory.pm
@@ -85,7 +85,7 @@ sub run {
         }
     }
 
-    my @biotype_groups = @{$mlss->get_gene_tree_member_biotype_groups()};
+    my @biotype_groups = @{$mlss->_get_gene_tree_member_biotype_groups()};
     my $biotype_group_placeholders = '(' . join(',', ('?') x @biotype_groups) . ')';
     my $biotype_group_sql_list = "('" . join("','", @biotype_groups) . "')";
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/FindOverlappingGenomes.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/FindOverlappingGenomes.pm
@@ -47,7 +47,7 @@ sub run {
     my $mlss_id = $self->param_required('mlss_id');
 
     my $mlss = $master_dba->get_MethodLinkSpeciesSetAdaptor->fetch_by_dbID($mlss_id);
-    my $mlss_info = $mlss->find_homology_mlss_sets();
+    my $mlss_info = $mlss->_find_homology_mlss_sets();
 
     $self->add_or_update_pipeline_wide_parameter('overlapping_genomes', stringify($mlss_info->{'overlap_gdb_ids'}));
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RemoveOverlappingHomologies.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RemoveOverlappingHomologies.pm
@@ -47,15 +47,15 @@ sub fetch_input {
     my $mlss_info           = $mlss->find_homology_mlss_sets();
     my @overlap_mlss_ids    = @{$mlss_info->{'overlap_mlss_ids'}};
 
-    $self->param('overlapping_mlsss', \@overlap_mlss_ids);
+    $self->param('overlapping_mlss_ids', \@overlap_mlss_ids);
 }
 
 sub run {
     my $self = shift;
 
-    foreach my $mlss (@{$self->param('overlapping_mlsss')}) {
-        warn "Going to remove ", $mlss->toString, "\n" if $self->debug;
-        $self->_remove_homologies($mlss->dbID);
+    foreach my $mlss_id (@{$self->param('overlapping_mlss_ids')}) {
+        warn "Going to remove ", $mlss_id, "\n" if $self->debug;
+        $self->_remove_homologies($mlss_id);
     }
 }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RemoveOverlappingHomologies.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RemoveOverlappingHomologies.pm
@@ -44,7 +44,7 @@ sub fetch_input {
     my $mlss_id             = $self->param_required('mlss_id');
 
     my $mlss                = $master_mlss_adaptor->fetch_by_dbID($mlss_id);
-    my $mlss_info           = $mlss->find_homology_mlss_sets();
+    my $mlss_info           = $mlss->_find_homology_mlss_sets();
     my @overlap_mlss_ids    = @{$mlss_info->{'overlap_mlss_ids'}};
 
     $self->param('overlapping_mlss_ids', \@overlap_mlss_ids);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/StoreMemberBiotypeGroupTag.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/StoreMemberBiotypeGroupTag.pm
@@ -34,7 +34,7 @@ sub run {
 
     my $mlss_id = $self->param_required('mlss_id');
     my $mlss = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor->fetch_by_dbID($mlss_id);
-    my $biotype_groups = $mlss->get_gene_tree_member_biotype_groups();
+    my $biotype_groups = $mlss->_get_gene_tree_member_biotype_groups();
     $mlss->store_tag('member_biotype_groups', join(',', @{$biotype_groups}));
 }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/StoreMemberBiotypeGroupTag.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/StoreMemberBiotypeGroupTag.pm
@@ -1,0 +1,42 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::StoreMemberBiotypeGroupTag
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::StoreMemberBiotypeGroupTag;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub run {
+    my $self = shift;
+
+    my $mlss_id = $self->param_required('mlss_id');
+    my $mlss = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor->fetch_by_dbID($mlss_id);
+    my $biotype_groups = $mlss->get_gene_tree_member_biotype_groups();
+    $mlss->store_tag('member_biotype_groups', join(',', @{$biotype_groups}));
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/UpdateGenomeHomologyStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/UpdateGenomeHomologyStats.pm
@@ -96,6 +96,8 @@ sub run {
 
             # Initialising homology stats with relevant members now
             # will make it easier to count only relevant homologies.
+            # Relevant members are in this genome and have a biotype_group
+            # (e.g. 'coding') associated with this gene-tree collection.
             %collection_hom_stats = map { $_ => {} } @{$members_by_biotype_group{$biotype_group}};
         }
 
@@ -123,7 +125,11 @@ sub run {
                 chomp($line);
                 my @hom_gene_member_ids = split(/\t/, $line);
                 foreach my $gene_member_id (@hom_gene_member_ids) {
-                    if (exists $collection_hom_stats{$gene_member_id}) {  # Count only relevant homologies.
+                    # Checking for $gene_member_id ensures we only count homologies for the relevant
+                    # gene members initialised earlier (i.e. members in this genome and gene-tree
+                    # collection). We do not compute homology stats for members of another genome
+                    # or gene-tree member type; we expect them to be counted in another job.
+                    if (exists $collection_hom_stats{$gene_member_id}) {
                         $collection_hom_stats{$gene_member_id}{$homology_type} += 1;
                     }
                 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/UpdateGenomeHomologyStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/UpdateGenomeHomologyStats.pm
@@ -83,7 +83,7 @@ sub run {
         my %gene_tree_gdb_id_set = map { $_->dbID => 1 } @{$gene_tree_mlss->species_set->genome_dbs};
         next unless exists $gene_tree_gdb_id_set{$genome_db_id};
 
-        my $collection_biotype_groups = $gene_tree_mlss->get_gene_tree_member_biotype_groups();
+        my $collection_biotype_groups = $gene_tree_mlss->_get_gene_tree_member_biotype_groups();
 
         my %collection_hom_stats;
         foreach my $biotype_group (@{$collection_biotype_groups}) {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/UpdateGenomeHomologyStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/UpdateGenomeHomologyStats.pm
@@ -78,7 +78,6 @@ sub run {
     my %gm_hom_stats;
     my %members_by_biotype_group;
     foreach my $gene_tree_mlss (@{$gene_tree_mlsses}) {
-        print STDERR 'processing gene-tree MLSS: ' . $gene_tree_mlss->name . "\n";
 
         # We should count homology stats for a gene-tree collection only if it contains this genome.
         my %gene_tree_gdb_id_set = map { $_->dbID => 1 } @{$gene_tree_mlss->species_set->genome_dbs};
@@ -102,7 +101,6 @@ sub run {
 
         my $homology_mlsses = $mlss_dba->fetch_gene_tree_homology_mlsses($gene_tree_mlss);
         foreach my $homology_mlss (@{$homology_mlsses}) {
-            print STDERR 'processing homology MLSS: ' . $homology_mlss->name . "\n";
 
             # We should count stats for a homology MLSS only if it contains this genome.
             my %homology_gdb_id_set = map { $_->dbID => 1 } @{$homology_mlss->species_set->genome_dbs};
@@ -119,7 +117,6 @@ sub run {
                 "${hom_mlss_id}.homologies.tsv",
             );
 
-            print STDERR 'processing homology dump file: ' . $homology_dump_file . "\n";
             open(my $fh, '<', $homology_dump_file) or $self->throw("Failed to open file [$homology_dump_file]");
             my $header = <$fh>;  # We can skip the header row.
             while ( my $line = <$fh> ) {
@@ -160,7 +157,6 @@ sub write_output {
     foreach my $clusterset_id (sort keys %{$gm_hom_stats}) {
         foreach my $gene_member_id (sort keys %{$gm_hom_stats->{$clusterset_id}}) {
 
-            print STDERR sprintf('updating homology stats for gene %d in collection %s', $gene_member_id, $clusterset_id) . "\n";
             my @hom_stat_values = map { $gm_hom_stats->{$clusterset_id}{$gene_member_id}{$_} // 0 } @{$hom_stat_names};
             $sth->execute(@hom_stat_values, $gene_member_id, $clusterset_id);
         }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/UpdateGenomeHomologyStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/UpdateGenomeHomologyStats.pm
@@ -99,7 +99,7 @@ sub run {
             %collection_hom_stats = map { $_ => {} } @{$members_by_biotype_group{$biotype_group}};
         }
 
-        my $homology_mlsses = $mlss_dba->fetch_gene_tree_homology_mlsses($gene_tree_mlss);
+        my $homology_mlsses = $mlss_dba->_fetch_gene_tree_homology_mlsses($gene_tree_mlss);
         foreach my $homology_mlss (@{$homology_mlsses}) {
 
             # We should count stats for a homology MLSS only if it contains this genome.

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/UpdateGenomeHomologyStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/UpdateGenomeHomologyStats.pm
@@ -1,0 +1,172 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::UpdateGenomeHomologyStats
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::UpdateGenomeHomologyStats;
+
+use strict;
+use warnings;
+
+use File::Spec::Functions qw(catfile);
+
+use Bio::EnsEMBL::Hive::Utils qw(dir_revhash);
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub fetch_input {
+    my $self = shift @_;
+
+    my $homology_method_types = $self->param_required('homology_method_types');
+
+    my $master_dba = $self->get_cached_compara_dba('master_db');
+    my $method_dba = $master_dba->get_MethodAdaptor();
+
+    my @hom_stat_names;
+    foreach my $homology_method_type (@{$homology_method_types}) {
+        my $method = $method_dba->fetch_by_type($homology_method_type);
+        push(@hom_stat_names, $method->display_name);
+    }
+    @hom_stat_names = sort @hom_stat_names;
+
+    $self->param('hom_stat_names', \@hom_stat_names);
+}
+
+sub run {
+    my $self = shift @_;
+
+    my $per_mlss_homology_dump_dir = $self->param_required('per_mlss_homology_dump_dir');
+    my $genome_db_id = $self->param_required('genome_db_id');
+    my $hom_stat_names = $self->param('hom_stat_names');
+
+    my $mlss_dba = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor();
+    my $helper = $self->compara_dba->dbc->sql_helper();
+
+    my $member_group_sql = q/
+        SELECT
+            gene_member_id
+        FROM
+            gene_member
+        WHERE
+            genome_db_id = ?
+        AND
+            biotype_group = ?
+    /;
+
+    my $gene_tree_mlsses = $mlss_dba->fetch_current_gene_tree_mlsses();
+    my %hom_stat_name_set = map { $_ => 1 } @{$hom_stat_names};
+
+    my %gm_hom_stats;
+    my %members_by_biotype_group;
+    foreach my $gene_tree_mlss (@{$gene_tree_mlsses}) {
+        print STDERR 'processing gene-tree MLSS: ' . $gene_tree_mlss->name . "\n";
+
+        # We should count homology stats for a gene-tree collection only if it contains this genome.
+        my %gene_tree_gdb_id_set = map { $_->dbID => 1 } @{$gene_tree_mlss->species_set->genome_dbs};
+        next unless exists $gene_tree_gdb_id_set{$genome_db_id};
+
+        my $collection_biotype_groups = $gene_tree_mlss->get_gene_tree_member_biotype_groups();
+
+        my %collection_hom_stats;
+        foreach my $biotype_group (@{$collection_biotype_groups}) {
+            if (!exists $members_by_biotype_group{$biotype_group}) {
+                $members_by_biotype_group{$biotype_group} = $helper->execute_simple(
+                    -SQL => $member_group_sql,
+                    -PARAMS => [$genome_db_id, $biotype_group],
+                );
+            }
+
+            # Initialising homology stats with relevant members now
+            # will make it easier to count only relevant homologies.
+            %collection_hom_stats = map { $_ => {} } @{$members_by_biotype_group{$biotype_group}};
+        }
+
+        my $homology_mlsses = $mlss_dba->fetch_gene_tree_homology_mlsses($gene_tree_mlss);
+        foreach my $homology_mlss (@{$homology_mlsses}) {
+            print STDERR 'processing homology MLSS: ' . $homology_mlss->name . "\n";
+
+            # We should count stats for a homology MLSS only if it contains this genome.
+            my %homology_gdb_id_set = map { $_->dbID => 1 } @{$homology_mlss->species_set->genome_dbs};
+            next unless exists $homology_gdb_id_set{$genome_db_id};
+
+            # We should count stats for a homology MLSS only if it contains homologies of a relevant type.
+            my $homology_type = $homology_mlss->method->display_name;
+            next unless exists $hom_stat_name_set{$homology_type};
+
+            my $hom_mlss_id = $homology_mlss->dbID;
+            my $homology_dump_file = catfile(
+                $per_mlss_homology_dump_dir,
+                dir_revhash($hom_mlss_id),
+                "${hom_mlss_id}.homologies.tsv",
+            );
+
+            print STDERR 'processing homology dump file: ' . $homology_dump_file . "\n";
+            open(my $fh, '<', $homology_dump_file) or $self->throw("Failed to open file [$homology_dump_file]");
+            my $header = <$fh>;  # We can skip the header row.
+            while ( my $line = <$fh> ) {
+                chomp($line);
+                my @hom_gene_member_ids = split(/\t/, $line);
+                foreach my $gene_member_id (@hom_gene_member_ids) {
+                    if (exists $collection_hom_stats{$gene_member_id}) {  # Count only relevant homologies.
+                        $collection_hom_stats{$gene_member_id}{$homology_type} += 1;
+                    }
+                }
+            }
+            close($fh) or $self->throw("Failed to close file [$homology_dump_file]");
+        }
+
+        my $clusterset_id = $gene_tree_mlss->species_set->name =~ s/^collection-//r;
+        $gm_hom_stats{$clusterset_id} = \%collection_hom_stats;
+    }
+
+    $self->param('gm_hom_stats', \%gm_hom_stats);
+}
+
+sub write_output {
+    my $self = shift;
+
+    my $hom_stat_names = $self->param('hom_stat_names');
+    my $gm_hom_stats   = $self->param('gm_hom_stats');
+
+    my @assignment_list = map { join(' ', ($_, '=', '?')) } @{$hom_stat_names};
+    my $assignment_text = join(', ', @assignment_list);
+    my $update_stats_sql = qq/
+        UPDATE gene_member_hom_stats
+        SET $assignment_text
+        WHERE gene_member_id = ?
+        AND collection = ?
+    /;
+
+    my $sth = $self->compara_dba->dbc->prepare($update_stats_sql);
+    foreach my $clusterset_id (sort keys %{$gm_hom_stats}) {
+        foreach my $gene_member_id (sort keys %{$gm_hom_stats->{$clusterset_id}}) {
+
+            print STDERR sprintf('updating homology stats for gene %d in collection %s', $gene_member_id, $clusterset_id) . "\n";
+            my @hom_stat_values = map { $gm_hom_stats->{$clusterset_id}{$gene_member_id}{$_} // 0 } @{$hom_stat_names};
+            $sth->execute(@hom_stat_values, $gene_member_id, $clusterset_id);
+        }
+    }
+    $sth->finish;
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareSpeciesSetsMLSS.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareSpeciesSetsMLSS.pm
@@ -89,7 +89,7 @@ sub write_output {
         foreach my $ml (@{$self->param('whole_method_links')}) {
             my $mlss = $self->_write_mlss( $ss, $ml );
 
-            if (($mlss->method->type eq 'PROTEIN_TREES' || $mlss->method->type eq 'NC_TREES')) {
+            if ($mlss->method->type eq 'PROTEIN_TREES' || $mlss->method->type eq 'NC_TREES') {
                 my $homology_range_index = $mlss->get_value_for_tag('homology_range_index');
                 push(@homology_range_indices, $homology_range_index) if defined $homology_range_index;
             }
@@ -159,7 +159,16 @@ sub _write_mlss {
     my $mlss;
     if ($self->param('reference_dba')) {
         $mlss = $self->param('reference_dba')->get_MethodLinkSpeciesSetAdaptor->fetch_by_method_link_id_species_set_id($method->dbID, $ss->dbID);
-        if ((not $mlss) and $self->param('reference_dba')->get_MethodAdaptor->fetch_by_dbID($method->dbID)) {
+        if ($mlss) {
+
+            if ($method->type eq 'PROTEIN_TREES' || $method->type eq 'NC_TREES') {
+                # Load the tagvalue hash, so that tags such
+                # as 'homology_range_index' will be loaded
+                # and stored along with this gene-tree MLSS.
+                $mlss->get_tagvalue_hash();
+            }
+
+        } elsif ($self->param('reference_dba')->get_MethodAdaptor->fetch_by_dbID($method->dbID)) {
             $self->die_no_retry(sprintf("The %s / %s MethodLinkSpeciesSet could not be found in the master database\n", $method->toString, $ss->toString));
         }
     }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareSpeciesSetsMLSS.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareSpeciesSetsMLSS.pm
@@ -68,7 +68,7 @@ sub fetch_input {
     my $method_adaptor = $self->compara_dba->get_MethodAdaptor;
     foreach my $cat (qw(whole singleton pairwise)) {
         my $param_name = "${cat}_method_links";
-        my @a = map {$method_adaptor->fetch_by_type($_) || die "Cannot find the method_link '$_'"} @{ $self->param($param_name) };
+        my @a = map {$method_adaptor->fetch_by_type($_) || $self->die_no_retry("Cannot find the method_link '$_'")} @{ $self->param($param_name) };
         $self->param($param_name, \@a);
     }
 }
@@ -160,7 +160,7 @@ sub _write_mlss {
     if ($self->param('reference_dba')) {
         $mlss = $self->param('reference_dba')->get_MethodLinkSpeciesSetAdaptor->fetch_by_method_link_id_species_set_id($method->dbID, $ss->dbID);
         if ((not $mlss) and $self->param('reference_dba')->get_MethodAdaptor->fetch_by_dbID($method->dbID)) {
-            die sprintf("The %s / %s MethodLinkSpeciesSet could not be found in the master database\n", $method->toString, $ss->toString);
+            $self->die_no_retry(sprintf("The %s / %s MethodLinkSpeciesSet could not be found in the master database\n", $method->toString, $ss->toString));
         }
     }
     unless ($mlss) {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/RemoveOverlappingDataByMember.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ProteinTrees/RemoveOverlappingDataByMember.pm
@@ -22,8 +22,8 @@ Bio::EnsEMBL::Compara::RunnableDB::ProteinTrees::RemoveOverlappingDataByMember
 =head1 DESCRIPTION
 
 When we infer protein trees for a complementary collection, we end up with some redundant homology data,
-which currently needs to be removed from the pipeline database of the complementary collection so that it
-does not clash with or duplicate the data in its reference collection(s). This runnable can be used to
+which may need to be removed from the pipeline database of the complementary collection so that it does
+not clash with or duplicate the data in higher-precedence collection(s). This runnable can be used to
 remove member-associated redundant homology data from a complementary collection pipeline database.
 
 =cut

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ReindexMembers/DeleteOldMember.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ReindexMembers/DeleteOldMember.pm
@@ -76,6 +76,8 @@ sub run {
             $dbc->do('DELETE FROM seq_member_projection_stable_id WHERE target_seq_member_id = ?',  undef, $self->param('seq_member_id'));
             $dbc->do('DELETE FROM seq_member_projection           WHERE source_seq_member_id = ?',  undef, $self->param('seq_member_id'));
             $dbc->do('DELETE FROM seq_member_projection           WHERE target_seq_member_id = ?',  undef, $self->param('seq_member_id'));
+            $dbc->do('DELETE FROM peptide_align_feature           WHERE qmember_id = ?',            undef, $self->param('seq_member_id'));
+            $dbc->do('DELETE FROM peptide_align_feature           WHERE hmember_id = ?',            undef, $self->param('seq_member_id'));
             $dbc->do('DELETE FROM hmm_annot                       WHERE seq_member_id = ?',         undef, $self->param('seq_member_id'));
     } );
 

--- a/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
@@ -29,7 +29,7 @@ package Bio::EnsEMBL::Compara::Utils::MasterDatabase;
 
 use strict;
 use warnings;
-use Bio::EnsEMBL::Utils::Exception qw(throw warning verbose);
+use Bio::EnsEMBL::Utils::Exception qw(deprecate throw warning verbose);
 use Bio::EnsEMBL::Utils::Argument qw(rearrange);
 use Bio::EnsEMBL::Utils::IO qw/:spurt/;
 
@@ -277,6 +277,11 @@ sub _check_is_good_for_alignment {
 
 sub find_overlapping_genome_db_ids {
     my ($compara_dba, $collection_name, $ref_collection_names) = @_;
+
+    deprecate(
+        "Bio::EnsEMBL::Compara::Utils::MasterDatabase::find_overlapping_genome_db_ids() is deprecated and will be removed in e116."
+        . "Use Bio::EnsEMBL::Compara::MethodLinkSpeciesSet::find_homology_mlss_sets() instead."
+    );
 
     my $species_set_adaptor = $compara_dba->get_SpeciesSetAdaptor;
 

--- a/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
@@ -29,7 +29,7 @@ package Bio::EnsEMBL::Compara::Utils::MasterDatabase;
 
 use strict;
 use warnings;
-use Bio::EnsEMBL::Utils::Exception qw(deprecate throw warning verbose);
+use Bio::EnsEMBL::Utils::Exception qw(throw warning verbose);
 use Bio::EnsEMBL::Utils::Argument qw(rearrange);
 use Bio::EnsEMBL::Utils::IO qw/:spurt/;
 
@@ -277,11 +277,6 @@ sub _check_is_good_for_alignment {
 
 sub find_overlapping_genome_db_ids {
     my ($compara_dba, $collection_name, $ref_collection_names) = @_;
-
-    deprecate(
-        "Bio::EnsEMBL::Compara::Utils::MasterDatabase::find_overlapping_genome_db_ids() is deprecated and will be removed in e116."
-        . "Use Bio::EnsEMBL::Compara::MethodLinkSpeciesSet::find_homology_mlss_sets() instead."
-    );
 
     my $species_set_adaptor = $compara_dba->get_SpeciesSetAdaptor;
 

--- a/scripts/pipeline/compara_db_config.rng
+++ b/scripts/pipeline/compara_db_config.rng
@@ -307,6 +307,13 @@
               <element name="protein_trees" blockly:blockName="Protein-trees">
                 <attribute name="collection" blockly:blockName="Collection name"/>
                 <optional>
+                  <attribute name="homology_range_index"
+                             blockly:blockName="Homology range index, to facilitate storing of multiple gene-tree collections in one Compara database.
+                             If set, homology-related dbIDs are offset by the product of this index and a multiplier.">
+                    <data type="integer"/>
+                  </attribute>
+                </optional>
+                <optional>
                   <attribute name="prefer_for_genomes"
                              blockly:blockName="If we must choose, this is the preferred strain collection for the given space-delimited list of genomes.">
                     <list>
@@ -319,6 +326,13 @@
               </element>
               <element name="nc_trees" blockly:blockName="ncRNA-trees">
                 <attribute name="collection" blockly:blockName="Collection name"/>
+                <optional>
+                  <attribute name="homology_range_index"
+                             blockly:blockName="Homology range index, to facilitate storing of multiple gene-tree collections in one Compara database.
+                             If set, homology-related dbIDs are offset by the product of this index and a multiplier.">
+                    <data type="integer"/>
+                  </attribute>
+                </optional>
                 <optional>
                   <attribute name="prefer_for_genomes"
                              blockly:blockName="If we must choose, this is the preferred strain collection for the given space-delimited list of genomes.">


### PR DESCRIPTION
## Description

This draft PR makes three main changes:
- it centralises configuration of homology ranges, and uses homology range indices to establish precedence between gene-tree MLSSes;
- it updates the `PostHomologyMerge` pipeline so that homology stats are recomputed after being merged into the release database; and
- it adds methods to standardise handling of gene-tree and homology MLSSes and species sets, and utilises these in various places including the `PostHomologyMerge` pipeline.

**Related JIRA tickets:**
- ENSCOMPARASW-6457
- ENSCOMPARASW-7640

## Overview of changes

### Centralising homology range configuration

- The `ref_collection`, `ref_collection_list` and `dbID_range_index` parameters are removed from gene-tree pipeline config files. In their place, the `homology_range_index` attribute is configured in the `mlss_conf.xml`,
loaded as an MLSS tag in `create_all_mlss.pl`, and accessed as needed to determine `dbID` offsets in gene-tree pipelines and the precedence of gene-tree collections.

### Standardising handling of gene-tree and homology MLSSes and species sets,

- Method `Bio::EnsEMBL::Compara::DBSQL::MethodLinkSpeciesSetAdaptor::fetch_current_gene_tree_mlsses` is added, to get a list (`arrayref`) of current gene-tree MLSSes, in the order determined by their respective `homology_range_index` attributes.
- Method `Bio::EnsEMBL::Compara::DBSQL::MethodLinkSpeciesSetAdaptor::_fetch_gene_tree_homology_mlsses` returns a list (`arrayref`) of current homology MLSSes associated with the given gene-tree MLSS.
- Method `Bio::EnsEMBL::Compara::MethodLinkSpeciesSet::_find_homology_mlss_sets` returns a mapping of four sets for a given gene-tree collection, taking account of higher-precedence ('reference') gene-tree MLSSes.
- Method `Bio::EnsEMBL::Compara::MethodLinkSpeciesSet::_get_gene_tree_member_biotype_groups` returns a list (`arrayref`) of the biotype groups of members in the given gene-tree MLSS.
- Method `Bio::EnsEMBL::Compara::Utils::MasterDatabase::find_overlapping_genome_db_ids` is deprecated, to be replaced by `Bio::EnsEMBL::Compara::MethodLinkSpeciesSet::find_homology_mlss_sets`.
- To reduce redundancy and simplify the code, these methods are used in various places, including the `PostHomologyMerge` pipeline.

### Recomputing homology stats after homology merge

- The `PostHomologyMerge` pipeline is updated to dump all homologies per MLSS, and then to compute homology stats per `GenomeDB` using the new runnable, `UpdateGenomeHomologyStats`.

### Misc

- A `StoreMemberBiotypeGroupTag` runnable is added, and it is used in `ProteinTrees` and `ncRNAtrees` pipelines to store the set of biotype groups of the members of the gene-tree collection.
- A `populate_new_member_stats` step is added to the `ReindexMembers` pipeline, to ensure that reindexed members have an entry in the `gene_member_hom_stats` table.

## Testing

See the related tickets for details on testing.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
