### PR TITLE
Updating DumpSpeciesDBToTsv to check line count of output file

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/DumpSpeciesDBToTsv.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/HomologyAnnotation/DumpSpeciesDBToTsv.pm
@@ -56,6 +56,16 @@ sub run {
     my $cmd = "python $dump_homologies_script -u $db_url -r $compara_db -o $out_dir/$filename";
     my $run_cmd = $self->run_command($cmd, { 'die_on_failure' => 1});
     print "Time for dumping the homologies... " . $run_cmd->runtime_msec . " msec\n" if $self->debug();
+    # Check if output file has at least 2 lines (header + at least one homology)
+    my $filepath = $self->param('filepath');
+    open(my $fh, '<', $filepath) or $self->throw("Cannot open $filepath: $!");
+    my $line_count = 0;
+    while (<$fh>) {
+        $line_count++;
+        last if $line_count > 1;
+    }
+    close($fh);
+    $self->throw("Output file $filepath has fewer than 2 lines!") if $line_count < 2;
 }
 
 sub write_output {


### PR DESCRIPTION
## Description

The DumpSpeciesDBToTsv module has been updated to add a validation step that checks the generated TSV output file. The job will now throw an error if the output file contains fewer than two lines (i.e. only the header or empty) or if the file does not exist.

**Related JIRA tickets:**
- ENSCOMPARASW-9106

## Overview of changes
A small change has been added to count the number of lines in the generated TSV file. If the line count is less than two, the job throws an error indicating that the output file contains insufficient data.

## Testing
Tested by temporarily modifying dump_homologies.py to simulate the following scenarios:
-  Producing a TSV file with only one line (header only)
-  Not producing an output file
In both cases, the module correctly throws an error indicating that the output file is invalid.

## Notes
_Optional extra information._

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
