### PR TITLE
Address various ancestral sequence issues

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/BaseGenomicAlignSet.pm
+++ b/modules/Bio/EnsEMBL/Compara/BaseGenomicAlignSet.pm
@@ -362,7 +362,7 @@ sub is_restricted {
                object
                It might be the case that the restricted region coincide with a gap
                in one or several GenomicAligns. By default these GenomicAligns are
-               returned with a dnafrag_end equals to its dnafrag_start + 1. For instance,
+               returned with a dnafrag_end equals to its dnafrag_start - 1. For instance,
                a GenomicAlign with dnafrag_start = 12345 and dnafrag_end = 12344
                correspond to a block which goes on this region from before 12345 to
                after 12344, ie just between 12344 and 12345. You can choose to remove

--- a/modules/Bio/EnsEMBL/Compara/Locus.pm
+++ b/modules/Bio/EnsEMBL/Compara/Locus.pm
@@ -469,6 +469,8 @@ sub get_sequence {
 
             if (!defined $slice) {
                 if ($self->dnafrag_end == $self->dnafrag_start - 1) {
+                    # We may end up here if a slice coincides with a gap in a GenomicAlign, leaving us with an empty sequence.
+                    # See: https://github.com/Ensembl/ensembl-compara/blob/release/115/modules/Bio/EnsEMBL/Compara/BaseGenomicAlignSet.pm#L365
                     $seq = '';
                 } else {
                     throw(sprintf("Failed to get slice for locus '%s'", $self->toString));

--- a/modules/Bio/EnsEMBL/Compara/Locus.pm
+++ b/modules/Bio/EnsEMBL/Compara/Locus.pm
@@ -465,16 +465,24 @@ sub get_sequence {
     } else {
         # If there is no file, query the database via the Core API
         $self->genome_db->db_adaptor->dbc->prevent_disconnect( sub {
-            if ($mask) {
+            my $slice = $self->get_Slice();
+
+            if (!defined $slice) {
+                if ($self->dnafrag_end == $self->dnafrag_start - 1) {
+                    $seq = '';
+                } else {
+                    throw(sprintf("Failed to get slice for locus '%s'", $self->toString));
+                }
+            } elsif ($mask) {
                 if ($mask =~ /^soft/i) {
-                    $seq = $self->get_Slice()->get_repeatmasked_seq(undef, 1)->seq;
+                    $seq = $slice->get_repeatmasked_seq(undef, 1)->seq;
                 } elsif ($mask =~ /^hard/i) {
-                    $seq = $self->get_Slice()->get_repeatmasked_seq()->seq;
+                    $seq = $slice->get_repeatmasked_seq()->seq;
                 } else {
                     throw("Unknown masking option '$mask'");
                 }
             } else {
-                $seq = $self->get_Slice()->seq;
+                $seq = $slice->seq;
             }
         });
     }

--- a/scripts/ancestral_sequences/get_ancestral_sequence.pl
+++ b/scripts/ancestral_sequences/get_ancestral_sequence.pl
@@ -43,6 +43,10 @@ The script creates a directory with a pair of BED+FASTA files for each
 chromosome of the query species. The FASTA file contains the actual sequence,
 while the BED file contains the phylogenetic tree associated with each region.
 
+Note that coordinates in the BED file are 1-based, so that an interval spanning
+the full extent of a chromosome of length 1000 bp would have a start position of
+1 in the chromStart column and an end position of 1000 in the chromEnd column.
+
 =head1 SYNOPSIS
 
 perl get_ancestral_sequence.pl --help
@@ -513,6 +517,10 @@ actg : low-confidence call, ancestral state supported by one sequence only
 N    : failure, the ancestral state is not supported by any other sequence
 -    : the extant species contains an insertion at this postion
 .    : no coverage in the alignment
+
+The convention for the ancestral sequence region coordinates is 1-based,
+so that in a chromosome of length 1000 bp, the first position would be 1
+and the final position would be 1000.
 
 You should find a summary.txt file, which contains statistics about the quality
 of the calls.

--- a/scripts/ancestral_sequences/get_ancestral_sequence.pl
+++ b/scripts/ancestral_sequences/get_ancestral_sequence.pl
@@ -311,6 +311,20 @@ my %karyo_slices = map {$_->seq_region_name => 1} @{ $slice_adaptor->fetch_all_k
 # partition the files into subdirs if this is the case
 # my $partition_files = ( scalar @$slices >= $max_files_per_dir ) ? 1 : 0;
 
+# We need to remove any previously written non-chromosomal
+# files at the outset, to enable a cleaner rerun if needed.
+my %non_karyo_coord_systems;
+foreach my $slice (@$slices) {
+    next if ($karyo_slices{$slice->seq_region_name});
+    $non_karyo_coord_systems{$slice->coord_system_name} = 1;
+}
+foreach my $coord_system_name (keys %non_karyo_coord_systems) {
+    foreach my $file_ext ('.bed', '.fa') {
+        my $file_path = sprintf('%s/%s_ancestor_%s.%s', $dir, $species_production_name, $coord_system_name, $file_ext);
+        unlink($file_path) if (-f $file_path);
+    }
+}
+
 foreach my $slice (@$slices) {
   next unless (!$ARGV[0] or $slice->seq_region_name eq $ARGV[0] or
       $slice->coord_system_name eq $ARGV[0]);

--- a/scripts/ancestral_sequences/get_ancestral_sequence.pl
+++ b/scripts/ancestral_sequences/get_ancestral_sequence.pl
@@ -374,10 +374,15 @@ sub dump_ancestral_sequence {
     }
 #    print $ref_aligned_sequence, "\n\n", "$ancestral_sequence\n\n\n\n";
     my $ref_ga = $ref_gat->genomic_align_group->get_all_GenomicAligns->[0];
-    my $tree = $this_genomic_align_tree->newick_format("simple");
-    $tree =~ s/\:[\d\.]+//g;
-    $tree =~ s/_\w+//g;
-    $tree =~ s/\[[\+\-]\]//g;
+
+    foreach my $node (@{$this_genomic_align_tree->get_all_leaves}) {
+      # Species-name prefix of subsitution regex adapted from:
+      # https://github.com/Ensembl/ensembl-datacheck/blob/6b3d185/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyFormat.pm#L59
+      my $node_name = $node->name =~ s/^(_?[a-z0-9]+_[a-z0-9_]+)_.+?_\d+_\d+\[[-+]\]$/$1/r;
+      $node->name($node_name);
+    }
+
+    my $tree = $this_genomic_align_tree->newick_format('ryo', '%{^-n|i}'); # simple, without branch lengths
     print $bed_fh join("\t", $ref_ga->dnafrag->name, $ref_ga->dnafrag_start,
         $ref_ga->dnafrag_end, $tree), "\n";
     $num_of_blocks++;

--- a/scripts/ancestral_sequences/get_ancestral_sequence.pl
+++ b/scripts/ancestral_sequences/get_ancestral_sequence.pl
@@ -156,7 +156,6 @@ perl $ENSEMBL_ROOT_DIR/ensembl-compara/scripts/ancestral_sequences/get_ancestral
 
 use Data::Dumper;
 use Getopt::Long;
-use List::Util qw/min/;
 use Pod::Usage;
 
 use Bio::EnsEMBL::Registry;


### PR DESCRIPTION
## Description

This PR makes several changes to the `get_ancestral_sequence.pl` script and related code.

**Related JIRA tickets:**
- ENSCOMPARASW-5011
- ENSCOMPARASW-5012
- ENSCOMPARASW-8594
- ENSCOMPARASW-8615

## Overview of changes

In the `get_ancestral_sequence.pl` script:
- A `--target_species` option is added. When specified, the ancestral sequence is taken from the most recent common ancestor of the query genome region and any of the target species regions.
- Non-chromosomal output files are cleaned up at the outset, allowing for cleaner reruns.
- Ancestral GenomicAlignTree formatting is updated to apply the node name regex per node, and to omit branch lengths from the formatted Newick string.
- Documentation is updated with a note about the coordinate convention used in BED output.

In the `Bio::EnsEMBL::Compara::Locus` module:
- When restricting an EPO GenomicAlignBlock, ancestral gap-only sequences are retained to preserve the GenomicAlignTree structure ( see the [documentation on GenomicAlignTree::restrict_between_alignment_positions](https://github.com/Ensembl/ensembl-compara/blob/941a5786185c460ca7ea1dcdc24bbcaf1193a13a/modules/Bio/EnsEMBL/Compara/GenomicAlignTree.pm#L638-L641) ). To enable access to the `aligned_sequence` of these ancestral nodes, an empty sequence is now returned by `Bio::EnsEMBL::Compara::Locus::get_sequence`.

## Testing

For more info on testing, please see related tickets ENSCOMPARASW-8594 and ENSCOMPARASW-8615.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
