### PR TITLE
Update MultipleAlignerStats pipeline for e116

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EpoExtended_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EpoExtended_conf.pm
@@ -141,6 +141,7 @@ sub tweak_analyses {
     $analyses_by_name->{'extended_genome_alignment_hugemem'}->{'-parameters'}->{'mlss_id'} = '#ext_mlss_id#';
     $analyses_by_name->{'gerp'}->{'-parameters'}->{'mlss_id'} = '#ext_mlss_id#';
     $analyses_by_name->{'gerp_himem'}->{'-parameters'}->{'mlss_id'} = '#ext_mlss_id#';
+    $analyses_by_name->{'set_multiplealigner_stats_table'}->{'-parameters'}->{'mlss_id'} = '#ext_mlss_id#';
     $analyses_by_name->{'multiplealigner_stats_factory'}->{'-parameters'}->{'mlss_id'} = '#ext_mlss_id#';
     $analyses_by_name->{'multiplealigner_stats'}->{'-parameters'}->{'mlss_id'} = '#ext_mlss_id#';
     $analyses_by_name->{'gab_factory'}->{'-parameters'}->{'mlss_id'} = '#ext_mlss_id#';

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadCactus_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadCactus_conf.pm
@@ -388,7 +388,10 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'set_multiplealigner_stats_table',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomicAlignBlock::SetMultipleAlignerStatsTable',
-            -flow_into  => 'multiplealigner_stats_factory',
+            -flow_into  => {
+                '1->A' => [ 'multiplealigner_stats_factory' ],
+                'A->1' => [ 'generate_msa_stats_report' ],
+            },
         },
 
         {   -logic_name => 'multiplealigner_stats_factory',
@@ -411,7 +414,6 @@ sub core_pipeline_analyses {
 
         {   -logic_name => 'block_size_distribution',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomicAlignBlock::MultipleAlignerBlockSize',
-            -flow_into  => [ 'generate_msa_stats_report' ],
         },
 
         {   -logic_name => 'generate_msa_stats_report',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MercatorPecan_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MercatorPecan_conf.pm
@@ -642,7 +642,7 @@ sub pipeline_analyses {
 			   },
 	    -flow_into => { 
 			    '1->A' => [ 'conservation_scores_healthcheck', 'conservation_jobs_healthcheck' ],
-			    'A->1' => WHEN( 'not #skip_multiplealigner_stats#' => [ 'multiplealigner_stats_factory' ] ),
+			    'A->1' => WHEN( 'not #skip_multiplealigner_stats#' => [ 'set_multiplealigner_stats_table' ] ),
 			   },
 
 	 },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MultipleAlignerStats_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MultipleAlignerStats_conf.pm
@@ -70,11 +70,20 @@ sub no_compara_schema {}    # Tell the base class not to create the Compara tabl
 
 sub pipeline_create_commands {
     my ($self) = @_;
-    return [
+
+    my $pipeline_create_commands = [
         @{$self->SUPER::pipeline_create_commands},  # inheriting database and hive tables' creation
         $self->pipeline_create_commands_rm_mkdir(['output_dir', 'bed_dir']),
-        $self->pipeline_create_commands_rm_mkdir(['msa_stats_shared_dir'], undef, 'do not rm'),
     ];
+
+    if (defined $self->o('msa_stats_shared_dir')) {
+        push(
+            @{$pipeline_create_commands},
+            $self->pipeline_create_commands_rm_mkdir(['msa_stats_shared_dir'], undef, 'do not rm')
+        );
+    }
+
+    return $pipeline_create_commands;
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MultipleAlignerStats_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MultipleAlignerStats_conf.pm
@@ -15,17 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-
-=head1 CONTACT
-
-  Please email comments or questions to the public Ensembl
-  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
-
-  Questions may also be sent to the Ensembl help desk at
-  <http://www.ensembl.org/Help/Contact>.
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::PipeConfig::MultipleAlignerStats_conf
@@ -34,28 +23,19 @@ Bio::EnsEMBL::Compara::PipeConfig::MultipleAlignerStats_conf
 
 Pipeline that computes and stores statistics for a multiple alignment.
 
+This pipeline requires two arguments: a 'compara_db' (to read the alignment
+and store the stats) and an 'mlss_id_list' indicating the alignment MLSSes
+for which stats should be updated. It is recommended to specify a 'division'.
+
 Note: This is usually embedded in all the multiple-alignment pipelines, but
 is also available as a standalone pipeline in case the stats have to be
 rerun or the alignment has been imported
 
 =head1 SYNOPSIS
 
-This pipeline requires two arguments: a compara database (to read the alignment
-and store the stats) and a mlss_id.
-
-The first analysis ("multiplealigner_stats_factory") can be re-seeded with extra parameters to
-compute stats on other alignments.
-
-=head1 AUTHORSHIP
-
-Ensembl Team. Individual contributions can be found in the GIT log.
-
-=head1 APPENDIX
-
-Example init : init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::MultipleAlignerStats_conf -host mysql-ens-compara-prod-2.ebi.ac.uk:4522 -pipeline_name <> -compara_db <> -mlss_id <>
-
-The rest of the documentation details each of the object methods.
-Internal methods are usually preceded with an underscore (_)
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::MultipleAlignerStats_conf \
+        -compara_db compara_curr -division $COMPARA_DIV -mlss_id_list '[1234,5678]' \
+        -host mysql-ens-compara-prod-X -port XXXX
 
 =cut
 
@@ -64,19 +44,30 @@ package Bio::EnsEMBL::Compara::PipeConfig::MultipleAlignerStats_conf;
 use strict;
 use warnings;
 
+use Bio::EnsEMBL::Hive::Utils qw(destringify);
+
 use Bio::EnsEMBL::Compara::PipeConfig::Parts::MultipleAlignerStats;
 
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
 
 sub default_options {
     my ($self) = @_;
+
+    my $pipeline_name = 'msa_stats_' . $self->o('rel_with_suffix');
+
+    if ($self->o('division')) {
+        $pipeline_name = $self->o('division') . '_' . $pipeline_name;
+    }
+
     return {
         %{$self->SUPER::default_options},   # inherit the generic ones
 
+        'pipeline_name' => $pipeline_name,
+
         # Dump location
         'dump_dir'      => $self->o('pipeline_dir'),
-        'bed_dir'       => $self->o('dump_dir').'bed_dir',
-        'output_dir'    => $self->o('dump_dir').'feature_dumps',
+        'bed_dir'       => $self->o('dump_dir') . '/' . 'bed_dir',
+        'output_dir'    => $self->o('dump_dir') . '/' . 'feature_dumps',
 
         'msa_stats_shared_dir' => undef,
     };
@@ -116,14 +107,23 @@ sub pipeline_wide_parameters {
 sub core_pipeline_analyses {
     my ($self) = @_;
 
-    my $pipeline_analyses = Bio::EnsEMBL::Compara::PipeConfig::Parts::MultipleAlignerStats::pipeline_analyses_multiple_aligner_stats($self);
-    $pipeline_analyses->[0]->{'-input_ids'} = [
-        {
-            'mlss_id'       => $self->o('mlss_id'),
-        }
-    ];
+    return [
 
-    return $pipeline_analyses;
+        {   -logic_name => 'msa_stats_mlss_factory',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+            -input_ids  => [
+                {
+                    'inputlist' => destringify($self->o('mlss_id_list')),
+                    'column_names' => [ 'mlss_id' ],
+                }
+            ],
+            -flow_into => {
+                2 => [ 'multiplealigner_stats_factory' ],
+            },
+        },
+
+        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::MultipleAlignerStats::pipeline_analyses_multiple_aligner_stats($self) },
+    ];
 }
 
 sub tweak_analyses {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MultipleAlignerStats_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MultipleAlignerStats_conf.pm
@@ -108,23 +108,23 @@ sub pipeline_wide_parameters {
 sub core_pipeline_analyses {
     my ($self) = @_;
 
-    return [
+    my $pipeline_analyses = Bio::EnsEMBL::Compara::PipeConfig::Parts::MultipleAlignerStats::pipeline_analyses_multiple_aligner_stats($self);
 
-        {   -logic_name => 'msa_stats_mlss_factory',
-            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
-            -input_ids  => [
-                {
-                    'inputlist' => destringify($self->o('mlss_id_list')),
-                    'column_names' => [ 'mlss_id' ],
-                }
-            ],
-            -flow_into => {
-                2 => [ 'multiplealigner_stats_factory' ],
-            },
+    unshift(@{$pipeline_analyses}, {
+        -logic_name => 'msa_stats_mlss_factory',
+        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+        -input_ids  => [
+            {
+                'inputlist' => destringify($self->o('mlss_id_list')),
+                'column_names' => [ 'mlss_id' ],
+            }
+        ],
+        -flow_into  => {
+            2 => [ 'set_multiplealigner_stats_table' ],
         },
+    });
 
-        @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::MultipleAlignerStats::pipeline_analyses_multiple_aligner_stats($self) },
-    ];
+    return $pipeline_analyses;
 }
 
 sub tweak_analyses {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MultipleAlignerStats_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MultipleAlignerStats_conf.pm
@@ -91,7 +91,6 @@ sub hive_meta_table {
     my ($self) = @_;
     return {
         %{$self->SUPER::hive_meta_table},       # here we inherit anything from the base class
-        'hive_use_param_stack'  => 1,           # switch on the new param_stack mechanism
     }
 }
 sub pipeline_wide_parameters {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/MultipleAlignerStats_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/MultipleAlignerStats_conf.pm
@@ -23,9 +23,9 @@ Bio::EnsEMBL::Compara::PipeConfig::MultipleAlignerStats_conf
 
 Pipeline that computes and stores statistics for a multiple alignment.
 
-This pipeline requires two arguments: a 'compara_db' (to read the alignment
-and store the stats) and an 'mlss_id_list' indicating the alignment MLSSes
-for which stats should be updated. It is recommended to specify a 'division'.
+This pipeline requires three arguments: a 'compara_db' (to read the
+alignment and store the stats), a 'division' name, and an 'mlss_id_list'
+indicating the alignment MLSSes for which stats should be updated.
 
 Note: This is usually embedded in all the multiple-alignment pipelines, but
 is also available as a standalone pipeline in case the stats have to be
@@ -52,17 +52,10 @@ use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
 
 sub default_options {
     my ($self) = @_;
-
-    my $pipeline_name = 'msa_stats_' . $self->o('rel_with_suffix');
-
-    if ($self->o('division')) {
-        $pipeline_name = $self->o('division') . '_' . $pipeline_name;
-    }
-
     return {
         %{$self->SUPER::default_options},   # inherit the generic ones
 
-        'pipeline_name' => $pipeline_name,
+        'pipeline_name' => $self->o('division') . '_msa_stats_' . $self->o('rel_with_suffix'),
 
         # Dump location
         'dump_dir'      => $self->o('pipeline_dir'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOAlignment.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EPOAlignment.pm
@@ -324,7 +324,7 @@ sub pipeline_analyses_healthcheck {
                         {'test' => 'conservation_scores'},
                     ],
                 }),
-                'A->1' => WHEN( 'not #skip_multiplealigner_stats#' => [ 'multiplealigner_stats_factory' ],
+                'A->1' => WHEN( 'not #skip_multiplealigner_stats#' => [ 'set_multiplealigner_stats_table' ],
                           ELSE [ 'end_pipeline' ]),
             },
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EpoExtended.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/EpoExtended.pm
@@ -398,7 +398,7 @@ sub pipeline_analyses_healthcheck {
                         {'test' => 'conservation_scores','method_link_species_set_id'=>'#cs_mlss_id#'},
                     ],
                 } ),
-                'A->1' => WHEN( 'not #skip_multiplealigner_stats#' => [ 'multiplealigner_stats_factory' ],
+                'A->1' => WHEN( 'not #skip_multiplealigner_stats#' => [ 'set_multiplealigner_stats_table' ],
                           ELSE [ 'end_pipeline' ]),
             },
         },

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/MultipleAlignerStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/MultipleAlignerStats.pm
@@ -37,6 +37,24 @@ use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;   # For WHEN
 sub pipeline_analyses_multiple_aligner_stats {
     my ($self) = @_;
     return [
+
+        {   -logic_name => 'set_multiplealigner_stats_table',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomicAlignBlock::SetMultipleAlignerStatsTable',
+            -flow_into  => {
+                '1->A' => [ 'multiplealigner_stats_factory' ],
+                'A->1' => [ 'msa_stats_report_decision' ],
+            },
+        },
+
+        {   -logic_name => 'msa_stats_report_decision',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
+            -flow_into  => {
+                1 => [
+                    WHEN( '#msa_stats_shared_dir#' => 'generate_msa_stats_report' ),
+                ],
+            },
+        },
+
         {   -logic_name => 'multiplealigner_stats_factory',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory',
             -flow_into  => {
@@ -68,9 +86,6 @@ sub pipeline_analyses_multiple_aligner_stats {
         {   -logic_name => 'block_size_distribution',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::GenomicAlignBlock::MultipleAlignerBlockSize',
             -rc_name => '1Gb_24_hour_job',
-            -flow_into  => [
-                WHEN( '#msa_stats_shared_dir#' => 'generate_msa_stats_report' ),
-            ],
         },
 
         {   -logic_name => 'generate_msa_stats_report',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/UpdateMSA_conf.pm
@@ -471,7 +471,7 @@ sub tweak_analyses {
             ]}
         ),
         'A->1' => WHEN(
-            'not #skip_multiplealigner_stats#' => { 'multiplealigner_stats_factory' => { 'mlss_id' => '#method_link_species_set_id#' } },
+            'not #skip_multiplealigner_stats#' => { 'set_multiplealigner_stats_table' => { 'mlss_id' => '#method_link_species_set_id#' } },
             ELSE                                  [ 'end_pipeline' ]
         ),
     };

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/PigBreedsEPOwithExt_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/PigBreedsEPOwithExt_conf.pm
@@ -69,7 +69,7 @@ sub tweak_analyses {
         'set_gerp_mlss_tag',
         'setup_extended_alignment',
         'update_max_alignment_length',
-        'multiplealigner_stats_factory',
+        'set_multiplealigner_stats_table',
     );
 
     foreach my $logic_name (@unguarded_funnel_analyses) {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomicAlignBlock/SetMultipleAlignerStatsTable.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomicAlignBlock/SetMultipleAlignerStatsTable.pm
@@ -49,8 +49,15 @@ sub run {
     if (grep { ! exists $species_tree_gdb_id_set{$_} } @species_set_gdb_ids) {
         $self->param('multiplealigner_stats_table', 'method_link_species_set_tag');
     }
+}
 
-    $self->add_or_update_pipeline_wide_parameter('multiplealigner_stats_table', $self->param('multiplealigner_stats_table'));
+
+sub write_output {
+    my $self = shift;
+
+    my $mlss_id = $self->param('mlss_id');
+    my $multiplealigner_stats_table = $self->param('multiplealigner_stats_table');
+    $self->dataflow_output_id({ 'mlss_id' => $mlss_id, 'multiplealigner_stats_table' => $multiplealigner_stats_table }, 1);
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomicAlignBlock/SetMultipleAlignerStatsTable.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/GenomicAlignBlock/SetMultipleAlignerStatsTable.pm
@@ -44,7 +44,7 @@ sub run {
     my $mlss = $mlss_adaptor->fetch_by_dbID($mlss_id);
 
     my %species_tree_gdb_id_set = map { $_->genome_db_id => 1 } @{$mlss->species_tree->root->get_all_leaves()};
-    my @species_set_gdb_ids = @{$mlss->species_set->genome_dbs};
+    my @species_set_gdb_ids = map { $_->dbID } @{$mlss->species_set->genome_dbs};
 
     if (grep { ! exists $species_tree_gdb_id_set{$_} } @species_set_gdb_ids) {
         $self->param('multiplealigner_stats_table', 'method_link_species_set_tag');


### PR DESCRIPTION
## Description

Tests of the new `AlignStatsCheck` pipeline have revealed discrepancies in some multiple genomic alignment statistics.

This PR would update the `MultipleAlignerStats` pipeline to facilitate update of statistics of such multiple alignment datasets.

**Related JIRA tickets:**
- ENSCOMPARASW-8966

## Overview of changes

Changes include:

- adding an `msa_stats_mlss_factory`, with an `mlss_id_list` parameter, to allow for statistics to be updated for many multiple alignment datasets in a single run, without having to repeatedly re-seed the pipeline;
- adding a default pipeline name;
- ensuring that the `bed_dir` and `output_dir` are created within `dump_dir`;
- updating documentation;
- moving `set_multiplealigner_stats_table` to the start of the `MultipleAlignerStats` pipeline part;
- creating `msa_stats_shared_dir` only if defined; and
- switching off `hive_use_param_stack` in `MultipleAlignerStats_conf`.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
