### PR TITLE
Add Oat cultivars protein-trees pipeline config and task

### DIFF
--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -106,6 +106,13 @@
          {
             "assignee": "<RelCo>",
             "component": "Production tasks",
+            "description": "*GitHub*: [OatCultivarsProteinTrees_conf.pm|https://github.com/Ensembl/ensembl-compara/blob/release/<version>/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/OatCultivarsProteinTrees_conf.pm]\n{code}isrun init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Plants::OatCultivarsProteinTrees_conf -host mysql-ens-compara-prod-X -port XXXX{code}",
+            "summary": "Run the oat cultivars Protein-trees pipeline",
+            "name_on_graph": "Protein-trees:Oat cultivars"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Production tasks",
             "description": "Review the gene-tree stats for each gene-tree pipeline, and address any issues.",
             "summary": "Check gene-tree stats"
          },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/OatCultivarsProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/OatCultivarsProteinTrees_conf.pm
@@ -1,0 +1,74 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Plants::OatCultivarsProteinTrees_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Plants::OatCultivarsProteinTrees_conf \
+    -host mysql-ens-compara-prod-X -port XXXX
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Plants::OatCultivarsProteinTrees_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::Plants::CultivarsProteinTrees_conf');
+
+
+sub default_options {
+    my ($self) = @_;
+
+    return {
+        %{$self->SUPER::default_options},
+
+        # Parameters to allow merging different protein-tree collections
+        'collection'       => 'oat_cultivars',
+        'label_prefix'     => 'oat_cultivars_',
+
+        # Flatten all the genomes under species 'Avena sativa'
+        'multifurcation_deletes_all_subnodes' => [4498],
+
+        # Clustering parameters:
+        'mapped_gene_ratio_per_taxon' => {
+            '2759' => 0.5,  # eukaryotes
+            '4498' => 0.9,  # avena sativa
+        },
+
+        # GOC parameters
+        'goc_taxlevels' => ['Avena'],
+    };
+}
+
+
+sub tweak_analyses {
+    my $self = shift;
+
+    $self->SUPER::tweak_analyses(@_);
+
+    my $analyses_by_name = shift;
+
+    # Flow 'examl_32_cores' #-2 to 'fasttree'
+    $analyses_by_name->{'examl_32_cores'}->{'-flow_into'}->{-2} = [ 'fasttree' ];
+}
+
+
+1;


### PR DESCRIPTION
This PR would add an Oat cultivars protein-trees pipeline config and production task (ENSCOMPARASW-8573).

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
