### PR TITLE
Access files via glob in DumpMultiAlign and Emf2Maf healthchecks

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/DumpMultiAlign.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/DumpMultiAlign.pm
@@ -115,19 +115,25 @@ sub write_output {
 sub _healthcheck {
     my ($self) = @_;
     
-    my $output_file = $self->param('output_file');
+    my $output_file_pattern = $self->param('output_file');
 
-    my $cmd;
+    my $cmd_prefix;
     if ($self->param('format') eq "emf") {
-        $cmd = "grep '^DATA\$' " . $output_file . " | wc -l";
-
+        $cmd_prefix = "grep '^DATA\$' ";
     } elsif ($self->param('format') eq "maf") {
-	$cmd = "grep ^a " . $output_file . " | wc -l";
+        $cmd_prefix = "grep ^a ";
     } else {
         die '_healthcheck() is not implemented for '.$self->param('format')."\n";
     }
-    my $num_blocks = $self->get_command_output($cmd);
-    chomp $num_blocks;
+
+    my $num_blocks = 0;
+    while (my $output_file = glob($output_file_pattern)) {  # we may need to check all supercontig* files
+        my $cmd = $cmd_prefix . $output_file . " | wc -l";
+        my $file_block_count = $self->get_command_output($cmd);
+        chomp $file_block_count;
+        $num_blocks += $file_block_count;
+    }
+
     if ($num_blocks != $self->param('num_blocks')) {
 	die("Number of block dumped is $num_blocks but should be " . $self->param('num_blocks'));
     } else {

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/Emf2Maf.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/Emf2Maf.pm
@@ -100,12 +100,18 @@ sub write_output {
 sub _healthcheck {
     my ($self) = @_;
 
-    my $output_file = $self->param('maf_file');
+    my $output_file_pattern = $self->param('maf_file');
     # $output_file =~ s/\.emf$/.maf/;
-    my $cmd = "grep ^a $output_file | wc -l";
+    my $cmd_prefix = "grep ^a ";
 
-    my $num_blocks = $self->get_command_output($cmd);
-    chomp $num_blocks;
+    my $num_blocks = 0;
+    while (my $output_file = glob($output_file_pattern)) {  # we may need to check all supercontig* files
+        my $cmd = $cmd_prefix . $output_file . " | wc -l";
+        my $file_block_count = $self->get_command_output($cmd);
+        chomp $file_block_count;
+        $num_blocks += $file_block_count;
+    }
+
     if ($num_blocks != $self->param_required('num_blocks')) {
 	die("Number of block dumped is $num_blocks but should be " . $self->param('num_blocks'));
     } elsif ($self->param('store_healthcheck_results')) {
@@ -114,7 +120,7 @@ sub _healthcheck {
 	#visual confirmation all is well
 	my $sql = "INSERT INTO healthcheck (filename, expected,dumped) VALUES (?,?,?)";
 	my $sth = $self->dbc->prepare($sql);
-	$sth->execute($output_file, $self->param('num_blocks'), $num_blocks);
+	$sth->execute($self->param('output_file'), $self->param('num_blocks'), $num_blocks);
 	$sth->finish();
     }
 }


### PR DESCRIPTION
## Description

An issue with the `DumpMultiAlign` healthcheck has been discovered during the redump of MAF files for LastZ alignments with `pelodiscus_sinensis` as their reference genome.

The `filename_suffix` is being set to wildcard character `*` on [line 90 of the CreateSuperJobs runnable](https://github.com/Ensembl/ensembl-compara/blob/ecdc9392ab0dc6151a1b49f250a964409f10fb6f/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/CreateSuperJobs.pm#L90), but this wildcard is not being handled as expected in the healthcheck of the [DumpMultiAlign runnable](https://github.com/Ensembl/ensembl-compara/blob/ecdc9392ab0dc6151a1b49f250a964409f10fb6f/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/DumpMultiAlign.pm), which incorrectly returns a MAF block count of zero in jobs flowed from `CreateSuperJobs`.

This PR would address the issue by accessing `DumpMultiAlign` output files via the Perl `glob` method, and summing the individual file block counts to calculate the total block count.

**Related JIRA tickets:**
- ENSCOMPARASW-9154

## Testing
The changes in this PR have been tested by a Compara FTP pipeline test run. See the related ticket for details.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
