### PR TITLE
Add SystemCommands runnable

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SystemCommands.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SystemCommands.pm
@@ -25,6 +25,8 @@ A runnable inheriting from SystemCmd, with two key differences:
 1) it takes an arrayref of commands instead of a string; and
 2) it does pre-cleanup of the dataflow file, if specified.
 
+As in SystemCmd, parameters are shared across all commands.
+
 =cut
 
 package Bio::EnsEMBL::Compara::RunnableDB::SystemCommands;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SystemCommands.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SystemCommands.pm
@@ -1,0 +1,70 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::SystemCommands
+
+=head1 DESCRIPTION
+
+A runnable inheriting from SystemCmd, with two key differences:
+1) it takes an arrayref of commands instead of a string; and
+2) it does pre-cleanup of the dataflow file, if specified.
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::SystemCommands;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Hive::RunnableDB::SystemCmd');
+
+
+sub pre_cleanup {
+    my $self = shift;
+
+    if ($self->param_is_defined('dataflow_file')) {
+        my $cmd = sprintf('rm -f %s', $self->param('dataflow_file'));
+        $self->run_command($cmd, { die_on_failure => 1 });
+    }
+}
+
+
+sub run {
+    my $self = shift;
+
+    my $commands = $self->param_required('commands');
+
+    my %transferred_options = map {$_ => $self->param($_)} qw(use_bash_pipefail use_bash_errexit timeout);
+
+    my ($return_value, $stderr, $flat_cmd, $stdout, $runtime_msec);
+    foreach my $command (@{$commands}) {
+        ($return_value, $stderr, $flat_cmd, $stdout, $runtime_msec) = $self->run_system_command($command, \%transferred_options);
+        last if $return_value;
+    }
+
+    # To be used in write_output()
+    $self->param('return_value', $return_value);
+    $self->param('stderr', $stderr);
+    $self->param('flat_cmd', $flat_cmd);
+    $self->param('stdout', $stdout);
+    $self->param('runtime_msec', $runtime_msec);
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SystemCommands.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SystemCommands.pm
@@ -40,7 +40,7 @@ sub pre_cleanup {
 
     if ($self->param_is_defined('dataflow_file')) {
         my $cmd = sprintf('rm -f %s', $self->param('dataflow_file'));
-        $self->run_command($cmd, { die_on_failure => 1 });
+        $self->run_system_command($cmd, { die_on_failure => 1 });
     }
 }
 


### PR DESCRIPTION
## Description

This PR would add a `SystemCommands` runnable inheriting from `SystemCmd`, with two key differences:
1. it takes an `arrayref` of commands instead of a string command; and
2. it does pre-cleanup of the dataflow file, if specified.

This runnable is intended to facilitate greater use of integrated healthchecks with less use of Perl.

**Related JIRA tickets:**
- ENSCOMPARASW-8461

## Testing
The runnable has been tested with sample commands such as the following:
```bash
$ standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::SystemCommands \
>     --commands='["echo hello world", "date"]'

Running 'Bio::EnsEMBL::Compara::RunnableDB::SystemCommands' with input_id='{"commands" => ["echo hello world","date"]}' :
Standalone worker 2025370 : specializing to Standalone_Dummy_Analysis(unstored)
hello world
Fri  6 Jun 12:02:30 BST 2025
```

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
