### PR TITLE
Configure gene_tree_method_types in LoadMembers and PostHomologyMerge

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
@@ -53,6 +53,8 @@ sub default_options {
 
         'do_nonblocking_checks' => 0,
 
+        'gene_tree_method_types' => ['PROTEIN_TREES', 'NC_TREES'],
+
     # "Member" parameters:
         'allow_ambiguity_codes'     => 1,
         'allow_missing_coordinates' => 0,
@@ -131,6 +133,7 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
         'reuse_member_db'       => $self->o('reuse_member_db'),
         'work_dir'              => $self->o('work_dir'),
         'do_nonblocking_checks' => $self->o('do_nonblocking_checks'),
+        'gene_tree_method_types' => $self->o('gene_tree_method_types'),
     };
 }
 
@@ -200,7 +203,7 @@ sub core_pipeline_analyses {
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
             -parameters => {
                 'compara_db'        => '#master_db#',   # that's where genome_db_ids come from
-                'all_in_current_gene_trees' => 1,
+                'all_in_current_mlsses_of_types' => '#gene_tree_method_types#',
                 'extra_parameters'  => [ 'locator' ],
             },
             -rc_name => '2Gb_job',
@@ -259,6 +262,9 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'create_reuse_ss',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::CreateReuseSpeciesSets',
+            -parameters => {
+                'whole_method_links' => '#gene_tree_method_types#',
+            },
             -rc_name    => '2Gb_job',
             -flow_into  => [ 'compare_non_reused_genome_list' ],
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PostHomologyMerge_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PostHomologyMerge_conf.pm
@@ -56,6 +56,7 @@ sub default_options {
         'master_db'       => 'compara_master',
         'compara_db'      => 'compara_curr',
 
+        'gene_tree_method_types'     => ['PROTEIN_TREES', 'NC_TREES'],
         'homology_method_types'      => ['ENSEMBL_ORTHOLOGUES', 'ENSEMBL_PARALOGUES', 'ENSEMBL_HOMOEOLOGUES'],
         'per_mlss_homology_dump_dir' => $self->o('pipeline_dir') . '/' . 'homologies',
 
@@ -94,6 +95,7 @@ sub pipeline_wide_parameters {
         'compara_db'            => $self->o('compara_db'),
         'db_conn'               => $self->o('compara_db'),
 
+        'gene_tree_method_types' => $self->o('gene_tree_method_types'),
         'homology_method_types'      => $self->o('homology_method_types'),
         'per_mlss_homology_dump_dir' => $self->o('per_mlss_homology_dump_dir'),
 
@@ -183,7 +185,7 @@ sub core_pipeline_analyses {
         {   -logic_name => 'hom_stats_genome_factory',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
             -parameters => {
-                'all_in_current_gene_trees' => 1,
+                'all_in_current_mlsses_of_types' => '#gene_tree_method_types#',
             },
             -rc_name    => '4Gb_job',
             -flow_into  => { 2 => 'update_genome_hom_stats' },

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomeDBFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomeDBFactory.pm
@@ -101,6 +101,10 @@ sub fetch_input {
     # We try our best to get a list of GenomeDBs
     my $genome_dbs;
 
+    if ($self->param('all_in_current_gene_trees')) {
+        $self->param('all_in_current_mlsses_of_types', ['PROTEIN_TREES', 'NC_TREES']);
+    }
+
     if (my $species_set_id = $self->param('species_set_id')) {
         assert_integer($species_set_id, 'species_set_id');
         my $species_set    = $self->compara_dba()->get_SpeciesSetAdaptor->fetch_by_dbID($species_set_id) or $self->die_no_retry("Could not fetch ss with dbID=$species_set_id");
@@ -124,10 +128,12 @@ sub fetch_input {
     } elsif ($self->param('all_current')) {
         $genome_dbs = $self->compara_dba->get_GenomeDBAdaptor->fetch_all_current();
 
-    } elsif ($self->param('all_in_current_gene_trees')) {
+    } elsif ($self->param_is_defined('all_in_current_mlsses_of_types')) {
+        my @method_types = @{$self->param('all_in_current_mlsses_of_types')};
+
         my %id_to_gdb;
         my $mlss_adaptor = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor();
-        foreach my $method_type ('PROTEIN_TREES', 'NC_TREES') {
+        foreach my $method_type (@method_types) {
             foreach my $mlss (@{$mlss_adaptor->fetch_all_by_method_link_type($method_type)}) {
                 next unless $mlss->is_current;
                 foreach my $genome_db (@{$mlss->species_set->genome_dbs}) {


### PR DESCRIPTION
## Description

This PR would add a `'gene_tree_method_types'` pipeline-wide parameter to the `LoadMembers` and `PostHomologyMerge` pipelines, and would use these in pipeline steps where they are needed.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
