### PR TITLE
Update SyntenyStats pipeline for e116

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/SyntenyStats_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/SyntenyStats_conf.pm
@@ -15,20 +15,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
 =head1 NAME
 
 Bio::EnsEMBL::Compara::PipeConfig::SyntenyStats_conf
 
 =head1 SYNOPSIS
 
-    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::SyntenyStats_conf -host mysql-ens-compara-prod-X -port XXXX \
-        -division $COMPARA_DIV
+    init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::SyntenyStats_conf \
+        -compara_db compara_curr -division $COMPARA_DIV -mlss_id_list '[1234,5678]' \
+        -host mysql-ens-compara-prod-X -port XXXX
 
 =head1 DESCRIPTION  
 
-Calculate synteny coverage statistics across a whole division (or any Registry alias).
+Calculate synteny coverage statistics for the specified MLSSes.
 
 =cut
 
@@ -37,12 +36,16 @@ package Bio::EnsEMBL::Compara::PipeConfig::SyntenyStats_conf;
 use strict;
 use warnings;
 
+use Bio::EnsEMBL::Hive::Utils qw(destringify);
+
 use base ('Bio::EnsEMBL::Compara::PipeConfig::ComparaGeneric_conf');
 
 sub default_options {
     my ($self) = @_;
     return {
         %{$self->SUPER::default_options},   # inherit the generic ones
+
+        'pipeline_name' => $self->o('division') . '_synteny_stats_' . $self->o('rel_with_suffix'),
 
         'compara_db'    => 'compara_curr',
     };
@@ -63,16 +66,16 @@ sub pipeline_analyses {
   
   return [
     {
-      -logic_name      => 'FetchMLSS',
-      -module          => 'Bio::EnsEMBL::Compara::RunnableDB::MLSSIDFactory',
-      -parameters      => {
-          'methods' => {
-              'SYNTENY' => 1,
-          },
-      },
+      -logic_name      => 'FlowMLSS',
+      -module          => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
       -max_retry_count => 0,
-      -input_ids       => [ {} ],
-      -flow_into       => ['SyntenyStats'],
+      -input_ids  => [
+          {
+              'inputlist' => destringify($self->o('mlss_id_list')),
+              'column_names' => [ 'mlss_id' ],
+          }
+      ],
+      -flow_into       => { 2 => 'SyntenyStats'},
     },
     
     {

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/SyntenyStats_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/SyntenyStats_conf.pm
@@ -82,7 +82,10 @@ sub pipeline_analyses {
       -logic_name      => 'SyntenyStats',
       -module          => 'Bio::EnsEMBL::Compara::RunnableDB::Synteny::SyntenyStats',
       -max_retry_count => 0,
-      -flow_into       => {-1 => 'synteny_stats_himem'},
+      -flow_into       => {
+          -1 => 'synteny_stats_himem',
+          -2 => 'synteny_stats_himem',
+      },
       -rc_name         => '1Gb_job',
     },
 
@@ -90,7 +93,7 @@ sub pipeline_analyses {
       -logic_name      => 'synteny_stats_himem',
       -module          => 'Bio::EnsEMBL::Compara::RunnableDB::Synteny::SyntenyStats',
       -max_retry_count => 0,
-      -rc_name         => '4Gb_job',
+      -rc_name         => '4Gb_24_hour_job',
     },
     
   ];


### PR DESCRIPTION
## Description

Tests of an updated `AlignStatsCheck` pipeline have revealed discrepancies in a subset of synteny statistics.

This PR would update the `SyntenyStats` pipeline to facilitate update of statistics of synteny stats.

**Related JIRA tickets:**
- ENSCOMPARASW-8978

## Overview of changes
Changes include:
- using a `JobFactory` to generate `SyntenyStats` jobs in place of an `MLSSIDFactory`, with an `mlss_id_list` parameter, to allow for statistics to be updated for many synteny datasets in a single run, rather than having to repeatedly re-seed the pipeline or update stats for the whole Compara database;
- adding a default pipeline name; and
- updating documentation.

## Testing
Testing in progress.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
