### PR TITLE
Merge gene-tree MLSS tags in per-MLSS homology merge

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DBMerge/CopyHomologiesByMLSS.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DBMerge/CopyHomologiesByMLSS.pm
@@ -71,7 +71,14 @@ sub run {
 
     if ($table_name =~ /^(homology|homology_member|method_link_species_set_attr|method_link_species_set_tag)$/) {
 
-        foreach my $mlss_id (@{$mlss_info->{'complementary_mlss_ids'}}) {
+        my @rel_mlss_ids = @{$mlss_info->{'complementary_mlss_ids'}};
+        # If a source database has gene-tree MLSS tags, we
+        # should merge them into the destination database.
+        if ($table_name eq 'method_link_species_set_tag' && exists $mlss_info->{'gene_tree_mlss_id'}) {
+            push(@rel_mlss_ids, $mlss_info->{'gene_tree_mlss_id'});
+        }
+
+        foreach my $mlss_id (@rel_mlss_ids) {
             $self->warning("Copying data for MLSS $mlss_id") if $self->debug;
 
             my $query;


### PR DESCRIPTION
## Description

The current implementation of per-MLSS homology merge does not merge gene-tree MLSS tags into the release database.

This PR fixes that by updating per-MLSS homology merge as follows:
- including a `'gene_tree_mlss_id'` entry in the `$mlss_info` hash used to guide per-MLSS homology merge;
- reinstating a primary-key check in the `method_link_species_set_tag` table for gene-tree MLSSes only;
- including the gene-tree MLSS ID in effective table size calculations and in the homology merge process itself;
- renaming homology MLSS ID variable `$mlss_id` to `$hom_mlss_id` to clarify the distinction between this and the gene-tree MLSS represented in `$mlss_id`.

**Related JIRA tickets:**
- ENSCOMPARASW-8430

## Testing
A test pipeline was run (see related ticket). No errors were encountered due to these changes.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
