### PR TITLE
Add internal AlignSlice methods to prune ancestral

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/AlignSlice.pm
+++ b/modules/Bio/EnsEMBL/Compara/AlignSlice.pm
@@ -445,16 +445,15 @@ sub adaptor {
 
 sub get_all_Slices {
   my ( $self, @species_names ) = @_;
-  return $self->_get_pruned_Slices(\@species_names, 'no_prune_ancestral');
+  return $self->_get_filtered_Slices(\@species_names);
 }
 
-sub _get_pruned_Slices {
-  my ( $self, $species_names, $no_prune_ancestral) = @_;
+sub _get_filtered_Slices {
+  my ( $self, $species_names, $prune_ancestral) = @_;
   # This is much the same as 'get_all_Slices', but with two key differences:
   # 1) Arg[1] is an arrayref of species names;
   # 2) Arg[2] is a flag indicating whether to prune an ancestral slice having
-  #    a child for which all extant genomes have been removed. If false, such
-  #    ancestral slices are pruned. If true, no ancestral pruning is done.
+  #    a child for which all extant genomes have been removed.
 
   my $slices = [];
 
@@ -480,7 +479,7 @@ sub _get_pruned_Slices {
 
     if (scalar(keys %removed_species) > 0
           && exists $species_to_keep{'ancestral_sequences'}
-          && !$no_prune_ancestral) {
+          && $prune_ancestral) {
       my @filtered_slices = ();
       foreach my $slice ( @$slices ) {
         if ($slice->genome_db->name eq 'ancestral_sequences') {
@@ -686,16 +685,15 @@ sub summary_as_hash {
 
 sub get_SimpleAlign {
   my ($self, @species) = @_;
-  return $self->_get_pruned_SimpleAlign(\@species, 'no_prune_ancestral');
+  return $self->_get_filtered_SimpleAlign(\@species);
 }
 
-sub _get_pruned_SimpleAlign {
-  my ( $self, $species, $no_prune_ancestral) = @_;
+sub _get_filtered_SimpleAlign {
+  my ( $self, $species, $prune_ancestral) = @_;
   # This is much the same as 'get_SimpleAlign', but with two key differences:
   # 1) Arg[1] is an arrayref of species names;
   # 2) Arg[2] is a flag indicating whether to prune an ancestral sequence having
-  #    a child for which all extant genomes have been removed. If false, such
-  #    ancestral sequences are pruned. If true, no ancestral pruning is done.
+  #    a child for which all extant genomes have been removed.
 
   my $simple_align;
 
@@ -706,7 +704,7 @@ sub _get_pruned_SimpleAlign {
 
   my $genome_db_name_counter;
 
-  foreach my $slice (@{$self->_get_pruned_Slices($species, $no_prune_ancestral)}) {
+  foreach my $slice (@{$self->_get_filtered_Slices($species, $prune_ancestral)}) {
     my $seq = Bio::LocatableSeq->new(
             -SEQ    => $slice->seq,
             -START  => $slice->start,


### PR DESCRIPTION
## Description

Until e104, web code to support display of EPO alignments pruned ancestral sequences if either of their children had no extant genomes visible in the given alignment view.

[ensembl-webcode PR 1078](https://github.com/Ensembl/ensembl-webcode/pull/1078) aims to restore this functionality. With the initial version of webcode PR 1078, ancestral sequences were pruned from the displayed image/text alignments, but not from exported alignment (e.g. FASTA) files.

This PR would make changes to `Bio::EnsEMBL::Compara::AlignSlice` to support webcode PR 1078, making it possible to prune ancestral sequences both in EPO alignment views and in exported data files.

## Overview of changes

Changes:
- addition of internal method `AlignSlice::_get_filtered_Slices`, which accepts two arguments: an arrayref listing the set of species for which slices should be returned, and a `$prune_ancestral` flag indicating if ancestral sequences should be pruned in accordance with the set of species, with the ancestral pruning code by muffato hailing from [lines 415-431 of the EnsEMBL::Web::Object module](https://github.com/Ensembl/ensembl-webcode/blob/release/114/modules/EnsEMBL/Web/Object.pm#L415-L431);
- addition of internal method `AlignSlice::_get_filtered_SimpleAlign`, which also accepts an arrayref of species and a `$prune_ancestral` flag, and filters alignment sequences accordingly; and
- refactoring of existing public methods `AlignSlice::get_all_Slices` and `AlignSlice::get_SimpleAlign` to call internal methods `_get_filtered_Slices` and `_get_filtered_SimpleAlign`, respectively. This is done so as to avoid a change in behaviour of the existing public methods. 

## Testing

The changes in this PR have been tested in the Compara web sandbox, in conjunction with those of webcode PR 1078.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
