### PR TITLE
Tidy up deprecated code

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/AlignedMember.pm
+++ b/modules/Bio/EnsEMBL/Compara/AlignedMember.pm
@@ -169,17 +169,18 @@ sub cigar_line {
   return $self->{'_cigar_line'};
 }
 
-
-sub get_cigar_breakout{
+sub get_cigar_breakout {  ## DEPRECATED
   my $self = shift;
-  deprecate('AlignedMember::get_cigar_breakout is deprecated and will be removed in e102. Use Bio::EnsEMBL::Compara::Utils::Cigars::get_cigar_breakout instead');
+  deprecate('AlignedMember::get_cigar_breakout is deprecated, and may be removed in a future release.'
+            . ' Use Bio::EnsEMBL::Compara::Utils::Cigars::get_cigar_breakout instead');
   return Bio::EnsEMBL::Compara::Utils::Cigars::get_cigar_breakout($self->{'_cigar_line'});
 }
 
 
-sub get_cigar_array{
+sub get_cigar_array {  ## DEPRECATED
   my $self = shift;
-  deprecate('AlignedMember::get_cigar_array is deprecated and will be removed in e102. Use Bio::EnsEMBL::Compara::Utils::Cigars::get_cigar_array instead');
+  deprecate('AlignedMember::get_cigar_array is deprecated, and may be removed in a future release.'
+            . ' Use Bio::EnsEMBL::Compara::Utils::Cigars::get_cigar_array instead');
   return Bio::EnsEMBL::Compara::Utils::Cigars::get_cigar_array($self->{'_cigar_line'});
 }
 

--- a/modules/Bio/EnsEMBL/Compara/BaseGenomicAlignSet.pm
+++ b/modules/Bio/EnsEMBL/Compara/BaseGenomicAlignSet.pm
@@ -79,7 +79,7 @@ sub slice {
   Arg [1]    : (optional) Bio::EnsEMBL::Slice $reference_slice
   Example    : my $reference_slice = $genomic_align_block->reference_slice;
   Example    : $genomic_align_block->reference_slice($slice);
-  Description: Alias for slice method. TO BE DEPRECATED.
+  Description: Alias for slice method.
   Returntype : Bio::EnsEMBL::Slice object
   Exceptions : 
   Caller     : general

--- a/modules/Bio/EnsEMBL/Compara/ConservationScore.pm
+++ b/modules/Bio/EnsEMBL/Compara/ConservationScore.pm
@@ -618,32 +618,6 @@ sub _reverse_score {
 }
 
 
-sub _print {    ## DEPRECATED
-  my ($self, $FILEH) = @_;
-
-#  my $verbose = verbose;
-#  verbose(0);
-  my $exp_score = 0;
-  if ($self->expected_score) {
-      $exp_score = $self->expected_score;
-  }
-  
-  $FILEH ||= \*STDOUT;
-  
-  print $FILEH
-
-"Bio::EnsEMBL::Compara::GenomicAlignBlock object ($self)
-  genomic_align_block = " . ($self->genomic_align_block) . "
-  genomic_align_block_id = " . ($self->genomic_align_block_id) . "
-  window_size = " . ($self->window_size) . "
-  position = " . ($self->position) . "
-  seq_region_pos = " . ($self->seq_region_pos) . "
-  diff_score = " . ($self->diff_score) . "
-  expected_score = $exp_score \n";
-
-}
-
-
 =head2 toString
 
   Example    : print $conservation_score->toString();

--- a/modules/Bio/EnsEMBL/Compara/DBSQL/MethodAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Compara/DBSQL/MethodAdaptor.pm
@@ -130,7 +130,7 @@ sub _objs_from_sth {
 sub fetch_by_type {
     my ($self, $type) = @_;
     if ($type =~ /EPO_LOW_COVERAGE/i) {
-        deprecate("EPO_LOW_COVERAGE is deprecated and will be replaced by EPO_EXTENDED in release 101.");
+        deprecate("EPO_LOW_COVERAGE is deprecated and was replaced by EPO_EXTENDED in release 101.");
         $type = "EPO_EXTENDED";
     }
     return $self->_id_cache->get_by_additional_lookup('type', uc $type);

--- a/modules/Bio/EnsEMBL/Compara/GeneTreeNode.pm
+++ b/modules/Bio/EnsEMBL/Compara/GeneTreeNode.pm
@@ -454,7 +454,7 @@ sub get_AlignedMemberSet {
   Returntype  : Bio::SimpleAlign
   Exceptions  :
   Caller      : general
-  Status      : At risk (may become deprecated soon)
+  Status      : At risk
 
 =cut
 
@@ -471,7 +471,7 @@ sub get_SimpleAlign {
                sub-tree. See Bio::EnsEMBL::Compara::AlignedMemberSet
   Returntype : string
   Caller     : general
-  Status     : At risk (may become deprecated soon)
+  Status     : At risk
 
 =cut
 

--- a/modules/Bio/EnsEMBL/Compara/GenomicAlign.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomicAlign.pm
@@ -1014,58 +1014,6 @@ sub _get_fake_aligned_sequence_from_cigar_line {
 }
 
 
-sub _print {    ## DEPRECATED
-  my ($self, $FILEH) = @_;
-
-  my $verbose = verbose;
-  verbose(0);
-  
-  $FILEH ||= \*STDOUT;
-
-#   print $FILEH
-# "Bio::EnsEMBL::Compara::GenomicAlign object ($self)
-#   dbID = ".($self->dbID or "-undef-")."
-#   adaptor = ".($self->adaptor or "-undef-")."
-#   genomic_align_block = ".($self->genomic_align_block or "-undef-")."
-#   genomic_align_block_id = ".($self->genomic_align_block_id or "-undef-")."
-#   method_link_species_set = ".($self->method_link_species_set or "-undef-")."
-#   method_link_species_set_id = ".($self->method_link_species_set_id or "-undef-")."
-#   dnafrag = ".($self->dnafrag or "-undef-")."
-#   dnafrag_id = ".($self->dnafrag_id or "-undef-")."
-#   dnafrag_start = ".($self->dnafrag_start or "-undef-")."
-#   dnafrag_end = ".($self->dnafrag_end or "-undef-")."
-#   dnafrag_strand = ".($self->dnafrag_strand or "-undef-")."
-#   cigar_line = ".($self->cigar_line or "-undef-")."
-#   visible = ".($self->visible or "-undef-")."
-#   original_sequence = ".($self->original_sequence or "-undef-")."
-#   aligned_sequence = ".($self->aligned_sequence or "-undef-")."
-  
-# ";
-    print $FILEH
-"Bio::EnsEMBL::Compara::GenomicAlign object ($self)
-  dbID = ".($self->dbID or "-undef-")."
-  adaptor = ".($self->adaptor or "-undef-")."
-  genomic_align_block = ".($self->genomic_align_block or "-undef-")."
-  genomic_align_block_id = ".($self->genomic_align_block_id or "-undef-")."
-  method_link_species_set = ".($self->method_link_species_set or "-undef-")."
-  method_link_species_set_id = ".($self->method_link_species_set_id or "-undef-")."
-  dnafrag_start = ".($self->dnafrag_start or "-undef-")."
-  dnafrag_end = ".($self->dnafrag_end or "-undef-")."
-  dnafrag_strand = ".($self->dnafrag_strand or "-undef-")."
-  dnafrag_name = ".($self->dnafrag->name)."
-  genome_db_name = ".($self->dnafrag->genome_db->name)."
-  cigar_line = ".($self->cigar_line or "-undef-")."
-  visible = ".($self->visible or "-undef-")."
-  original_sequence = ".($self->original_sequence or "-undef-")."
-  aligned_sequence = ".($self->aligned_sequence or "-undef-")."
-  
-";
-
-  verbose($verbose);
-
-}
-
-
 =head2 toString
 
   Example    : print $genomic_align->toString();
@@ -1316,7 +1264,6 @@ sub get_Mapper {
     } else {
       my $cigar_line = $self->cigar_line;
       if (!$cigar_line) {
-        $self->_print;
         throw("[$self] has no cigar_line and cannot be retrieved by any means");
       }
       my $alignment_position = (eval{$self->genomic_align_block->start} or 1);

--- a/modules/Bio/EnsEMBL/Compara/GenomicAlignBlock.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomicAlignBlock.pm
@@ -1546,32 +1546,6 @@ sub get_GenomicAlignTree {
 }
 
 
-sub _print {    ## DEPRECATED
-  my ($self, $FILEH) = @_;
-
-  $FILEH ||= \*STDOUT;
-  print $FILEH
-"Bio::EnsEMBL::Compara::GenomicAlignBlock object ($self)
-  dbID = ", ($self->dbID or "-undef-"), "
-  adaptor = ", ($self->adaptor or "-undef-"), "
-  method_link_species_set = ", ($self->method_link_species_set or "-undef-"), "
-  method_link_species_set_id = ", ($self->method_link_species_set_id or "-undef-"), "
-  genomic_aligns = ", (scalar(@{$self->genomic_align_array}) or "-undef-"), "
-  score = ", ($self->score or "-undef-"), "
-  length = ", ($self->length or "-undef-"), "
-  alignments: \n";
-  foreach my $this_genomic_align (@{$self->genomic_align_array()}) {
-    my $species_name = $this_genomic_align->genome_db->name;
-    if ($self->reference_genomic_align and $self->reference_genomic_align == $this_genomic_align) {
-      print $FILEH "    * ", $this_genomic_align->toString, "\n";
-    } else {
-      print $FILEH "    - ", $this_genomic_align->toString, "\n";
-    }
-  }
-
-}
-
-
 =head2 get_mapper_coordinates
 
 Arg [1]    : start coordinates

--- a/modules/Bio/EnsEMBL/Compara/GenomicAlignTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/GenomicAlignTree.pm
@@ -271,42 +271,18 @@ sub get_all_genomic_aligns_for_node {
   return $self->genomic_align_group->get_all_GenomicAligns;
 }
 
-=head2 genomic_align_array (DEPRECATED)
-
-  Arg [1]     : -none-
-  Example     : $genomic_aligns = $object->genomic_align_array
-  Description : Alias for get_all_genomic_aligns_for_node. TO BE DEPRECATED
-  Returntype  : listref of Bio::EnsEMBL::Compara::GenomicAlign objects
-  Exceptions  : none
-  Caller      : general
-  Status      : Stable
-
-=cut
-
-sub genomic_align_array {
+sub genomic_align_array {  ## DEPRECATED
     my $self = shift(@_);
-
-    deprecate("Use Bio::EnsEMBL::Compara::GenomicAlignTree->get_all_genomic_aligns_for_node() method instead");
+    deprecate('GenomicAlignTree::genomic_align_array is deprecated, and may be removed in a future release.'
+              . ' Use Bio::EnsEMBL::Compara::GenomicAlignTree->get_all_genomic_aligns_for_node() instead');
     return($self->get_all_genomic_aligns_for_node);
 
 }
 
-=head2 get_all_GenomicAligns (DEPRECATED)
-
-  Arg [1]     : -none-
-  Example     : $genomic_aligns = $object->get_all_GenomicAligns
-  Description : Alias for get_all_genomic_aligns_for_node. TO BE DEPRECATED
-  Returntype  : listref of Bio::EnsEMBL::Compara::GenomicAlign objects
-  Exceptions  : none
-  Caller      : general
-  Status      : Stable
-
-=cut
-
-sub get_all_GenomicAligns {
+sub get_all_GenomicAligns {  ## DEPRECATED
     my $self = shift(@_);
-
-    deprecate("Use Bio::EnsEMBL::Compara::GenomicAlignTree->get_all_genomic_aligns_for_node() method instead");
+    deprecate('GenomicAlignTree::get_all_GenomicAligns is deprecated, and may be removed in a future release.'
+              . ' Use Bio::EnsEMBL::Compara::GenomicAlignTree->get_all_genomic_aligns_for_node() instead');
     return($self->get_all_genomic_aligns_for_node);
 
 }

--- a/modules/Bio/EnsEMBL/Compara/HAL/HALXS/integration_test.pl
+++ b/modules/Bio/EnsEMBL/Compara/HAL/HALXS/integration_test.pl
@@ -95,49 +95,6 @@ my $mlss = $mlssa->fetch_by_dbID(835); # all strains
 # $mu->dump();
 
 ############################################################
-#               GenomicAlignBlock tests                    #
-############################################################
-# my ( $start, $end ) = ( 5000000, 5100000 ); # 5000000, 5100000
-# print "\n-----------SLICE GABS---------------\n\n";
-# my $sliceAdaptor = $registry->get_adaptor('mus_castaneus', 'Core', 'Slice');
-# my $slice = $sliceAdaptor->fetch_by_region('chromosome', '5', $start, $end);
-
-# my $slice_gabs = $gaba->fetch_all_by_MethodLinkSpeciesSet_Slice( $mlss->[0], $slice, $limit_number );
-
-# my $c = 0;
-# foreach my $gab ( @$slice_gabs ) {
-# 	print "$c : ";
-# 	$gab->_print;
-# 	$c++;
-# }
-
-# print "-----------DNAFRAG GABS-------------\n";
-# my $dnafrag_adaptor = $registry->get_adaptor( 'mouse_master', 'compara', 'DnaFrag' );
-# my $dnafrag = $dnafrag_adaptor->fetch_by_Slice( $slice );
-
-# my $dnafrag_gabs = $gaba->fetch_all_by_MethodLinkSpeciesSet_DnaFrag( $mlss->[0], $dnafrag, $start, $end, $limit_number );
-
-# $c = 0;
-# foreach my $gab ( @$dnafrag_gabs ) {
-# 	print "$c : ";
-# 	$gab->_print;
-# 	$c++;
-# }
-
-# print "-----------DNA_DNA GABS-------------\n";
-# my $gdba = $registry->get_adaptor( 'mouse_master', 'compara', 'GenomeDB' );
-# my $nonref_gdb = $gdba->fetch_by_name_assembly( 'mus_spretus', 'CURRENT' );
-# my $nonref_dnafrag = $dnafrag_adaptor->fetch_by_GenomeDB_and_name( $nonref_gdb, '5' );
-# my $dna_dna_gabs = $gaba->fetch_all_by_MethodLinkSpeciesSet_DnaFrag_DnaFrag( $mlss->[0], $dnafrag, $start, $end, $nonref_dnafrag, $limit_number );
-
-# $c = 0;
-# foreach my $gab ( @$dna_dna_gabs ) {
-# 	print "$c : ";
-# 	$gab->_print;
-# 	$c++;
-# }
-
-############################################################
 #                   Sandbox Testing                        #
 ############################################################
 
@@ -178,20 +135,6 @@ my $c = 0;
 # #    print Dumper $projection;
 # }
 
-
-# #print "\n\n------------BLOCKS-------------\n";
-# #for my $gblock ( @{ $alignSlice->get_all_GenomicAlignBlocks } ){
-# #	$gblock->_print;
-# #	#print ">>>>>>>\n\n";
-# #	#for my $g ( @{ $gblock->genomic_align_array } ) {
-# #	#      $g->_print;
-# #	#}
-# #	#print "<<<<<<<\n\n";
-# #}
-# #$c++;
-# print "\n-----------------------------------\n\n";
-
-#}
 
 my $slice_gabs = $gaba->fetch_all_by_MethodLinkSpeciesSet_Slice( $mlss, $slice, $limit_number );
 

--- a/modules/Bio/EnsEMBL/Compara/MemberSet.pm
+++ b/modules/Bio/EnsEMBL/Compara/MemberSet.pm
@@ -485,7 +485,7 @@ sub get_all_GeneMembers {
 
 =cut
 
-sub gene_list {  # DEPRECATED ?
+sub gene_list {
     my $self = shift;
     return $self->get_all_GeneMembers
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/AddHMMLib.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/AddHMMLib.pm
@@ -37,6 +37,8 @@ use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
 sub run {
     my $self = shift;
 
+    $self->warning("RunnableDB::FTPDumps::AddHMMLib is deprecated, and may be removed in a future release");
+
     # Get the name of the current library
     my $hmm_library_basedir = $self->param_required('hmm_library_basedir');
     chop $hmm_library_basedir if $hmm_library_basedir =~ /\/$/; # otherwise basename returns an empty string

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/PatchLastzDump.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/PatchLastzDump.pm
@@ -25,6 +25,10 @@ Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::PatchLastzDump
 	2. untar/gz the old dump to tmp dir (because the new and old dir names will be the same - avoid clashes or uncertainty)
 	3. copy everything to patch dump dir, md5sum, re-tar/gz
 
+=head1 DEPRECATION NOTICE
+
+This runnable is deprecated, and may be removed in a future release.
+
 =cut
 
 package Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::PatchLastzDump;
@@ -70,7 +74,7 @@ sub fetch_input {
 sub run {
 	my $self = shift;
 
-    $self->warning("RunnableDB::FTPDumps::PatchLastzDump is deprecated");
+    $self->warning("RunnableDB::FTPDumps::PatchLastzDump is deprecated, and may be removed in a future release");
 
 	my $prev_rel_tarball = $self->param('prev_rel_tarball');
 	my $patch_dump_dir = $self->param('patch_dump_dir');

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/SymlinkPreviousDumps.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/SymlinkPreviousDumps.pm
@@ -19,6 +19,10 @@ limitations under the License.
 
 Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::SymlinkPreviousDumps
 
+=head1 DEPRECATION NOTICE
+
+This runnable is deprecated, and may be removed in a future release.
+
 =cut
 
 package Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::SymlinkPreviousDumps;
@@ -85,7 +89,7 @@ sub fetch_input {
 sub run {
 	my $self = shift;
 
-    $self->warning("RunnableDB::FTPDumps::SymlinkPreviousDumps is deprecated");
+    $self->warning("RunnableDB::FTPDumps::SymlinkPreviousDumps is deprecated, and may be removed in a future release");
 
 	my @symlink_cmds = @{ $self->param('symlink_cmds') };
 	foreach my $this_cmd ( @symlink_cmds ) {


### PR DESCRIPTION
## Description

This PR tidies up Compara API methods and runnables that are deprecated or candidates for deprecation.

**Related JIRA tickets:**
- ENSCOMPARASW-5372

## Overview of changes

Changes include:

- removal of the following deprecated internal methods, as well as every instance in which they are invoked:
  * `ConservationScore::_print`
  * `GenomicAlign::_print`
  * `GenomicAlignBlock::_print`

- removal of documentation and updates to deprecation messages of methods:
  * `AlignedMember::get_cigar_array`
  * `AlignedMember::get_cigar_breakout`
  * `GenomicAlignTree::genomic_align_array`
  * `GenomicAlignTree::get_all_GenomicAligns`

- updates to runnable deprecation message/notice in:
  * `RunnableDB::FTPDumps::AddHMMLib`
  * `RunnableDB::FTPDumps::PatchLastzDump`
  * `RunnableDB::FTPDumps::SymlinkPreviousDumps`

- updates to documentation of deprecation candidates:
  * `BaseGenomicAlignSet::reference_slice`
  * `GeneTreeNode::get_AlignedMemberSet`
  * `GeneTreeNode::get_SimpleAlign`

- an update to the `EPO_LOW_COVERAGE` deprecation message in `MethodAdaptor::fetch_by_type`
