### PR TITLE
Add DumpCactus pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpCactus_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpCactus_conf.pm
@@ -1,0 +1,226 @@
+
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::DumpCactus_conf
+
+=head1 DESCRIPTION
+
+This pipeline makes use of various software tools for processing alignments in HAL or MAF format,
+including Cactus ( Armstrong et al. 2020; https://doi.org/10.1038/s41586-020-2871-y ),
+hal2maf ( Hickey et al. 2013; https://doi.org/10.1093/bioinformatics/btt128 ),
+taffy ( https://github.com/ComparativeGenomicsToolkit/taffy ),
+mafDuplicateFilter ( Earl et al. 2014; https://doi.org/10.1101/gr.174920.114 ),
+Biopython ( Cock et al. 2009; https://doi.org/10.1093/bioinformatics/btp163 ),
+and NumPy ( Harris et al. 2020; https://doi.org/10.1038/s41586-020-2649-2 ).
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::DumpCactus_conf;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Hive::Version v2.4;
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
+
+
+sub default_options {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::default_options},
+
+        'pipeline_name'     => 'dump_cactus',
+
+        # pipeline settings
+        'chunk_size'        => 500_000,
+        'maf_dump_capacity' => 150,
+
+         # data directories:
+        'work_dir'          => $self->o('pipeline_dir'),
+        'dump_dir'          => $self->o('work_dir') . '/' . 'dumps',
+    };
+}
+
+
+sub no_compara_schema {}
+
+
+sub pipeline_checks_pre_init {
+    my ($self) = @_;
+
+    die "Pipeline parameter 'hal_file' is undefined, but must be specified" unless $self->o('hal_file');
+    die "Pipeline parameter 'ref_hal_genome' is undefined, but must be specified" unless $self->o('ref_hal_genome');
+    die "Pipeline parameter 'target_genomes' is undefined, but must be specified" unless $self->o('target_genomes');
+    die "Pipeline parameter 'output_file' is undefined, but must be specified" unless $self->o('output_file');
+}
+
+
+sub pipeline_create_commands {
+    my ($self) = @_;
+
+    return [
+        @{$self->SUPER::pipeline_create_commands},
+
+        $self->pipeline_create_commands_rm_mkdir(['dump_dir', 'work_dir']),
+    ];
+}
+
+
+sub pipeline_wide_parameters {
+    my ($self) = @_;
+
+    return {
+        %{$self->SUPER::pipeline_wide_parameters},
+        'dump_dir'               => $self->o('dump_dir'),
+        'work_dir'               => $self->o('work_dir'),
+
+        'hal_file'               => $self->o('hal_file'),
+        'ref_hal_genome'         => $self->o('ref_hal_genome'),
+        'target_genomes'         => $self->o('target_genomes'),
+        'output_file'            => $self->o('output_file'),
+
+        'hal2maf_exe'            => $self->o('hal2maf_exe'),
+        'halStats_exe'           => $self->o('halStats_exe'),
+        'mafDuplicateFilter_exe' => $self->o('mafDuplicateFilter_exe'),
+        'process_cactus_maf_exe' => $self->o('process_cactus_maf_exe'),
+        'taffy_exe'              => $self->o('taffy_exe'),
+    };
+}
+
+
+sub core_pipeline_analyses {
+    my ($self) = @_;
+
+    my %dump_maf_params = (
+        'hashed_chunk_index' => '#expr(dir_revhash(#hal_chunk_index#))expr#',
+        'maf_parent_dir'     => '#dump_dir#/maf/#hal_genome_name#/#hashed_chunk_index#',
+        'maf_file'           => '#maf_parent_dir#/#hal_chunk_index#.dumped.maf',
+    );
+
+    return [
+
+        {   -logic_name => 'fire_dump_cactus',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -input_ids  => [ { } ],
+            -flow_into  => {
+                '1->A' => { 'hal_seq_chunk_factory' => INPUT_PLUS( { 'hal_genome_name' => '#ref_hal_genome#' } ) },
+                'A->1' => [ 'concatenate_maf' ],
+            },
+        },
+
+        {   -logic_name => 'hal_seq_chunk_factory',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::HAL::halSeqChunkFactory',
+            -rc_name    => '4Gb_job',
+            -parameters => {
+                'hal_stats_exe' => $self->o('halStats_exe'),
+                'chunk_size'    => $self->o('chunk_size'),
+            },
+            -flow_into  => {
+                2 => { 'dump_maf' => INPUT_PLUS() },
+            },
+        },
+
+        {   -logic_name => 'dump_maf',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::HAL::DumpCactusMaf',
+            -hive_capacity => $self->o('maf_dump_capacity'),
+            -rc_name    => '8Gb_24_hour_job',
+            -parameters => { %dump_maf_params },
+            -flow_into => {
+               -1 => 'dump_maf_himem',
+                2 => 'maf_processing_decision',
+            },
+        },
+
+        {   -logic_name => 'dump_maf_himem',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::HAL::DumpCactusMaf',
+            -hive_capacity => $self->o('maf_dump_capacity'),
+            -rc_name    => '16Gb_24_hour_job',
+            -parameters => { %dump_maf_params },
+            -flow_into => {
+               -1 => 'dump_maf_hugemem',
+                2 => 'maf_processing_decision',
+            },
+        },
+
+        {   -logic_name => 'dump_maf_hugemem',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::HAL::DumpCactusMaf',
+            -hive_capacity => $self->o('maf_dump_capacity'),
+            -rc_name    => '32Gb_24_hour_job',
+            -parameters => { %dump_maf_params },
+            -flow_into  => {
+                2 => 'maf_processing_decision',
+            },
+        },
+
+        {   -logic_name => 'maf_processing_decision',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => {
+                1 => WHEN( '#dumped_maf_block_count# > 0' => 'process_maf' ),
+            },
+        },
+
+        {   -logic_name => 'process_maf',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::HAL::ProcessCactusMaf',
+            -analysis_capacity => 700,
+            -rc_name    => '1Gb_job',
+            -parameters => {
+                'processed_maf_file'        => '#maf_parent_dir#/#hal_chunk_index#.processed.maf',
+                'max_block_length_to_merge' => 200,
+                'max_gap_length'            => 30,
+            },
+            -flow_into  => {
+                2 => WHEN(
+                    '#maf_block_count# > 0' => [
+                        '?accu_name=chunked_maf_files&accu_address=[hal_chunk_index]&accu_input_variable=processed_maf_file',
+                        '?accu_name=maf_block_counts&accu_address=[hal_chunk_index]&accu_input_variable=maf_block_count',
+                    ],
+                ),
+            },
+        },
+
+        {   -logic_name => 'concatenate_maf',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::HAL::ConcatenateMaf',
+            -rc_name    => '1Gb_24_hour_job',
+            -parameters => {
+                'healthcheck_list' => ['maf_block_count', 'unexpected_nulls'],
+            },
+        },
+     ];
+}
+
+sub tweak_analyses {
+    my $self = shift;
+
+    $self->SUPER::tweak_analyses(@_);
+
+    my $analyses_by_name = shift;
+
+    my @unguarded_funnels = (
+        'concatenate_maf',
+    );
+
+    foreach my $logic_name (@unguarded_funnels) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HAL/ConcatenateMaf.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HAL/ConcatenateMaf.pm
@@ -1,0 +1,127 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::HAL::ConcatenateMaf
+
+=head1 DESCRIPTION
+
+This runnable concatenates many MAF files into one, keeping
+comments and metadata from the first of the input MAF files.
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::HAL::ConcatenateMaf;
+
+use strict;
+use warnings;
+
+use File::Basename qw(fileparse);
+use File::Copy qw(move);
+use File::Path qw(make_path);
+use File::Spec::Functions qw(catfile);
+use File::Temp qw(tempdir);
+use List::Util qw(sum);
+
+use Bio::EnsEMBL::Compara::Utils::FlatFile qw(check_for_null_characters);
+use Bio::EnsEMBL::Hive::Utils qw(destringify);
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub run {
+    my $self = shift;
+
+    my $input_maf_files = $self->param_required('chunked_maf_files');
+    my $maf_block_counts = $self->param_required('maf_block_counts');
+    my $cat_maf_parent_dir = $self->param_required('work_dir');
+    my $cat_maf_file_name = $self->param_required('output_file');
+
+    my ($first_input_maf_file, @other_input_maf_files) = grep { defined $_ } @{$input_maf_files};
+
+    my $temp_dir = tempdir( CLEANUP => 1, DIR => $self->worker_temp_directory );
+    my $temp_cat_maf_file_path = catfile($temp_dir, $cat_maf_file_name);
+
+    my $cmd1 = "cp $first_input_maf_file $temp_cat_maf_file_path";
+    $self->run_command($cmd1, { die_on_failure => 1 });
+
+    foreach my $other_input_maf_file (@other_input_maf_files) {
+        my $cmd2 = "grep -v '^#' $other_input_maf_file >> $temp_cat_maf_file_path";
+        $self->run_command($cmd2, { die_on_failure => 1 });
+    }
+
+    my $exp_maf_block_count = sum(@{$maf_block_counts});
+
+    $self->param('exp_maf_block_count', $exp_maf_block_count);
+    $self->param('temp_cat_maf_file_path', $temp_cat_maf_file_path);
+}
+
+
+sub write_output {
+    my $self = shift;
+
+    my $temp_cat_maf_file_path = $self->param_required('temp_cat_maf_file_path');
+    my $cat_maf_parent_dir = $self->param_required('work_dir');
+    my $cat_maf_file_name = $self->param_required('output_file');
+
+    my $cat_maf_file_path = catfile($cat_maf_parent_dir, $cat_maf_file_name);
+
+    if ( $self->param_is_defined('healthcheck_list') ) {
+        $self->_healthcheck();
+    }
+
+    make_path($cat_maf_parent_dir);
+    move($temp_cat_maf_file_path, $cat_maf_file_path);
+}
+
+
+sub _healthcheck {
+    my $self = shift;
+
+    my $healthcheck_list = destringify($self->param_required('healthcheck_list'));
+    my $temp_cat_maf_file_path = $self->param('temp_cat_maf_file_path');
+
+    foreach my $hc_type (@{$healthcheck_list}) {
+        if ( $hc_type eq 'maf_block_count' ) {
+
+            my $maf_block_count_cmd = "grep -c '^a' $temp_cat_maf_file_path";
+            my $run_cmd = $self->run_command($maf_block_count_cmd);
+            $run_cmd->die_with_log() if $run_cmd->exit_code >= 2;
+            my ($obs_maf_block_count) = split(/\n/, $run_cmd->out);
+
+            my $exp_maf_block_count = $self->param_required('exp_maf_block_count');
+            if ($obs_maf_block_count != $exp_maf_block_count) {
+                $self->die_no_retry(
+                    sprintf(
+                        "Number of MAF blocks in concatenated file is %d but should be %d",
+                        $obs_maf_block_count,
+                        $exp_maf_block_count,
+                    )
+                );
+            }
+
+        } elsif ( $hc_type eq 'unexpected_nulls' ) {
+            check_for_null_characters($temp_cat_maf_file_path);
+        } else {
+            $self->die_no_retry("Healthcheck type '$hc_type' not recognised");
+        }
+    }
+}
+
+
+1;


### PR DESCRIPTION
## Description

This PR introduces a `DumpCactus` pipeline to be used for extracting a MAF file from a Cactus HAL.

It makes some changes to `LoadCactus` pipeline runnables to support dumping MAFs independently of a Compara database.

**Related JIRA tickets:**
- ENSCOMPARASW-8436
- ENSCOMPARASW-8474

## Overview of changes

Changes include:
- addition of pipeline config `DumpCactus_conf.pm`;
- addition of runnable `ConcatenateMaf` to concatenate an ordered list of chunked MAF files;
- adaptation of `halSeqChunkFactory` to allow parameter `hal_file` to be explicitly specified, and to generate a numeric `hal_chunk_index` which can be more easily used to accumulate an ordered list of processed MAF file paths;
- adaptation of `DumpCactusMaf` to allow parameters `hal_file`, `max_block_length_to_dump` and `target_genomes` to be explicitly configured, and to pass the `hal_chunk_index` parameter into output dataflows;
- adaptation of `ProcessCactusMaf` to allow parameters `hal_file` and `target_genomes` to be explicitly specified, to ensure the reference genome is included in the processed MAF, and to pass the `hal_chunk_index` parameter into output dataflows.

## Testing
This pipeline was tested by dumping genomic alignments in MAF format from a Cactus HAL file. 

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
