### PR TITLE
Add genomic alignment stats check tasks

### DIFF
--- a/conf/fungi/jira_recurrent_tickets.json
+++ b/conf/fungi/jira_recurrent_tickets.json
@@ -132,6 +132,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://embl.atlassian.net/wiki/spaces/EnsCom/pages/27104891/Creation+of+a+new+release+database#Check-genomic-alignment-stats",
+            "summary": "Check alignment stats"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "https://embl.atlassian.net/wiki/spaces/EnsCom/pages/27104181/Merge+the+DNA+data",
             "summary": "Merge DNA data",
             "name_on_graph": "Merge all for OrthWGA"

--- a/conf/metazoa/jira_recurrent_tickets.json
+++ b/conf/metazoa/jira_recurrent_tickets.json
@@ -189,6 +189,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://embl.atlassian.net/wiki/spaces/EnsCom/pages/27104891/Creation+of+a+new+release+database#Check-genomic-alignment-stats",
+            "summary": "Check alignment stats"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "https://embl.atlassian.net/wiki/spaces/EnsCom/pages/27104181/Merge+the+DNA+data",
             "summary": "Merge DNA data",
             "name_on_graph": "Merge all for OrthWGA"

--- a/conf/plants/jira_recurrent_tickets.json
+++ b/conf/plants/jira_recurrent_tickets.json
@@ -194,6 +194,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://embl.atlassian.net/wiki/spaces/EnsCom/pages/27104891/Creation+of+a+new+release+database#Check-genomic-alignment-stats",
+            "summary": "Check alignment stats"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "https://embl.atlassian.net/wiki/spaces/EnsCom/pages/27104181/Merge+the+DNA+data",
             "summary": "Merge DNA data",
             "name_on_graph": "Merge all for OrthWGA"

--- a/conf/protists/jira_recurrent_tickets.json
+++ b/conf/protists/jira_recurrent_tickets.json
@@ -132,6 +132,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://embl.atlassian.net/wiki/spaces/EnsCom/pages/27104891/Creation+of+a+new+release+database#Check-genomic-alignment-stats",
+            "summary": "Check alignment stats"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "https://embl.atlassian.net/wiki/spaces/EnsCom/pages/27104181/Merge+the+DNA+data",
             "summary": "Merge DNA data",
             "name_on_graph": "Merge all for OrthWGA"

--- a/conf/vertebrates/jira_recurrent_tickets.json
+++ b/conf/vertebrates/jira_recurrent_tickets.json
@@ -327,6 +327,12 @@
          {
             "assignee": "<RelCo>",
             "component": "Relco tasks",
+            "description": "https://embl.atlassian.net/wiki/spaces/EnsCom/pages/27104891/Creation+of+a+new+release+database#Check-genomic-alignment-stats",
+            "summary": "Check alignment stats"
+         },
+         {
+            "assignee": "<RelCo>",
+            "component": "Relco tasks",
             "description": "https://embl.atlassian.net/wiki/spaces/EnsCom/pages/27104181/Merge+the+DNA+data",
             "summary": "Merge DNA data",
             "name_on_graph": "Merge all for OrthWGA"


### PR DESCRIPTION
## Description

This PR would add a new production task to check genomic alignment stats in the release database.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
