### PR TITLE
Update genomes of interest for the ETM project

### DIFF
--- a/conf/etm/additional_species.json
+++ b/conf/etm/additional_species.json
@@ -1,22 +1,14 @@
 {
     "plants": [
-        "aegilops_tauschii",
-        "arabidopsis_thaliana",
         "arabidopsis_thaliana_gca001651475v1gb",
         "arabidopsis_thaliana_gca978657495v1gb",
-        "avena_sativa_ot3098",
-        "brassica_napus",
+        "avena_sativa_gca022788535v1",
         "brassica_napus_gca905183035v1gb",
-        "chlamydomonas_reinhardtii",
         "hordeum_vulgare",
-        "hordeum_vulgare_barke",
-        "medicago_truncatula",
-        "oryza_sativa",
-        "oryza_sativa_ir64",
-        "solanum_lycopersicum_gca000188115v5cm",
-        "solanum_tuberosum",
-        "triticum_aestivum",
-        "zea_mays"
+        "hordeum_vulgare_gca949782835v1cm",
+        "oryza_sativa_gca001433935v1cm",
+        "oryza_sativa_gca009914875v1",
+        "solanum_lycopersicum_gca000188115v5cm"
     ],
     "vertebrates": [
         "caenorhabditis_elegans",

--- a/conf/etm/species_tree.topology.nw
+++ b/conf/etm/species_tree.topology.nw
@@ -187,23 +187,23 @@
                           (
                             (
                               (
-                                avena_sativa_ot3098,
+                                avena_sativa_gca022788535v1,
                                 avena_sativa_sang
                               ),
                               (
                                 (
-                                  avena_sativa_ot3098_A,
+                                  avena_sativa_gca022788535v1_A,
                                   avena_sativa_sang_A
                                 )
                               ),
                               (
                                 (
-                                  avena_sativa_ot3098_C,
+                                  avena_sativa_gca022788535v1_C,
                                   avena_sativa_sang_C
                                 )
                               ),
                               (
-                                avena_sativa_ot3098_D,
+                                avena_sativa_gca022788535v1_D,
                                 avena_sativa_sang_D
                               ),
                               avena_sativa_sang_U[&&NHX:unassigned_region_component=1]
@@ -214,7 +214,7 @@
                             (
                               (
                                 hordeum_vulgare,
-                                hordeum_vulgare_barke
+                                hordeum_vulgare_gca949782835v1cm
                               )Hordeum_vulgare,
                               secale_cereale
                             )Hordeinae,
@@ -270,8 +270,8 @@
                             oryza_rufipogon,
                             (
                               oryza_indica,
-                              oryza_sativa,
-                              oryza_sativa_ir64
+                              oryza_sativa_gca001433935v1cm,
+                              oryza_sativa_gca009914875v1
                             )Oryza_sativa
                           )Oryza
                         )Oryzinae


### PR DESCRIPTION
## Description

As requested I have updated the `additional_species.json` list with the genomes we are interested to bring on top of e116 genomes for the ETM project.

I have also added the missing genomes to the `species_tree.topology.nw` tree.

And important disclaimer: if it is going to be trouble, happy to use the e116 core databases, but for `avena_sativa_ot3098`, `hordeum_vulgare_barke`, `oryza_sativa` and `oryza_sativa_ir64` we would like to use the new site's core databases instead as they have been reloaded and a few issues have been corrected (however, I cannot recall if these were just metadata issues or something more profound, thus why the alternative may be fine for us).
