### PR TITLE
Deprecate MasterDatabase::find_overlapping_genome_db_ids

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -8,6 +8,12 @@
 
 ----
 
+# Deprecated methods scheduled for deletion
+
+## Ensembl 116
+
+* `Bio::EnsEMBL::Compara::Utils::MasterDatabase::find_overlapping_genome_db_ids`
+
 # Deprecated methods not yet scheduled for deletion
 
 * `AlignedMember::get_cigar_array()`

--- a/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/MasterDatabase.pm
@@ -29,7 +29,7 @@ package Bio::EnsEMBL::Compara::Utils::MasterDatabase;
 
 use strict;
 use warnings;
-use Bio::EnsEMBL::Utils::Exception qw(throw warning verbose);
+use Bio::EnsEMBL::Utils::Exception qw(deprecate throw warning verbose);
 use Bio::EnsEMBL::Utils::Argument qw(rearrange);
 use Bio::EnsEMBL::Utils::IO qw/:spurt/;
 
@@ -277,6 +277,11 @@ sub _check_is_good_for_alignment {
 
 sub find_overlapping_genome_db_ids {
     my ($compara_dba, $collection_name, $ref_collection_names) = @_;
+
+    deprecate(
+        "Bio::EnsEMBL::Compara::Utils::MasterDatabase::find_overlapping_genome_db_ids() is deprecated and will be removed in e116."
+        . "Use Bio::EnsEMBL::Compara::MethodLinkSpeciesSet::_find_homology_mlss_sets() instead."
+    );
 
     my $species_set_adaptor = $compara_dba->get_SpeciesSetAdaptor;
 


### PR DESCRIPTION
## Description

This PR marks method `Bio::EnsEMBL::Compara::Utils::MasterDatabase::find_overlapping_genome_db_ids` as deprecated, with removal scheduled for e116.

**Related JIRA tickets:**
- ENSINT-2139

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
