### PR TITLE
Avoid stable ID clashes in homology ID mapping and get_all_GeneMembers

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/Homology.pm
+++ b/modules/Bio/EnsEMBL/Compara/Homology.pm
@@ -387,13 +387,40 @@ sub toJSON {
 }
 
 
+=head2 _unique_homology_key
+
+  Example    : my $key = $homology->_unique_homology_key;
+  Description: Internal method which returns a string uniquely identifying
+               this homology within an Ensembl Compara division.
+  Returntype : string
+
+=cut
+
+sub _unique_homology_key {
+    my $self = shift;
+
+    if (!defined($self->{'_unique_homology_key'})) {
+
+        my @gene_members = sort {
+            $a->genome_db_id <=> $b->genome_db_id
+            || $a->stable_id cmp $b->stable_id
+        } @{$self->get_all_GeneMembers};
+
+        my @gene_member_keys = map { $_->genome_db_id . '|' . $_->stable_id } @gene_members;
+
+        $self->{'_unique_homology_key'} = join('|', @gene_member_keys);
+    }
+
+    return $self->{'_unique_homology_key'};
+}
+
+
 =head2 homology_key
 
   Example    : my $key = $homology->homology_key;
-  Description: returns a string uniquely identifying this homology in world space.
-               uses the gene_stable_ids of the members and orders them by taxon_id
-               and concatenates them together.
-  Returntype : string
+  Description: returns a string that uniquely identifies this homology
+               within an Ensembl Compara division, provided that the
+               gene_stable_ids of its members are unique.
   Exceptions :
   Caller     :
 

--- a/modules/Bio/EnsEMBL/Compara/MemberSet.pm
+++ b/modules/Bio/EnsEMBL/Compara/MemberSet.pm
@@ -468,7 +468,8 @@ sub get_all_GeneMembers {
         # The genome_db_id is not the one requested
         next if ((defined $genome_db_id) and ($member->genome_db_id != $genome_db_id));
 
-        $seen_gene_members{$member->stable_id} = $member->gene_member;
+        my $member_id = $member->dbID ? $member->dbID : $member->stable_id;
+        $seen_gene_members{$member_id} = $member->gene_member;
     }
 
     return [values %seen_gene_members];


### PR DESCRIPTION
## Description

This pull request addresses stable ID clashes in the `HomologyIDMapping` runnable and in API method `MemberSet::get_all_GeneMembers`.

**Related JIRA tickets:**
- ENSCOMPARASW-7514
- ENSCOMPARASW-7517

## Testing

Changes were tested by running a test pipeline on a small dataset.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
