### PR TITLE
Include namespace but not schemaLocation in PhyloXMLWriter output

### DIFF
--- a/modules/Bio/EnsEMBL/Compara/Graph/PhyloXMLWriter.pm
+++ b/modules/Bio/EnsEMBL/Compara/Graph/PhyloXMLWriter.pm
@@ -207,8 +207,7 @@ sub _write_opening {
   $w->xmlDecl("UTF-8");
   $w->forceNSDecl($phylo_uri);
   $w->forceNSDecl($xsi_uri);
-  $w->startTag("phyloxml", [$xsi_uri, 'schemaLocation'] =>
-   "${phylo_uri} ${phylo_uri}/1.10/phyloxml.xsd");
+  $w->startTag("phyloxml");
   return;
 }
 


### PR DESCRIPTION
## Description

This PR would remove the optional `schemaLocation` attribute from PhyloXMLWriter output, keeping the required PhyloXML namespace attribute.

## Testing
This has been tested with the PhyloXML export functionality of the Ensembl Vertebrates website. [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Gene/Compara_Tree?g=ENSG00000139618) vs [June 2026 site](https://jun2026.archive.ensembl.org/Homo_sapiens/Gene/Compara_Tree?g=ENSG00000139618).

---

For code reviewers: [code review SOP](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Code+review+SOP)
