### PR TITLE
Replace family member loading with translation sequence check

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/LoadMembers_conf.pm
@@ -50,6 +50,8 @@ sub default_options {
 
         'division' => 'fungi',
 
+        'do_nonblocking_checks' => 1,
+
         # Names of species we do not want to reuse this time
         'do_not_reuse_list' => [],
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
@@ -51,6 +51,8 @@ sub default_options {
         #'do_not_reuse_list'     => [ 'homo_sapiens', 'mus_musculus', 'rattus_norvegicus', 'mus_spretus_spreteij', 'danio_rerio', 'sus_scrofa' ],
         'do_not_reuse_list'     => [ ],
 
+        'do_nonblocking_checks' => 0,
+
     # "Member" parameters:
         'allow_ambiguity_codes'     => 1,
         'allow_missing_coordinates' => 0,
@@ -128,6 +130,7 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'master_db'             => $self->o('master_db'),
         'reuse_member_db'       => $self->o('reuse_member_db'),
         'work_dir'              => $self->o('work_dir'),
+        'do_nonblocking_checks' => $self->o('do_nonblocking_checks'),
     };
 }
 
@@ -517,7 +520,45 @@ sub core_pipeline_analyses {
                 'registry_file'    => $self->o('reg_conf'),
                 'dbtype'           => 'compara',
             },
+            -flow_into       => WHEN( '#do_nonblocking_checks#' => 'fire_nonblocking_checks' ),
             -max_retry_count => 0,
+        },
+
+# ---------------------------------------------[non-blocking checks]------------------------------------------------------------
+
+        {   -logic_name    => 'fire_nonblocking_checks',
+            -module        => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into     => [ 'translation_healthcheck_factory' ],
+        },
+
+        {   -logic_name    => 'translation_healthcheck_factory',
+            -module        => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+            -parameters    => {
+                'inputquery' => q/
+                    SELECT DISTINCT genome_db_id
+                    FROM gene_member
+                    JOIN genome_db USING (genome_db_id)
+                    WHERE genome_db.name IN (
+                        SELECT
+                            gdb.name
+                        FROM
+                            genome_db gdb
+                        JOIN
+                            species_set ss USING (genome_db_id)
+                        JOIN
+                            species_set_header ssh USING (species_set_id)
+                        WHERE
+                            ssh.name = 'reuse'
+                    )
+                /,
+            },
+            -flow_into  => [ 'hc_translations' ],
+        },
+
+        {   -logic_name    => 'hc_translations',
+            -module        => 'Bio::EnsEMBL::Compara::RunnableDB::LoadMembers::TranslationHealthcheck',
+            -hive_capacity => $self->o('loadmembers_capacity'),
+            -rc_name       => '1Gb_24_hour_job',
         },
 
     ];

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/LoadMembers_conf.pm
@@ -51,6 +51,8 @@ sub default_options {
 
         'division'  => 'metazoa',
 
+        'do_nonblocking_checks' => 1,
+
         # Names of species we do not want to reuse this time
         # 'do_not_reuse_list' => [ 'oryza_indica', 'vitis_vinifera' ],
         'do_not_reuse_list' => [],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/LoadMembers_conf.pm
@@ -51,6 +51,8 @@ sub default_options {
 
         'division'    => 'pan',
 
+        'do_nonblocking_checks' => 1,
+
     # names of species we don't want to reuse this time
         'do_not_reuse_list' => [ ],
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/LoadMembers_conf.pm
@@ -51,6 +51,8 @@ sub default_options {
 
         'division'    => 'plants',
 
+        'do_nonblocking_checks' => 1,
+
     # names of species we don't want to reuse this time
         #'do_not_reuse_list' => [ 'oryza_indica', 'vitis_vinifera' ],
         'do_not_reuse_list' => [ ],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/LoadMembers_conf.pm
@@ -50,6 +50,8 @@ sub default_options {
 
         'division'  => 'protists',
 
+        'do_nonblocking_checks' => 1,
+
         # Names of species we do not want to reuse this time
         # 'do_not_reuse_list' => [ 'bigelowiella_natans', 'emiliania_huxleyi' ],
         'do_not_reuse_list' => [],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/LoadMembers_conf.pm
@@ -51,6 +51,8 @@ sub default_options {
 
         'division'   => 'vertebrates',
 
+        'do_nonblocking_checks' => 1,
+
     # names of species we don't want to reuse this time
         #'do_not_reuse_list' => [ 'homo_sapiens', 'mus_musculus', 'rattus_norvegicus', 'mus_spretus_spreteij', 'danio_rerio', 'sus_scrofa' ],
         'do_not_reuse_list' => [ ],

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers/TranslationHealthcheck.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers/TranslationHealthcheck.pm
@@ -1,0 +1,101 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::LoadMembers::TranslationHealthcheck
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::LoadMembers::TranslationHealthcheck;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub run {
+    my $self = shift;
+
+    my $genome_db_id = $self->param_required('genome_db_id');
+
+    my $compara_dba = $self->compara_dba;
+    my $genome_dba = $compara_dba->get_GenomeDBAdaptor();
+    my $dnafrag_dba = $compara_dba->get_DnaFragAdaptor();
+    my $gene_member_dba = $compara_dba->get_GeneMemberAdaptor();
+
+    my $genome_db = $genome_dba->fetch_by_dbID($genome_db_id);
+    my $core_dba = $genome_db->db_adaptor;
+    my $translation_adaptor = $core_dba->get_TranslationAdaptor();
+
+    my $num_mismatches = 0;
+    foreach my $dnafrag (@{$dnafrag_dba->fetch_all_by_GenomeDB($genome_db)}) {
+
+        foreach my $gene_member (@{$gene_member_dba->fetch_all_by_DnaFrag($dnafrag)}) {
+            next unless $gene_member->biotype_group eq 'coding';
+
+            my $seq_member = $gene_member->get_canonical_SeqMember();
+            next unless defined $seq_member;
+
+            my $translation = $translation_adaptor->fetch_by_stable_id($seq_member->stable_id);
+
+            if (defined $translation) {
+
+                if ($seq_member->sequence ne $translation->seq) {
+                    $num_mismatches += 1;
+                    if ($self->debug) {
+                        $self->warning(
+                            sprintf(
+                                "Canonical sequence of %s gene member '%s' does not match its corresponding translation in the core database.",
+                                $genome_db->name,
+                                $gene_member->stable_id,
+                            )
+                        );
+                    }
+                }
+
+            } else {
+                $num_mismatches += 1;
+                if ($self->debug) {
+                    $self->warning(
+                        sprintf(
+                            "Canonical sequence of %s gene member '%s' has no corresponding translation in the core database.",
+                            $genome_db->name,
+                            $gene_member->stable_id,
+                        )
+                    );
+                }
+            }
+        }
+    }
+
+    if ($num_mismatches > 0) {
+        $self->die_no_retry(
+            sprintf(
+                "GenomeDB %s has %d gene members with a canonical protein sequence mismatch.",
+                $genome_db->name,
+                $num_mismatches,
+            )
+        );
+    }
+}
+
+
+1;


### PR DESCRIPTION
## Description

This PR would:
- remove the family member-loading branch of the `LoadMembers` pipeline; and
- add a non-blocking check branch after `datachecks`, which would check the sequence of coding members against the canonical translation of their corresponding gene in the core database.

**Related JIRA tickets:**
- ENSCOMPARASW-8460

## Testing
Details to follow.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
