### PR TITLE
Make further preparations for post-release comparative analyses

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/BuildNewMasterDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/BuildNewMasterDatabase_conf.pm
@@ -93,6 +93,8 @@ sub default_options {
         'update_metadata_script'  => $self->check_exe_in_ensembl('ensembl-compara/scripts/pipeline/update_master_db.pl'),
         'assembly_patch_species'  => [], # by default, skip this step
         'additional_species'      => {}, # by default, skip this step
+        'do_copy_to_shared_loc'   => 0,
+        'do_copy_to_warehouse'    => 0,
         'do_update_from_metadata' => 0,
         'do_load_timetree'        => 0,
         'meta_host'               => undef, # required but not used: do_update_from_metadata = 0
@@ -124,8 +126,10 @@ sub pipeline_wide_parameters {
         
         'init_reg_conf'    => $self->o('init_reg_conf'),
         'do_clone_species' => $self->o('do_clone_species'),
-        
+
         # Define the flags so they can be seen by Parts::PrepareMasterDatabaseForRelease
+        'do_copy_to_shared_loc'   => $self->o('do_copy_to_shared_loc'),
+        'do_copy_to_warehouse'    => $self->o('do_copy_to_warehouse'),
         'do_update_from_metadata' => $self->o('do_update_from_metadata'),
         'do_load_timetree'        => $self->o('do_load_timetree'),
     };

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/BuildNewMasterDatabase_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/BuildNewMasterDatabase_conf.pm
@@ -127,6 +127,8 @@ sub pipeline_wide_parameters {
         'init_reg_conf'    => $self->o('init_reg_conf'),
         'do_clone_species' => $self->o('do_clone_species'),
 
+        'annotation_file'  => $self->o('annotation_file'),
+
         # Define the flags so they can be seen by Parts::PrepareMasterDatabaseForRelease
         'do_copy_to_shared_loc'   => $self->o('do_copy_to_shared_loc'),
         'do_copy_to_warehouse'    => $self->o('do_copy_to_warehouse'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/EG/LoadMembers_conf.pm
@@ -60,9 +60,6 @@ sub default_options {
     # connection parameters to various databases:
         'master_db_is_missing_dnafrags' => 1,
 
-        # list of species that got an annotation update
-        'expected_updates_file' => undef,
-
     # Ensembl-specific databases
         #'staging_loc' => {
             #-host   => 'mysql-ens-sta-1',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/ENV.pm
@@ -96,8 +96,8 @@ sub shared_default_options {
         #'hmm_library_basedir'   => $self->o('shared_hps_dir') . '/compara_hmm_91/',
         
         'homology_dumps_shared_basedir' => $self->o('shared_hps_dir') . '/homology_dumps/'. $self->o('division'),
-        'gene_tree_stats_shared_basedir' => $self->o('shared_hps_dir') . '/gene_tree_stats/' . $self->o('division'),
-        'msa_stats_shared_basedir'       => $self->o('shared_hps_dir') . '/msa_stats/' . $self->o('division'),
+        'gene_tree_stats_shared_basedir' => $self->o('work_dir') . '/gene_tree_stats/',
+        'msa_stats_shared_basedir'       => $self->o('work_dir') . '/msa_stats/',
     }
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Example/LoadMembersQfo_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Example/LoadMembersQfo_conf.pm
@@ -60,9 +60,6 @@ sub default_options {
 
     #load uniprot members for family pipeline
         'load_uniprot_members'      => 0,
-
-        # list of species that got an annotation update
-        'expected_updates_file' => undef,
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/LoadMembers_conf.pm
@@ -84,6 +84,7 @@ sub default_options {
 
         # the master database for synchronization of various ids (use undef if you don't have a master database)
         'master_db' => 'compara_master',
+        'master_prep_db' => 'master_prep',
         'master_db_is_missing_dnafrags' => 0,
 
         # NOTE: The databases referenced in the following arrays have to be hashes (not URLs)
@@ -99,10 +100,6 @@ sub default_options {
         'include_nonreference' => 0,
         'include_patches'      => 0,
         'include_lrg'          => 0,
-
-        # list of species that got an annotation update
-        # ... assuming the same person has run both pipelines
-        'expected_updates_file' => $self->o('shared_hps_dir') . '/genome_reports/annotation_updates.' . $self->o('division') . '.' . $self->o('ensembl_release') . '.list',
     };
 }
 
@@ -130,6 +127,7 @@ sub pipeline_wide_parameters {  # these parameter values are visible to all anal
 
         # Database connection
         'master_db'             => $self->o('master_db'),
+        'master_prep_db'        => $self->o('master_prep_db'),
         'reuse_member_db'       => $self->o('reuse_member_db'),
         'work_dir'              => $self->o('work_dir'),
         'do_nonblocking_checks' => $self->o('do_nonblocking_checks'),
@@ -266,13 +264,17 @@ sub core_pipeline_analyses {
                 'whole_method_links' => '#gene_tree_method_types#',
             },
             -rc_name    => '2Gb_job',
-            -flow_into  => [ 'compare_non_reused_genome_list' ],
+            -flow_into  => [ 'find_non_reused_genome_list' ],
+        },
+
+        {   -logic_name => 'find_non_reused_genome_list',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::LoadMembers::FindNonReusedGenomeList',
+            -flow_into  => { 2 => 'compare_non_reused_genome_list' },
         },
 
         {   -logic_name => 'compare_non_reused_genome_list',
             -module     => 'Bio::EnsEMBL::Compara::RunnableDB::LoadMembers::CompareNonReusedGenomeList',
             -parameters => {
-                'expected_updates_file' => $self->o('expected_updates_file'),
                 'current_release'       => $self->o('ensembl_release'),
             },
             -flow_into  => [ 'nonpolyploid_genome_reuse_factory' ],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Pan/LoadMembers_conf.pm
@@ -70,11 +70,6 @@ sub tweak_analyses {
     $self->SUPER::tweak_analyses(@_);
     my $analyses_by_name = shift;
 
-    # The metadata service reports human annotation updates almost every
-    # release because of LRGs and assembly patches, which we don't care
-    # about in this division.
-    $analyses_by_name->{compare_non_reused_genome_list}->{'-parameters'}->{'ok_homo_sapiens'} = 1;
-
     # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
     my @unguarded_funnel_analyses = (
         'offset_tables',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
@@ -171,6 +171,7 @@ sub pipeline_analyses_prep_master_db_for_release {
             -parameters => {
                 'master_db' => $self->o('master_db'),
                 'allowed_species_file' => $self->o('config_dir') . '/' . 'allowed_species.json',
+                'annotation_file'      => $self->o('annotation_file'),
             },
             -flow_into  => {
                 '2->A' => [ 'add_species_into_master' ],

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
@@ -47,6 +47,15 @@ sub pipeline_analyses_prep_master_db_for_release {
                 'cmd' => [$self->o('patch_db_exe'), '--reg_conf', $self->o('reg_conf'), '--reg_alias', '#master_db#', '--fix', '--oldest', '#oldest_patch_release#', '--nointeractive'],
                 'oldest_patch_release' => $self->o('rel_with_suffix'),
             },
+            -flow_into  => ['hc_metadata'],
+        },
+
+        {   -logic_name => 'hc_metadata',
+            -module     => 'Bio::EnsEMBL::Compara::RunnableDB::PrepareMaster::SqlHealthChecks',
+            -parameters => {
+                'db_conn' => '#master_db#',
+                'mode'    => 'metadata',
+            },
             -flow_into  => ['check_ncbi_taxa_consistency'],
         },
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PrepareMasterDatabaseForRelease.pm
@@ -307,7 +307,10 @@ sub pipeline_analyses_prep_master_db_for_release {
                 'src_db_conn' => '#master_db#',
                 'output_file' => $self->o('master_backup_file'),
             },
-            -flow_into  => [ 'copy_pre_backup_to_warehouse' ],
+            -flow_into  => [
+                WHEN( '#do_copy_to_shared_loc#' => 'copy_annotations_to_shared_loc' ),
+                WHEN( '#do_copy_to_warehouse#' => 'copy_pre_backup_to_warehouse' ),
+            ],
             -rc_name    => '1Gb_job',
         },
 
@@ -328,9 +331,6 @@ sub pipeline_analyses_prep_master_db_for_release {
                 'warehouse_dir' => $self->o('warehouse_dir'),
                 'cmd'           => 'cp #backups_dir#/compara_master_#division#.post#release#.sql #warehouse_dir#/master_db_dumps/ensembl_compara_master_#division#.$(date "+%Y%m%d").during#release#.sql',
             },
-            -flow_into  => WHEN(
-                '#do_update_from_metadata#' => 'copy_annotations_to_shared_loc'
-            ),
         },
 
         {   -logic_name => 'copy_annotations_to_shared_loc',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/LoadMembers_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/LoadMembers_conf.pm
@@ -74,11 +74,6 @@ sub tweak_analyses {
     # Genomes such as avena_sativa_ot3098 need a little more memory.
     $analyses_by_name->{'check_reusability'}->{'-rc_name'} = '4Gb_job';
 
-    # The metadata service reports human annotation updates almost every
-    # release because of LRGs and assembly patches, which we don't care
-    # about in this division.
-    $analyses_by_name->{compare_non_reused_genome_list}->{'-parameters'}->{'ok_homo_sapiens'} = 1;
-
     # Block unguarded funnel analyses; to be unblocked as needed during pipeline execution.
     my @unguarded_funnel_analyses = (
         'offset_tables',

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Plants/ProteinTrees_conf.pm
@@ -94,6 +94,11 @@ sub default_options {
 
         # WGA OrthologQM homology method_link_species_set
         'homology_method_link_types' => ['ENSEMBL_ORTHOLOGUES', 'ENSEMBL_HOMOEOLOGUES'],
+
+        # Do we need a mapping between homology_ids of this database to another database?
+        'do_homology_id_mapping' => 0,
+        # Do we expect to need shared homology dumps in a future release to facilitate reuse of WGA coverage data ?
+        'homology_dumps_shared_dir' => undef,
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
@@ -89,6 +89,8 @@ sub default_options {
         'additional_species_file' => undef,
         'species_trees'          => undef,
 
+        'do_copy_to_shared_loc'   => 0,
+        'do_copy_to_warehouse'    => 0,
         'do_update_from_metadata' => 1,
         'do_load_timetree'        => 0,
 
@@ -117,6 +119,8 @@ sub pipeline_wide_parameters {
         'release'    => $self->o('ensembl_release'),
         'hc_version' => 1,
         # Define the flags so they can be seen by Parts::PrepareMasterDatabaseForRelease
+        'do_copy_to_shared_loc'   => $self->o('do_copy_to_shared_loc'),
+        'do_copy_to_warehouse'    => $self->o('do_copy_to_warehouse'),
         'do_update_from_metadata' => $self->o('do_update_from_metadata'),
         'do_load_timetree'        => $self->o('do_load_timetree'),
     };

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/PrepareMasterDatabaseForRelease_conf.pm
@@ -118,6 +118,7 @@ sub pipeline_wide_parameters {
         'division'   => $self->o('division'),
         'release'    => $self->o('ensembl_release'),
         'hc_version' => 1,
+        'annotation_file' => $self->o('annotation_file'),
         # Define the flags so they can be seen by Parts::PrepareMasterDatabaseForRelease
         'do_copy_to_shared_loc'   => $self->o('do_copy_to_shared_loc'),
         'do_copy_to_warehouse'    => $self->o('do_copy_to_warehouse'),

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ProteinTrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ProteinTrees_conf.pm
@@ -96,6 +96,11 @@ sub default_options {
                 'thresholds'    => [ 50, 50, 25 ],
             },
         ],
+
+        # Do we need a mapping between homology_ids of this database to another database?
+        'do_homology_id_mapping' => 0,
+        # Do we expect to need shared homology dumps in a future release to facilitate reuse of WGA coverage data ?
+        'homology_dumps_shared_dir' => undef,
     };
 }
 

--- a/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ncRNAtrees_conf.pm
+++ b/modules/Bio/EnsEMBL/Compara/PipeConfig/Vertebrates/ncRNAtrees_conf.pm
@@ -86,6 +86,9 @@ sub default_options {
                 'thresholds'    => [ 50, 50, 25 ],
             },
         ],
+
+        # Do we expect to need shared homology dumps in a future release to facilitate reuse of WGA coverage data ?
+        'homology_dumps_shared_dir' => undef,
     };
 } 
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers/CompareNonReusedGenomeList.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers/CompareNonReusedGenomeList.pm
@@ -75,6 +75,8 @@ package Bio::EnsEMBL::Compara::RunnableDB::LoadMembers::CompareNonReusedGenomeLi
 use strict;
 use warnings;
 
+use List::Util qw/sum/;
+
 use Bio::EnsEMBL::Utils::IO qw/slurp_to_array/;
 
 use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
@@ -106,7 +108,12 @@ sub fetch_input {
 
     my $nonreuse_ss_id  = $self->param_required('nonreuse_ss_id');
     my $nonreuse_ss     = $self->compara_dba->get_SpeciesSetAdaptor->fetch_by_dbID($nonreuse_ss_id);
-    my %nonreuse_gdbs   = map {$_->name => $_->dbID} @{$nonreuse_ss->genome_dbs};  # map GenomeDB name to dbID, so we can use both later
+
+    # map GenomeDB name to dbIDs, so we can use them later
+    my %nonreuse_gdbs;
+    foreach my $gdb (@{$nonreuse_ss->genome_dbs}) {
+        push(@{$nonreuse_gdbs{$gdb->name}}, $gdb->dbID);
+    }
 
     my $do_not_reuse_list   = $self->param('do_not_reuse_list');
     my %do_not_reuse_hash   = map {$_ => 1} @$do_not_reuse_list;
@@ -133,7 +140,8 @@ sub run {
         next if exists $do_not_reuse_hash->{$name};
         next if exists $expected_updated_gdbs->{$name};
         next if $self->param_exists("ok_$name") && $self->param("ok_$name");
-        next if $reuse_member_adaptor->count_all_by_GenomeDB($nonreuse_gdbs->{$name}) == 0;
+        my $member_count = sum map { $reuse_member_adaptor->count_all_by_GenomeDB($_) } @{$nonreuse_gdbs->{$name}};
+        next if $member_count == 0;
         $error_msg .= "$name can't be reused but is not listed as having an updated annotation.\n";
     }
 

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers/FindNonReusedGenomeList.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/LoadMembers/FindNonReusedGenomeList.pm
@@ -1,0 +1,72 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Compara::RunnableDB::LoadMembers::FindNonReusedGenomeList
+
+=cut
+
+package Bio::EnsEMBL::Compara::RunnableDB::LoadMembers::FindNonReusedGenomeList;
+
+use strict;
+use warnings;
+
+use File::Spec::Functions qw(catdir);
+use List::Util qw(max);
+
+use Bio::EnsEMBL::Hive::Utils qw(destringify);
+
+use base ('Bio::EnsEMBL::Compara::RunnableDB::BaseRunnable');
+
+
+sub fetch_input {
+    my $self = shift @_;
+
+    my $annotation_file;
+    if($self->param_is_defined('master_db')) {
+
+        if (!$self->param_is_defined('master_prep_db')) {
+            $self->die_no_retry("Master database specified without master-prep database; both are required to find the annotation update file");
+        }
+
+        my $master_prep_dba = $self->get_cached_compara_dba('master_prep_db');
+
+        my $hive_pipeline = Bio::EnsEMBL::Hive::HivePipeline->new(
+            -no_sql_schema_version_check => 1,
+            -dbconn => $master_prep_dba->dbc,
+        );
+
+        my $pipeline_param_dba = $hive_pipeline->hive_dba->get_PipelineWideParametersAdaptor();
+
+        $annotation_file = destringify($pipeline_param_dba->fetch_all("param_name = 'annotation_file'", 'one_per_key', undef, 'param_value'));
+    }
+
+    $self->param('expected_updates_file', $annotation_file);
+}
+
+
+sub write_output {
+    my ($self) = @_;
+
+    my $expected_updates_file = $self->param('expected_updates_file');
+
+    $self->dataflow_output_id({'expected_updates_file' => $expected_updates_file}, 2);
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/SqlHealthChecks.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/SqlHealthChecks.pm
@@ -58,6 +58,19 @@ use base ('Bio::EnsEMBL::Hive::RunnableDB::SqlHealthcheck');
 
 my $config = {
 
+    metadata => {
+        params => [ 'division', 'release' ],
+        tests => [
+            {
+                description => 'compara master database must have expected division',
+                query => "SELECT * from meta WHERE meta_key = 'division' and meta_value != '#division#';",
+            },
+            {
+                description => 'compara master database must have expected release',
+                query => "SELECT * from meta WHERE meta_key = 'schema_version' and meta_value != '#release#';",
+            },
+        ],
+    },
 
     ## ensure no duplicate names ##
     ###############################

--- a/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromRegFactory.pm
+++ b/modules/Bio/EnsEMBL/Compara/RunnableDB/PrepareMaster/UpdateGenomesFromRegFactory.pm
@@ -87,12 +87,17 @@ sub fetch_input {
 
     my $master_dba = $self->get_cached_compara_dba('master_db');
     my $current_genomes = [grep { $_->name ne 'ancestral_sequences' && !defined $_->genome_component } @{$master_dba->get_GenomeDBAdaptor->fetch_all_current()}];
-    my (@genomes_to_update, @genomes_to_retire, @genomes_to_verify);
+    my (@genomes_to_update, @genomes_to_retire, @genomes_to_verify, @updated_annotations);
     if ( @$current_genomes ) {
         foreach my $genome ( @$current_genomes ) {
             if ( $core_dbas{$genome->name} ) {
                 if ( $genome->assembly eq $core_dbas{$genome->name}->assembly_name ) {
                     push @genomes_to_verify, $genome->name;
+
+                    if ( $genome->genebuild ne $core_dbas{$genome->name}->get_MetaContainer->get_genebuild() ) {
+                        push @updated_annotations, $genome->name;
+                    }
+
                 } else {
                     push @genomes_to_update, $genome->name;
                 }
@@ -121,6 +126,7 @@ sub fetch_input {
     print Dumper \@genomes_to_verify;
 
     $self->param('genomes_to_update', \@genomes_to_update);
+    $self->param('genomes_with_updated_annotation', \@updated_annotations);
     $self->param('genomes_to_retire', \@genomes_to_retire);
     $self->param('genomes_to_verify', \@genomes_to_verify);
 }
@@ -134,6 +140,11 @@ sub write_output {
     $self->dataflow_output_id(\@genomes_to_retire, 3);
     my @genomes_to_verify = map { {species_name => $_} } @{ $self->param('genomes_to_verify') };
     $self->dataflow_output_id(\@genomes_to_verify, 5);
+
+    $self->_spurt(
+        $self->param_required('annotation_file'),
+        join("\n", @{$self->param('genomes_to_update')}, @{$self->param('genomes_with_updated_annotation')}),
+    );
 }
 
 


### PR DESCRIPTION
## Description

This PR introduces several further changes preparing for comparative analyses post release 116.

**Related JIRA tickets:**
- ENSCOMPARASW-9147

## Overview of changes

Changes include:
- moving gene-tree and MSA stats output from a shared directory to the pipeline directory;
- switching off shared homology dumps in Vertebrates and Plants;
- adding options `do_copy_to_shared_loc` and `do_copy_to_warehouse` to PrepareMaster (switched off by default);
- adding a metadata healthcheck to the `PrepMaster` pipelines;
- outputting an annotation update file in `UpdateGenomesFromRegFactory` similar to the one output by `UpdateGenomesFromMetadataFactory`;
- fetching the annotation update file via the `PrepMaster` pipeline instead of through a shared location;
- including every `GenomeDB` of a genome in the member count in `CompareNonReusedGenomeList`.

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
