### PR TITLE
Update synteny pipeline to facilitate self-synteny

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Synteny_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Synteny_conf.pm
@@ -289,7 +289,7 @@ sub pipeline_analyses {
                                    mlss_id  => '#synteny_mlss_id#',
                                   },
               -flow_into => {
-                              2 => WHEN( '(#avg_genomic_coverage# < #min_genome_coverage#)' => 'delete_synteny',
+                              2 => WHEN( '(#species_set_size# > 1 && #avg_genomic_coverage# < #min_genome_coverage#)' => 'delete_synteny',
                                          ELSE 'update_mlss_tag_table',
                                         ),
                             },

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Synteny/LoadDnafragRegions.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Synteny/LoadDnafragRegions.pm
@@ -68,6 +68,15 @@ sub run {
     my $synteny_mlss_id = $self->param('synteny_mlss_id');
     my $qy_species = $self->param_required('ref_species');
     my ($gdb1, $gdb2) = @{$self->param('synteny_mlss')->species_set->genome_dbs()};
+
+    my $species_set_size;
+    if (defined $gdb2) {
+        $species_set_size = 2;
+    } else {
+        $species_set_size = 1;
+        $gdb2 = $gdb1;
+    }
+
     my ($qy_gdb, $tg_gdb) = $gdb1->name eq $qy_species ? ($gdb1,$gdb2) : ($gdb2,$gdb1);
 
     my $dfa = $self->compara_dba->get_DnaFragAdaptor();
@@ -80,6 +89,30 @@ sub run {
         chomp $line;
         if ($line =~ /^(\S+)\t.*\t.*\t(\d+)\t(\d+)\t.*\t(-1|1)\t.*\t(\S+)\t(\d+)\t(\d+)$/) {#####This will need to be changed
             my ($qy_chr,$qy_start,$qy_end,$rel,$tg_chr,$tg_start,$tg_end) = ($1,$2,$3,$4,$5,$6,$7);
+
+            if ($species_set_size == 1
+                    && $qy_chr eq $tg_chr
+                    && (
+                            ($qy_start <= $tg_start && $tg_end <= $qy_end)
+                            ||
+                            ($tg_start <= $qy_start && $qy_end <= $tg_end)
+                        )
+                ) {
+
+                $self->warning(
+                    sprintf(
+                        "skipping nested synteny region %s:%d-%d vs %s:%d-%d",
+                        $qy_chr,
+                        $qy_start,
+                        $qy_end,
+                        $tg_chr,
+                        $tg_start,
+                        $tg_end,
+                    )
+                );
+
+                next;
+            }
 
             my $qy_dnafrag = $dfa->fetch_by_GenomeDB_and_name($qy_gdb, $qy_chr);
             my $tg_dnafrag = $dfa->fetch_by_GenomeDB_and_name($tg_gdb, $tg_chr);

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/Synteny/SyntenyStats.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/Synteny/SyntenyStats.pm
@@ -204,7 +204,7 @@ sub calculate_stats {
   }
 
   my $avg_genomic_coverage = ($tags{'ref_genome_coverage'}/$tags{'ref_genome_length'}+$tags{'non_ref_genome_coverage'}/$tags{'non_ref_genome_length'}) / 2;
-  $self->dataflow_output_id( {'avg_genomic_coverage' => $avg_genomic_coverage}, 2);
+  $self->dataflow_output_id( {'avg_genomic_coverage' => $avg_genomic_coverage, 'species_set_size' => $mlss->species_set->size}, 2);
 
 }
 

--- a/scripts/synteny/DumpGFFAlignmentsForSynteny.pl
+++ b/scripts/synteny/DumpGFFAlignmentsForSynteny.pl
@@ -105,14 +105,15 @@ if ($mlss_id) {
     $mlss = $mlssa->fetch_by_dbID($mlss_id);
     my $found_query = 0;
     #find target gdb from mlss
-    foreach my $genome_db (@{$mlss->species_set->genome_dbs}) {
-        if ($qy_gdb->name ne $genome_db->name) {
-            $tg_gdb = $genome_db;
-        } else {
-            $found_query = 1;
-        }
+    my ($mlss_qy_gdb, $mlss_tg_gdb) = $mlss->find_pairwise_reference();
+
+    if (defined $mlss_tg_gdb) {
+        $tg_gdb = $mlss_tg_gdb;
+    } else {  # self-alignment
+        $tg_gdb = $mlss_qy_gdb;
     }
-    unless ($found_query) {
+
+    unless ($mlss_qy_gdb->name eq $qy_gdb->name) {
         die "Unable to find query species $qy_species in this method_link_species_set $mlss_id " . $mlss->name;
     }
 } else {


### PR DESCRIPTION
## Description

This PR would update several aspects of the `Synteny` pipeline to facilitate comparative datasets such as the Human self-synteny MLSS.

**Related JIRA tickets:**
- ENSCOMPARASW-7059

## Overview of changes

Changes include:
- more robust fetching of self-synteny GenomeDB objects in the `LoadDnafragRegions` runnable and `DumpGFFAlignmentsForSynteny.pl` script;
- filtering out of nested and trivial self-synteny regions in the `LoadDnafragRegions` runnable; and
- dataflowing the `species_set_size` from the `SyntenyStats` runnable, and updating the `Synteny` pipeline to check genomic coverage only in synteny MLSSes with a `species_set_size` greater than one.

## Testing

These changes have been tested in a production pipeline.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
