### PR TITLE
Configure redump of all Metazoa LastZ MAF files

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Metazoa/DumpAllForRelease_conf.pm
@@ -50,6 +50,23 @@ sub default_options {
         'dump_dir'         => $self->o('dump_root') . '/release-' . $self->o('eg_release'),
 
         'division'         => 'metazoa',
+
+         # mlss_ids of LastZ alignments to redump
+        'updated_mlss_ids' => [
+            9560,  # Agam-Asin LastZ (on Agam)
+            9706,  # Aalv-Agam LastZ (on Agam)
+            9726,  # Acep-Amel LastZ (on Acep)
+            9728,  # Acep-Nvit LastZ (on Acep)
+            9736,  # Amel-Nvit LastZ (on Amel)
+            9773,  # Acep-Sinv LastZ (on Acep)
+            9774,  # Acep-Bimp LastZ (on Acep)
+            9777,  # Amel-Sinv LastZ (on Amel)
+            9778,  # Amel-Bimp LastZ (on Amel)
+            9779,  # Nvit-Sinv LastZ (on Nvit)
+            9780,  # Bimp-Nvit LastZ (on Nvit)
+            9781,  # Bimp-Sinv LastZ (on Sinv)
+            9784,  # Gfus-Gmor LastZ (on Gmor)
+        ],
     };
 }
 


### PR DESCRIPTION
## Description

This PR would configure a redump of all Metazoa LastZ MAF files in this release, to give effect to the bugfix in [commit 0c15c6c](https://github.com/Ensembl/ensembl-compara/commit/0c15c6c8dfead96ecf110e26d275d2738dba3fc7).

**Related JIRA tickets:**
- ENSCOMPARASW-9021

## Testing
Details of the Metazoa test pipeline are in [ENSCOMPARASW-9021](https://embl.atlassian.net/browse/ENSCOMPARASW-9021).

## Notes

The `updated_mlss_ids` parameter is used [here](https://github.com/Ensembl/ensembl-compara/blob/0c15c6c8dfead96ecf110e26d275d2738dba3fc7/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/CreateDumpJobs.pm#L84-L89).

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
