### PR TITLE
Block unguarded funnel jobs in various pipelines

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/LoadMembers_conf.pm
@@ -61,6 +61,7 @@ sub default_options {
 
 sub tweak_analyses {
     my $self = shift;
+    $self->SUPER::tweak_analyses(@_);
     my $analyses_by_name = shift;
 
     # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/LoadMembers_conf.pm
@@ -29,6 +29,9 @@ Bio::EnsEMBL::Compara::PipeConfig::Fungi::LoadMembers_conf
 Specialized version of the LoadMembers pipeline for Fungi. Please, refer
 to the parent class for further information.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Fungi::LoadMembers_conf;
@@ -54,6 +57,27 @@ sub default_options {
         'store_ncrna'   => 0,  # Store ncRNA genes
         'store_others'  => 0,  # Store other genes
     };
+}
+
+sub tweak_analyses {
+    my $self = shift;
+    my $analyses_by_name = shift;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'offset_tables',
+        'load_all_genomedbs_from_registry',
+        'create_reuse_ss',
+        'polyploid_genome_reuse_factory',
+        'polyploid_genome_load_fresh_factory',
+        'nonpolyploid_genome_load_fresh_factory',
+        'hc_members_globally',
+    );
+
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/MergeDBsIntoRelease_conf.pm
@@ -75,6 +75,7 @@ sub default_options {
 
 sub tweak_analyses {
     my $self = shift;
+    $self->SUPER::tweak_analyses(@_);
     my $analyses_by_name = shift;
 
     # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/MergeDBsIntoRelease_conf.pm
@@ -32,6 +32,9 @@ The default parameters work well in the context of a Compara release for Fungi (
 Registry file). If the list of source databases is different, have a look at the bottom of the base file
 for alternative configurations.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Fungi::MergeDBsIntoRelease_conf;
@@ -68,6 +71,22 @@ sub default_options {
             'mapping_session' => 'master_db',
         },
     };
+}
+
+sub tweak_analyses {
+    my $self = shift;
+    my $analyses_by_name = shift;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'fire_post_merge_processing',
+        'enable_keys',
+    );
+
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeDBsIntoRelease_conf.pm
@@ -153,7 +153,7 @@ sub hive_meta_table {
 
 =head2 core_pipeline_analyses
 
-    Description : Implements core_pipeline_analyses() interface method of Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf that defines the structure of the pipeline: analyses, jobs, rules, etc.
+    Description : Implements core_pipeline_analyses() interface method of Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf that defines the structure of the pipeline: analyses, jobs, rules, etc.
                   Here it defines three analyses:
                     * 'generate_job_list'           generates a list of tables to be copied / merged
                     * 'copy_table'                  dumps tables from source_db and re-creates them in pipeline_db

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeDBsIntoRelease_conf.pm
@@ -151,9 +151,9 @@ sub hive_meta_table {
 }
 
 
-=head2 pipeline_analyses
+=head2 core_pipeline_analyses
 
-    Description : Implements pipeline_analyses() interface method of Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf that defines the structure of the pipeline: analyses, jobs, rules, etc.
+    Description : Implements core_pipeline_analyses() interface method of Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf that defines the structure of the pipeline: analyses, jobs, rules, etc.
                   Here it defines three analyses:
                     * 'generate_job_list'           generates a list of tables to be copied / merged
                     * 'copy_table'                  dumps tables from source_db and re-creates them in pipeline_db
@@ -163,7 +163,7 @@ sub hive_meta_table {
 
 =cut
 
-sub pipeline_analyses {
+sub core_pipeline_analyses {
     my ($self) = @_;
     return [
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/LoadMembers_conf.pm
@@ -63,6 +63,7 @@ sub default_options {
 
 sub tweak_analyses {
     my $self = shift;
+    $self->SUPER::tweak_analyses(@_);
     my $analyses_by_name = shift;
 
     $analyses_by_name->{'check_reusability'}->{'-parameters'}{'list_must_reuse_species_exe'} = $self->o('list_must_reuse_species_exe');

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/LoadMembers_conf.pm
@@ -28,6 +28,9 @@ Bio::EnsEMBL::Compara::PipeConfig::Metazoa::LoadMembers_conf
 Specialized version of the LoadMembers pipeline for Metazoa. Please, refer
 to the parent class for further information.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Metazoa::LoadMembers_conf;
@@ -66,6 +69,22 @@ sub tweak_analyses {
     $analyses_by_name->{'check_reusability'}->{'-parameters'}{'must_reuse_collection_file'} = catfile($self->o('config_dir'), 'must_reuse_collections.json');
     $analyses_by_name->{'check_reusability'}->{'-parameters'}{'mlss_conf_file'} = catfile($self->o('config_dir'), 'mlss_conf.xml');
     $analyses_by_name->{'check_reusability'}->{'-parameters'}{'ensembl_release'} = $self->o('ensembl_release');
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'offset_tables',
+        'load_all_genomedbs_from_registry',
+        'create_reuse_ss',
+        'polyploid_genome_reuse_factory',
+        'polyploid_genome_load_fresh_factory',
+        'nonpolyploid_genome_load_fresh_factory',
+        'hc_members_globally',
+    );
+
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/MergeDBsIntoRelease_conf.pm
@@ -33,6 +33,9 @@ The default parameters work well in the context of a Compara release for Metazoa
 Registry file). If the list of source-databases is different, have a look at the bottom of the base file
 for alternative configurations.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Metazoa::MergeDBsIntoRelease_conf;
@@ -95,4 +98,21 @@ sub default_options {
         ],
     }
 }
+
+sub tweak_analyses {
+    my $self = shift;
+    my $analyses_by_name = shift;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'fire_post_merge_processing',
+        'enable_keys',
+    );
+
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+
+}
+
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/MergeDBsIntoRelease_conf.pm
@@ -101,6 +101,7 @@ sub default_options {
 
 sub tweak_analyses {
     my $self = shift;
+    $self->SUPER::tweak_analyses(@_);
     my $analyses_by_name = shift;
 
     # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/LoadMembers_conf.pm
@@ -65,6 +65,7 @@ sub default_options {
 
 sub tweak_analyses {
     my $self = shift;
+    $self->SUPER::tweak_analyses(@_);
     my $analyses_by_name = shift;
 
     # The metadata service reports human annotation updates almost every

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/LoadMembers_conf.pm
@@ -30,6 +30,9 @@ Bio::EnsEMBL::Compara::PipeConfig::Pan::LoadMembers_conf
 Specialized version of the LoadMembers pipeline for Pan. Please, refer
 to the parent class for further information.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Pan::LoadMembers_conf;
@@ -68,6 +71,22 @@ sub tweak_analyses {
     # release because of LRGs and assembly patches, which we don't care
     # about in this division.
     $analyses_by_name->{compare_non_reused_genome_list}->{'-parameters'}->{'ok_homo_sapiens'} = 1;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'offset_tables',
+        'load_all_genomedbs_from_registry',
+        'create_reuse_ss',
+        'polyploid_genome_reuse_factory',
+        'polyploid_genome_load_fresh_factory',
+        'nonpolyploid_genome_load_fresh_factory',
+        'hc_members_globally',
+    );
+
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/MergeDBsIntoRelease_conf.pm
@@ -80,6 +80,7 @@ sub default_options {
 
 sub tweak_analyses {
     my $self = shift;
+    $self->SUPER::tweak_analyses(@_);
     my $analyses_by_name = shift;
 
     # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/MergeDBsIntoRelease_conf.pm
@@ -40,6 +40,9 @@ The default parameters work well in the context of a Compara release for Pan (wi
 Registry file). If the list of source-databases is different, have a look at the bottom of the base file
 for alternative configurations.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Pan::MergeDBsIntoRelease_conf;
@@ -73,6 +76,22 @@ sub default_options {
             'mapping_session'         => 'master_db',
         },
     };
+}
+
+sub tweak_analyses {
+    my $self = shift;
+    my $analyses_by_name = shift;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'fire_post_merge_processing',
+        'enable_keys',
+    );
+
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/LoadMembers_conf.pm
@@ -66,6 +66,7 @@ sub default_options {
 
 sub tweak_analyses {
     my $self = shift;
+    $self->SUPER::tweak_analyses(@_);
     my $analyses_by_name = shift;
 
     # Genomes such as avena_sativa_ot3098 need a little more memory.

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/LoadMembers_conf.pm
@@ -30,6 +30,9 @@ Bio::EnsEMBL::Compara::PipeConfig::Plants::LoadMembers_conf
 Specialized version of the LoadMembers pipeline for Plants. Please, refer
 to the parent class for further information.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Plants::LoadMembers_conf;
@@ -72,6 +75,21 @@ sub tweak_analyses {
     # release because of LRGs and assembly patches, which we don't care
     # about in this division.
     $analyses_by_name->{compare_non_reused_genome_list}->{'-parameters'}->{'ok_homo_sapiens'} = 1;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'offset_tables',
+        'load_all_genomedbs_from_registry',
+        'create_reuse_ss',
+        'polyploid_genome_reuse_factory',
+        'polyploid_genome_load_fresh_factory',
+        'nonpolyploid_genome_load_fresh_factory',
+        'hc_members_globally',
+    );
+
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/MergeDBsIntoRelease_conf.pm
@@ -40,6 +40,9 @@ The default parameters work well in the context of a Compara release for Plants 
 Registry file). If the list of source-databases is different, have a look at the bottom of the base file
 for alternative configurations.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Plants::MergeDBsIntoRelease_conf;
@@ -94,6 +97,22 @@ sub default_options {
             'barley_prot_db' => [qw(ortholog_quality datacheck_results)],
         },
     };
+}
+
+sub tweak_analyses {
+    my $self = shift;
+    my $analyses_by_name = shift;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'fire_post_merge_processing',
+        'enable_keys',
+    );
+
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/MergeDBsIntoRelease_conf.pm
@@ -101,6 +101,7 @@ sub default_options {
 
 sub tweak_analyses {
     my $self = shift;
+    $self->SUPER::tweak_analyses(@_);
     my $analyses_by_name = shift;
 
     # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/LoadMembers_conf.pm
@@ -29,6 +29,9 @@ Bio::EnsEMBL::Compara::PipeConfig::Protists::LoadMembers_conf
 Specialized version of the LoadMembers pipeline for Protists. Please, refer
 to the parent class for further information.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Protists::LoadMembers_conf;
@@ -55,6 +58,27 @@ sub default_options {
         'store_ncrna'   => 0,  # Store ncRNA genes
         'store_others'  => 0,  # Store other genes
     };
+}
+
+sub tweak_analyses {
+    my $self = shift;
+    my $analyses_by_name = shift;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'offset_tables',
+        'load_all_genomedbs_from_registry',
+        'create_reuse_ss',
+        'polyploid_genome_reuse_factory',
+        'polyploid_genome_load_fresh_factory',
+        'nonpolyploid_genome_load_fresh_factory',
+        'hc_members_globally',
+    );
+
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/LoadMembers_conf.pm
@@ -62,6 +62,7 @@ sub default_options {
 
 sub tweak_analyses {
     my $self = shift;
+    $self->SUPER::tweak_analyses(@_);
     my $analyses_by_name = shift;
 
     # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/MergeDBsIntoRelease_conf.pm
@@ -75,6 +75,7 @@ sub default_options {
 
 sub tweak_analyses {
     my $self = shift;
+    $self->SUPER::tweak_analyses(@_);
     my $analyses_by_name = shift;
 
     # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/MergeDBsIntoRelease_conf.pm
@@ -32,6 +32,9 @@ The default parameters work well in the context of a Compara release for Protist
 Registry file). If the list of source-databases is different, have a look at the bottom of the base file
 for alternative configurations.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Protists::MergeDBsIntoRelease_conf;
@@ -68,6 +71,22 @@ sub default_options {
             'mapping_session'         => 'master_db',
         },
     };
+}
+
+sub tweak_analyses {
+    my $self = shift;
+    my $analyses_by_name = shift;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'fire_post_merge_processing',
+        'enable_keys',
+    );
+
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/LoadMembers_conf.pm
@@ -30,6 +30,9 @@ Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::LoadMembers_conf
 Specialized version of the LoadMembers pipeline for Vertebrates. Please, refer
 to the parent class for further information.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::LoadMembers_conf;
@@ -62,5 +65,25 @@ sub default_options {
     };
 }
 
+sub tweak_analyses {
+    my $self = shift;
+    my $analyses_by_name = shift;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'offset_tables',
+        'load_all_genomedbs_from_registry',
+        'create_reuse_ss',
+        'polyploid_genome_reuse_factory',
+        'polyploid_genome_load_fresh_factory',
+        'nonpolyploid_genome_load_fresh_factory',
+        'hc_members_globally',
+    );
+
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+
+}
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/LoadMembers_conf.pm
@@ -67,6 +67,7 @@ sub default_options {
 
 sub tweak_analyses {
     my $self = shift;
+    $self->SUPER::tweak_analyses(@_);
     my $analyses_by_name = shift;
 
     # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MergeDBsIntoRelease_conf.pm
@@ -43,6 +43,9 @@ The default parameters work well in the context of a Compara release for Vertebr
 Registry file). If the list of source-databases is different, have a look at the bottom of the base file
 for alternative configurations.
 
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
 =cut
 
 package Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::MergeDBsIntoRelease_conf;
@@ -104,6 +107,22 @@ sub default_options {
             'pig_ncrna_db'   => [qw(ortholog_quality datacheck_results method_link_species_set_attr)],
         },
    };
+}
+
+sub tweak_analyses {
+    my $self = shift;
+    my $analyses_by_name = shift;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'fire_post_merge_processing',
+        'enable_keys',
+    );
+
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MergeDBsIntoRelease_conf.pm
@@ -111,6 +111,7 @@ sub default_options {
 
 sub tweak_analyses {
     my $self = shift;
+    $self->SUPER::tweak_analyses(@_);
     my $analyses_by_name = shift;
 
     # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.


### PR DESCRIPTION
## Description

Block unguarded funnel jobs in LoadMembers and MergeDBsIntoRelease pipelines.

**Related JIRA tickets:**
- ENSCOMPARASW-8410
- ENSCOMPARASW-8411 

## Overview of changes

Added pipeline tweaks to set the analysis capacity of relevant jobs to zero.

## Testing

The Metazoa LoadMembers and MergeDBsIntoRelease pipelines were initialised with the changes.


---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
