### PR TITLE
Add CAFEGeneFamily nhx_format method

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/CAFEGeneFamily.pm
+++ b/modules/Bio/EnsEMBL/Compara/CAFEGeneFamily.pm
@@ -314,6 +314,10 @@ sub get_expansions {
     return $expansions;
 }
 
+sub nhx_format {
+    my ($self) = @_;
+    return $self->root->nhx_format('cafe_gene_gain_loss_tree');
+}
 
 =head2 toString
 

--- a/modules/Bio/EnsEMBL/Compara/NestedSet.pm
+++ b/modules/Bio/EnsEMBL/Compara/NestedSet.pm
@@ -1057,6 +1057,7 @@ my %nhx_ryo_modes_1 = (
     'phylip' => $ryo_modes{'phylip'},
     'genome_gene_stable_id' => '%{-S"|"}%{-i}:%{d}',
     'genome_product_stable_id' => '%{-S"|"}%{-n}:%{d}',
+    'cafe_gene_gain_loss_tree' => '%{y_}:%{d}',
 );
 
 my %nhx_ryo_modes_2 = (
@@ -1071,6 +1072,7 @@ my %nhx_ryo_modes_2 = (
     'treebest_ortho' => $nhx1.$nhx2.':S=%{-x}%{C(species_tree_node,taxon_id)-}',
     'genome_gene_stable_id' => $nhx1.'%{":G="-r}'.$nhx2,
     'genome_product_stable_id' => $nhx1.'%{":G="-i}'.$nhx2,
+    'cafe_gene_gain_loss_tree' => ':T=%{-x}%{C(taxon_id)-}' . '%{":lambda="R}%{":present_count="N}%{":pvalue="P}',
 );
 
 

--- a/modules/Bio/EnsEMBL/Compara/Utils/FormatTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/Utils/FormatTree.pm
@@ -92,7 +92,7 @@ Method_caller : "C(" string ( "," string )(s?) ")"
     "C";
 }
 
-Letter_code : "n" | "c" | "d" | "t" | "r" | "l" | "L" | "h" | "s" | "p" | "m" | "g" | "i" | "o" | "x" | "y" | "X" | "S" | "N" | "P" | "E" | Tag_reader | Method_caller
+Letter_code : "n" | "c" | "d" | "t" | "r" | "l" | "L" | "h" | "s" | "p" | "m" | "g" | "i" | "o" | "x" | "y" | "X" | "S" | "N" | "P" | "R" | "E" | Tag_reader | Method_caller
 
 preliteral  : string
 {
@@ -334,6 +334,19 @@ my $pvalue_cb = sub {
     return undef;
 };
 
+# C(lambdas)
+my $lambda_cb = sub {
+    my ($self) = @_;
+    if ($self->{tree}->isa('Bio::EnsEMBL::Compara::CAFEGeneFamilyNode')
+            && $self->{tree}->node_id == $self->{tree}->root->node_id
+            && $self->{tree}->can('lambdas')) {
+        my $lambda = $self->{tree}->lambdas;
+        return $lambda+0 if defined $lambda;
+    }
+    return undef;
+};
+
+
 my $empty_cb = sub {
     return '';
 };
@@ -379,6 +392,7 @@ my %callbacks = (
         'S' => $sp_name_cb,
         'N' => $n_members_cb, # Used in cafe trees (number of members)
         'P' => $pvalue_cb, # Used in cafe trees (pvalue)
+        'R' => $lambda_cb, # Used in cafe trees (lambda)
         'E' => $empty_cb, ## Implement the "Empty" option
         'T' => $tag_cb,
         'C' => $method_cb,


### PR DESCRIPTION
## Description

This PR would make it possible to serialise a CAFE gene family in NHX format.

Example for `ENSG00000252459`:
```
(((((Homo_sapiens:8[&&NHX:T=9606:present_count=5:pvalue=0.0324],
Pan_troglodytes:8[&&NHX:T=9598:present_count=4:pvalue=0.5598])Homininae:43[&&NHX:T=207598:present_count=4:pvalue=0.0789],
Callithrix_jacchus:43[&&NHX:T=9483:present_count=3:pvalue=0.6608])Simiiformes:85[&&NHX:T=314293:present_count=3:pvalue=0.0824],
Mus_musculus:85[&&NHX:T=10090:present_count=1:pvalue=0.3203])Euarchontoglires:319[&&NHX:T=314146:present_count=2:pvalue=0.7985],
Taeniopygia_guttata:319[&&NHX:T=59729:present_count=1:pvalue=0.5454])Amniota:175868[&&NHX:T=32524:present_count=2:pvalue=0.5605],
Danio_rerio:334983[&&NHX:T=7955:present_count=1:pvalue=0.875])Euteleostomi:0[&&NHX:T=117571:lambda=2.98523e-06:present_count=2];
```

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
