### PR TITLE
Apply tweaks and fixes to production setup code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_install:
     - git-ensembl --clone --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH --depth 1 ensembl-io
     - git-ensembl --clone --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH --depth 1 ensembl
     - git-ensembl --clone --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH --depth 1 ensembl-datacheck
+    - git-ensembl --clone --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH --depth 1 ensembl-metadata
     # yamllint enable rule:line-length
     - git-ensembl --clone --branch version/2.7.0 --depth 1 ensembl-hive
     - git-ensembl --clone --branch main --depth 1 ensembl-taxonomy

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ before_install:
     - export PERL5LIB=$PERL5LIB:$PWD/ensembl-taxonomy/modules
     - export PERL5LIB=$PERL5LIB:$PWD/ensembl-io/modules
     - export PERL5LIB=$PERL5LIB:$PWD/ensembl-datacheck/lib
+    - export PERL5LIB=$PERL5LIB:$PWD/ensembl-metadata/modules
     - cp -f travisci/MultiTestDB.conf.travisci  modules/t/MultiTestDB.conf
     - cp -f ensembl-rest/travisci/MultiTestDB.conf.travisci ensembl-rest/t/MultiTestDB.conf
     - cp -f ensembl/travisci/MultiTestDB.conf.travisci.mysql  ensembl/modules/t/MultiTestDB.conf

--- a/conf/plants/mlss_conf.xml
+++ b/conf/plants/mlss_conf.xml
@@ -4,103 +4,113 @@
   <!-- Collections are species-sets that are needed to define several mlsss -->
   <collections>
 
-    <!-- All plants except the triticum_aestivum cultivars -->
+    <!-- Non-reference rice cultivars -->
+    <collection name="non_ref_rice_cultivars" no_store="1">
+      <genome name="oryza_sativa_arc"/>
+      <genome name="oryza_sativa_azucena"/>
+      <genome name="oryza_sativa_chaomeo"/>
+      <genome name="oryza_sativa_gobolsailbalam"/>
+      <genome name="oryza_sativa_ir64"/>
+      <genome name="oryza_sativa_ketannangka"/>
+      <genome name="oryza_sativa_khaoyaiguang"/>
+      <genome name="oryza_sativa_larhamugad"/>
+      <genome name="oryza_sativa_lima"/>
+      <genome name="oryza_sativa_liuxu"/>
+      <genome name="oryza_sativa_mh63"/>
+      <genome name="oryza_sativa_n22"/>
+      <genome name="oryza_sativa_natelboro"/>
+      <genome name="oryza_sativa_pr106"/>
+      <genome name="oryza_sativa_zs97"/>
+    </collection>
+
+    <!-- Non-reference barley cultivars -->
+    <collection name="non_ref_barley_cultivars" no_store="1">
+      <genome name="hordeum_vulgare_10tj18"/>
+      <genome name="hordeum_vulgare_aizu6"/>
+      <genome name="hordeum_vulgare_akashinriki"/>
+      <genome name="hordeum_vulgare_barke"/>
+      <genome name="hordeum_vulgare_bonus"/>
+      <genome name="hordeum_vulgare_bowman"/>
+      <genome name="hordeum_vulgare_chikurinibaraki1"/>
+      <genome name="hordeum_vulgare_foma"/>
+      <genome name="hordeum_vulgare_ft11"/>
+      <genome name="hordeum_vulgare_ft144"/>
+      <genome name="hordeum_vulgare_ft262"/>
+      <genome name="hordeum_vulgare_ft286"/>
+      <genome name="hordeum_vulgare_ft333"/>
+      <genome name="hordeum_vulgare_ft628"/>
+      <genome name="hordeum_vulgare_ft67"/>
+      <genome name="hordeum_vulgare_ft880"/>
+      <genome name="hordeum_vulgare_goldenmelon"/>
+      <genome name="hordeum_vulgare_goldenpromise"/>
+      <genome name="hordeum_vulgare_hid055"/>
+      <genome name="hordeum_vulgare_hid101"/>
+      <genome name="hordeum_vulgare_hid249"/>
+      <genome name="hordeum_vulgare_hid357"/>
+      <genome name="hordeum_vulgare_hid380"/>
+      <genome name="hordeum_vulgare_hockett"/>
+      <genome name="hordeum_vulgare_hor10096"/>
+      <genome name="hordeum_vulgare_hor10350"/>
+      <genome name="hordeum_vulgare_hor10892"/>
+      <genome name="hordeum_vulgare_hor1168"/>
+      <genome name="hordeum_vulgare_hor12184"/>
+      <genome name="hordeum_vulgare_hor12541"/>
+      <genome name="hordeum_vulgare_hor13594"/>
+      <genome name="hordeum_vulgare_hor13663"/>
+      <genome name="hordeum_vulgare_hor13821"/>
+      <genome name="hordeum_vulgare_hor13942"/>
+      <genome name="hordeum_vulgare_hor14061"/>
+      <genome name="hordeum_vulgare_hor14121"/>
+      <genome name="hordeum_vulgare_hor14273"/>
+      <genome name="hordeum_vulgare_hor1702"/>
+      <genome name="hordeum_vulgare_hor18321"/>
+      <genome name="hordeum_vulgare_hor19184"/>
+      <genome name="hordeum_vulgare_hor21256"/>
+      <genome name="hordeum_vulgare_hor21322"/>
+      <genome name="hordeum_vulgare_hor21595"/>
+      <genome name="hordeum_vulgare_hor21599"/>
+      <genome name="hordeum_vulgare_hor2180"/>
+      <genome name="hordeum_vulgare_hor2779"/>
+      <genome name="hordeum_vulgare_hor2830"/>
+      <genome name="hordeum_vulgare_hor3081"/>
+      <genome name="hordeum_vulgare_hor3365"/>
+      <genome name="hordeum_vulgare_hor3474"/>
+      <genome name="hordeum_vulgare_hor4224"/>
+      <genome name="hordeum_vulgare_hor495"/>
+      <genome name="hordeum_vulgare_hor6220"/>
+      <genome name="hordeum_vulgare_hor7172"/>
+      <genome name="hordeum_vulgare_hor7385"/>
+      <genome name="hordeum_vulgare_hor7552"/>
+      <genome name="hordeum_vulgare_hor8117"/>
+      <genome name="hordeum_vulgare_hor8148"/>
+      <genome name="hordeum_vulgare_hor9043"/>
+      <genome name="hordeum_vulgare_hor9972"/>
+      <genome name="hordeum_vulgare_igri"/>
+      <genome name="hordeum_vulgare_maximus"/>
+      <genome name="hordeum_vulgare_oun333"/>
+      <genome name="hordeum_vulgare_rgtplanet"/>
+      <genome name="hordeum_vulgare_tritex"/>
+      <genome name="hordeum_vulgare_wbdc078"/>
+      <genome name="hordeum_vulgare_wbdc103"/>
+      <genome name="hordeum_vulgare_wbdc133"/>
+      <genome name="hordeum_vulgare_wbdc184"/>
+      <genome name="hordeum_vulgare_wbdc199"/>
+      <genome name="hordeum_vulgare_wbdc207"/>
+      <genome name="hordeum_vulgare_wbdc237"/>
+      <genome name="hordeum_vulgare_wbdc348"/>
+      <genome name="hordeum_vulgare_wbdc349"/>
+      <genome name="hordeum_vulgare_zdm01467"/>
+      <genome name="hordeum_vulgare_zdm02064"/>
+    </collection>
+
+    <!-- All plants except cultivars -->
     <collection name="default">
       <taxonomic_group taxon_name="Eukaryota">
-        <!-- But exclude all triticum_aestivum cultivars -->
+        <!-- exclude triticum_aestivum cultivars -->
         <ref_for_taxon name="triticum_aestivum"/>
       </taxonomic_group>
-      <genome name="hordeum_vulgare_10tj18" exclude="1"/>
-      <genome name="hordeum_vulgare_aizu6" exclude="1"/>
-      <genome name="hordeum_vulgare_akashinriki" exclude="1"/>
-      <genome name="hordeum_vulgare_barke" exclude="1"/>
-      <genome name="hordeum_vulgare_bonus" exclude="1"/>
-      <genome name="hordeum_vulgare_bowman" exclude="1"/>
-      <genome name="hordeum_vulgare_chikurinibaraki1" exclude="1"/>
-      <genome name="hordeum_vulgare_foma" exclude="1"/>
-      <genome name="hordeum_vulgare_ft11" exclude="1"/>
-      <genome name="hordeum_vulgare_ft144" exclude="1"/>
-      <genome name="hordeum_vulgare_ft262" exclude="1"/>
-      <genome name="hordeum_vulgare_ft286" exclude="1"/>
-      <genome name="hordeum_vulgare_ft333" exclude="1"/>
-      <genome name="hordeum_vulgare_ft628" exclude="1"/>
-      <genome name="hordeum_vulgare_ft67" exclude="1"/>
-      <genome name="hordeum_vulgare_ft880" exclude="1"/>
-      <genome name="hordeum_vulgare_goldenmelon" exclude="1"/>
-      <genome name="hordeum_vulgare_goldenpromise" exclude="1"/>
-      <genome name="hordeum_vulgare_hid055" exclude="1"/>
-      <genome name="hordeum_vulgare_hid101" exclude="1"/>
-      <genome name="hordeum_vulgare_hid249" exclude="1"/>
-      <genome name="hordeum_vulgare_hid357" exclude="1"/>
-      <genome name="hordeum_vulgare_hid380" exclude="1"/>
-      <genome name="hordeum_vulgare_hockett" exclude="1"/>
-      <genome name="hordeum_vulgare_hor10096" exclude="1"/>
-      <genome name="hordeum_vulgare_hor10350" exclude="1"/>
-      <genome name="hordeum_vulgare_hor10892" exclude="1"/>
-      <genome name="hordeum_vulgare_hor1168" exclude="1"/>
-      <genome name="hordeum_vulgare_hor12184" exclude="1"/>
-      <genome name="hordeum_vulgare_hor12541" exclude="1"/>
-      <genome name="hordeum_vulgare_hor13594" exclude="1"/>
-      <genome name="hordeum_vulgare_hor13663" exclude="1"/>
-      <genome name="hordeum_vulgare_hor13821" exclude="1"/>
-      <genome name="hordeum_vulgare_hor13942" exclude="1"/>
-      <genome name="hordeum_vulgare_hor14061" exclude="1"/>
-      <genome name="hordeum_vulgare_hor14121" exclude="1"/>
-      <genome name="hordeum_vulgare_hor14273" exclude="1"/>
-      <genome name="hordeum_vulgare_hor1702" exclude="1"/>
-      <genome name="hordeum_vulgare_hor18321" exclude="1"/>
-      <genome name="hordeum_vulgare_hor19184" exclude="1"/>
-      <genome name="hordeum_vulgare_hor21256" exclude="1"/>
-      <genome name="hordeum_vulgare_hor21322" exclude="1"/>
-      <genome name="hordeum_vulgare_hor21595" exclude="1"/>
-      <genome name="hordeum_vulgare_hor21599" exclude="1"/>
-      <genome name="hordeum_vulgare_hor2180" exclude="1"/>
-      <genome name="hordeum_vulgare_hor2779" exclude="1"/>
-      <genome name="hordeum_vulgare_hor2830" exclude="1"/>
-      <genome name="hordeum_vulgare_hor3081" exclude="1"/>
-      <genome name="hordeum_vulgare_hor3365" exclude="1"/>
-      <genome name="hordeum_vulgare_hor3474" exclude="1"/>
-      <genome name="hordeum_vulgare_hor4224" exclude="1"/>
-      <genome name="hordeum_vulgare_hor495" exclude="1"/>
-      <genome name="hordeum_vulgare_hor6220" exclude="1"/>
-      <genome name="hordeum_vulgare_hor7172" exclude="1"/>
-      <genome name="hordeum_vulgare_hor7385" exclude="1"/>
-      <genome name="hordeum_vulgare_hor7552" exclude="1"/>
-      <genome name="hordeum_vulgare_hor8117" exclude="1"/>
-      <genome name="hordeum_vulgare_hor8148" exclude="1"/>
-      <genome name="hordeum_vulgare_hor9043" exclude="1"/>
-      <genome name="hordeum_vulgare_hor9972" exclude="1"/>
-      <genome name="hordeum_vulgare_igri" exclude="1"/>
-      <genome name="hordeum_vulgare_maximus" exclude="1"/>
-      <genome name="hordeum_vulgare_oun333" exclude="1"/>
-      <genome name="hordeum_vulgare_rgtplanet" exclude="1"/>
-      <genome name="hordeum_vulgare_tritex" exclude="1"/>
-      <genome name="hordeum_vulgare_wbdc078" exclude="1"/>
-      <genome name="hordeum_vulgare_wbdc103" exclude="1"/>
-      <genome name="hordeum_vulgare_wbdc133" exclude="1"/>
-      <genome name="hordeum_vulgare_wbdc184" exclude="1"/>
-      <genome name="hordeum_vulgare_wbdc199" exclude="1"/>
-      <genome name="hordeum_vulgare_wbdc207" exclude="1"/>
-      <genome name="hordeum_vulgare_wbdc237" exclude="1"/>
-      <genome name="hordeum_vulgare_wbdc348" exclude="1"/>
-      <genome name="hordeum_vulgare_wbdc349" exclude="1"/>
-      <genome name="hordeum_vulgare_zdm01467" exclude="1"/>
-      <genome name="hordeum_vulgare_zdm02064" exclude="1"/>
-      <genome name="oryza_sativa_arc" exclude="1"/>
-      <genome name="oryza_sativa_azucena" exclude="1"/>
-      <genome name="oryza_sativa_chaomeo" exclude="1"/>
-      <genome name="oryza_sativa_gobolsailbalam" exclude="1"/>
-      <genome name="oryza_sativa_ir64" exclude="1"/>
-      <genome name="oryza_sativa_ketannangka" exclude="1"/>
-      <genome name="oryza_sativa_khaoyaiguang" exclude="1"/>
-      <genome name="oryza_sativa_larhamugad" exclude="1"/>
-      <genome name="oryza_sativa_lima" exclude="1"/>
-      <genome name="oryza_sativa_liuxu" exclude="1"/>
-      <genome name="oryza_sativa_mh63" exclude="1"/>
-      <genome name="oryza_sativa_n22" exclude="1"/>
-      <genome name="oryza_sativa_natelboro" exclude="1"/>
-      <genome name="oryza_sativa_pr106" exclude="1"/>
-      <genome name="oryza_sativa_zs97" exclude="1"/>
+      <composable_collection name="non_ref_barley_cultivars" exclude="1"/>
+      <composable_collection name="non_ref_rice_cultivars" exclude="1"/>
     </collection>
     
     <!-- Rice species tree including nearest grass relative -->
@@ -241,6 +251,9 @@
 
     <!-- Rice Cultivars -->
     <collection name="rice_cultivars" strain_type="cultivar">
+      <!--Outgroup -->
+      <genome name="leersia_perrieri"/>
+      <!-- Rice genomes -->
       <genome name="oryza_glaberrima"/>
       <genome name="oryza_brachyantha"/>
       <genome name="oryza_sativa"/>
@@ -251,107 +264,17 @@
       <genome name="oryza_rufipogon"/>
       <genome name="oryza_meridionalis"/>
       <genome name="oryza_longistaminata"/>
-      <genome name="oryza_sativa_arc"/>
-      <genome name="oryza_sativa_azucena"/>
-      <genome name="oryza_sativa_chaomeo"/>
-      <genome name="oryza_sativa_gobolsailbalam"/>
-      <genome name="oryza_sativa_ir64"/>
-      <genome name="oryza_sativa_ketannangka"/>
-      <genome name="oryza_sativa_khaoyaiguang"/>
-      <genome name="oryza_sativa_larhamugad"/>
-      <genome name="oryza_sativa_lima"/>
-      <genome name="oryza_sativa_liuxu"/>
-      <genome name="oryza_sativa_mh63"/>
-      <genome name="oryza_sativa_n22"/>
-      <genome name="oryza_sativa_natelboro"/>
-      <genome name="oryza_sativa_pr106"/>
-      <genome name="oryza_sativa_zs97"/>
-      <!--Outgroup -->
-      <genome name="leersia_perrieri"/>
+      <composable_collection name="non_ref_rice_cultivars"/>
     </collection>
 
     <!-- Barley Cultivars -->
     <collection name="barley_cultivars" strain_type="cultivar">
-      <genome name="hordeum_vulgare"/>
-      <genome name="hordeum_vulgare_10tj18"/>
-      <genome name="hordeum_vulgare_aizu6"/>
-      <genome name="hordeum_vulgare_akashinriki"/>
-      <genome name="hordeum_vulgare_barke"/>
-      <genome name="hordeum_vulgare_bonus"/>
-      <genome name="hordeum_vulgare_bowman"/>
-      <genome name="hordeum_vulgare_chikurinibaraki1"/>
-      <genome name="hordeum_vulgare_foma"/>
-      <genome name="hordeum_vulgare_ft11"/>
-      <genome name="hordeum_vulgare_ft144"/>
-      <genome name="hordeum_vulgare_ft262"/>
-      <genome name="hordeum_vulgare_ft286"/>
-      <genome name="hordeum_vulgare_ft333"/>
-      <genome name="hordeum_vulgare_ft628"/>
-      <genome name="hordeum_vulgare_ft67"/>
-      <genome name="hordeum_vulgare_ft880"/>
-      <genome name="hordeum_vulgare_goldenmelon"/>
-      <genome name="hordeum_vulgare_goldenpromise"/>
-      <genome name="hordeum_vulgare_hid055"/>
-      <genome name="hordeum_vulgare_hid101"/>
-      <genome name="hordeum_vulgare_hid249"/>
-      <genome name="hordeum_vulgare_hid357"/>
-      <genome name="hordeum_vulgare_hid380"/>
-      <genome name="hordeum_vulgare_hockett"/>
-      <genome name="hordeum_vulgare_hor10096"/>
-      <genome name="hordeum_vulgare_hor10350"/>
-      <genome name="hordeum_vulgare_hor10892"/>
-      <genome name="hordeum_vulgare_hor1168"/>
-      <genome name="hordeum_vulgare_hor12184"/>
-      <genome name="hordeum_vulgare_hor12541"/>
-      <genome name="hordeum_vulgare_hor13594"/>
-      <genome name="hordeum_vulgare_hor13663"/>
-      <genome name="hordeum_vulgare_hor13821"/>
-      <genome name="hordeum_vulgare_hor13942"/>
-      <genome name="hordeum_vulgare_hor14061"/>
-      <genome name="hordeum_vulgare_hor14121"/>
-      <genome name="hordeum_vulgare_hor14273"/>
-      <genome name="hordeum_vulgare_hor1702"/>
-      <genome name="hordeum_vulgare_hor18321"/>
-      <genome name="hordeum_vulgare_hor19184"/>
-      <genome name="hordeum_vulgare_hor21256"/>
-      <genome name="hordeum_vulgare_hor21322"/>
-      <genome name="hordeum_vulgare_hor21595"/>
-      <genome name="hordeum_vulgare_hor21599"/>
-      <genome name="hordeum_vulgare_hor2180"/>
-      <genome name="hordeum_vulgare_hor2779"/>
-      <genome name="hordeum_vulgare_hor2830"/>
-      <genome name="hordeum_vulgare_hor3081"/>
-      <genome name="hordeum_vulgare_hor3365"/>
-      <genome name="hordeum_vulgare_hor3474"/>
-      <genome name="hordeum_vulgare_hor4224"/>
-      <genome name="hordeum_vulgare_hor495"/>
-      <genome name="hordeum_vulgare_hor6220"/>
-      <genome name="hordeum_vulgare_hor7172"/>
-      <genome name="hordeum_vulgare_hor7385"/>
-      <genome name="hordeum_vulgare_hor7552"/>
-      <genome name="hordeum_vulgare_hor8117"/>
-      <genome name="hordeum_vulgare_hor8148"/>
-      <genome name="hordeum_vulgare_hor9043"/>
-      <genome name="hordeum_vulgare_hor9972"/>
-      <genome name="hordeum_vulgare_igri"/>
-      <genome name="hordeum_vulgare_maximus"/>
-      <genome name="hordeum_vulgare_oun333"/>
-      <genome name="hordeum_vulgare_rgtplanet"/>
-      <genome name="hordeum_vulgare_tritex"/>
-      <genome name="hordeum_vulgare_wbdc078"/>
-      <genome name="hordeum_vulgare_wbdc103"/>
-      <genome name="hordeum_vulgare_wbdc133"/>
-      <genome name="hordeum_vulgare_wbdc184"/>
-      <genome name="hordeum_vulgare_wbdc199"/>
-      <genome name="hordeum_vulgare_wbdc207"/>
-      <genome name="hordeum_vulgare_wbdc237"/>
-      <genome name="hordeum_vulgare_wbdc348"/>
-      <genome name="hordeum_vulgare_wbdc349"/>
-      <genome name="hordeum_vulgare_zdm01467"/>
-      <genome name="hordeum_vulgare_zdm02064"/>
       <!-- Outgroups -->
       <genome name="secale_cereale"/>
       <genome name="triticum_aestivum"/>
+      <!-- Barley genomes -->
+      <genome name="hordeum_vulgare"/>
+      <composable_collection name="non_ref_barley_cultivars"/>
     </collection>
   </collections>
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
@@ -139,6 +139,7 @@ sub pipeline_analyses_prep_master_db_for_release {
                 'report_genomes_script' => $self->o('report_genomes_script'),
                 'work_dir'              => $self->o('work_dir'),
                 'annotation_file'       => $self->o('annotation_file'),
+                'compara_updates_file'  => $self->o('compara_updates_file'),
                 'meta_host'             => $self->o('meta_host'),
                 'allowed_species_file'  => $self->o('config_dir') . '/allowed_species.json',
                 'perc_threshold'        => $self->o('perc_threshold'),
@@ -203,7 +204,7 @@ sub pipeline_analyses_prep_master_db_for_release {
             -parameters => {
                 'update_metadata_script' => $self->o('update_metadata_script'),
                 'reg_conf'               => $self->o('reg_conf'),
-                'cmd'                    => 'perl #update_metadata_script# --reg_conf #reg_conf# --compara #master_db#',
+                'cmd'                    => 'perl #update_metadata_script# --reg_conf #reg_conf# --compara #master_db# --check_species_missing_from_compara',
             },
             -flow_into  => [ 'update_collection' ],
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
@@ -75,6 +75,7 @@ sub default_options {
         'xml_file'            => $self->check_file_in_ensembl('ensembl-compara/conf/' . $self->o('division') . '/mlss_conf.xml'),
         'report_file'         => $self->o( 'work_dir' ) . '/mlss_ids_' . $self->o('division') . '.list',
         'annotation_file'     => $self->o('work_dir') . '/annotation_updates.' . $self->o('division') . '.' . $self->o('ensembl_release') . '.list',
+        'compara_updates_file' => $self->o('work_dir') . '/compara_updates.' . $self->o('division') . '.' . $self->o('ensembl_release') . '.json',
         'master_backup_file'  => $self->o('backups_dir') . '/compara_master_' . $self->o('division') . '.post' . $self->o('ensembl_release') . '.sql',
 
         'patch_dir'   => $self->check_dir_in_ensembl('ensembl-compara/sql/'),

--- a/scripts/pipeline/compara_db_config.rng
+++ b/scripts/pipeline/compara_db_config.rng
@@ -164,6 +164,19 @@
                   </element>
               </optional>
               <ref name="new_named_species_set"/>
+              <zeroOrMore>
+                <element name="composable_collection" blockly:blockName="Include or exclude collection">
+                  <attribute name="name" blockly:blockName="Collection name"/>
+                  <optional>
+                    <attribute name="exclude" blockly:blockName="Exclude this collection">
+                      <choice>
+                        <value blockly:blockName="Yes">1</value>
+                        <value blockly:blockName="No">0</value>
+                      </choice>
+                    </attribute>
+                  </optional>
+                </element>
+              </zeroOrMore>
             </element>
           </oneOrMore>
         </element>

--- a/scripts/pipeline/create_all_mlss.pl
+++ b/scripts/pipeline/create_all_mlss.pl
@@ -314,6 +314,10 @@ sub make_species_set_from_XML_node {
         # include all genomes in this base collection
         my $base_collection = find_collection_from_xml_node_attribute($child, 'name', 'base collection');
         $some_genome_dbs = $base_collection->genome_dbs;
+      } elsif ($child->nodeName eq 'composable_collection') {
+        # get all genomes in this composable collection
+        my $composable_collection = find_collection_from_xml_node_attribute($child, 'name', 'composable collection');
+        $some_genome_dbs = $composable_collection->genome_dbs;
       } else {
         throw(sprintf('Unknown child: %s (line %d)', $child->nodeName, $child->line_number));
       }

--- a/scripts/pipeline/update_master_db.pl
+++ b/scripts/pipeline/update_master_db.pl
@@ -164,6 +164,11 @@ foreach my $db_adaptor (@{Bio::EnsEMBL::Registry->get_all_DBAdaptors(-GROUP => '
 
     my $master_genome_db = $genome_db_adaptor->fetch_by_name_assembly($that_species, $that_assembly, $c);
 
+    my $that_genome_name = defined $c
+                         ? "'$that_species' (assembly '$that_assembly', component '$c')"
+                         : "'$that_species' (assembly '$that_assembly')"
+                         ;
+
     # Time to test !
     if ($master_genome_db) {
         $found_genome_db_ids{$master_genome_db->dbID} = 1;
@@ -175,22 +180,22 @@ foreach my $db_adaptor (@{Bio::EnsEMBL::Registry->get_all_DBAdaptors(-GROUP => '
             $proper_genome_db->first_release($master_genome_db->first_release);
             $proper_genome_db->is_good_for_alignment($master_genome_db->is_good_for_alignment);
             $proper_genome_db->adaptor($genome_db_adaptor);
-            warn "> Differences for '$that_species' (assembly '$that_assembly')\n\t".($proper_genome_db->toString)."\n\t".($master_genome_db->toString)."\n$diffs\n";
+            warn "> Differences for $that_genome_name\n\t".($proper_genome_db->toString)."\n\t".($master_genome_db->toString)."\n$diffs\n";
             $proper_genome_db->dbID($master_genome_db->dbID);
             if ($dry_run) {
                 $has_errors = 1;
             } else {
-                $genome_db_adaptor->update($proper_genome_db);
-                warn "\t> Successfully updated the master database\n";
+                #$genome_db_adaptor->update($proper_genome_db);
+                warn "\t> Would have updated $that_genome_name in the master database\n";
             }
         } elsif ($master_genome_db->is_current) {
-            print "> '$that_species' (assembly '$that_assembly') OK\n";
+            print "> $that_genome_name OK\n";
         } else {
-            warn "> '$that_species' (assembly '$that_assembly') is in the master database, but is not yet 'current' (i.e. first/last_release are not properly set). It should be fixed after running edit_collection.pl\n";
+            warn "> $that_genome_name is in the master database, but is not yet 'current' (i.e. first/last_release are not properly set). It should be fixed after running edit_collection.pl\n";
         }
     } elsif ($check_species_missing_from_compara) {
         $has_errors = 1;
-        warn "> Could not find the species '$that_species' (assembly '$that_assembly') in the genome_db table. You should probably add it.\n";
+        warn "> Could not find the species $that_genome_name in the genome_db table. You should probably add it.\n";
     }
 
     # Genome components loop


### PR DESCRIPTION
## Description

This PR would apply various tweaks and fixes to production setup code for e115.

## Related tickets

- ENSCOMPARASW-7969

## Overview of changes
This pull request would:
- Add support for composable collections to the MLSS config schema. These are a type of collection that can be configured so that their genomes are added or subtracted from other collections.
- Add Rice and Barley "non-reference" composable collections to the Plants MLSS config. This reduces the number of lines in `conf/plants/mlss_conf.xml` by ~20%.
- Add default metadata to Compara updates file in genome update factory.
- Always generate `compara_updates_file` during master database preparation pipeline.
- Add undocumented parameters `force_retire_genomes` and `force_update_genomes` to `UpdateGenomesFromMetadataFactory` runnable. This enables a manual override for genomes that might otherwise flow inappropriately to `verify_genome` or `rename_genome`.
- Always check for genomes missing from Compara in `sync_metadata` step of the master database prep pipeline. This should catch cases where genome components are added in a second or subsequent Compara production cycle.
- Add information on genome component to warning output of `update_master_db.pl`.

## Testing

These changes have been tested in e115 Plants production.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
