### PR TITLE
Updating the registry, conf for oat_prot_db and type annotations for lastz coverage stats script

### DIFF
--- a/conf/plants/production_reg_conf.pl
+++ b/conf/plants/production_reg_conf.pl
@@ -115,28 +115,29 @@ my $compara_dbs = {
     'compara_curr'   => [ 'mysql-ens-compara-prod-5', "ensembl_compara_plants_${curr_eg_release}_${curr_release}" ],
     'compara_prev'   => [ 'mysql-ens-compara-prod-5', "ensembl_compara_plants_${prev_eg_release}_${prev_release}" ],
 
+    compara_staging => [ 'mysql-ens-compara-prod-6', 'ensembl_compara_plants_staging_116'], 
     # homology dbs
-    'compara_members'        => [ 'mysql-ens-compara-prod-5', 'twalsh_plants_load_members_115'],
-    'compara_ptrees'         => [ 'mysql-ens-compara-prod-9', 'twalsh_default_plants_protein_trees_115' ],
+    'compara_members'        => [ 'mysql-ens-compara-prod-5', 'sbhurji_plants_load_members_116'],
+    'compara_ptrees'         => [ 'mysql-ens-compara-prod-5', 'sbhurji_default_plants_protein_trees_116' ],
     'wheat_cultivars_ptrees' => [ 'mysql-ens-compara-prod-6', 'thiagogenez_wheat_cultivars_plants_protein_trees_113' ],
-    'rice_cultivars_ptrees'  => [ 'mysql-ens-compara-prod-7', 'twalsh_rice_cultivars_plants_protein_trees_lsf_112' ],
+    'rice_cultivars_ptrees'  => [ 'mysql-ens-compara-prod-6', 'sbhurji_rice_cultivars_plants_protein_trees_116' ],
     'barley_cultivars_ptrees' => [ 'mysql-ens-compara-prod-5', 'twalsh_barley_cultivars_plants_protein_trees_take2_115' ],
     'oat_cultivars_ptrees'    => [ 'mysql-ens-compara-prod-7', 'twalsh_oat_cultivars_plants_protein_trees_take2_116' ],
 
     # LASTZ dbs
-    'lastz_batch_1'  => [ 'mysql-ens-compara-prod-7', 'twalsh_plants_lastz_batch1_115' ],
+    'lastz_batch_1'  => [ 'mysql-ens-compara-prod-8', 'sbhurji_plants_lastz_batch1_116' ],
 
     # other alignments
     #'barley_cactus' => [ 'mysql-ens-compara-prod-X', '' ],
 
     # synteny
-    'compara_syntenies' => [ 'mysql-ens-compara-prod-7', 'twalsh_plants_synteny_115' ],
+    'compara_syntenies' => [ 'mysql-ens-compara-prod-8', 'sbhurji_plants_synteny_116' ],
 
     # EPO dbs
     ## rice
-    'rice_epo_high_low' => [ 'mysql-ens-compara-prod-5', "ensembl_compara_plants_${prev_eg_release}_${prev_release}" ],
-    'rice_epo_prev'     => [ 'mysql-ens-compara-prod-5', "ensembl_compara_plants_${prev_eg_release}_${prev_release}" ],
-    'rice_epo_anchors'  => [ 'mysql-ens-compara-prod-5', 'cristig_generate_anchors_rice_99' ],
+    #'rice_epo_high_low' => [ 'mysql-ens-compara-prod-5', "ensembl_compara_plants_${prev_eg_release}_${prev_release}" ],
+    #'rice_epo_prev'     => [ 'mysql-ens-compara-prod-5', "ensembl_compara_plants_${prev_eg_release}_${prev_release}" ],
+    #'rice_epo_anchors'  => [ 'mysql-ens-compara-prod-5', 'cristig_generate_anchors_rice_99' ],
 };
 
 Bio::EnsEMBL::Compara::Utils::Registry::add_compara_dbas( $compara_dbs );

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/MergeDBsIntoRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/MergeDBsIntoRelease_conf.pm
@@ -68,6 +68,7 @@ sub default_options {
             'rice_prot_db'  => 'rice_cultivars_ptrees',
             'barley_prot_db' => 'barley_cultivars_ptrees',
             'members_db'    => 'compara_members',
+            'oat_prot_db'   => 'oat_cultivars_ptrees',
         },
 
         # From these databases, only copy these tables
@@ -95,6 +96,7 @@ sub default_options {
             'wheat_prot_db'  => [qw(ortholog_quality datacheck_results)],
             'rice_prot_db'   => [qw(ortholog_quality datacheck_results)],
             'barley_prot_db' => [qw(ortholog_quality datacheck_results)],
+            'oat_prot_db'    => [qw(ortholog_quality datacheck_results)],
         },
     };
 }

--- a/scripts/production/lastz_coverage_stats.py
+++ b/scripts/production/lastz_coverage_stats.py
@@ -26,8 +26,10 @@ Example command:
 import argparse
 import csv
 from collections import defaultdict
+from collections.abc import Iterable
+from typing import Any
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import bindparam, create_engine, text
 
 
 get_lastz_mlss_from_first_release = """
@@ -89,7 +91,7 @@ get_query_for_results = """
     """
 
 
-def calculate_coverage_ratios(results):
+def calculate_coverage_ratios(results: Iterable[Any]) -> list[dict[str, Any]]:
     """
     Calculate the coverage ratios from the query results.
 
@@ -138,7 +140,7 @@ def calculate_coverage_ratios(results):
     return calculated_results
 
 
-def write_to_tsv(filename, results):
+def write_to_tsv(filename: str, results: list[dict[str, Any]]) -> None:
     """
     Write the calculated results to a TSV file.
 
@@ -173,7 +175,7 @@ def write_to_tsv(filename, results):
             )
 
 
-def process_database(url, output_file, release=None):
+def process_database(url: str, output_file: str, release: int | None = None) -> None:
     """
     Process the database to retrieve coverage ratios and write the result to a TSV file.
 
@@ -206,13 +208,15 @@ def process_database(url, output_file, release=None):
             mlss_ids.extend([row[0] for row in get_rerun_mlsses])
 
         if mlss_ids:
-            param_ids = {"mlss_ids": mlss_ids}
-            result_query = connection.execute(text(get_query_for_results), param_ids)
+            result_query = connection.execute(
+                text(get_query_for_results).bindparams(bindparam("mlss_ids", expanding=True)),
+                {"mlss_ids": mlss_ids},
+            )
             calculated_results = calculate_coverage_ratios(result_query)
             write_to_tsv(output_file, calculated_results)
 
 
-def main():
+def main() -> None:
     """
     Main function to parse user input and process the database.
     """

--- a/scripts/production/lastz_coverage_stats.py
+++ b/scripts/production/lastz_coverage_stats.py
@@ -101,7 +101,7 @@ def calculate_coverage_ratios(results: Iterable[Any]) -> list[dict[str, Any]]:
     Returns:
         A list of dictionaries with the calculated coverage ratios.
     """
-    data = defaultdict(dict)
+    data: defaultdict[Any, dict[str, Any]] = defaultdict(dict)
     for mlss, tag, value in results:
         data[mlss][tag] = value
 


### PR DESCRIPTION
## Description

### Update Plants registry and merge pipeline config for e116.

Updates the Plants production registry (conf/plants/production_reg_conf.pl) for the e116 release cycle.

Adds oat_prot_db to the Plants MergeDBsIntoRelease pipeline config (MergeDBsIntoRelease_conf.pm), since oat cultivar protein trees were computed in e116.

### Add type annotations to Lastz coverage stats script

Also adds type annotations to lastz_coverage_stats.py and updates the SQLAlchemy IN-clause query to use expanding=True for SQLAlchemy 2.0 compatibility.

After updating lastz_coverage_stats, I tested the script by running the following command with the appropriate URL for the plants 116 release db. 

```
# Lastz db (gets all LASTZ_NET MLSSes)
./lastz_coverage_stats.py "mysql://user:pass@mysql-ens-compara-prod-X:port/sbhurji_plants_lastz_batch1_116" output.tsv

# Release db (gets only e116 MLSSes)
./lastz_coverage_stats.py "mysql://user:pass@mysql-ens-compara-prod-X:port/ensembl_compara_plants_63_116" output.tsv --release 116

```


---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
