### PR TITLE
Move store_member_biotype_group_tag to PostHomologyMerge pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PostHomologyMerge_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PostHomologyMerge_conf.pm
@@ -130,6 +130,29 @@ sub core_pipeline_analyses {
                 'datacheck_names' => [ 'HomologyRanges' ],
                 'registry_file'   => $self->o('reg_conf'),
             },
+            -flow_into  => 'gene_tree_mlss_id_factory',
+        },
+
+        {   -logic_name => 'gene_tree_mlss_id_factory',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::MLSSIDFactory',
+            -parameters => {
+                'methods' => {
+                    'PROTEIN_TREES' => 2,
+                    'NC_TREES' => 2,
+                },
+            },
+            -flow_into => {
+                '2->A' => ['store_member_biotype_group_tag'],
+                'A->1' => ['member_biotype_funnel_check'],
+            },
+        },
+
+        {   -logic_name => 'store_member_biotype_group_tag',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::StoreMemberBiotypeGroupTag',
+        },
+
+        {   -logic_name => 'member_biotype_funnel_check',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
             -flow_into  => 'homology_dumps_mlss_id_factory',
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ProteinTrees_conf.pm
@@ -3513,7 +3513,7 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'rib_fire_tree_stats',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-            -flow_into  => [ 'gene_count_factory', 'store_member_biotype_group_tag' ],
+            -flow_into  => [ 'gene_count_factory' ],
         },
 
         {   -logic_name => 'rib_fire_hmm_build',
@@ -3764,10 +3764,6 @@ sub core_pipeline_analyses {
             -parameters => {
                 'gene_count_exe' => $self->o('count_genes_in_tree_exe'),
             },
-        },
-
-        {   -logic_name => 'store_member_biotype_group_tag',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::StoreMemberBiotypeGroupTag',
         },
 
         {   -logic_name => 'homology_stats_factory',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ncRNAtrees_conf.pm
@@ -1443,7 +1443,7 @@ sub core_pipeline_analyses {
         {   -logic_name => 'rib_fire_tree_stats',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -flow_into  => {
-                '1->A' => [ 'gene_count_factory', 'store_member_biotype_group_tag' ],
+                '1->A' => [ 'gene_count_factory' ],
                 'A->1' => 'gene_count_funnel_check',
             },
         },
@@ -1471,10 +1471,6 @@ sub core_pipeline_analyses {
             -parameters => {
                 'gene_count_exe' => $self->o('count_genes_in_tree_exe'),
             },
-        },
-
-        {   -logic_name => 'store_member_biotype_group_tag',
-            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GeneTrees::StoreMemberBiotypeGroupTag',
         },
 
         {   -logic_name => 'rib_fire_homology_processing',


### PR DESCRIPTION
## Description

This PR would move the `store_member_biotype_group_tag` analysis from the `ProteinTrees` and `ncRNAtrees` pipelines to the `PostHomologyMerge` pipeline.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
