### PR TITLE
Update PairAlignerStats pipeline for e116

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/PairAlignerStats_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Fungi/PairAlignerStats_conf.pm
@@ -1,0 +1,74 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Fungi::PairAlignerStats_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Fungi::PairAlignerStats_conf \
+        -compara_db compara_curr -mlss_id_list '[1234,5678]' \
+        -host mysql-ens-compara-prod-X -port XXXX
+
+=head1 DESCRIPTION
+
+This is a Fungi configuration file for the PairAlignerStats pipeline.
+Please refer to the parent class for further information.
+
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Fungi::PairAlignerStats_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::PairAlignerStats_conf');
+
+
+sub default_options {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::default_options},
+
+        'division'  => 'fungi',
+    };
+}
+
+
+sub tweak_analyses {
+    my $self = shift;
+    $self->SUPER::tweak_analyses(@_);
+    my $analyses_by_name = shift;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'coding_exon_stats_summary',
+    );
+
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/PairAlignerStats_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/PairAlignerStats_conf.pm
@@ -1,0 +1,74 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Metazoa::PairAlignerStats_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Metazoa::PairAlignerStats_conf \
+        -compara_db compara_curr -mlss_id_list '[1234,5678]' \
+        -host mysql-ens-compara-prod-X -port XXXX
+
+=head1 DESCRIPTION
+
+This is a Metazoa configuration file for the PairAlignerStats pipeline.
+Please refer to the parent class for further information.
+
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Metazoa::PairAlignerStats_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::PairAlignerStats_conf');
+
+
+sub default_options {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::default_options},
+
+        'division'  => 'metazoa',
+    };
+}
+
+
+sub tweak_analyses {
+    my $self = shift;
+    $self->SUPER::tweak_analyses(@_);
+    my $analyses_by_name = shift;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'coding_exon_stats_summary',
+    );
+
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAlignerStats_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAlignerStats_conf.pm
@@ -15,17 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::PipeConfig::PairAlignerStats_conf
@@ -34,28 +23,18 @@ Bio::EnsEMBL::Compara::PipeConfig::PairAlignerStats_conf
 
 Pipeline that computes and stores statistics for a pairwise alignment.
 
+This pipeline requires three arguments: a compara database (to read the alignment
+and store the stats), the division name and a list of mlss_ids.
+
 Note: This is usually embedded in all the pairwise-alignment pipelines, but
 is also available as a standalone pipeline in case the stats have to be
 rerun or the alignment has been imported
 
 =head1 SYNOPSIS
 
-This pipeline requires two arguments: a compara database (to read the alignment
-and store the stats) and a mlss_id.
-
-The first analysis ("pairaligner_stats") can be re-seeded with extra parameters to
-compute stats on other alignments.
-
-=head1 AUTHORSHIP
-
-Ensembl Team. Individual contributions can be found in the GIT log.
-
-=head1 APPENDIX
-
-The rest of the documentation details each of the object methods.
-Internal methods are usually preceded with an underscore (_)
-
-example : init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::PairAlignerStats_conf -compara_db <> -mlss_id <> -host <> -port <> --reg_conf
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::PairAlignerStats_conf \
+        -compara_db compara_curr -division $COMPARA_DIV -mlss_id_list '[1234,5678]' \
+        -host mysql-ens-compara-prod-X -port XXXX
 
 =cut
 
@@ -64,12 +43,16 @@ package Bio::EnsEMBL::Compara::PipeConfig::PairAlignerStats_conf;
 use strict;
 use warnings;
 
+use Bio::EnsEMBL::Hive::Utils qw(destringify);
+
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
 
 sub default_options {
     my ($self) = @_;
     return {
         %{$self->SUPER::default_options},   # inherit the generic ones
+
+        'pipeline_name' => $self->o('division') . '_pairaligner_stats_' . $self->o('rel_with_suffix'),
 
         # Dump location
         'dump_dir'      => $self->o('pipeline_dir'),
@@ -120,10 +103,24 @@ sub pipeline_wide_parameters {
 }
 
 
-sub pipeline_analyses {
+sub core_pipeline_analyses {
     my ($self) = @_;
 
     return [
+
+        {   -logic_name => 'pairaligner_stats_factory',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+            -input_ids  => [
+                {
+                    'inputlist' => destringify($self->o('mlss_id_list')),
+                    'column_names' => [ 'mlss_id' ],
+                }
+            ],
+            -flow_into => {
+                2 => [ 'pairaligner_stats' ],
+            },
+        },
+
         {   -logic_name => 'pairaligner_stats',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::PairAligner::PairAlignerStats',
             -parameters => {
@@ -131,24 +128,18 @@ sub pipeline_analyses {
                 'compare_beds'              => $self->o('compare_beds_exe'),
                 'create_pair_aligner_page'  => $self->o('create_pair_aligner_page_exe'),
                 'bed_dir'                   => $self->o('bed_dir'),
-                'ensembl_release'           => $self->o('ensembl_release'),
                 'output_dir'                => $self->o('output_dir'),
             },
-            -input_ids  => [
-                {
-                    'mlss_id'       => $self->o('mlss_id'),
-                }
-            ],
             -flow_into  => {
                 'A->1' => [ 'coding_exon_stats_summary' ],
                 '2->A' => [ 'coding_exon_stats' ],
             },
-            -rc_name    => '1Gb_job',
+            -rc_name    => '2Gb_job',
         },
         {   -logic_name => 'coding_exon_stats',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::PairAligner::PairAlignerCodingExonStats',
-            -rc_name    => '1Gb_job',
-            -analysis_capacity  => 100,
+            -rc_name    => '2Gb_job',
+            -hive_capacity => 5,
         },
         {   -logic_name => 'coding_exon_stats_summary',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::PairAligner::PairAlignerCodingExonSummary',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAlignerStats_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PairAlignerStats_conf.pm
@@ -56,8 +56,8 @@ sub default_options {
 
         # Dump location
         'dump_dir'      => $self->o('pipeline_dir'),
-        'bed_dir'       => $self->o('dump_dir').'bed_dir',
-        'output_dir'    => $self->o('dump_dir').'output_dir',
+        'bed_dir'       => $self->o('dump_dir') . '/' . 'bed_dir',
+        'output_dir'    => $self->o('dump_dir') . '/' . 'output_dir',
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/PairAlignerStats_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/PairAlignerStats_conf.pm
@@ -1,0 +1,74 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Plants::PairAlignerStats_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Plants::PairAlignerStats_conf \
+        -compara_db compara_curr -mlss_id_list '[1234,5678]' \
+        -host mysql-ens-compara-prod-X -port XXXX
+
+=head1 DESCRIPTION
+
+This is a Plants configuration file for the PairAlignerStats pipeline.
+Please refer to the parent class for further information.
+
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Plants::PairAlignerStats_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::PairAlignerStats_conf');
+
+
+sub default_options {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::default_options},
+
+        'division'  => 'plants',
+    };
+}
+
+
+sub tweak_analyses {
+    my $self = shift;
+    $self->SUPER::tweak_analyses(@_);
+    my $analyses_by_name = shift;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'coding_exon_stats_summary',
+    );
+
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/PairAlignerStats_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Protists/PairAlignerStats_conf.pm
@@ -1,0 +1,75 @@
+
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Protists::PairAlignerStats_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Protists::PairAlignerStats_conf \
+        -compara_db compara_curr -mlss_id_list '[1234,5678]' \
+        -host mysql-ens-compara-prod-X -port XXXX
+
+=head1 DESCRIPTION
+
+This is a Protists configuration file for the PairAlignerStats pipeline.
+Please refer to the parent class for further information.
+
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Protists::PairAlignerStats_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::PairAlignerStats_conf');
+
+
+sub default_options {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::default_options},
+
+        'division'  => 'protists',
+    };
+}
+
+
+sub tweak_analyses {
+    my $self = shift;
+    $self->SUPER::tweak_analyses(@_);
+    my $analyses_by_name = shift;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'coding_exon_stats_summary',
+    );
+
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/PairAlignerStats_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/PairAlignerStats_conf.pm
@@ -1,0 +1,74 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::PairAlignerStats_conf
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::PairAlignerStats_conf \
+        -compara_db compara_curr -mlss_id_list '[1234,5678]' \
+        -host mysql-ens-compara-prod-X -port XXXX
+
+=head1 DESCRIPTION
+
+This is a Vertebrates configuration file for the PairAlignerStats pipeline.
+Please refer to the parent class for further information.
+
+Selected funnel analyses are blocked on pipeline initialisation.
+These should be unblocked as needed during pipeline execution.
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::Vertebrates::PairAlignerStats_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::PairAlignerStats_conf');
+
+
+sub default_options {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::default_options},
+
+        'division'  => 'vertebrates',
+    };
+}
+
+
+sub tweak_analyses {
+    my $self = shift;
+    $self->SUPER::tweak_analyses(@_);
+    my $analyses_by_name = shift;
+
+    # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
+    my @unguarded_funnel_analyses = (
+        'coding_exon_stats_summary',
+    );
+
+    foreach my $logic_name (@unguarded_funnel_analyses) {
+        $analyses_by_name->{$logic_name}->{'-analysis_capacity'} = 0;
+    }
+}
+
+
+1;


### PR DESCRIPTION
## Description

Tests of the new `GenomicAlignStats` datacheck have revealed discrepancies in genomic alignment statistics.

This PR would update the  `PairAlignerStats` pipeline to facilitate update of pairwise genomic alignment statistics.

**Related JIRA tickets:**
- ENSCOMPARASW-8898

## Overview of changes

Changes include:
- adding a `pairaligner_stats_factory`, with an `mlss_id_list` parameter, to allow for statistics to be updated for multiple pairwise alignment datasets in a single run;
- updating analysis resource classes;
- adding a default pipeline name; and
- adding division-specific `PairAlignerStats_conf.pm` files, with a configured `"division"` and with unguarded funnels blocked.

## Testing

The updated pipeline has been tested on a copy of a Compara release database containing pairwise genomic alignments.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
