### PR TITLE
Update subspeciation rank list in NCBITaxon

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/NCBITaxon.pm
+++ b/modules/Bio/EnsEMBL/Compara/NCBITaxon.pm
@@ -352,11 +352,35 @@ sub _is_rank_within_species {
     my $node = $self;
 
     # Go past the rankless nodes
-    while (($node->rank eq 'no rank') && $node->has_parent) {
+    while (($node->rank eq 'clade' || $node->rank eq 'no rank') && $node->has_parent) {
         $node = $node->parent;
     }
-    # SELECT DISTINCT n2.rank FROM ncbi_taxa_node n1 JOIN ncbi_taxa_node n2 ON n2.parent_id=n1.taxon_id WHERE n1.rank = "species";
-    if (($node->rank eq 'species') or ($node->rank eq 'subspecies') or ($node->rank eq 'forma') or ($node->rank eq 'varietas')) {
+
+    # Rank order info as described in
+    # Schoch et al. (2020) NCBI Taxonomy: a comprehensive update on curation, resources and tools.
+    # <https://europepmc.org/article/MED/32761142>.
+    # This hard-coded subspeciation rank list is not an ideal solution,
+    # but if we must use it, we may as well try to keep it current.
+    my @subspeciation_ranks = (
+        'isolate',
+        'strain',
+        'serotype',
+        'biotype',
+        'genotype',
+        'serogroup',
+        'pathogroup',
+        'forma',
+        'subvariety',
+        'varietas',
+        'form',
+        'morph',
+        'subspecies',
+        'forma specialis',
+        'special form',
+        'species',
+    );
+
+    if (grep { $node->rank eq $_ } @subspeciation_ranks) {
         return 1;
     }
     return 0;


### PR DESCRIPTION
## Description

This PR would update the list of subspeciation ranks in `NCBITaxon::_is_rank_within_species`, and would add `'clade'` to the set of rankless nodes.

This change would enhance the classification of subspeciation nodes in gene trees.

For example, in the [tree of Puccinia_graminis gene PGTG_18546](https://fungi.ensembl.org/Puccinia_graminis/Gene/Compara_Tree?collapse=none;db=core;g=PGTG_18546), the first speciation-type ancestor of `PGTG_18546` is currently labelled as a "Speciation" because the rank of its associated taxon is `'forma specialis'`.

<img width="514" height="284" alt="p_graminis_forma_specialis" src="https://github.com/user-attachments/assets/b3079a54-11ee-4f23-92f4-c900e93074a6" />

With the changes in this PR, that node would be labelled as a "Sub-speciation".

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
