### PR TITLE
Flow taxonomy updates

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
@@ -346,7 +346,17 @@ sub core_pipeline_analyses {
                 'reuse_db'          => '#reuse_member_db#',
             },
             -hive_capacity => $self->o('reuse_capacity'),
-            -flow_into => [ 'hc_members_per_genome' ],
+            -flow_into => [ 'sync_member_taxon_ids' ],
+        },
+
+        {   -logic_name => 'sync_member_taxon_ids',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::SyncTaxa',
+            -parameters => {
+                'from_table' => 'genome_db',
+                'to_tables'  => ['gene_member', 'seq_member'],
+            },
+            -hive_capacity => $self->o('reuse_capacity'),
+            -flow_into  => [ 'hc_members_per_genome' ],
         },
 
         {   -logic_name => 'dnafrag_table_reuse',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PostHomologyMerge_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PostHomologyMerge_conf.pm
@@ -110,6 +110,15 @@ sub core_pipeline_analyses {
         {   -logic_name => 'summarise_wga_stats',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::SummariseWGAStats',
             -input_ids  => [ {} ],
+            -flow_into  => 'sync_taxon_ids',
+        },
+
+        {   -logic_name => 'sync_taxon_ids',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::SyncTaxa',
+            -parameters => {
+                'from_table' => 'genome_db',
+                'to_tables'  => ['gene_member', 'seq_member', 'species_tree_node'],
+            },
             -flow_into  => 'check_homology_ranges',
         },
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/SqlHealthChecks.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/SqlHealthChecks.pm
@@ -204,8 +204,16 @@ our $config = {
                 query => 'SELECT gene_member_id FROM gene_member WHERE genome_db_id IS NULL',
             },
             {
+                description => 'All the gene_members have a taxon_id consistent with the genome_db table',
+                query => 'SELECT DISTINCT genome_db_id FROM gene_member gm JOIN genome_db gdb USING (genome_db_id) WHERE gdb.taxon_id IS NOT NULL AND gm.taxon_id != gdb.taxon_id',
+            },
+            {
                 description => 'All the seq_members should have a genome_db_id',
                 query => 'SELECT seq_member_id FROM seq_member WHERE genome_db_id IS NULL AND source_name NOT LIKE "Uniprot%"',
+            },
+            {
+                description => 'All the seq_members have a taxon_id consistent with the genome_db table',
+                query => 'SELECT DISTINCT genome_db_id FROM seq_member gm JOIN genome_db gdb USING (genome_db_id) WHERE gdb.taxon_id IS NOT NULL AND gm.taxon_id != gdb.taxon_id AND source_name NOT LIKE "Uniprot%"',
             },
         ],
     },

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/SyncTaxa.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/SyncTaxa.pm
@@ -1,0 +1,60 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::SyncTaxa
+
+=head1 DESCRIPTION
+
+This RunnableDB synchronises taxon_ids between the 'from_table'
+and one or more 'to_tables', updating the latter so that their
+taxon_id values are synchronised with those of the former.
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::SyncTaxa;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Compara::Utils::NCBITaxa qw(sync_taxon_ids_by_genome_db_id);
+use Bio::EnsEMBL::Utils::Scalar qw(wrap_array);
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub run {
+    my $self = shift;
+
+    my $from_table = $self->param_required('from_table');
+    my $to_tables = $self->param_required('to_tables');
+    my $genome_db_id = $self->param('genome_db_id');
+
+    my $genome_db_ids = wrap_array($genome_db_id);
+    foreach my $to_table (@{$to_tables}) {
+        sync_taxon_ids_by_genome_db_id(
+            $self->compara_dba,
+            $from_table,
+            $to_table,
+            $genome_db_ids,
+        );
+    }
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/Utils/NCBITaxa.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/NCBITaxa.pm
@@ -1,0 +1,142 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::Utils::NCBITaxa
+
+=head1 DESCRIPTION
+
+Utility module for handling NCBI Taxonomy data.
+
+=cut
+
+package Bio::EnsEMBL::Compara::Utils::NCBITaxa;
+
+use strict;
+use warnings;
+
+use List::Util qw(sum);
+
+use Bio::EnsEMBL::Utils::Exception qw(throw);
+use Bio::EnsEMBL::Utils::Scalar qw(assert_ref check_ref);
+
+use base qw(Exporter);
+
+
+our @EXPORT_OK = qw(
+    sync_taxon_ids_by_genome_db_id
+);
+
+
+sub _fetch_genome_taxa_mapping {
+    my ($sql_helper, $table_name, $genome_db_ids) = @_;
+
+    my $sql = qq/
+        SELECT DISTINCT genome_db_id, taxon_id
+        FROM $table_name
+        WHERE genome_db_id IS NOT NULL
+    /;
+
+    if (defined $genome_db_ids
+            && check_ref($genome_db_ids, 'ARRAY')
+            && scalar(@{$genome_db_ids}) > 0) {
+        my $placeholders = '(' . join(',', ('?') x @{$genome_db_ids}) . ')';
+        $sql .= " AND genome_db_id IN $placeholders";
+    } else {
+        $genome_db_ids = [];
+    }
+
+    my $results = $sql_helper->execute( -SQL => $sql,  -PARAMS => $genome_db_ids, -USE_HASHREFS => 1 );
+
+    my %genome_taxa_map;
+    foreach my $row (@{$results}) {
+        my $gdb_id = $row->{'genome_db_id'};
+        my $taxon_id = $row->{'taxon_id'};
+        push(@{$genome_taxa_map{$gdb_id}}, $taxon_id);
+    }
+
+    return \%genome_taxa_map;
+}
+
+
+=head2 sync_taxon_ids_by_genome_db_id
+
+  Arg[1]      : Bio::EnsEMBL::Compara::DBSQL::DBAdaptor $compara_dba
+  Arg[2]      : string $src_table
+  Arg[3]      : string $dest_table
+  Arg[4]      : (optional) arrayref of integers $genome_db_ids
+  Example     : sync_taxon_ids_by_genome_db_id($compara_dba, 'genome_db', 'species_tree_node');
+  Description : Given a source and destination table in the specified Compara database,
+                this function will identify the mapping of genome_db_id to taxon_id in
+                each table, and will try to resolve any discrepancies by updating the
+                destination table so that it matches the source table.
+  Returntype  : none
+  Exceptions  : throws if an argument test fails, or if any genome_db_id in
+                the source table is associated with multiple taxon_id values
+  Status      : Experimental
+
+=cut
+
+sub sync_taxon_ids_by_genome_db_id {
+    my ($compara_dba, $src_table, $dest_table, $genome_db_ids) = @_;
+
+    assert_ref($compara_dba, 'Bio::EnsEMBL::Compara::DBSQL::DBAdaptor', 'compara_dba');
+    throw('NCBITaxa::sync_taxon_ids_by_genome_db_id() requires a $src_table') unless $src_table;
+    throw('NCBITaxa::sync_taxon_ids_by_genome_db_id() requires a $dest_table') unless $dest_table;
+
+    my $helper = $compara_dba->dbc->sql_helper;
+
+    my $src_map = _fetch_genome_taxa_mapping($helper, $src_table, $genome_db_ids);
+    my $dest_map = _fetch_genome_taxa_mapping($helper, $dest_table, $genome_db_ids);
+    my @common_gdb_ids = grep { exists $dest_map->{$_} } keys %{$src_map};
+
+    my %sync_map;
+    foreach my $gdb_id (sort { $a <=> $b } @common_gdb_ids) {
+        my $src_taxon_ids = $src_map->{$gdb_id};
+
+        my $src_taxon_id;
+        if (scalar(@{$src_taxon_ids}) == 1) {
+            $src_taxon_id = $src_taxon_ids->[0];
+        } else {  # i.e. scalar(@{$src_taxon_ids}) > 1
+            throw(
+                "cannot sync taxon_ids for genome_db_id $gdb_id because"
+                . " it is associated with multiple taxon_ids in $src_table"
+            )
+        }
+
+        my $dest_taxon_ids = $dest_map->{$gdb_id};
+        if (scalar(@{$dest_taxon_ids}) == 1) {
+            my $dest_taxon_id = $dest_taxon_ids->[0];
+            if ((defined($src_taxon_id) xor defined($dest_taxon_id))
+                    || (defined($src_taxon_id) && defined($dest_taxon_id) && $dest_taxon_id != $src_taxon_id)) {
+                $sync_map{$gdb_id} = $src_taxon_id;
+            }
+        } else {  # i.e. scalar(@{$dest_taxon_ids}) > 1
+            $sync_map{$gdb_id} = $src_taxon_id;
+        }
+    }
+
+    foreach my $gdb_id (sort { $a <=> $b } keys %sync_map) {
+        my $taxon_id = $sync_map{$gdb_id};
+        my $update_statement = qq/UPDATE $dest_table SET taxon_id = ? WHERE genome_db_id = ?/;
+        $helper->execute_update( -SQL => $update_statement, -PARAMS => [$taxon_id, $gdb_id] );
+    }
+}
+
+
+1;

--- a/scripts/pipeline/populate_new_database.pl
+++ b/scripts/pipeline/populate_new_database.pl
@@ -165,6 +165,11 @@ instead of the range of genomic_align_id
 
 Do not store Conservation Score or Constrained Element data.
 
+=item B<--sync_taxa>
+
+When copying species trees, synchronise species_tree_node
+taxon_id values with the genome_db table.
+
 =back
 
 =head2 OLD DATA
@@ -181,6 +186,7 @@ use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Utils::Exception qw(throw warning);
 use Bio::EnsEMBL::Utils::Scalar qw(:assert);
 use Bio::EnsEMBL::Compara::Utils::CopyData qw(:table_copy);
+use Bio::EnsEMBL::Compara::Utils::NCBITaxa qw(sync_taxon_ids_by_genome_db_id);
 use Getopt::Long;
 use JSON;
 
@@ -201,6 +207,7 @@ my $filter_by_mlss = 0;
 my $alignments_only = 0;
 my $skip_gerp = 0;
 my $skip_mlsses = [];
+my $sync_taxa = 0;
 
 GetOptions(
     "help" => \$help,
@@ -220,6 +227,7 @@ GetOptions(
     'alignments_only' => \$alignments_only,
     'skip_gerp' => \$skip_gerp,
     'skip_mlss=s@' => \$skip_mlsses,
+    'sync_taxa' => \$sync_taxa,
   );
 
 
@@ -358,6 +366,8 @@ if ($old_dba and !$skip_data) {
   copy_all_mlss_tags($old_dba, $new_dba, $all_default_method_link_species_sets);
 ## Copy all the SpecieTree entries
   copy_all_species_tres($old_dba, $new_dba, $all_default_method_link_species_sets);
+  print "Synchronising species_tree_node taxon_ids ...\n";
+  sync_taxon_ids_by_genome_db_id($new_dba, 'genome_db', 'species_tree_node') if ($sync_taxa);
 
 ## Copy DNA-DNA alignments
   copy_dna_to_dna_alignments($old_dba, $new_dba, $all_default_method_link_species_sets);


### PR DESCRIPTION
## Description

Updates to NCBI Taxonomy data in core databases are currently propagated to the `genome_db` table as  part of production setup. However, these updates may not be propagated to reused member data in the `gene_member`  or `seq_member` table, or to `species_tree_node` entries associated with reused gene-tree or genomic-alignment datasets.

The changes in this PR would ensure that a `genome_db.taxon_id` update would be propagated as appropriate during the course of a typical Compara production process.

## Overview of changes

This PR:
- adds module `Bio::EnsEMBL::Compara::Utils::NCBITaxa` with function `sync_taxon_ids_by_genome_db_id`;
- adds runnable `Bio::EnsEMBL::Compara::RunnableDB::SyncTaxa`, which wraps `sync_taxon_ids_by_genome_db_id` for use in an eHive pipeline;
- adds a `sync_member_taxon_ids` (`SyncTaxa`) step to the `LoadMembers` pipeline, between `all_table_reuse` and `hc_members_per_genome`;
- updates the `members_globally` mode of `Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::SqlHealthChecks` to check `taxon_id` consistency between each `GeneMember`/`SeqMember` and its corresponding `GenomeDB`;
- adds option `--sync_taxa` to script `populate_new_database.pl` so that `taxon_id` values can be updated automatically in species trees linked to reused genomic alignment datasets as they are merged into a new Compara release database; and
- adds a `sync_taxon_ids` (`SyncTaxa`) step to the `PostHomologyMerge` pipeline to ensure outdated `taxon_id` values are updated in reused homology data.


## Testing

With a mocked-up `taxon_id` update of `drosophila_melanogaster`, test runs have been done for each updated pipeline, as well as for updated script `populate_new_database.pl`, to confirm that `taxon_id` values are synchronised correctly.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
