### PR TITLE
Skip MLSS ID check and guard funnels in reindexing pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ReindexMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/ReindexMembers_conf.pm
@@ -64,6 +64,15 @@ sub tweak_analyses {
     $analyses_by_name->{'copy_table_from_prev_db'}->{'-rc_name'} = '1Gb_24_hour_job';
 
     $analyses_by_name->{'hc_members_per_genome'}->{'-parameters'}->{'allow_ambiguity_codes'} = 1;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'reindex_member_ids',
+        'datacheck_funnel',
+    );
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ReindexMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ReindexMembers_conf.pm
@@ -258,7 +258,7 @@ sub core_pipeline_analyses {
             -module        => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into     => WHEN(
                 '#do_genome_reindexing#' => 'prep_genome_reindexing',
-                ELSE 'assert_mlsses_match',
+                ELSE 'gene_tree_tables_factory',
             ),
         },
 
@@ -269,14 +269,6 @@ sub core_pipeline_analyses {
                 'genome_dumps_dir' => $self->o('genome_dumps_dir'),
             },
             -flow_into  => 'gene_tree_tables_factory',
-        },
-
-        {   -logic_name    => 'assert_mlsses_match',
-            -module        => 'Bio::EnsEMBL::Compara::RunnableDB::AssertNumericParamsEqual',
-            -parameters        => {
-                'param_names' => ['mlss_id', 'prev_mlss_id'],
-            },
-            -flow_into     => 'gene_tree_tables_factory',
         },
 
         {   -logic_name => 'gene_tree_tables_factory',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsReindexMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/StrainsReindexMembers_conf.pm
@@ -84,4 +84,21 @@ sub default_options {
     };
 }
 
+sub tweak_analyses {
+    my $self = shift;
+
+    $self->SUPER::tweak_analyses(@_);
+
+    my $analyses_by_name = shift;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'reindex_member_ids',
+        'datacheck_funnel',
+    );
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+}
+
 1;


### PR DESCRIPTION
## Description

This PR aims to facilitate running the member reindexing pipeline in three ways:
- skipping an unneeded MLSS IID check;
- adding funnel checks where possible; and
- blocking funnels where funnel checks could not be easily added.

**Related JIRA tickets:**
- ENSCOMPARASW-8418
- ENSCOMPARASW-8431

## Testing
A test pipeline was initialised.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
