### PR TITLE
Filter out alt_allele homologies during TSV concatenation

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/ConcatenateTSV.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/FTPDumps/ConcatenateTSV.pm
@@ -56,11 +56,11 @@ sub run {
     my $temp_dir = tempdir( CLEANUP => 1, DIR => $self->worker_temp_directory );
     my $temp_cat_tsv_file_path = catfile($temp_dir, $cat_tsv_file_name);
 
-    my $cmd1 = "cp $first_input_tsv_file $temp_cat_tsv_file_path";
+    my $cmd1 = qq/awk '\$5 != "alt_allele" {print \$0}' $first_input_tsv_file > $temp_cat_tsv_file_path/;
     $self->run_command($cmd1, { die_on_failure => 1 });
 
     foreach my $other_input_tsv_file (@other_input_tsv_files) {
-        my $cmd2 = "tail -n +2 $other_input_tsv_file >> $temp_cat_tsv_file_path";
+        my $cmd2 = qq/tail -n +2 $other_input_tsv_file | awk '\$5 != "alt_allele" {print \$0}' >> $temp_cat_tsv_file_path/;
         $self->run_command($cmd2, { die_on_failure => 1 });
     }
 
@@ -104,6 +104,10 @@ sub _healthcheck {
     foreach my $hc_type (@{$healthcheck_list}) {
         if ( $hc_type eq 'line_count' ) {
             my $exp_line_count = $self->param_required('exp_line_count') + 1; # incl header line
+
+            my $num_alt_allele_homologies = $self->_count_alt_allele_homologies();
+            $exp_line_count -= $num_alt_allele_homologies; # excl alt-allele homologies
+
             check_line_counts($temp_cat_csv_file_path, $exp_line_count);
         } elsif ( $hc_type eq 'unexpected_nulls' ) {
             check_for_null_characters($temp_cat_csv_file_path);
@@ -113,5 +117,21 @@ sub _healthcheck {
     }
 }
 
+
+sub _count_alt_allele_homologies {
+    my $self = shift;
+
+    my @input_tsv_files = grep { defined $_ } @{$self->param_required('tsv_files')};
+
+    my $num_alt_alleles = 0;
+    foreach my $input_tsv_file (@input_tsv_files) {
+        my $cmd = qq/awk '\$5 == "alt_allele" {print \$0}' $input_tsv_file | wc -l/;
+        my $file_alt_allele_count = $self->get_command_output($cmd);
+        chomp $file_alt_allele_count;
+        $num_alt_alleles += $file_alt_allele_count;
+    }
+
+    return $num_alt_alleles;
+}
 
 1;


### PR DESCRIPTION
## Description

Following changes in release 114 to the way homology TSV files are generated by the Compara FTP pipeline, `alt_allele` homologies have been inadvertently included in homology TSV dumps. In cases where allele biotype groups differ (e.g. one allele is coding and the other non-coding), each allele has been dumped to a different homology TSV file (e.g. `Compara.115.protein_default.homologies.tsv` and `Compara.115.ncrna_default.homologies.tsv`, respectively).

This PR would address the issue by filtering out `alt_allele` homologies during concatenation of homology TSV files.

It would also adjust the expected homology count by the number of removed alt-allele homologies, so that the `line_count` healthcheck should still pass if all non-`alt_allele` homologies are present.

## Testing

The updated `ConcatenateTSV` runnable has been tested on copies of human genome-specific homology TSV files, using a command like the following:
```bash
standaloneJob.pl Bio::EnsEMBL::Compara::RunnableDB::FTPDumps::ConcatenateTSV \
  -tsv_files '["/path/to/Compara.115.protein_default.homologies.tsv","/path/to/Compara.115.ncrna_default.homologies.tsv"]' \
  -output_file '/path/to/concatenated.tsv' \
  -healthcheck line_count \
  -exp_line_count 5689726
```

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
