### PR TITLE
Write MD5SUM for genome-specific homology TSV files

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
@@ -90,7 +90,10 @@ sub pipeline_analyses_dump_trees {
         {   -logic_name => 'md5sum_tree_funnel_check',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck',
             -rc_name    => '1Gb_job',
-            -flow_into  => [ { 'md5sum_tree_factory' => INPUT_PLUS() } ],
+            -flow_into  => [ {
+                'md5sum_genome_homologies_factory' => INPUT_PLUS(),
+                'md5sum_tree_factory' => INPUT_PLUS(),
+            } ],
         },
 
         {   -logic_name => 'mk_work_dir',
@@ -507,6 +510,22 @@ sub pipeline_analyses_dump_trees {
             },
         },
 
+        {   -logic_name => 'md5sum_genome_homologies_factory',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::FindGenomeHomologySubdirectories',
+            -parameters => {
+                'search_path' => '#tsv_dir#',
+            },
+            -flow_into => {
+                2 => [ 'md5sum_genome_homologies' ],
+            },
+        },
+
+        {   -logic_name => 'md5sum_genome_homologies',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -parameters => {
+                'cmd' => q/cd #directory# ; md5sum *.gz > MD5SUM/,
+            },
+        },
     ];
 }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/FindGenomeHomologySubdirectories.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/FindGenomeHomologySubdirectories.pm
@@ -1,0 +1,69 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::FindGenomeHomologySubdirectories
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::FindGenomeHomologySubdirectories;
+
+use strict;
+use warnings;
+
+use File::Find;
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub run {
+    my $self = shift;
+
+    my $search_path = $self->param_required('search_path');
+    $search_path =~ s|/+$||;
+
+    my %sub_dir_set;
+    {
+        local $File::Find::dont_use_nlink = 1;
+
+        find(sub {
+            my $dir_path = $File::Find::dir;
+            $dir_path =~ s|/+$||;
+            if (/\.gz$/ && $dir_path ne $search_path) {
+                $sub_dir_set{$dir_path} = 1;
+            }
+        }, $search_path);
+    }
+
+    my @directories = sort keys %sub_dir_set;
+    $self->param('directories', \@directories);
+}
+
+
+sub write_output {
+    my $self = shift;
+
+    my $directories = $self->param('directories');
+
+    foreach my $directory (@{$directories}) {
+        $self->dataflow_output_id( { directory => $directory }, 2 );
+    }
+}
+
+
+1;


### PR DESCRIPTION
## Description

This PR would fix an issue whereby `MD5SUM` files are not being generated for genome-specific homology TSV files.

## Testing
This bugfix has been tested by generating `MD5SUM` files for a set of genome-specific homology TSV files.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
