### PR TITLE
Block unguarded funnel analyses in ProteinTrees

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/ProteinTrees_conf.pm
@@ -28,6 +28,9 @@ Bio::EnsEMBL::Compara::PipeConfig::Fungi::ProteinTrees_conf
 
 The Fungi PipeConfig file for ProteinTrees pipeline automating execution of homology-specific analyses.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Fungi::ProteinTrees_conf;
@@ -92,6 +95,22 @@ sub tweak_analyses {
     $analyses_by_name->{'members_against_allspecies_factory'}->{'-parameters'}->{'num_sequences_per_blast_job'} = 5000;
 
     $analyses_by_name->{'make_treebest_species_tree'}->{'-parameters'}->{'allow_subtaxa'} = 1;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'create_mlss_ss',
+        'datacheck_funnel',
+        'exon_boundaries_prep',
+        'hc_cafe_results',
+        'hc_post_tree',
+        'hcluster_dump_input_all_pafs',
+        'ortholog_mlss_factory',
+        'panther_paralogs',
+        'store_tags',
+    );
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ProteinTrees_conf.pm
@@ -27,6 +27,9 @@ Bio::EnsEMBL::Compara::PipeConfig::Metazoa::ProteinTrees_conf
 
 The Metazoa PipeConfig file for ProteinTrees pipeline that should automate most of the pre-execution tasks.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Metazoa::ProteinTrees_conf;
@@ -121,6 +124,22 @@ sub tweak_analyses {
 
     foreach my $logic_name (keys %overriden_rc_names) {
         $analyses_by_name->{$logic_name}->{'-rc_name'} = $overriden_rc_names{$logic_name};
+    }
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'create_mlss_ss',
+        'datacheck_funnel',
+        'exon_boundaries_prep',
+        'hc_cafe_results',
+        'hc_post_tree',
+        'hcluster_dump_input_all_pafs',
+        'ortholog_mlss_factory',
+        'panther_paralogs',
+        'store_tags',
+    );
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
     }
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/ProteinTrees_conf.pm
@@ -30,6 +30,9 @@ Bio::EnsEMBL::Compara::PipeConfig::Pan::ProteinTrees_conf
 
 The Pan PipeConfig file for ProteinTrees pipeline that should automate most of the pre-execution tasks.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Pan::ProteinTrees_conf;
@@ -121,6 +124,22 @@ sub tweak_analyses {
     );
     foreach my $logic_name (keys %overriden_rc_names) {
         $analyses_by_name->{$logic_name}->{'-rc_name'} = $overriden_rc_names{$logic_name};
+    }
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'create_mlss_ss',
+        'datacheck_funnel',
+        'exon_boundaries_prep',
+        'hc_cafe_results',
+        'hc_post_tree',
+        'hcluster_dump_input_all_pafs',
+        'ortholog_mlss_factory',
+        'panther_paralogs',
+        'store_tags',
+    );
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
     }
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/CultivarsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/CultivarsProteinTrees_conf.pm
@@ -115,15 +115,14 @@ sub core_pipeline_analyses {
 
 sub tweak_analyses {
     my $self = shift;
+
+    $self->SUPER::tweak_analyses(@_);
+
     my $analyses_by_name = shift;
 
     $analyses_by_name->{'make_treebest_species_tree'}->{'-parameters'}->{'allow_subtaxa'} = 1;  # We have sub-species
     $analyses_by_name->{'make_treebest_species_tree'}->{'-parameters'}->{'multifurcation_deletes_all_subnodes'} = $self->o('multifurcation_deletes_all_subnodes');
     $analyses_by_name->{'split_genes'}->{'-hive_capacity'} = 300;
-
-    # datacheck specific tweaks for pipelines
-    $analyses_by_name->{'datacheck_factory'}->{'-parameters'} = {'dba' => '#compara_db#'};
-    $analyses_by_name->{'store_results'}->{'-parameters'} = {'dbname' => '#db_name#'};
 
     # Wire up cultivar-specific analyses
     $analyses_by_name->{'remove_blocklisted_genes'}->{'-flow_into'} = ['find_overlapping_genomes'];

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
@@ -29,6 +29,9 @@ Bio::EnsEMBL::Compara::PipeConfig::Plants::ProteinTrees_conf
 
 The Plants PipeConfig file for ProteinTrees pipeline that should automate most of the pre-execution tasks.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Plants::ProteinTrees_conf;
@@ -131,6 +134,21 @@ sub tweak_analyses {
     $analyses_by_name->{'check_file_copy'}->{'-rc_name'}   = '1Gb_job';
 
 
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'create_mlss_ss',
+        'datacheck_funnel',
+        'exon_boundaries_prep',
+        'hc_cafe_results',
+        'hc_post_tree',
+        'hcluster_dump_input_all_pafs',
+        'ortholog_mlss_factory',
+        'panther_paralogs',
+        'store_tags',
+    );
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -3097,6 +3097,7 @@ sub core_pipeline_analyses {
         {   -logic_name => 'final_tree_steps',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => [ 'ktreedist', 'consensus_cigar_line_prep' ],
+            %decision_analysis_params,
         },
 
         {   -logic_name    => 'ktreedist',
@@ -3840,8 +3841,8 @@ sub tweak_analyses {
     my $analyses_by_name = shift;
 
     # datacheck specific tweaks for pipelines
-    $analyses_by_name->{'datacheck_factory'}->{'-parameters'} = {'dba' => '#compara_db#'};
-    $analyses_by_name->{'store_results'}->{'-parameters'} = {'dbname' => '#db_name#'};
+    $analyses_by_name->{'datacheck_factory'}->{'-parameters'}{'dba'} = '#compara_db#';
+    $analyses_by_name->{'store_results'}->{'-parameters'}{'dbname'} = '#db_name#';
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/ProteinTrees_conf.pm
@@ -28,6 +28,9 @@ Bio::EnsEMBL::Compara::PipeConfig::Protists::ProteinTrees_conf
 
 The Protists PipeConfig file for ProteinTrees pipeline automating execution of homology-specific analyses.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Protists::ProteinTrees_conf;
@@ -100,6 +103,22 @@ sub tweak_analyses {
     $analyses_by_name->{'HMMer_classify_factory'}->{'-parameters'}->{'step'} = 50;
 
     $analyses_by_name->{'make_treebest_species_tree'}->{'-parameters'}->{'allow_subtaxa'} = 1;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'create_mlss_ss',
+        'datacheck_funnel',
+        'exon_boundaries_prep',
+        'hc_cafe_results',
+        'hc_post_tree',
+        'hcluster_dump_input_all_pafs',
+        'ortholog_mlss_factory',
+        'panther_paralogs',
+        'store_tags',
+    );
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ProteinTrees_conf.pm
@@ -29,6 +29,9 @@ Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::ProteinTrees_conf
 
 The Vertebrates PipeConfig file for ProteinTrees pipeline that should automate most of the pre-execution tasks.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::ProteinTrees_conf;
@@ -118,7 +121,23 @@ sub tweak_analyses {
         $analyses_by_name->{$logic_name}->{'-rc_name'} = $overriden_rc_names{$logic_name};
     }
     $analyses_by_name->{'CAFE_analysis'}->{'-parameters'}{'pvalue_lim'} = 1;
-    $analyses_by_name->{'make_treebest_species_tree'}->{'-parameters'}->{'allow_subtaxa'} = 1;
+    $analyses_by_name->{'make_treebest_species_tree'}->{'-parameters'}->{'allow_subtaxa'} = 1;  # We have sub-species
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'create_mlss_ss',
+        'datacheck_funnel',
+        'exon_boundaries_prep',
+        'hc_cafe_results',
+        'hc_post_tree',
+        'hcluster_dump_input_all_pafs',
+        'ortholog_mlss_factory',
+        'panther_paralogs',
+        'store_tags',
+    );
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsProteinTrees_conf.pm
@@ -118,15 +118,14 @@ sub core_pipeline_analyses {
 
 sub tweak_analyses {
     my $self = shift;
+
+    $self->SUPER::tweak_analyses(@_);
+
     my $analyses_by_name = shift;
 
     $analyses_by_name->{'make_treebest_species_tree'}->{'-parameters'}->{'allow_subtaxa'} = 1;  # We have sub-species
     $analyses_by_name->{'make_treebest_species_tree'}->{'-parameters'}->{'multifurcation_deletes_all_subnodes'} = $self->o('multifurcation_deletes_all_subnodes');
     $analyses_by_name->{'split_genes'}->{'-hive_capacity'} = 300;
-
-    # datacheck specific tweaks for pipelines
-    $analyses_by_name->{'datacheck_factory'}->{'-parameters'} = {'dba' => '#compara_db#'};
-    $analyses_by_name->{'store_results'}->{'-parameters'} = {'dbname' => '#db_name#'};
 
     # wire up strain-specific analyses
     $analyses_by_name->{'remove_blocklisted_genes'}->{'-flow_into'} = ['find_overlapping_genomes'];


### PR DESCRIPTION
## Description

Compara Hive pipelines in recent production cycles have been affected by a sporadic issue with premature semaphore release that has proved time-consuming to deal with, difficult to reproduce and challenging to eliminate completely.

This PR implements a mitigating measure, by blocking unguarded funnel analyses in the `ProteinTrees` pipeline, with the expectation that these would be unblocked as needed during pipeline execution.

**Related JIRA tickets:**
- ENSCOMPARASW-8408

## Overview of changes

Changes include:
- Compara divsion protein-tree pipeline config files are tweaked to block unguarded funnel analyses;
- strain/breed/cultivar `tweak_analyses` now call the superclass method, so that relevant tweaks configured in parent pipeline configs are applied in strain/breed/cultivar protein-tree pipelines; and
- `final_tree_steps` is configured with `%decision_analysis_params` to ensure that the capacity of this analysis just downstream of `hc_post_tree` is kept within a reasonable limit.

## Testing
Test pipelines were initialised to confirm that funnel-blocking tweaks were applied successfully.

Details of the test pipelines can be found in the related ticket.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
