### PR TITLE
Include ncRNA alignment sequences in ensembl compara

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MergeDBsIntoRelease_conf.pm
@@ -107,6 +107,9 @@ sub default_options {
         # Tables to merge per MLSS
         'per_mlss_merge_tables' => [],
 
+        # Tables to merge by priority
+        'priority_merge_tables' => [],
+
         # Dump directory
         'work_dir'      => $self->o('pipeline_dir'),
         'mlss_info_dir' => $self->o('work_dir') . '/' . 'mlsses',
@@ -175,6 +178,7 @@ sub core_pipeline_analyses {
                 'only_tables'       => $self->o('only_tables'),
                 'src_db_aliases'    => [ref($self->o('src_db_aliases')) ? keys %{$self->o('src_db_aliases')} : ()],
                 'per_mlss_merge_tables' => $self->o('per_mlss_merge_tables'),
+                'priority_merge_tables' => $self->o('priority_merge_tables'),
                 'die_if_unknown_table'  => $self->o('die_if_unknown_table'),
             },
             -rc_name    => '2Gb_24_hour_job',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MergeDBsIntoRelease_conf.pm
@@ -117,7 +117,7 @@ sub tweak_analyses {
     $self->SUPER::tweak_analyses(@_);
     my $analyses_by_name = shift;
 
-    analyses_by_name->{'generate_job_list'}->{'-rc_name'} = '4Gb_job';
+    $analyses_by_name->{'generate_job_list'}->{'-rc_name'} = '4Gb_job';
 
     # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
     my @unguarded_funnel_analyses = (

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/MergeDBsIntoRelease_conf.pm
@@ -88,7 +88,6 @@ sub default_options {
             'hmm_annot'             => 'protein_db',
             'gene_member'           => 'members_db',
             'seq_member'            => 'members_db',
-            'other_member_sequence' => 'members_db',
             'sequence'              => 'members_db',
             'exon_boundaries'       => 'members_db',
             'seq_member_projection_stable_id' => 'members_db',
@@ -106,6 +105,10 @@ sub default_options {
             'pig_prot_db'    => [qw(ortholog_quality datacheck_results)],
             'pig_ncrna_db'   => [qw(ortholog_quality datacheck_results method_link_species_set_attr)],
         },
+
+        'priority_merge_tables' => {
+            'other_member_sequence' => ['members_db', 'ncrna_db', 'mouse_ncrna_db', 'pig_ncrna_db'],
+        }
    };
 }
 
@@ -113,6 +116,8 @@ sub tweak_analyses {
     my $self = shift;
     $self->SUPER::tweak_analyses(@_);
     my $analyses_by_name = shift;
+
+    analyses_by_name->{'generate_job_list'}->{'-rc_name'} = '4Gb_job';
 
     # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
     my @unguarded_funnel_analyses = (

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/CopyMembersByGenomeDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/CopyMembersByGenomeDB.pm
@@ -69,7 +69,18 @@ sub run {
     $self->_copy_data_wrapper('gene_member', 'SELECT * FROM gene_member');
     $self->_copy_data_wrapper('sequence', 'SELECT sequence.* FROM seq_member JOIN sequence USING (sequence_id)');
     $self->_copy_data_wrapper('seq_member', 'SELECT * FROM seq_member');
-    $self->_copy_data_wrapper('other_member_sequence', 'SELECT other_member_sequence.* FROM seq_member JOIN other_member_sequence USING (seq_member_id)');
+
+    # We exclude 'filtered' and 'seq_with_flanking' sequences from member
+    # reuse, to facilitate their inclusion from ncRNAtrees data sources.
+    my $other_member_sequence_sql = q/
+        SELECT other_member_sequence.*
+        FROM seq_member
+        JOIN other_member_sequence USING (seq_member_id)
+        WHERE seq_type NOT LIKE "%filtered"
+        AND seq_type != "seq_with_flanking"
+    /;
+    $self->_copy_data_wrapper('other_member_sequence', $other_member_sequence_sql);
+
     $self->_copy_data_wrapper('exon_boundaries', 'SELECT exon_boundaries.* FROM seq_member JOIN exon_boundaries USING (seq_member_id)');
     $self->_copy_data_wrapper('hmm_annot', 'SELECT hmm_annot.* FROM seq_member JOIN hmm_annot USING (seq_member_id)');
     $self->_copy_data_wrapper('seq_member_projection_stable_id', 'SELECT seq_member_projection_stable_id.* FROM seq_member JOIN seq_member_projection_stable_id ON seq_member_id = target_seq_member_id');

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CopyCanonRefMembersByGenomeDB.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/CopyCanonRefMembersByGenomeDB.pm
@@ -75,15 +75,24 @@ sub run {
     $self->_copy_data_wrapper_join('gene_member');
     $self->_copy_data_wrapper_join('sequence', 'sequence USING (sequence_id)');
     $self->_copy_data_wrapper_join('seq_member');
-    $self->_copy_data_wrapper_join('other_member_sequence', 'other_member_sequence USING (seq_member_id)');
+
+    # We exclude 'filtered' and 'seq_with_flanking' sequences from member
+    # reuse, to facilitate their inclusion from ncRNAtrees data sources.
+    $self->_copy_data_wrapper_join(
+        'other_member_sequence',
+        'other_member_sequence USING (seq_member_id)',
+        'seq_type NOT LIKE "%filtered" AND seq_type != "seq_with_flanking"',
+    );
+
     $self->_copy_data_wrapper_join('exon_boundaries', 'exon_boundaries USING (seq_member_id)');
     $self->_copy_data_wrapper_join('hmm_annot', 'hmm_annot USING (seq_member_id)');
     $self->_copy_data_wrapper_join('seq_member_projection_stable_id', 'seq_member_projection_stable_id ON seq_member_id = target_seq_member_id');
 }
 
 
+
 sub _copy_data_wrapper_join {
-    my ($self, $table, $extra_join) = @_;
+    my ($self, $table, $extra_join, $extra_condition) = @_;
 
     #If the parameter exclude_tables is defined in the pipeline configuration, the tables defined there will be excluded from the copy.
     return if ((defined $self->param('exclude_tables')) and exists( $self->param('exclude_tables')->{$table} ));
@@ -93,7 +102,8 @@ sub _copy_data_wrapper_join {
     my $input_query     = 'SELECT ' . $table . '.* FROM gene_member JOIN dnafrag USING (dnafrag_id) JOIN seq_member ON canonical_member_id = seq_member_id'
                           . ($extra_join ? ' JOIN '.$extra_join : '')
                           . ' WHERE is_reference = 1 AND has_translation_edits = 0'
-                          . ($biotype_filter ? ' AND '.$biotype_filter : '');
+                          . ($biotype_filter ? ' AND '.$biotype_filter : '')
+                          . ($extra_condition ? ' AND '.$extra_condition : '');
 
     $self->_copy_data_wrapper($table, $input_query, 'gene_member.');
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RenameLabels.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GeneTrees/RenameLabels.pm
@@ -44,6 +44,8 @@ sub param_defaults {
                     'UPDATE gene_tree_root SET clusterset_id = "#clusterset_id#" WHERE clusterset_id = "default"',
                     'UPDATE gene_tree_root SET stable_id = CONCAT("#label_prefix#", stable_id) WHERE stable_id IS NOT NULL AND stable_id NOT LIKE "#label_prefix#%"',
                     'UPDATE hmm_profile SET type = CONCAT("#label_prefix#", type) WHERE type NOT LIKE "#label_prefix#%"',
+                    'UPDATE other_member_sequence SET seq_type = CONCAT("#label_prefix#", seq_type) WHERE "#clusterset_id#" != "default" AND seq_type = "filtered"',
+                    'UPDATE gene_align SET seq_type = CONCAT("#label_prefix#", seq_type) WHERE "#clusterset_id#" != "default" AND seq_type = "filtered"',
                 ],
     }
 }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/ReindexMembers/ReindexMemberIDs.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/ReindexMembers/ReindexMemberIDs.pm
@@ -94,6 +94,11 @@ sub write_output {
             $dbc->do('UPDATE hmm_annot             SET seq_member_id = ?        WHERE seq_member_id = ?',        undef, @$r);
             $dbc->do('UPDATE peptide_align_feature SET qmember_id = ?           WHERE qmember_id = ?',           undef, @$r);
             $dbc->do('UPDATE peptide_align_feature SET hmember_id = ?           WHERE hmember_id = ?',           undef, @$r);
+
+            # Assuming that 'filtered' and 'seq_with_flanking' ncRNA alignment sequences have been successfully excluded from
+            # the 'genome_member_copy' step and consequently included in 'copy_table_from_prev_db', we should reindex them.
+            $dbc->do('UPDATE other_member_sequence SET seq_member_id = ? WHERE seq_member_id = ?'
+                     .' AND (seq_type LIKE "%filtered" OR seq_type = "seq_with_flanking")',                      undef, @$r);
         }
 
         $dbc->do('ALTER TABLE peptide_align_feature DROP KEY qmember_id');


### PR DESCRIPTION
## Description

ncRNA alignments and trees are being inferred using `filtered` and `seq_with_flanking` sequences that are not currently merged into the Ensembl Compara release database.

Those `filtered` and `seq_with_flanking` ncRNA alignment sequences that _are_ included in the Compara release database have been copied along with reused member data for many releases in succession, with the number of remaining ncRNA alignment sequences declining over time.

This PR would facilitate the inclusion of these sequences in the Vertebrates Compara database, enhancing the accessibility of the sequence data used to infer ncRNA alignments and trees.

## Overview of changes

Changes include:
- excluding `filtered` and `seq_with_flanking` sequences from reuse in runnables `CopyMembersByGenomeDB` and `CopyCanonRefMembersByGenomeDB`, to facilitate instead merging these sequences from the ncRNAtrees pipelines in which they're generated;
- reindexing of `filtered` and `seq_with_flanking` sequences in `ReindexMemberIDs`, working on the assumption that, having been excluded from member reuse, these will have been copied from the configured `prev_tree_db`;
- updating the `RenameLabels` runnable to add a prefix to `filtered` ncRNA alignments and sequences in non-default gene-tree collections such as Murinae and Pig-breeds;
- adding a `priority_merge_tables` option to the `MergeDBsIntoRelease` pipeline and the `DBMergeCheck` runnable, to enable configuration of tables to be merged by priority;
- adding `priority_merge_tables` config for the `other_member_sequence` table in the Vertebrates `MergeDBsIntoRelease` pipeline config, with data merged from `members_db` (as before), followed by each of the ncRNAtrees databases in turn, to merge their `filtered` and `seq_with_flanking` alignment sequences;
- updating the `DBMergeCheck` to implement priority merge for the `other_member_sequence` table, such that it is merged in `ignore` mode from each of the configured source databases in order;
- updating internal method `DBMergeCheck::_check_primary_keys` to tolerate primary-key collisions for priority-merge tables if all rows for a given primary key are essentially identical.

## Testing

The most significant changes were tested by:
- copying the most recent Murinae and Pig-breeds ncRNAtrees pipelines and running `GeneTrees::RenameLabels` on each of the copied databases to add gene-tree collection-specific prefixes to `filtered` alignment sequences; and
- doing a trial run of the homology merge pipeline to test the priority merge process on the `other_member_sequence` table.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)