### PR TITLE
Fix issues in AlignStatsCheck pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/AlignStatsCheck_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/AlignStatsCheck_conf.pm
@@ -104,6 +104,11 @@ sub core_pipeline_analyses {
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::DnaFragFactory',
             -rc_name    => '4Gb_24_hour_job',
             -hive_capacity => 50,
+            -parameters => {
+                'filters' => {
+                    -IS_REFERENCE => 1,
+                },
+            },
             -flow_into  => {
                 2 => [ 'coding_exon_length_stats' ],
             },

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Alignment/FlagOutdatedAlignStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Alignment/FlagOutdatedAlignStats.pm
@@ -107,7 +107,7 @@ sub run {
                         && exists $gdb_id_2_node_hash->{$gdb_id}
                         && $gdb_id_2_node_hash->{$gdb_id}->has_tag($tag)) {
                     $gdb_stats{$tag} = $gdb_id_2_node_hash->{$gdb_id}->get_value_for_tag($tag);
-                } elsif (defined $mlss->has_tag("${tag}_${gdb_id}")) {
+                } elsif ($mlss->has_tag("${tag}_${gdb_id}")) {
                     $gdb_stats{$tag} = $mlss->get_value_for_tag("${tag}_${gdb_id}");
                 }
             }

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Alignment/FlagOutdatedAlignStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Alignment/FlagOutdatedAlignStats.pm
@@ -124,7 +124,11 @@ sub run {
     } else {
         my ($ref_gdb, $non_ref_gdb) = $mlss->find_pairwise_reference();
 
-        my @non_ref_tags = ('non_ref_coding_exon_length', 'non_ref_genome_length');
+        if (!defined $non_ref_gdb) {
+            $non_ref_gdb = $ref_gdb;
+        }
+
+        my @non_ref_tags = grep { $mlss->has_tag($_) } ('non_ref_coding_exon_length', 'non_ref_genome_length');
         my %non_ref_stats = map { $_ => $mlss->get_value_for_tag($_) } @non_ref_tags;
 
         if (exists $non_ref_stats{'non_ref_coding_exon_length'}) {
@@ -135,7 +139,7 @@ sub run {
             $stored_genome_lengths{$non_ref_gdb->dbID} = $non_ref_stats{'non_ref_genome_length'};
         }
 
-        my @ref_tags = ('ref_coding_exon_length', 'ref_genome_length');
+        my @ref_tags = grep { $mlss->has_tag($_) } ('ref_coding_exon_length', 'ref_genome_length');
         my %ref_stats = map { $_ => $mlss->get_value_for_tag($_) } @ref_tags;
 
         if (exists $ref_stats{'ref_coding_exon_length'}) {


### PR DESCRIPTION
## Description

This PR would fix several issues in the `AlignStatsCheck` pipeline:
- it adds some defensive code to handling of pairwise alignment MLSS tags;
- it fixes a condition checking for a coverage MLSS tag in a multiple alignment;
- it filters the set of DnaFrags from which coding exon length is calculated, so that only coding exons from reference DnaFrags are included.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
