### PR TITLE
Update handling of Jira search requests

### DIFF
--- a/scripts/jira_tickets/create_datacheck_tickets.pl
+++ b/scripts/jira_tickets/create_datacheck_tickets.pl
@@ -207,11 +207,10 @@ sub find_labeled_ticket {
     my ($jira_adaptor, $label) = @_;
 
     my $jql = "labels=$label";
-    my $labeled_ticket = $jira_adaptor->fetch_tickets($jql);
-
+    my $labeled_ticket = $jira_adaptor->fetch_tickets( -JQL => $jql, -FIELDS => ['key'] );
     # Check that we have actually found the ticket (and only one)
-    die "Cannot find any ticket with the label '$label'" if (! $labeled_ticket->{total});
-    die "Found more than one ticket with the label '$label'" if ($labeled_ticket->{total} > 1);
+    die "Cannot find any ticket with the label '$label'" if (scalar(@{$labeled_ticket->{issues}}) == 0);
+    die "Found more than one ticket with the label '$label'" if (scalar(@{$labeled_ticket->{issues}}) > 1);
     print "Found ticket key '" . $labeled_ticket->{issues}->[0]->{key} . "'\n";
 
     return $labeled_ticket->{issues}->[0]->{key};

--- a/scripts/production/batch_lastz.pl
+++ b/scripts/production/batch_lastz.pl
@@ -187,10 +187,10 @@ if ($jira_off) {
     # Get the parent JIRA ticket key, i.e. the production pipelines JIRA ticket for
     # the given division and release
     my $jql = 'labels=Production_anchor';
-    my $existing_tickets = $jira_adaptor->fetch_tickets($jql);
+    my $existing_tickets = $jira_adaptor->fetch_tickets( -JQL => $jql, -FIELDS => ['key', 'labels', 'summary'] );
     # Check that we have actually found the ticket (and only one)
-    die 'Cannot find any ticket with the label "Production_anchor"' if (! $existing_tickets->{total});
-    die 'Found more than one ticket with the label "Production_anchor"' if ($existing_tickets->{total} > 1);
+    die 'Cannot find any ticket with the label "Production_anchor"' if (scalar(@{$existing_tickets->{issues}}) == 0);
+    die 'Found more than one ticket with the label "Production_anchor"' if (scalar(@{$existing_tickets->{issues}}) > 1);
     my $jira_prod_key = $existing_tickets->{issues}->[0]->{key};
     # Create the subtask JIRA ticket template
     %ticket_tmpl = (


### PR DESCRIPTION
## Description

This PR would update handling of Jira search requests to use the current API.

**Related JIRA tickets:**
- ENSCOMPARASW-8728

## Overview of changes

- Update of the Jira search endpoint.
- Addition of a `-FIELDS` parameter to `Utils::JIRA::fetch_tickets`, and use of that parameter as appropriate.
- Replacement of a Unicode escape sequence in the `fetch_tickets` JQL with a double-quoted literal space.
- Update to calculation of ticket count in `create_datacheck_tickets.pl` and `batch_lastz.pl`.

## Testing

Changes to `Utils::JIRA` and `batch_lastz.pl` have been tested by doing dry runs of `batch_lastz.pl` and `create_compara_release_JIRA_tickets.pl`.

Changes to `create_datacheck_tickets.pl` have been tested with a dry run, to the extent that is possible without creating a datacheck ticket.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
