### PR TITLE
Species tree pipeline: tweaks to mitigate SLURM issues

### DIFF
--- a/pipelines/SpeciesTreeFromBusco/nextflow.config
+++ b/pipelines/SpeciesTreeFromBusco/nextflow.config
@@ -17,7 +17,10 @@
 includeConfig "$ENSEMBL_ROOT_DIR/ensembl-compara/pipelines/nextflow.config"
 
 executor{
-  queueSize=500
+  queueSize = 50
+  queueStatTimeout = '30m'
+  pollInterval = '30s'
+  exitReadTimeout = '30m'
 }
 
 params {
@@ -82,7 +85,7 @@ params {
     // Path to gffread binary:
     gffread_exe = "$COMPARA_SOFTWARE/shared/build/gffread/0.12.7/bin/gffread"
     // Path to miniprot binary:
-    miniprot_exe = "$COMPARA_SOFTWARE/shared/build/miniprot/0.12/bin/miniprot"
+    miniprot_exe = "$COMPARA_SOFTWARE/shared/build/miniprot/0.18/bin/miniprot"
     // Path to iqtree2 binary:
     iqtree_exe = "$COMPARA_SOFTWARE/shared/build/iqtree2/2.2.0.3/bin/iqtree2"
     // Path to trimal binary:

--- a/pipelines/nextflow.config
+++ b/pipelines/nextflow.config
@@ -133,6 +133,13 @@ process {
        time = 168.h
        maxRetries = { (task.exitStatus == 137) ? 4 : 1 }
     }
+    withLabel: retry_with_256gb_mem_c32 {
+       cpus = 32
+       errorStrategy = { (task.exitStatus == 137) ? 'retry' : 'terminate' }
+       memory = { 256.GB * task.attempt }
+       time = 168.h
+       maxRetries = { (task.exitStatus == 137) ? 4 : 1 }
+    }
     withLabel: retry_with_e64gb_mem_c16 {
        cpus = 16
        errorStrategy = { (task.exitStatus == 137) ? 'retry' : 'terminate' }


### PR DESCRIPTION
## Description

Recently, the species tree pipeline runs on SLURM have been unstable.
This PR tries to mitigate the issue, though crashes might still happen in an unpredictable manner.

**Related JIRA tickets:**
- ENSCOMPARASW-8568

## Overview of changes

#### Change 1
Using more memory by default for the `buscoAnnot` process.

#### Change 2
Tweak SLURM timeout parameters to increase tolerance to unresponsiveness.

#### Change 3
Use less of the available cores (30 of 32) in the `buscoAnnot` process. Update miniprot version.

## Testing
The pipeline was run multiple times on a set of 178 fish genomes.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
