### PR TITLE
Add AlignStatsCheck pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/AlignStatsCheck_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/AlignStatsCheck_conf.pm
@@ -1,0 +1,175 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::PipeConfig::AlignStatsCheck_conf
+
+=head1 DESCRIPTION
+
+Pipeline to check genomic alignment statistics.
+
+=head1 SYNOPSIS
+
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::AlignStatsCheck_conf \
+        -compara_db compara_curr -division $COMPARA_DIV \
+        -host mysql-ens-compara-prod-X -port XXXX
+
+=cut
+
+package Bio::EnsEMBL::Compara::PipeConfig::AlignStatsCheck_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
+
+sub default_options {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::default_options},   # inherit the generic ones
+
+        'pipeline_name' => $self->o('division') . '_align_stats_check_' . $self->o('rel_with_suffix'),
+
+        # List of methods for which coding exon stats are calculated.
+        # Currently used in coding_exon_genome_factory and coding_exon_length_stats analyses.
+        'coding_exon_method_types' => ['CACTUS_DB', 'EPO', 'EPO_EXTENDED', 'LASTZ_NET', 'PECAN'],
+    };
+}
+
+sub no_compara_schema {}    # Tell the base class not to create the Compara tables in the database
+
+sub pipeline_create_commands {
+    my ($self) = @_;
+    return [
+        @{$self->SUPER::pipeline_create_commands},
+        # Create CodingExon coverage statistics table
+        $self->db_cmd('CREATE TABLE IF NOT EXISTS statistics (
+        method_link_species_set_id  int(10) unsigned NOT NULL,
+        genome_db_id                int(10) unsigned NOT NULL,
+        dnafrag_id                  bigint unsigned NOT NULL,
+        matches                     INT(10) DEFAULT 0,
+        mis_matches                 INT(10) DEFAULT 0,
+        ref_insertions              INT(10) DEFAULT 0,
+        non_ref_insertions          INT(10) DEFAULT 0,
+        uncovered                   INT(10) DEFAULT 0,
+        coding_exon_length          INT(10) DEFAULT 0,
+        PRIMARY KEY (method_link_species_set_id,dnafrag_id)
+        ) COLLATE=latin1_swedish_ci ENGINE=InnoDB;'),
+    ];
+}
+
+sub pipeline_wide_parameters {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::pipeline_wide_parameters},
+        'compara_db' => $self->o('compara_db'),
+        'coding_exon_method_types' => $self->o('coding_exon_method_types'),
+    }
+}
+
+sub core_pipeline_analyses {
+    my ($self) = @_;
+
+    return [
+
+        {   -logic_name => 'coding_exon_genome_factory',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
+            -parameters => {
+                'all_in_current_mlsses_of_types' => '#coding_exon_method_types#',
+            },
+            -input_ids  => [ {} ],
+            -rc_name    => '2Gb_job',
+            -flow_into  => {
+                '2->A' => [ 'coding_exon_dnafrag_factory' ],
+                'A->1' => [ 'coding_exon_funnel_check' ],
+            },
+        },
+
+        {   -logic_name => 'coding_exon_dnafrag_factory',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::DnaFragFactory',
+            -rc_name    => '4Gb_24_hour_job',
+            -hive_capacity => 50,
+            -flow_into  => {
+                2 => [ 'coding_exon_length_stats' ],
+            },
+        },
+
+        {   -logic_name => 'coding_exon_length_stats',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::Alignment::CodingExonLengthStats',
+            -rc_name    => '2Gb_job',
+            -hive_capacity => 50,
+        },
+
+        {   -logic_name => 'coding_exon_funnel_check',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
+            -flow_into  => [ 'align_stats_mlss_factory' ],
+        },
+
+        {   -logic_name => 'align_stats_mlss_factory',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::MLSSIDFactory',
+            -parameters => {
+                'methods' => {
+                    'CACTUS_DB' => 2,
+                    'CACTUS_HAL' => 2,
+                    'EPO' => 2,
+                    'EPO_EXTENDED' => 2,
+                    'LASTZ_NET' => 2,
+                    'PECAN' => 2,
+                },
+            },
+            -flow_into  => {
+                2 => [ 'align_stats_check' ],
+            },
+        },
+
+        {   -logic_name => 'align_stats_check',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::Alignment::FlagOutdatedAlignStats',
+            -analysis_capacity => 50,
+            -rc_name    => '4Gb_job',
+            -parameters => {
+                'methods' => {
+                    'CACTUS_DB' => 3,
+                    'CACTUS_HAL' => 4,
+                    'EPO' => 3,
+                    'EPO_EXTENDED' => 3,
+                    'LASTZ_NET' => 2,
+                    'PECAN' => 3,
+                },
+            },
+            -flow_into  => {
+                2 => [ 'outdated_pwa_mlsses' ],
+                3 => [ 'outdated_msa_mlsses' ],
+                4 => [ 'outdated_cactus_hal_mlsses' ],
+            },
+        },
+
+        {   -logic_name => 'outdated_pwa_mlsses',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+        },
+
+        {   -logic_name => 'outdated_msa_mlsses',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+        },
+
+        {   -logic_name => 'outdated_cactus_hal_mlsses',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+        },
+    ];
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Alignment/CodingExonLengthStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Alignment/CodingExonLengthStats.pm
@@ -1,0 +1,100 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::Alignment::CodingExonLengthStats
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::Alignment::CodingExonLengthStats;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Compara::Utils::Stats qw(get_coding_exon_regions);
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub run {
+    my $self = shift;
+
+    my $method_types = $self->param_required('coding_exon_method_types');
+    my $dnafrag_id = $self->param_required('dnafrag_id');
+
+    my $mlss_dba = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor;
+    my $dnafrag_dba = $self->compara_dba->get_DnaFragAdaptor;
+
+    my $dnafrag = $dnafrag_dba->fetch_by_dbID($dnafrag_id);
+    my $genome_db = $dnafrag->genome_db;
+    $self->param('genome_db', $genome_db);
+
+    my @mlss_ids;
+    foreach my $method_type (@{$method_types}) {
+        my $mlsses_of_type = $mlss_dba->fetch_all_by_method_link_type_GenomeDB($method_type, $genome_db);
+        foreach my $mlss (@{$mlsses_of_type}) {
+            push(@mlss_ids, $mlss->dbID);
+        }
+    }
+    $self->param('mlss_ids', \@mlss_ids);
+
+    my $totals = { 'coding_exon_length' => 0 };
+    $dnafrag->genome_db->db_adaptor->dbc->prevent_disconnect( sub {
+
+        my $slice_dba = $dnafrag->genome_db->db_adaptor->get_SliceAdaptor();
+
+        #Necessary to get unique bits of Y
+        my $slices = $slice_dba->fetch_by_region_unique('toplevel', $dnafrag->name);
+        die "No slices for dnafrag ".$dnafrag->name unless @$slices;
+
+        foreach my $slice (@$slices) {
+            my $slice_coding_exons = get_coding_exon_regions($slice);
+            foreach my $coding_exon (@$slice_coding_exons) {
+                my ($start, $end) = @$coding_exon;
+                $totals->{'coding_exon_length'} += ($end - $start + 1);
+            }
+        }
+    });
+
+    $self->param('totals', $totals);
+}
+
+
+sub write_output {
+    my $self = shift;
+
+    my $mlss_ids = $self->param('mlss_ids');
+    my $totals = $self->param('totals');
+
+    my $sql = q/
+        REPLACE INTO statistics
+            (method_link_species_set_id, genome_db_id, dnafrag_id, coding_exon_length)
+        VALUES
+            (?,?,?,?)
+    /;
+
+    my $sth = $self->dbc->prepare($sql);
+    foreach my $mlss_id (@{$mlss_ids}) {
+        $sth->execute($mlss_id, $self->param('genome_db')->dbID, $self->param('dnafrag_id'), $totals->{'coding_exon_length'});
+    }
+
+    $sth->finish;
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Alignment/FlagOutdatedAlignStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Alignment/FlagOutdatedAlignStats.pm
@@ -1,0 +1,242 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::Alignment::FlagOutdatedAlignStats
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::Alignment::FlagOutdatedAlignStats;
+
+use strict;
+use warnings;
+
+use List::Util qw(sum);
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub param_defaults {
+    return {
+        'methods'   => {
+        #    'CACTUS_DB' => 2,
+        #    'CACTUS_HAL' => 2,
+        #    'EPO' => 2,
+        #    'EPO_EXTENDED' => 2,
+        #    'LASTZ_NET' => 2,
+        #    'PECAN' => 2,
+        },
+    }
+}
+
+
+sub run {
+    my $self = shift @_;
+
+    my $mlss_id = $self->param_required('mlss_id');
+
+    my $mlss_dba = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor();
+    my $mlss = $mlss_dba->fetch_by_dbID($mlss_id);
+    my $mlss_name = $mlss->name;
+
+    my %outdated_stats;
+
+    my $num_blocks_tag = $mlss->get_tagvalue('num_blocks');
+    if (defined $num_blocks_tag) {
+
+        my $stored_num_blocks = $mlss->method->type eq 'EPO'
+                              ? 2 * $num_blocks_tag
+                              : $num_blocks_tag
+                              ;
+
+        my $num_blocks_sql = q/
+            SELECT
+                COUNT(*)
+            FROM
+                genomic_align_block
+            WHERE
+                method_link_species_set_id = ?
+        /;
+
+        my $actual_num_blocks = $self->compara_dba->dbc->sql_helper->execute_single_result(
+            -SQL => $num_blocks_sql,
+            -PARAMS => [$mlss_id],
+        );
+
+        if ($stored_num_blocks != $actual_num_blocks) {
+            $outdated_stats{'num_blocks'} += 1;
+            $self->warning(
+                sprintf(
+                    "Mismatch between stored num_blocks (%d) and "
+                    . "actual value (%d) for MLSS '%s' (mlss_id:%d)",
+                    $stored_num_blocks,
+                    $actual_num_blocks,
+                    $mlss_name,
+                    $mlss_id,
+                )
+            );
+        }
+    }
+
+    my %stored_genome_lengths;
+    my %stored_coding_exon_lengths;
+    if ($mlss->species_set->size > 2) {
+
+        my $gdb_id_2_node_hash = $mlss->species_tree && $mlss->species_tree->get_genome_db_id_2_node_hash;
+        foreach my $gdb (@{$mlss->species_set->genome_dbs}) {
+            my $gdb_id = $gdb->dbID;
+
+            my %gdb_stats;
+            foreach my $tag ('coding_exon_length', 'genome_length') {
+                if ($gdb_id_2_node_hash
+                        && exists $gdb_id_2_node_hash->{$gdb_id}
+                        && $gdb_id_2_node_hash->{$gdb_id}->has_tag($tag)) {
+                    $gdb_stats{$tag} = $gdb_id_2_node_hash->{$gdb_id}->get_value_for_tag($tag);
+                } elsif (defined $mlss->has_tag("${tag}_${gdb_id}")) {
+                    $gdb_stats{$tag} = $mlss->get_value_for_tag("${tag}_${gdb_id}");
+                }
+            }
+
+            if (exists $gdb_stats{'coding_exon_length'}) {
+                $stored_coding_exon_lengths{$gdb_id} = $gdb_stats{'coding_exon_length'};
+            }
+
+            if (exists $gdb_stats{'genome_length'}) {
+                $stored_genome_lengths{$gdb_id} = $gdb_stats{'genome_length'};
+            }
+        }
+
+    } else {
+        my ($ref_gdb, $non_ref_gdb) = $mlss->find_pairwise_reference();
+
+        my @non_ref_tags = ('non_ref_coding_exon_length', 'non_ref_genome_length');
+        my %non_ref_stats = map { $_ => $mlss->get_value_for_tag($_) } @non_ref_tags;
+
+        if (exists $non_ref_stats{'non_ref_coding_exon_length'}) {
+            $stored_coding_exon_lengths{$non_ref_gdb->dbID} = $non_ref_stats{'non_ref_coding_exon_length'};
+        }
+
+        if (exists $non_ref_stats{'non_ref_genome_length'}) {
+            $stored_genome_lengths{$non_ref_gdb->dbID} = $non_ref_stats{'non_ref_genome_length'};
+        }
+
+        my @ref_tags = ('ref_coding_exon_length', 'ref_genome_length');
+        my %ref_stats = map { $_ => $mlss->get_value_for_tag($_) } @ref_tags;
+
+        if (exists $ref_stats{'ref_coding_exon_length'}) {
+            $stored_coding_exon_lengths{$ref_gdb->dbID} = $ref_stats{'ref_coding_exon_length'};
+        }
+
+        if (exists $ref_stats{'ref_genome_length'}) {
+            $stored_genome_lengths{$ref_gdb->dbID} = $ref_stats{'ref_genome_length'};
+        }
+    }
+
+    my %id_to_gdb = map { $_->dbID => $_ } @{$mlss->species_set->genome_dbs};
+    my %gdb_id_to_name = map { $_ => $id_to_gdb{$_}->name } keys %id_to_gdb;
+
+    if (%stored_genome_lengths) {
+        my $dnafrag_dba = $self->compara_dba->get_DnaFragAdaptor();
+
+        my %actual_genome_lengths;
+        foreach my $gdb (values %id_to_gdb) {
+            my $dnafrags = $dnafrag_dba->fetch_all_by_GenomeDB($gdb, -IS_REFERENCE => 1);
+            $actual_genome_lengths{$gdb->dbID} = sum map { $_->length } @{$dnafrags};
+        }
+
+        while (my ($gdb_id, $stored_genome_length) = each %stored_genome_lengths) {
+            my $actual_genome_length = $actual_genome_lengths{$gdb_id};
+            if ($stored_genome_length != $actual_genome_length) {
+                $outdated_stats{'genome_length'} += 1;
+                $self->warning(
+                    sprintf(
+                        "Mismatch between stored genome_length (%d) and "
+                        . "actual value (%d) for %s in MLSS '%s' (mlss_id:%d)",
+                        $stored_genome_length,
+                        $actual_genome_length,
+                        $gdb_id_to_name{$gdb_id},
+                        $mlss_name,
+                        $mlss_id,
+                    )
+                );
+            }
+        }
+    }
+
+    if (%stored_coding_exon_lengths) {
+        my $coding_exon_length_sql = q/
+            SELECT
+                genome_db_id,
+                SUM(coding_exon_length)
+            FROM
+                statistics
+            WHERE
+                method_link_species_set_id = ?
+            GROUP BY
+                genome_db_id
+        /;
+
+        my $result = $self->dbc->db_handle->selectall_arrayref($coding_exon_length_sql, undef, $mlss_id);
+
+        my %actual_coding_exon_lengths;
+        foreach my $row (@{$result}) {
+            my ($gdb_id, $coding_exon_length) = @{$row};
+            $actual_coding_exon_lengths{$gdb_id} = $coding_exon_length;
+        }
+
+        while (my ($gdb_id, $stored_coding_exon_length) = each %stored_coding_exon_lengths) {
+            my $actual_coding_exon_length = $actual_coding_exon_lengths{$gdb_id};
+            if ($stored_coding_exon_length != $actual_coding_exon_length) {
+                $outdated_stats{'coding_exon_length'} += 1;
+                $self->warning(
+                    sprintf(
+                        "Mismatch between stored coding_exon_length (%d) and"
+                        . " actual value (%d) for %s in MLSS '%s' (mlss_id:%d)",
+                        $stored_coding_exon_length,
+                        $actual_coding_exon_length,
+                        $gdb_id_to_name{$gdb_id},
+                        $mlss_name,
+                        $mlss_id,
+                    )
+                );
+            }
+        }
+    }
+
+    $self->param('outdated_stats', \%outdated_stats);
+    $self->param('mlss', $mlss);
+}
+
+
+sub write_output {
+    my $self = shift;
+
+    my $outdated_stats = $self->param_required('outdated_stats') // {};
+    my $methods = $self->param_required('methods');
+    my $mlss = $self->param_required('mlss');
+
+    my $branch_number = $methods->{$mlss->method->type};
+
+    if (%{$outdated_stats}) {
+        my $output_id = {'mlss_id' => $mlss->dbID, 'outdated_stats' => $outdated_stats};
+        $self->dataflow_output_id($output_id, $branch_number);
+    }
+}
+
+
+1;


### PR DESCRIPTION
## Description

This PR would add an `AlignStatsCheck` pipeline to flag outdated genomic alignment stats.

It does this based on recomputation of three bellwether stats:
- `coding_exon_length`
- `genome_length`
- `num_blocks`

Discrepancies in any of these stats result in the given MLSS being flagged.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
