### PR TITLE
Add species param and output size check to genome dump script

### DIFF
--- a/scripts/dumps/dump_genome_from_core.pl
+++ b/scripts/dumps/dump_genome_from_core.pl
@@ -23,10 +23,11 @@ use Bio::EnsEMBL::Utils::IO::FASTASerializer;
 use Bio::EnsEMBL::DBSQL::DBAdaptor;
 
 use Getopt::Long;
+use POSIX qw(ceil);
 
-my ($dbname, $host, $port, $user, $pass, $mask, $genome_component, $genome_dump_file, $help);
+my ($dbname, $host, $port, $user, $pass, $mask, $species, $genome_component, $genome_dump_file, $help);
 my $desc = "
-This script dumps all toplevel sequences from a core database and stores them in fasta file.
+This script dumps toplevel sequences from a core database and stores them in fasta file.
 The sequences can be unmasked, soft masked or hard masked.
 
 USAGE dump_genome_from_core.pl [-mask] -core-db COREDB -host HOST -port PORT -outfile OUTFILE
@@ -47,6 +48,9 @@ Options:
 * --mask
       level of masking of the dumped sequences [soft/hard]. If this option is not defined then the
       sequence will be unmasked.
+* --species
+      name of genome whose sequences should be dumped.
+      Required when dumping from a collection core database.
 * --genome-component
       component of a polyploid genome for which sequences should be dumped.
       By default, sequences are dumped for all components of a polyploid genome.
@@ -60,6 +64,7 @@ GetOptions(
     'user=s'             => \$user,
     'pass=s'             => \$pass,
     'mask=s'             => \$mask,
+    'species=s'          => \$species,
     'genome-component=s' => \$genome_component,
     'outfile=s'          => \$genome_dump_file,
     'help'               => \$help
@@ -71,6 +76,12 @@ if ($help) {
     exit(0);
 }
 
+my $multispecies_db = ($dbname =~ /^(\w+_collection_\w+(?:_\d+)?)_((\d+)_\w+)/) ? 1 : 0;
+
+if ($multispecies_db && !defined $species) {
+    die "ERROR: '--species' is required when dumping from a multispecies core database\n"
+}
+
 if ( defined $mask && $mask !~ /soft|hard/ ) {
     die "ERROR: '--mask' has to be either 'soft' or 'hard'\n"
 }
@@ -80,14 +91,17 @@ my $dba = Bio::EnsEMBL::DBSQL::DBAdaptor->new( -user   => $user,
                                                -dbname => $dbname,
                                                -host   => $host,
                                                -port   => $port,
+                                               -species => $species,
+                                               -multispecies_db => $multispecies_db,
                                                -driver => 'mysql');
 
+my $genome_container = $dba->get_GenomeContainer();
 my $slice_adaptor = $dba->get_SliceAdaptor();
 
 my $slices;
 if (defined $genome_component) {
     # validate the genome component, if specified
-    my @core_db_components = @{$dba->get_GenomeContainer->get_genome_components()};
+    my @core_db_components = @{$genome_container->get_genome_components()};
     if (!@core_db_components) {
         die "ERROR: invalid option '--genome-component' - no components found in core database '$dbname'\n";
     }
@@ -114,6 +128,8 @@ my $serializer = Bio::EnsEMBL::Utils::IO::FASTASerializer->new(
 );
 
 # dump the slices
+my $exp_dump_file_size = 0;
+my $total_dump_seq_length = 0;
 foreach my $slice (@$slices){
     if (defined $mask && $mask eq "soft"){
         $slice = $slice->get_repeatmasked_seq(undef, 1);
@@ -123,6 +139,33 @@ foreach my $slice (@$slices){
     }
     my $padded_slice = Bio::EnsEMBL::PaddedSlice->new(-SLICE => $slice);
     $serializer->print_Seq($padded_slice);
+
+    my $seq_name = $slice->seq_region_name;
+    my $seq_length = $slice->seq_region_length;
+    $total_dump_seq_length += $seq_length;
+
+    my $fasta_header_length = length(">$seq_name\n");
+    my $fasta_body_length = $seq_length + ceil($seq_length / $serializer->line_width);
+    $exp_dump_file_size += $fasta_header_length + $fasta_body_length;
 }
 
 close($filehandle) or die "can't close $genome_dump_file\n";
+
+# if dumping a whole genome and 'ref_length' genome statistic available, check total dump sequence length
+if (!defined $genome_component) {
+    my $ref_length = $genome_container->get_ref_length();
+    if (defined $ref_length) {
+        if ($total_dump_seq_length != $ref_length) {
+            die "length of dumped genome sequences ($total_dump_seq_length) does not match expected reference length ($ref_length)\n";
+        }
+    }
+}
+
+# check observed vs expected fasta file size
+my $obs_dump_file_size = -s $genome_dump_file;
+if ($obs_dump_file_size == $exp_dump_file_size) {
+    print "Output genome dump file '$genome_dump_file' is of expected size.\n";
+}
+else {
+     die "size of genome dump file '$genome_dump_file' ($obs_dump_file_size) does not match expected size ($exp_dump_file_size)\n";
+}


### PR DESCRIPTION
## Description

This PR would:
- add rudimentary checks of dumped sequence genome length and file size; and
- add a `--species` parameter to pass to the core `DBAdaptor`.

**Related JIRA tickets:**
- ENSCOMPARASW-7576

## Testing
The updated script was tested on `drosophila_melanogaster_core_115_11` and `ovis_aries_core_115_3`.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
