### PR TITLE
Update allowed_species.json

### DIFF
--- a/conf/vertebrates/allowed_species.json
+++ b/conf/vertebrates/allowed_species.json
@@ -256,7 +256,6 @@
     "sus_scrofa_gca037447515v1",
     "sus_scrofa_gca039654815v1",
     "sus_scrofa_gca040869115v1",
-    "sus_scrofa_gca041729645v1",
     "sus_scrofa_gca041937265v1",
     "sus_scrofa_gca044906105v1",
     "sus_scrofa_gca044906185v1",


### PR DESCRIPTION
removed GCA_041729645.1 pig from allowed species list

## Description

removed GCA_041729645.1 pig from list

@EreboPSilva 

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
