### PR TITLE
Generalise handling of polyploid U components

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/Utils/SpeciesTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/SpeciesTree.pm
@@ -299,8 +299,18 @@ sub new_from_newick {
         my $gdb = $all_genome_dbs{lc $name};
         if ((not $gdb) and ($name =~ m/^(.*)_([^_]*)$/)) {
             # Perhaps the node represents the component of a polyploid genome
-            my $comp_gdb_key = lc($1) . '_' . $2;
-            $gdb = $all_genome_dbs{$comp_gdb_key};
+            my $species_name = $1;
+            my $component_name = $2;
+            my $pgdb = $all_genome_dbs{lc $species_name};
+            if ($pgdb and $pgdb->is_polyploid) {
+                my $comp_gdb_key = lc($species_name) . '_' . $component_name;
+                $gdb = $all_genome_dbs{$comp_gdb_key};
+
+                if (!$gdb) {
+                    warn "No component named '$component_name' in '$species_name'\n";
+                    next;
+                }
+            }
         }
         if ($gdb) {
             $node->genome_db_id($gdb->dbID);

--- a/modules/t/Utils/SpeciesTree.t
+++ b/modules/t/Utils/SpeciesTree.t
@@ -97,7 +97,7 @@ subtest 'new_from_newick' => sub {
         Bio::EnsEMBL::Compara::Utils::SpeciesTree->new_from_newick( '(aegilops_tauschii_A)', $dba );
     } qr/'aegilops_tauschii_A' not found in the genome_db table/;
 
-    throws_ok {Bio::EnsEMBL::Compara::Utils::SpeciesTree->new_from_newick( '(triticum_aestivum_X)', $dba )}
+    warning_like {Bio::EnsEMBL::Compara::Utils::SpeciesTree->new_from_newick( '(triticum_aestivum_X)', $dba )}
                 qr/No component named 'X' in 'triticum_aestivum'/, 'Non-existing component';
 
     my $new_root = Bio::EnsEMBL::Compara::Utils::SpeciesTree->new_from_newick( '(genus_species)', $dba);


### PR DESCRIPTION
## Description

This PR would implement more general handling of polyploid U-component genomes.

**Related JIRA tickets:**
- ENSCOMPARASW-8158

## Changes

- In `OrthoTree`, a hash is generated that contains `genome_db_id` values corresponding to species-tree nodes that represent an unassigned-region component. This hash is used to identify homologies involving a U-component gene, and to handle those homologies accordingly.
- `CreateReuseSpeciesSets` has been changed to remove the ad-hoc handling of T. aestivum Sy Mattis. Now any component genome can be excluded from a gene-tree collection if it lacks gene members.
- Ad-hoc handling of T. aestivum Sy Mattis has been removed from `SpeciesTree`. All `GenomeDBs` — including principal and component genomes — are added to the `%all_genome_dbs` hash, so component genomes can be identified more easily.
- In `MakeSpeciesTree`, node tags (e.g. `unassigned_region_component`) are synchronised to the database as part of the same transaction in which the species tree is written.

## Testing

Changes to `OrthoTree` were tested by running `ortho_tree` jobs in a protein-trees pipeline in which U-component genomes had been patched with `unassigned_region_component` tags, and confirming the switch from homeology to paralogy in those homologies involving at least one U-component gene member.

Changes to `CreateReuseSpeciesSets`, `MakeSpeciesTree` and `SpeciesTree` were tested by initialising a protein-trees pipeline for each of the default and Wheat cultivar collections, and running selected initial pipeline steps, including `create_mlss_ss` and `make_treebest_species_tree`.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
