### PR TITLE
Enhance FTP dump validation

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -129,6 +129,7 @@ sub executable_locations {
         'DumpGFFAlignmentsForSynteny_exe'   => $self->check_exe_in_ensembl('ensembl-compara/scripts/synteny/DumpGFFAlignmentsForSynteny.pl'),
         'DumpGFFHomologuesForSynteny_exe'   => $self->check_exe_in_ensembl('ensembl-compara/scripts/synteny/DumpGFFHomologuesForSynteny.pl'),
         'emf2maf_program'                   => $self->check_exe_in_ensembl('ensembl-compara/scripts/dumps/emf2maf.pl'),
+        'ftp_file_check_exe'                => $self->check_exe_in_ensembl('ensembl-compara/scripts/dumps/check_compara_ftp_files.pl'),
         'init_dump_registry_exe'            => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/init_dump_registry.pl'),
         'list_must_reuse_species_exe'       => $self->check_exe_in_ensembl('ensembl-compara/scripts/production/list_must_reuse_species.py'),
         'msa_stats_report_exe'              => $self->check_exe_in_ensembl('ensembl-compara/scripts/production/msa_stats.pl'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConstrainedElements.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpConstrainedElements.pm
@@ -54,7 +54,7 @@ sub pipeline_analyses_dump_constrained_elems {
                 'extra_parameters'      => [ 'name' ],
             },
             -flow_into      => {
-                '2->A' => [ 'dump_constrained_elements' ],
+                '2->A' => [ 'fetch_exp_ce_line_count' ],
                 'A->1' => [ 'ce_funnel_check' ],
             },
         },
@@ -65,24 +65,34 @@ sub pipeline_analyses_dump_constrained_elems {
             -flow_into  => [ { 'md5sum_ce' => INPUT_PLUS() } ],
         },
 
-        {   -logic_name     => 'dump_constrained_elements',
-            -module         => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -parameters     => {
-                'cmd'   => '#dump_features_exe# --feature ce_#mlss_id# --compara_db #compara_db# --species #name# --lex_sort --reg_conf "#registry#" | tail -n+2 > #bed_file#',
-                'registry' => '#reg_conf#',
+        {   -logic_name => 'fetch_exp_ce_line_count',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+            -parameters => {
+                'db_conn'    => '#compara_db#',
+                'inputquery' => q/
+                    SELECT COUNT(DISTINCT dnafrag_id, dnafrag_start, dnafrag_end) AS exp_ce_line_count
+                    FROM constrained_element
+                    JOIN dnafrag USING (dnafrag_id)
+                    WHERE method_link_species_set_id = #mlss_id#
+                    AND genome_db_id = #genome_db_id#
+                /,
             },
-            -rc_name        => '4Gb_24_hour_job',
-            -hive_capacity => $self->o('dump_ce_capacity'),
-            -flow_into      => [ 'check_not_empty' ],
+            -flow_into  => { 2 => { 'dump_constrained_elements' => INPUT_PLUS() } },
         },
 
-        {   -logic_name     => 'check_not_empty',
-            -module         => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::CheckNotEmpty',
-            -rc_name        => '1Gb_job',
+        {   -logic_name     => 'dump_constrained_elements',
+            -module         => 'Bio::EnsEMBL::Compara::RunnableDB::SystemCommands',
             -parameters     => {
-                'min_number_of_lines'   => 1,   # The header is always present
-                'filename'              => '#bed_file#',
+                'commands' => [
+                    q/#dump_features_exe# --feature ce_#mlss_id# --compara_db #compara_db# --species #name# --lex_sort --reg_conf "#registry#" | tail -n+2 > #bed_file#/,
+                    q/#textlint_exe# null #bed_file#/,
+                    q/[[ $(grep -vc '^track\b' #bed_file#) -eq #exp_ce_line_count# ]]/,  # to keep it simple we do not count BED track lines
+                ],
+                'registry' => '#reg_conf#',
+                'textlint_exe' => $self->o('textlint_exe'),
             },
+            -rc_name        => '4Gb_24_hour_job',
+            -hive_capacity  => $self->o('dump_ce_capacity'),
             -flow_into      => [ 'convert_to_bigbed' ],
         },
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/CheckFTPSkeleton.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/CheckFTPSkeleton.pm
@@ -1,0 +1,103 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::CheckFTPSkeleton
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::CheckFTPSkeleton;
+
+use strict;
+use warnings;
+
+use File::Spec::Functions qw(catdir);
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub param_defaults {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::param_defaults},
+        ftp_locations => {
+            LASTZ_NET => ['maf/ensembl-compara/pairwise_alignments'],
+            EPO => ['emf/ensembl-compara/multiple_alignments', 'maf/ensembl-compara/multiple_alignments'],
+            EPO_EXTENDED => ['emf/ensembl-compara/multiple_alignments', 'maf/ensembl-compara/multiple_alignments'],
+            PECAN => ['emf/ensembl-compara/multiple_alignments', 'maf/ensembl-compara/multiple_alignments'],
+            GERP_CONSTRAINED_ELEMENT => ['bed/ensembl-compara'],
+            GERP_CONSERVATION_SCORE  => ['compara/conservation_scores'],
+        },
+        copy_ancestral_alleles => 0,
+    }
+}
+
+
+sub fetch_input {
+    my $self = shift;
+
+    my %ftp_locations = %{ $self->param_required('ftp_locations') };
+
+    my %rel_base_dirs;
+    foreach my $method_type ( keys %ftp_locations ) {
+        my $method_base_dirs = $self->_mlss_base_dirs($method_type);
+        foreach my $method_base_dir (@{$method_base_dirs}) {
+            $rel_base_dirs{$method_base_dir} = 1;
+        }
+    }
+
+    if ($self->param_required('copy_ancestral_alleles')) {
+        my $anc_out_base_dir = $self->param_required('anc_output_basedir');
+        $rel_base_dirs{$anc_out_base_dir} = 1;
+    }
+
+    $self->param('base_dirs', [sort keys %rel_base_dirs]);
+}
+
+
+sub run {
+    my $self = shift;
+
+    my $dump_dir = $self->param_required('dump_dir');
+
+    foreach my $base_dir_rel_path ( @{ $self->param('base_dirs') } ) {
+        my $base_dir_full_path = catdir($dump_dir, $base_dir_rel_path);
+        unless ( -e $base_dir_full_path && -d $base_dir_full_path ) {
+            $self->die_no_retry("cannot find FTP base directory '$base_dir_full_path'");
+        }
+    }
+}
+
+
+sub _mlss_base_dirs {
+    my ($self, $method_type) = @_;
+
+    my $mlss_adaptor = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor;
+    my @mlsses = map { $mlss_adaptor->fetch_by_dbID($_) } @{ $self->param_required('mlss_ids') };
+
+    my $method_base_dirs = [];
+    if (grep { $_->method->type eq $method_type } @mlsses) {
+        my $base_dirs_by_method_type = $self->param_is_defined('ftp_locations') ? $self->param('ftp_locations') : [];
+        $method_base_dirs = $base_dirs_by_method_type->{$method_type};
+    }
+
+    return $method_base_dirs;
+}
+
+
+1;


### PR DESCRIPTION
## Description

This PR would make various changes to enhance validation in the Compara FTP dump pipeline.

**Related JIRA tickets:**
- ENSCOMPARASW-8465
- ENSCOMPARASW-8466
- ENSCOMPARASW-8467
- ENSCOMPARASW-8420

## Overview of changes

Proposed changes include:
- add runnable `CheckFTPSkeleton`, and using this in `DumpAllForRelease` analysis to `check_prev_ftp_skeleton`;
- integrate XML validation into `dump_a_tree` / `dump_a_tree_himem`;
- change `dump_constrained_elements` to use the `SystemCommands` runnable;
- integrate a `null_character` healthcheck into `dump_constrained_elements`;
- integrate a `line_count` healthcheck into `dump_constrained_elements`, remove the subsequent `check_not_empty` step, and place `fetch_exp_ce_line_count` just upstream to fetch the expected data-line count;
- integrate `check_compara_ftp_files.pl` into a `final_checks` step after the `final_registry_backup`.


## Testing
These changes were checked by doing test runs of the relevant sections of the Compara FTP dump pipeline.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
