### PR TITLE
Update alignment stats and CIGAR lines for alignment of homologues

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/GeneTree.pm
+++ b/modules/Bio/EnsEMBL/Compara/GeneTree.pm
@@ -708,6 +708,10 @@ sub get_alignment_of_homologues {
         $new_aligment->add_Member($member) if $members_to_keep{$member->dbID};
     }
 
+    # Homologues for a particular type or species are typically a subset of the
+    # complete gene-tree alignment, so we update alignment stats and CIGAR lines.
+    $new_aligment->update_alignment_stats();
+
     return $new_aligment;
 }
 


### PR DESCRIPTION
## Description

This pull request would call the `update_alignment_stats` method (see [here](https://github.com/Ensembl/ensembl-compara/blob/dc107cc6a9cfd0400e0b2e224e3175d2d440d753/modules/Bio/EnsEMBL/Compara/AlignedMemberSet.pm#L842)) on the homologue alignment before it is returned from `Bio::EnsEMBL::Compara::GeneTree::get_alignment_of_homologues`.

The `update_alignment_stats` method minimises CIGAR lines. Because most sets of homologues for a particular type or species are likely to be a subset of the full gene-tree alignment, CIGAR minimisation results in a more compact alignment, potentially significantly more compact.

An example can be seen by comparing the Os05g0421750 orthologue page in the [sandbox](http://wp-np2-35.ebi.ac.uk:5098/Oryza_sativa/Gene/Compara_Ortholog?g=Os05g0421750) to the corresponding view in the [June 2026 site](https://jun2026-plants.ensembl.org/Oryza_sativa/Gene/Compara_Ortholog?g=Os05g0421750). (See also the example alignment blocks in the comments.)

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
