### PR TITLE
Fix issues flagged by e116 Plants FTP dump pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
+++ b/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
@@ -406,6 +406,62 @@ sub filename {
 }
 
 
+sub _get_unique_filename {
+    my $self = shift;
+
+    my $name = $self->filename;
+
+    if (!$self->adaptor) {
+        throw("Cannot get unique filename without MLSS adaptor");
+    }
+
+    my @supported_method_types = (
+        'EPO',
+        'EPO_EXTENDED',
+        'GERP_CONSTRAINED_ELEMENT',
+        'GERP_CONSERVATION_SCORE',
+        'LASTZ_NET',
+        'PECAN',
+    );
+
+    my $clashing_mlss_found = 0;
+    foreach my $method_type (@supported_method_types) {
+        my $mlsses_of_type = $self->adaptor->fetch_all_by_method_link_type($method_type);
+        foreach my $mlss (@{$mlsses_of_type}) {
+            if ($mlss->filename eq $name && $mlss->dbID != $self->dbID) {
+                $clashing_mlss_found = 1;
+            }
+        }
+    }
+
+    if ($clashing_mlss_found) {
+        # This is very similar to code in 'MethodLinkSpeciesSet::filename',
+        # but uses the full production name instead of species short name.
+        if ( $self->species_set->size == 2 ) {
+            my ($ref_gdb, $nonref_gdb) = $self->find_pairwise_reference();
+            $name = $ref_gdb->name . "_" . $ref_gdb->assembly . '.v.';
+            $name .= $nonref_gdb->name . "_" . $nonref_gdb->assembly;
+        } elsif ( $self->species_set->size == 1 && $self->method->class =~ /pairwise/ ) {
+            my $self_aln_gdb = $self->species_set->genome_dbs->[0];
+            my $species_label = $self_aln_gdb->name . "_" . $self_aln_gdb->assembly;
+            $name = "$species_label.v.$species_label";
+        } else {
+            throw(
+                sprintf(
+                    "Cannot make unique filename for MLSS '%s' (mlss_id:%d)",
+                    $self->name,
+                    $self->dbID,
+                )
+            );
+        }
+    }
+
+    my $type = $self->method->type;
+    my $dir = lc "$name.$type";
+    return $dir;
+}
+
+
 =head2 _find_homology_mlss_sets
 
   Example    : my $mlss_info = $mlss->_find_homology_mlss_sets();

--- a/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
+++ b/modules/Bio/EnsEMBL/Compara/MethodLinkSpeciesSet.pm
@@ -454,11 +454,12 @@ sub _get_unique_filename {
                 )
             );
         }
+
+        my $type = $self->method->type;
+        $name = lc "$name.$type";
     }
 
-    my $type = $self->method->type;
-    my $dir = lc "$name.$type";
-    return $dir;
+    return $name;
 }
 
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/DumpTrees.pm
@@ -75,6 +75,7 @@ sub pipeline_analyses_dump_trees {
 
         {   -logic_name => 'map_member_types',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::MapMemberTypes',
+            -rc_name    => '1Gb_24_hour_job',
             -flow_into  => { 2 => 'collection_factory' },
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/DumpAllForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/DumpAllForRelease_conf.pm
@@ -344,4 +344,15 @@ sub default_options {
     };
 }
 
+
+sub tweak_analyses {
+    my $self = shift;
+
+    $self->SUPER::tweak_analyses(@_);
+
+    my $analyses_by_name = shift;
+
+    $analyses_by_name->{'md5sum_aln'}->{'-parameters'}->{'cmd'} = q/cd #output_dir# && find . -maxdepth 1 -name '*.#format#*' -printf '%f\\n' | xargs --max-args 128 md5sum > MD5SUM/;
+}
+
 1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/MLSSJobFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/MLSSJobFactory.pm
@@ -136,7 +136,7 @@ sub _dataflow_mlss {
     my ($self, $mlss, $extra_params) = @_;
 
     my $mlss_id     = $mlss->dbID();
-    my $filename = $mlss->filename;
+    my $filename = $mlss->_get_unique_filename();
 
     if ($self->param('add_conservation_scores')) {
         my $cs_mlsss = $mlss->get_all_sister_mlss_by_class('ConservationScore.conservation_score');

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/MkDirConservationScores.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/MkDirConservationScores.pm
@@ -52,7 +52,7 @@ sub write_output {
     print "Fetching mlss " . $self->param_required('mlss_id') . "\n" if $self->debug;
     my $mlss = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor->fetch_by_dbID($self->param_required('mlss_id'));
 
-    my $dirname = $mlss->filename;
+    my $dirname = $mlss->_get_unique_filename();
     $self->param( 'dirname', $dirname );
 
     my $output_dir = $self->param_required('cs_output_dir');

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/MkDirConstrainedElements.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/MkDirConstrainedElements.pm
@@ -51,7 +51,7 @@ sub write_output {
 
     my $mlss = $self->compara_dba->get_MethodLinkSpeciesSetAdaptor->fetch_by_dbID($self->param_required('mlss_id'));
 
-    my $dirname = $mlss->filename;
+    my $dirname = $mlss->_get_unique_filename();
 
     my $work_dir = $self->param_required('work_dir').'/'.$dirname;
     make_path($work_dir) unless -d $work_dir;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/FTPSkeleton.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/FTPSkeleton.pm
@@ -127,7 +127,7 @@ sub _mlss_dirs {
 	my @these_mlsses = map { $mlss_adaptor->fetch_by_dbID($_) } @{ $self->param_required('mlss_ids') };
 	my %mlss_dirs;
 	foreach my $mlss ( @these_mlsses ) {
-		$mlss_dirs{ $mlss->filename } = $mlss->dbID if $mlss->method->type eq $method_type;
+		$mlss_dirs{ $mlss->_get_unique_filename() } = $mlss->dbID if $mlss->method->type eq $method_type;
 	}
 	return \%mlss_dirs;
 }

--- a/scripts/dumps/check_compara_ftp_files.pl
+++ b/scripts/dumps/check_compara_ftp_files.pl
@@ -323,7 +323,7 @@ foreach my $mlss (@{$const_elem_mlsses}) {
     }
 
     push(@{$expectations{'CONSTRAINED_ELEMENT'}{'bb'}}, {
-        'dir_path' => $mlss->filename,
+        'dir_path' => $mlss->_get_unique_filename(),
         'meta_file_names' => ['MD5SUM', 'README'],
         'data_file_names' => \@bigbed_file_names,
     });
@@ -341,7 +341,7 @@ foreach my $mlss (@{$cons_score_mlsses}) {
     }
 
     push(@{$expectations{'CONSERVATION_SCORE'}{'bw'}}, {
-        'dir_path' => $mlss->filename,
+        'dir_path' => $mlss->_get_unique_filename(),
         'meta_file_names' => ['MD5SUM', 'README'],
         'data_file_names' => \@bigwig_file_names,
     });
@@ -506,7 +506,7 @@ my $msa_mlsses;
 foreach my $method_type ('EPO', 'EPO_EXTENDED', 'PECAN') {
     foreach my $mlss (@{$mlss_dba->fetch_all_by_method_link_type($method_type)}) {
         my $msa_part_names = get_msa_part_names($mlss);
-        my $mlss_filename = $mlss->filename;
+        my $mlss_filename = $mlss->_get_unique_filename();
 
         foreach my $format ('emf', 'maf') {
             my @file_patterns;
@@ -532,7 +532,7 @@ print STDERR "Checking for LASTZ_NET expectations ... \n";
 
 my @lastz_file_names;
 foreach my $mlss (@{$mlss_dba->fetch_all_by_method_link_type('LASTZ_NET')}) {
-    push(@lastz_file_names, $mlss->filename . '.tar.gz');
+    push(@lastz_file_names, $mlss->_get_unique_filename() . '.tar.gz');
 }
 
 if (@lastz_file_names) {

--- a/scripts/dumps/verify_ftp_dumps.pl
+++ b/scripts/dumps/verify_ftp_dumps.pl
@@ -90,7 +90,7 @@ foreach my $mlss ( @$mlsses ) {
     next unless defined $glob_exp_for_type;
     
     if ( $glob_exp_for_type =~ /#mlss_filename#/ ) {
-        my $mlss_filename = $mlss->filename;
+        my $mlss_filename = $mlss->_get_unique_filename();
         $glob_exp_for_type =~ s/#mlss_filename#/$mlss_filename/ig;
         my @files = glob $glob_exp_for_type;
         if ( (!defined $files[0] || !-e $files[0]) && $mlss->method->type eq 'LASTZ_NET' ) {

--- a/scripts/production/report_gerp_score_bigwig_urls.pl
+++ b/scripts/production/report_gerp_score_bigwig_urls.pl
@@ -109,7 +109,7 @@ foreach my $genome_db (@rel_genome_dbs) {
 
     @curr_mlsses = sort { $b->species_set->size <=> $a->species_set->size } @curr_mlsses;
 
-    my $mlss_filename = $curr_mlsses[0]->filename;
+    my $mlss_filename = $curr_mlsses[0]->_get_unique_filename();
 
     my $prod_name = $genome_db->name;
     my $bigwig_url = sprintf(


### PR DESCRIPTION
## Description

Several issues have been flagged by the e116 Plants Compara FTP dump pipeline:
1. multiple `dumpMultiAlign` jobs have failed due to LastZ MAF name clashes:
`taes_iwgsc.v.tama_pgsbv2.1.lastz_net.tar.gz` was claimed by two LastZ MLSSes named `Taes-Tama LastZ (on Taes)` (one involving T. aestivum Mace and the other involving T. aestivum Mattis), while `taes_iwgsc.v.tala_pgsbv2.1.lastz_net.tar.gz` was claimed by two LastZ MLSSes named `Taes-Tala LastZ (on Taes)` (one involving T. aestivum Landmark and the other involving T. aestivum Lancer);
2. `md5sum_aln` encountered an “Argument list too long” error due when processing the `triticum_aestivum` LastZ self-alignment;
3. analysis `map_member_types` hit a `RUNTIME` limit.

**Related JIRA tickets:**
- ENSCOMPARASW-9127

## Overview of changes

This pull request would:
1. add method `MethodLinkSpeciesSet::_get_unique_filename` to try to get a unique MLSS filename in the event of a clash, and use this method as appropriate;
2. use `find` with `xargs` in the Plants `md5sum_aln` step, facilitating redumping of `taes_iwgsc.v.taes_iwgsc.lastz_net.tar.gz` ;
3. extend the walltime limit of `map_member_types` in the Compara FTP dump pipeline.

## Testing

The changes in this PR were tested by Compara FTP pipeline test runs. See the related ticket for details.

## Notes

Some files named using `MethodLinkSpeciesSet::_get_unique_filename` may end up being very long, but they will not be so long that they would be impractical to download.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
