### PR TITLE
Update calculation of supertree orthology cardinality

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/OrthoTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/OrthoTree.pm
@@ -468,6 +468,14 @@ sub tag_orthologues
     my $count1 = $species_hash->{$pep1->genome_db_id};
     my $count2 = $species_hash->{$pep2->genome_db_id};
 
+    return $self->_classify_orthologues($count1, $count2);
+}
+
+
+sub _classify_orthologues
+{
+    my ( $self, $count1, $count2 ) = @_;
+
     if ($count1 == 1 and $count2 == 1) {
         return 'ortholog_one2one';
     } elsif ($count1 == 1 or $count2 == 1) {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/PantherParalogs.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/PantherParalogs.pm
@@ -54,7 +54,10 @@ package Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::PantherParalogs;
 use strict;
 use warnings;
 
+use List::Util qw(sum);
+
 use Bio::EnsEMBL::Compara::Graph::Link;
+use Bio::EnsEMBL::Compara::Graph::Node;
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::OtherParalogs');
 
@@ -71,7 +74,11 @@ sub rec_add_paralogs {
     my $ngenepairlinks = 0;
 
     # Iterate over all pairs of children
+    # while identifying orthologous subclades.
     my @children = @{$ancestor->children};
+    my @subclade_graph_links;
+    my %subclade_graph_nodes;
+    my %subtree_nodes_by_id;
     while (@children) {
         my $child1 = shift @children;
         foreach my $child2 (@children) {
@@ -82,7 +89,34 @@ sub rec_add_paralogs {
 
             # When checking all the genome_db_ids we should find some paralogues
             unless ($n_para or $self->param('genome_db_id')) {
-                # If not, the sub-families are across different parts of the taxonomy and we are missing some orthologs. Let's add them !
+                # If not, the sub-families are across different parts of the taxonomy and we are missing some orthologs.
+                # Let's add these orthologous subtrees to the subclade graph !
+
+                foreach my $child ($child1, $child2) {
+                    my $child_node_id = $child->node_id;
+                    if (!exists $subclade_graph_nodes{$child_node_id}) {
+                        my $subclade_node = Bio::EnsEMBL::Compara::Graph::Node->new();
+                        $subclade_node->node_id($child_node_id);
+                        $subclade_graph_nodes{$child_node_id} = $subclade_node;
+                        $subtree_nodes_by_id{$child_node_id} = $child;
+                    }
+                }
+
+                my $subclade1_node = $subclade_graph_nodes{$child1->node_id};
+                my $subclade2_node = $subclade_graph_nodes{$child2->node_id};
+                my $subclade_link = $subclade1_node->create_link_to_node($subclade2_node);
+                push(@subclade_graph_links, $subclade_link);
+            }
+        }
+    }
+
+    {  # <-- These braces were placed here only to minimise the diff between versions; please feel free to remove them.
+        if (@subclade_graph_links) {
+            foreach my $subclade_link (@subclade_graph_links) {
+                my ($subclade1, $subclade2) = $subclade_link->get_nodes();
+                my $child1 = $subtree_nodes_by_id{$subclade1->node_id};
+                my $child2 = $subtree_nodes_by_id{$subclade2->node_id};
+                # The sub-families are across different parts of the taxonomy and we are missing some orthologs. Let's add them !
                 my $gene_hash1 = $child1->get_value_for_tag('gene_hash');
                 my $gene_hash2 = $child2->get_value_for_tag('gene_hash');
                 my $n_ortho = 0;
@@ -95,6 +129,8 @@ sub rec_add_paralogs {
                             foreach my $gene2 (@{$gene_hash2->{$gdb_id2}}) {
                                 my $genepairlink = new Bio::EnsEMBL::Compara::Graph::Link($gene1, $gene2);
                                 $genepairlink->add_tag("ancestor", $ancestor);
+                                $genepairlink->add_tag("subclade_link", $subclade_link);
+                                $genepairlink->add_tag("subtrees", \%subtree_nodes_by_id);
                                 $genepairlink->add_tag("subtree1", $child1);
                                 $genepairlink->add_tag("subtree2", $child2);
                                 $self->tag_genepairlink($genepairlink, $self->tag_orthologues($genepairlink), 0);
@@ -112,6 +148,60 @@ sub rec_add_paralogs {
         $ngenepairlinks += $self->rec_add_paralogs($child);
     }
     return $ngenepairlinks;
+}
+
+
+sub tag_orthologues
+{
+    my ($self, $genepairlink) = @_;
+
+    my ($pep1, $pep2) = $genepairlink->get_nodes;
+    my $gdb_id1 = $pep1->genome_db_id;
+    my $gdb_id2 = $pep2->genome_db_id;
+
+    my $subclade_link = $genepairlink->get_value_for_tag('subclade_link');
+    my $subtree_nodes_by_id = $genepairlink->get_value_for_tag('subtrees');
+
+    # We take the first linked subclade node as our entry point
+    # to the subclade graph, though either one would be OK.
+    my ($subclade_node) = $subclade_link->get_nodes();
+
+    # We need orthologue counts by subclade and genome for
+    # each of the genomes linked by this orthology relationship.
+    my %subclade_counts;
+    foreach my $subclade (@{$subclade_node->all_nodes_in_graph()}) {
+        my $subtree = $subtree_nodes_by_id->{$subclade->node_id};
+        my $species_hash = $self->get_ancestor_species_hash($subtree);
+        $subclade_counts{$subclade->node_id}{$gdb_id1} = $species_hash->{$gdb_id1} // 0;
+        $subclade_counts{$subclade->node_id}{$gdb_id2} = $species_hash->{$gdb_id2} // 0;
+    }
+
+    # From the current subclade graph node representing a set of orthologues, we identify
+    # the local subgraph within which every node has genes in one of the two genomes
+    # involved in this orthology. All the genes in this subgraph are linked, directly
+    # or indirectly, by orthology relationships with the current orthologue pair.
+    my @nodes_to_check = ($subclade_node);
+    my @connected_subclades;
+    my %node_visited;
+    while (@nodes_to_check) {
+        my $node = pop @nodes_to_check;
+        $node_visited{$node->node_id} = 1;
+        if ($subclade_counts{$node->node_id}{$gdb_id1} > 0
+                || $subclade_counts{$node->node_id}{$gdb_id2} > 0) {
+            push(@connected_subclades, $node);
+            foreach my $neighbor (@{$node->neighbors}) {
+                if (!$node_visited{$neighbor->node_id}) {
+                    push(@nodes_to_check, $neighbor);
+                }
+            }
+        }
+    }
+
+    # We sum up counts of homologues from each genome from across the local subgraph.
+    my $count1 = sum map { $subclade_counts{$_->node_id}{$gdb_id1} } @connected_subclades;
+    my $count2 = sum map { $subclade_counts{$_->node_id}{$gdb_id2} } @connected_subclades;
+
+    return $self->_classify_orthologues($count1, $count2);
 }
 
 


### PR DESCRIPTION
## Description

`RunnableDB::GeneTrees::PantherParalogs` can infer orthologues between subtrees of a Panther supertree if they represent non-overlapping parts of the taxonomy. This is determined for each pair of subtrees by checking whether the two subtrees lack paralogues between them.

A subset of orthologues inferred by this approach have cardinality annotations that are an overestimate of the actual cardinality, because the supertree is flat. One solution that has been proposed (`ENSCOMPARASW-2451`) would be to resolve the supertree and infer orthologues in a more conventional manner.

This PR addresses the issue by constructing a graph linking each pair of subtrees for which orthologues are inferred, and computing cardinality for each orthology only on the local subgraph within which all the genes in the subgraph are linked, directly or indirectly, by orthology relationships with the given orthologue pair.

<img width="875" height="360" alt="supertree_ortholog_cardinality" src="https://github.com/user-attachments/assets/599f80ef-664b-431f-87ec-7efa09a97d62" />

## Testing

The `panther_paralogs` analysis of the e115 Plants protein-trees pipeline was rerun twice, a test run with the changes in this PR and a baseline run without them. The output `orthotree.tsv` files were checked to identify mismatches between observed and annotated orthology groups. Mismatches were found in 109032 orthology _groups_ in the baseline orthotree files, while no mismatches were found in the test orthotree files.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
