### PR TITLE
Add genome-member tree format modes

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/NestedSet.pm
+++ b/modules/Bio/EnsEMBL/Compara/NestedSet.pm
@@ -1035,6 +1035,8 @@ my %ryo_modes = (
     'int_node_id' => '%{-n}%{o-}:%{d}',
     'full_web' => '%{n-}%{-n|p}%{"_"-s}%{":"d}',
     'phylip' => '%21{n}:%{d}',
+    'genome_gene_stable_id' => '%{-S"|"}%{-i}:%{d}',
+    'genome_product_stable_id' => '%{-S"|"}%{-n}:%{d}',
 );
 
 my $nhx0 = '%{-n|i|C(taxonomy_level)}:%{d}';
@@ -1053,6 +1055,8 @@ my %nhx_ryo_modes_1 = (
     'treebest_ortho' => '%{-m}%{"_"-x}'.$nhx0,
     'simple' => $ryo_modes{'simple'},
     'phylip' => $ryo_modes{'phylip'},
+    'genome_gene_stable_id' => '%{-S"|"}%{-i}:%{d}',
+    'genome_product_stable_id' => '%{-S"|"}%{-n}:%{d}',
 );
 
 my %nhx_ryo_modes_2 = (
@@ -1065,6 +1069,8 @@ my %nhx_ryo_modes_2 = (
     'display_label' => $nhx1.$nhx2,
     'display_label_composite' => $nhx1.$nhx2,
     'treebest_ortho' => $nhx1.$nhx2.':S=%{-x}%{C(species_tree_node,taxon_id)-}',
+    'genome_gene_stable_id' => $nhx1.'%{":G="-r}'.$nhx2,
+    'genome_product_stable_id' => $nhx1.'%{":G="-i}'.$nhx2,
 );
 
 


### PR DESCRIPTION
## Description

This PR would add `genome_gene_stable_id` and `genome_product_stable_id` Newick and NHX format modes.

These modes would give the option to export an unambiguous Newick/NHX gene tree containing clashing member stable IDs.

Example BRCA2 Newick in `genome_gene_stable_id` mode:
```
(((pan_troglodytes|ENSPTRG00000005766:0.000451,
pan_paniscus|ENSPPAG00000002166:0.000791):0.001943,
homo_sapiens|ENSG00000139618:0.001905):0.000218,
gorilla_gorilla|ENSGGOG00000015808:0.001767):0.004755;
```

Example BRCA2 NHX in `genome_gene_stable_id` mode:
```
(((pan_troglodytes|ENSPTRG00000005766:0.000451[&&NHX:D=N:G=ENSPTRT00000010605:T=9598],
pan_paniscus|ENSPPAG00000002166:0.000791[&&NHX:D=N:G=ENSPPAT00000003886:T=9597]):0.001943[&&NHX:D=N:B=100:T=9596],
homo_sapiens|ENSG00000139618:0.001905[&&NHX:D=N:G=ENST00000380152:T=9606]):0.000218[&&NHX:D=N:B=34:T=207598],
gorilla_gorilla|ENSGGOG00000015808:0.001767[&&NHX:D=N:G=ENSGGOT00000011464:T=9595]):0.004755[&&NHX:D=N:B=34:T=207598];
```

Example BRCA2 Newick in `genome_product_stable_id` mode:
```
(((pan_troglodytes|ENSPTRP00000009812:0.000451,
pan_paniscus|ENSPPAP00000000836:0.000791):0.001943,
homo_sapiens|ENSP00000369497:0.001905):0.000218,
gorilla_gorilla|ENSGGOP00000027226:0.001767):0.004755;
```

Example BRCA2 NHX in `genome_product_stable_id` mode:
```
(((pan_troglodytes|ENSPTRP00000009812:0.000451[&&NHX:D=N:G=ENSPTRG00000005766:T=9598],
pan_paniscus|ENSPPAP00000000836:0.000791[&&NHX:D=N:G=ENSPPAG00000002166:T=9597]):0.001943[&&NHX:D=N:B=100:T=9596],
homo_sapiens|ENSP00000369497:0.001905[&&NHX:D=N:G=ENSG00000139618:T=9606]):0.000218[&&NHX:D=N:B=34:T=207598],
gorilla_gorilla|ENSGGOP00000027226:0.001767[&&NHX:D=N:G=ENSGGOG00000015808:T=9595]):0.004755[&&NHX:D=N:B=34:T=207598];
```

## Testing
These modes were tested on a web sandbox by exporting gene trees in each of the new format modes.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
