### PR TITLE
Add null bytes healthcheck to dump_conservation_scores

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConservationScores.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConservationScores.pm
@@ -88,6 +88,7 @@ sub pipeline_analyses_dump_conservation_scores {
             -rc_name           => '2Gb_24_hour_job',
             -parameters        => {
                 'registry'     => '#reg_conf#',
+                'healthcheck_list' => ['unexpected_nulls'],
             },
             -flow_into         => {
                 1 => '?accu_name=all_bedgraph_files&accu_address=[chunkset_id]&accu_input_variable=this_bedgraph',


### PR DESCRIPTION
## Description

Check for presence of null bytes in bigbed output.

**Related JIRA tickets:**
- ENSCOMPARASW-8099

## Overview of changes

#### Change 1

Add heatcheck.

## Testing

The relevant steps were run in a vertebrates FTP dumps pipeline.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
