### PR TITLE
Configure DumpAllForRelease to take_first on_core_clash

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/DumpAllForRelease_conf.pm
@@ -306,6 +306,7 @@ sub core_pipeline_analyses {
                     'alignment_dump_options' => $self->o('alignment_dump_options'),
                     'default_dump_options' => $self->o('default_dump_options'),
                     'ancestral_db'         => $self->o('ancestral_db'),
+                    'on_core_clash'        => 'take_first',
                 } ],
             -parameters => {
                 'init_dump_registry_exe' => $self->o('init_dump_registry_exe'),

--- a/scripts/pipeline/init_dump_registry.pl
+++ b/scripts/pipeline/init_dump_registry.pl
@@ -153,6 +153,12 @@ pod2usage(-exitvalue => 0, -verbose => 1) if $help;
 pod2usage(-verbose => 1) if !$division or !$release or !$outfile;
 
 
+my %known_overlap_species = (
+    'caenorhabditis_elegans' => 1,
+    'drosophila_melanogaster' => 1,
+    'saccharomyces_cerevisiae' => 1,
+);
+
 my $eg_release = $release - 53;
 
 my %div_to_compara_db_name = (
@@ -215,12 +221,15 @@ if (defined $core_dump_hosts) {
 }
 
 my %exp_sp_info;
+my %exp_overlap_species;
 foreach my $species_name (@{$allowed_species}) {
     $exp_sp_info{$division}{$species_name} = 1;
+    $exp_overlap_species{$species_name} = 1 if ($known_overlap_species{$species_name});
 }
 while (my ($division, $species_names) = each %{$additional_species}) {
     foreach my $species_name (@{$species_names}) {
         $exp_sp_info{$division}{$species_name} = 1;
+        $exp_overlap_species{$species_name} = 1 if ($known_overlap_species{$species_name});
     }
 }
 
@@ -286,7 +295,8 @@ foreach my $core_host (@{$dump_host_map{'core_dump_hosts'}}) {
                 throw("species $species_name has unknown division '$species_division'");
             }
 
-            if ($core_version == $release && exists $exp_sp_info{$species_division}{$species_name}) {
+            if ($core_version == $release && (exists $exp_sp_info{$species_division}{$species_name}
+                    || exists $exp_overlap_species{$species_name})) {
                 if (exists $core_adaptor_param_sets{$species_name}) {
                     my $existing = $core_adaptor_param_sets{$species_name};
                     my $msg = sprintf("specified core hosts have multiple databases for species %s: %s vs %s:%d/%s", $species_name,


### PR DESCRIPTION
## Description

This PR would configure the default behaviour of the `DumpAllForRelease` pipeline to `take_first` core `on_core_clash`.

## Testing

These changes have been tested by initialising the Compara FTP dump pipeline for Plants and Pan Compara.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
