### PR TITLE
Update Microbes LastZ config for e116

### DIFF
--- a/conf/fungi/mlss_conf.xml
+++ b/conf/fungi/mlss_conf.xml
@@ -12,14 +12,14 @@
   <pairwise_alignments>
     <all_vs_all method="LASTZ_NET">
       <species_set>
-       <genome name="ashbya_gossypii"/>
+       <genome name="eremothecium_gossypii_fdag1_gca_000968835"/>
        <genome name="fusarium_oxysporum"/>
        <genome name="fusarium_solani"/>
        <genome name="fusarium_verticillioides"/>
-       <genome name="magnaporthe_oryzae"/>
        <genome name="magnaporthe_poae"/>
        <genome name="puccinia_graminis"/>
        <genome name="puccinia_triticina"/>
+       <genome name="pyricularia_oryzae"/>
        <genome name="saccharomyces_cerevisiae"/>
        <genome name="schizosaccharomyces_cryophilus"/>
        <genome name="schizosaccharomyces_japonicus"/>

--- a/conf/protists/mlss_conf.xml
+++ b/conf/protists/mlss_conf.xml
@@ -17,6 +17,7 @@
     <!-- LastZ batch -->
     <all_vs_all method="LASTZ_NET">
       <species_set>
+        <genome name="globisporangium_ultimum"/>
         <genome name="phytophthora_infestans"/>
         <genome name="phytophthora_kernoviae"/>
         <genome name="phytophthora_lateralis"/>
@@ -26,10 +27,8 @@
         <genome name="pythium_arrhenomanes"/>
         <genome name="pythium_irregulare"/>
         <genome name="pythium_iwayamai"/>
-        <genome name="pythium_ultimum"/>
         <genome name="pythium_vexans"/>
 
-        <genome name="albugo_laibachii"/>
         <genome name="bigelowiella_natans"/>
         <genome name="emiliania_huxleyi"/>
         <genome name="entamoeba_histolytica"/>


### PR DESCRIPTION
## Description

In conjunction with [ensembl-comparar PR 947](https://github.com/Ensembl/ensembl-compara/pull/947), this pull request would update the LastZ configuration for Protists and Fungi for release 116.

Changes include:
- replacement of `ashbya_gossypii` with `eremothecium_gossypii_fdag1_gca_000968835`;
- replacement of `magnaporthe_oryzae` with `pyricularia_oryzae`;
- replacement of `pythium_ultimum` with `globisporangium_ultimum`;
- removal of `albugo_laibachii` LastZ config.