### PR TITLE
Block unguarded funnel analyses in ncRNAtrees

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsNcRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsNcRNAtrees_conf.pm
@@ -102,6 +102,9 @@ sub core_pipeline_analyses {
 
 sub tweak_analyses {
     my $self = shift;
+
+    $self->SUPER::tweak_analyses(@_);
+
     my $analyses_by_name = shift;
 
     $analyses_by_name->{'insert_member_projections'}->{'-parameters'}->{'source_species_names'} = $self->o('projection_source_species_names');
@@ -112,10 +115,6 @@ sub tweak_analyses {
     # wire up strain-specific analyses
     $analyses_by_name->{'expand_clusters_with_projections'}->{'-flow_into'} = 'find_overlapping_genomes';
     push @{$analyses_by_name->{'fire_final_analyses'}->{'-flow_into'}}, 'remove_overlapping_homologies';
-
-    # datacheck specific tweaks for pipelines
-    $analyses_by_name->{'datacheck_factory'}->{'-parameters'} = {'dba' => '#compara_db#'};
-    $analyses_by_name->{'store_results'}->{'-parameters'} = {'dbname' => '#db_name#'};
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ncRNAtrees_conf.pm
@@ -25,8 +25,12 @@ Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::ncRNAtrees_conf
 
 =head1 DESCRIPTION
 
-This is the Vertebrates PipeConfig for the ncRNAtrees pipeline. Please, refer
-to the parent class for further information.
+This is the Vertebrates PipeConfig for the ncRNAtrees pipeline.
+Further information on this PipeConfig may be obtained in the
+parent class documentation.
+
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
 
 =head1 EXAMPLES
 
@@ -94,6 +98,16 @@ sub tweak_analyses {
 
     $analyses_by_name->{'make_species_tree'}->{'-parameters'}->{'allow_subtaxa'} = 1;
     $analyses_by_name->{'make_full_species_tree'}->{'-parameters'}->{'allow_subtaxa'} = 1;
+
+    ## Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'hc_cafe_results',
+        'ortholog_mlss_factory',
+        'treebest_mmerge',
+    );
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -102,6 +102,7 @@ sub default_options {
         'aligner_for_tree_break_capacity' => 200,
         'infernal_capacity'               => 200,
         'orthotree_capacity'              => 200,
+        'ktreedist_capacity'              => 150,
         'treebest_capacity'               => 400,
         'genomic_tree_capacity'           => 300,
         'genomic_alignment_capacity'      => 700,
@@ -1329,6 +1330,7 @@ sub core_pipeline_analyses {
 
         {   -logic_name    => 'ktreedist',
             -module        => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::Ktreedist',
+            -analysis_capacity => $self->o('ktreedist_capacity'),
             -parameters => {
                             'treebest_exe'  => $self->o('treebest_exe'),
                             'ktreedist_exe' => $self->o('ktreedist_exe'),
@@ -1338,6 +1340,7 @@ sub core_pipeline_analyses {
 
         {   -logic_name     => 'consensus_cigar_line_prep',
             -module         => 'Bio::EnsEMBL::Compara::RunnableDB::ObjectStore::GeneTreeAlnConsensusCigarLine',
+            -analysis_capacity => $self->o('ktreedist_capacity'),
             -rc_name        => '4Gb_job',
             -batch_size     => 20,
         },
@@ -1553,8 +1556,8 @@ sub tweak_analyses {
     my $analyses_by_name = shift;
 
     # datacheck specific tweaks for pipelines
-    $analyses_by_name->{'datacheck_factory'}->{'-parameters'} = {'dba' => '#compara_db#'};
-    $analyses_by_name->{'store_results'}->{'-parameters'} = {'dbname' => '#db_name#'};
+    $analyses_by_name->{'datacheck_factory'}->{'-parameters'}{'dba'} = '#compara_db#';
+    $analyses_by_name->{'store_results'}->{'-parameters'}{'dbname'} = '#db_name#';
 }
 
 1;


### PR DESCRIPTION
## Description

Compara Hive pipelines in recent production cycles have been affected by a sporadic issue with premature semaphore release that has proved time-consuming to deal with, difficult to reproduce and challenging to eliminate completely.

This PR implements a mitigating measure, by blocking unguarded funnel analyses in the `ncRNAtrees` pipeline, with the expectation that these would be unblocked as needed during pipeline execution.

**Related JIRA tickets:**
- ENSCOMPARASW-8409

## Overview of changes

Changes include:
- Compara division ncRNA-tree pipeline config files are tweaked to block unguarded funnel analyses;
- strain/breed `tweak_analyses` now call the superclass method, so that relevant tweaks configured in parent pipeline configs are applied in strain/breed ncRNA-tree pipelines; and
- `ktreedist` and `consensus_cigar_line_prep` are configured to ensure that the capacity of these analyses just downstream of `treebest_mmerge` are kept within reasonable limits.

## Testing
Test pipelines were initialised to confirm that funnel-blocking tweaks were applied successfully.

Details of the test pipelines can be found in the related ticket.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
