### PR TITLE
Do not store homology_range_index in pipeline databases

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareSpeciesSetsMLSS.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareSpeciesSetsMLSS.pm
@@ -90,11 +90,16 @@ sub write_output {
             my $mlss = $self->_write_mlss( $ss, $ml );
 
             if ($mlss->method->type eq 'PROTEIN_TREES' || $mlss->method->type eq 'NC_TREES') {
-                my $homology_range_index = $self->param('reference_dba')->dbc->sql_helper->execute_single_result(
+
+                my $tmp = $self->param('reference_dba')->dbc->sql_helper->execute_simple(
                     -SQL => 'SELECT value FROM method_link_species_set_tag WHERE method_link_species_set_id = ? AND tag = "homology_range_index"',
                     -PARAMS => [$mlss->dbID]
                 );
-                push(@homology_range_indices, $homology_range_index) if defined $homology_range_index;
+
+                if (defined $tmp && scalar(@$tmp) == 1) {
+                    my $homology_range_index = $tmp->[0];
+                    push(@homology_range_indices, $homology_range_index) if defined $homology_range_index;
+                }
             }
 
             # The last method_link listed in whole_method_links will make

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareSpeciesSetsMLSS.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareSpeciesSetsMLSS.pm
@@ -90,7 +90,10 @@ sub write_output {
             my $mlss = $self->_write_mlss( $ss, $ml );
 
             if ($mlss->method->type eq 'PROTEIN_TREES' || $mlss->method->type eq 'NC_TREES') {
-                my $homology_range_index = $mlss->get_value_for_tag('homology_range_index');
+                my $homology_range_index = $self->param('reference_dba')->dbc->sql_helper->execute_single_result(
+                    -SQL => 'SELECT value FROM method_link_species_set_tag WHERE method_link_species_set_id = ? AND tag = "homology_range_index"',
+                    -PARAMS => [$mlss->dbID]
+                );
                 push(@homology_range_indices, $homology_range_index) if defined $homology_range_index;
             }
 
@@ -159,16 +162,8 @@ sub _write_mlss {
     my $mlss;
     if ($self->param('reference_dba')) {
         $mlss = $self->param('reference_dba')->get_MethodLinkSpeciesSetAdaptor->fetch_by_method_link_id_species_set_id($method->dbID, $ss->dbID);
-        if ($mlss) {
 
-            if ($method->type eq 'PROTEIN_TREES' || $method->type eq 'NC_TREES') {
-                # Load the tagvalue hash, so that tags such
-                # as 'homology_range_index' will be loaded
-                # and stored along with this gene-tree MLSS.
-                $mlss->get_tagvalue_hash();
-            }
-
-        } elsif ($self->param('reference_dba')->get_MethodAdaptor->fetch_by_dbID($method->dbID)) {
+        if ((not $mlss) && $self->param('reference_dba')->get_MethodAdaptor->fetch_by_dbID($method->dbID)) {
             $self->die_no_retry(sprintf("The %s / %s MethodLinkSpeciesSet could not be found in the master database\n", $method->toString, $ss->toString));
         }
     }


### PR DESCRIPTION
## Description

Runnable PrepareSpeciesSetsMLSS has been updated on the main branch of ensembl-compara so that the 'homology_range_index' MLSS tag is set as a pipeline-wide parameter but not stored as an MLSS tag in the pipeline database.

**Related JIRA tickets:**
- ENSCOMPARASW-8429

## Testing
The changes were tested on an insects protein trees pipeline.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
